### PR TITLE
Allow to filter Mesh input

### DIFF
--- a/src/core/fem/src/discretization/4C_fem_discretization.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization.cpp
@@ -115,7 +115,7 @@ void Core::FE::Discretization::fill_from_mesh(
     Core::Elements::ElementDefinition element_definition;
 
     unsigned ele_count = 0;
-    for (const auto& [eb_id, eb] : mesh.cell_blocks)
+    for (const auto& [eb_id, eb] : mesh.cell_blocks())
     {
       // Remove this once we support pure geometry meshes without user elements
       if (!eb.specific_data) continue;
@@ -147,7 +147,7 @@ void Core::FE::Discretization::fill_from_mesh(
     // Now add all the nodes to the discretization on rank 0. They are distributed later during
     // the rebalancing process.
     int id = 0;
-    for (const auto& point : mesh.points)
+    for (const auto& point : mesh.points())
     {
       // Discard additional coordinates but only if they are zero.
       for (auto i = point.size() - 1; i >= n_dim_; --i)

--- a/src/core/fem/src/discretization/4C_fem_discretization.hpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization.hpp
@@ -80,7 +80,7 @@ namespace Core::IO
   namespace MeshInput
   {
     template <unsigned dim>
-    struct Mesh;
+    class Mesh;
   }  // namespace MeshInput
 
   class DiscretizationWriter;

--- a/src/core/io/src/4C_io_exodus.cpp
+++ b/src/core/io/src/4C_io_exodus.cpp
@@ -125,10 +125,10 @@ namespace
 
 
 
-Core::IO::MeshInput::Mesh<3> Core::IO::Exodus::read_exodus_file(
+Core::IO::MeshInput::RawMesh<3> Core::IO::Exodus::read_exodus_file(
     const std::filesystem::path& exodus_file)
 {
-  Core::IO::MeshInput::Mesh<3> mesh{};
+  Core::IO::MeshInput::RawMesh<3> mesh{};
 
   int CPU_word_size, IO_word_size;
   float exoversion;               /* version of exodus */
@@ -259,6 +259,7 @@ Core::IO::MeshInput::Mesh<3> Core::IO::Exodus::read_exodus_file(
 
   CHECK_EXODUS_CALL(ex_close(exo_handle));
 
+  MeshInput::assert_valid(mesh);
   return mesh;
 }
 

--- a/src/core/io/src/4C_io_exodus.hpp
+++ b/src/core/io/src/4C_io_exodus.hpp
@@ -18,7 +18,7 @@ FOUR_C_NAMESPACE_OPEN
 
 namespace Core::IO::Exodus
 {
-  MeshInput::Mesh<3> read_exodus_file(const std::filesystem::path& exodus_file);
+  MeshInput::RawMesh<3> read_exodus_file(const std::filesystem::path& exodus_file);
 }  // namespace Core::IO::Exodus
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/io/src/4C_io_mesh.hpp
+++ b/src/core/io/src/4C_io_mesh.hpp
@@ -14,6 +14,7 @@
 #include "4C_io_input_parameter_container.hpp"
 #include "4C_linalg_symmetric_tensor.hpp"
 #include "4C_utils_exceptions.hpp"
+#include "4C_utils_owner_or_view.hpp"
 
 #include <cstddef>
 #include <map>
@@ -52,6 +53,10 @@ namespace Core::IO::MeshInput
   using InternalIdType = int;
   using ExternalIdType = int;
 
+  /**
+   * Constant representing an invalid external ID.
+   */
+  constexpr ExternalIdType invalid_external_id = -1;
 
   /*!
    * @brief These are the supported field data (scalars, vectors, symmetric tensors and tensors)
@@ -89,7 +94,7 @@ namespace Core::IO::MeshInput
    * Discretization from it.
    */
   template <unsigned dim>
-  struct Mesh
+  struct RawMesh
   {
     /**
      * The points in the mesh.
@@ -193,7 +198,7 @@ namespace Core::IO::MeshInput
      */
     [[nodiscard]] auto cells() const
     {
-      auto indices = std::views::iota(std::size_t(0), size());
+      auto indices = std::views::iota(size_t{0}, size());
       return indices |
              std::views::transform(
                  [this](std::size_t i)
@@ -237,11 +242,222 @@ namespace Core::IO::MeshInput
     std::optional<std::string> name{};
   };
 
-  /*!
-   * @brief Asserts that the given mesh internals are consistent and valid.
+  namespace Internal
+  {
+    /**
+     * A lightweight reference to a point in a Mesh used to provide a nicer interface.
+     *
+     * @note This class does not own any data and only refers to data in the RawMesh. Thus, it can
+     * only be used as long as the corresponding RawMesh is alive.
+     */
+    template <unsigned dim, bool is_const>
+    struct PointReference
+    {
+      template <typename T>
+      using MaybeConst = std::conditional_t<is_const, const T, T>;
+
+      PointReference(MaybeConst<RawMesh<dim>>* raw_mesh, size_t index)
+          : raw_mesh_(raw_mesh), index_(index)
+      {
+        FOUR_C_ASSERT(raw_mesh_ != nullptr, "RawMesh pointer must not be null.");
+        FOUR_C_ASSERT(
+            index_ < raw_mesh_->points.size(), "Point index {} is out of bounds.", index_);
+      }
+
+      /**
+       * Get the spatial coordinates of the point.
+       */
+      [[nodiscard]] MaybeConst<std::array<double, dim>>& coordinate() const
+      {
+        return raw_mesh_->points[index_];
+      }
+
+      /**
+       * Get the ID of the point in the mesh. This is the ID that cells use to form their
+       * connectivity.
+       */
+      [[nodiscard]] size_t id() const { return index_; }
+
+      /**
+       * Get the external ID of the point (if available). If not available, returns
+       * #invalid_external_id.
+       */
+      [[nodiscard]] ExternalIdType external_id() const
+      {
+        return raw_mesh_->external_ids ? (*raw_mesh_->external_ids)[index_] : invalid_external_id;
+      }
+
+
+      [[nodiscard]] EligibleFieldTypes<dim> data(const std::string& field_name)
+      {
+        return std::visit([this](auto& variant_vector) -> EligibleFieldTypes<dim>
+            { return variant_vector[index_]; }, raw_mesh_->point_data.at(field_name));
+      }
+
+      template <typename T>
+      // requires eligible
+      [[nodiscard]] const T& data_as(const std::string& field_name) const
+      {
+        const auto* vector = std::get_if<std::vector<T>>(&raw_mesh_->point_data.at(field_name));
+        FOUR_C_ASSERT_ALWAYS(vector, "bal");
+
+        return (*vector)[index_];
+      }
+
+     private:
+      MaybeConst<RawMesh<dim>>* raw_mesh_;
+      size_t index_;
+    };
+  }  // namespace Internal
+
+  /**
+   * @brief An interface to a mesh.
+   *
+   * This class internally uses a RawMesh and exposes a reduced interface to it that is easier
+   * to work with as it does not require knowledge of the internals. Also, this allows us to
+   * implement filtering operations that return a new Mesh object with only a subset of
+   * selected entities.
    */
   template <unsigned dim>
-  void assert_valid(const Mesh<dim>& mesh);
+  class Mesh
+  {
+   public:
+    /**
+     * Default constructor creating an empty mesh.
+     */
+    Mesh();
+
+    /**
+     * Construct a mesh from a RawMesh. The Mesh takes ownership of the @p raw_mesh.
+     */
+    explicit Mesh(RawMesh<dim>&& raw_mesh);
+
+    /**
+     * Construct a mesh that is a view on the given RawMesh. The Mesh does not take ownership of
+     * the @p raw_mesh.
+     */
+    static Mesh create_view(RawMesh<dim>& raw_mesh);
+
+    /**
+     * Get a range of all cell blocks defined in this mesh.
+     */
+    [[nodiscard]] auto cell_blocks() const
+    {
+      return cell_blocks_ids_filter_ | std::views::transform([this](size_t id) -> decltype(auto)
+                                           { return *raw_mesh_->cell_blocks.find(id); });
+    }
+
+    [[nodiscard]] auto cell_blocks()
+    {
+      return cell_blocks_ids_filter_ | std::views::transform([this](size_t id) -> decltype(auto)
+                                           { return *raw_mesh_->cell_blocks.find(id); });
+    }
+
+    /**
+     * Get a range of all points defined in this mesh. This only returns the coordinates of the
+     * points. See points_with_data() if you also need other associated data.
+     */
+    [[nodiscard]] auto points() const
+    {
+      return point_ids_filter_ | std::views::transform([this](std::size_t i) -> decltype(auto)
+                                     { return raw_mesh_->points[i]; });
+    }
+
+    [[nodiscard]] auto points()
+    {
+      return point_ids_filter_ | std::views::transform([this](std::size_t i) -> decltype(auto)
+                                     { return raw_mesh_->points[i]; });
+    }
+
+    /**
+     * Return true if the mesh has point data with the given @p field_name.
+     *
+     * @note If a field of the given name exists, point data is guaranteed to be available for all
+     * points in the mesh.
+     */
+    [[nodiscard]] bool has_point_data(const std::string& field_name) const;
+
+    /**
+     * Get a range of all points defined in this mesh along with their associated data (if any).
+     * This method is likely slower than points(), so only use it if you actually need the
+     * associated data.
+     */
+    [[nodiscard]] auto points_with_data() const
+    {
+      return point_ids_filter_ |
+             std::views::transform([this](std::size_t i)
+                 { return Internal::PointReference<dim, true>(raw_mesh_.get(), i); });
+    }
+
+    [[nodiscard]] auto points_with_data()
+    {
+      return point_ids_filter_ |
+             std::views::transform([this](std::size_t i)
+                 { return Internal::PointReference<dim, false>(raw_mesh_.get(), i); });
+    }
+
+    /**
+     * Get a range of all point sets defined in this mesh.
+     */
+    [[nodiscard]] auto point_sets() const
+    {
+      return point_sets_ids_filter_ | std::views::transform([this](std::size_t i) -> decltype(auto)
+                                          { return *raw_mesh_->point_sets.find(i); });
+    }
+
+    [[nodiscard]] auto point_sets()
+    {
+      return point_sets_ids_filter_ | std::views::transform([this](std::size_t i) -> decltype(auto)
+                                          { return *raw_mesh_->point_sets.find(i); });
+    }
+
+    /**
+     * Filter the mesh to only contain cell blocks with the given IDs. The points are filtered to
+     * only contain those that are used by the remaining cell blocks. Point sets must either
+     * contain all the remaining points or none of them, otherwise an error is thrown. Only the
+     * point sets that contain all the remaining points are kept.
+     *
+     * @note The returned filtered mesh is a view on the original mesh and does not own any data.
+     */
+    [[nodiscard]] Mesh filter_by_cell_block_ids(
+        const std::vector<ExternalIdType>& cell_block_ids) const;
+
+   private:
+    /**
+     * Setup default indices including all entities in the mesh.
+     */
+    void default_fill_indices();
+
+    /**
+     * Underlying raw mesh.
+     */
+    Utils::OwnerOrView<RawMesh<dim>> raw_mesh_;
+
+    /**
+     * A list of filtered indices to be used to filter cell blocks when accessing them. By default,
+     * nothing is filtered.
+     */
+    std::vector<ExternalIdType> cell_blocks_ids_filter_{};
+
+    /**
+     * A list of filtered indices to be used to filter point sets when accessing them.
+     */
+    std::vector<ExternalIdType> point_sets_ids_filter_{};
+
+    /**
+     * A list of filtered indices to be used to filter points when accessing them.
+     */
+    std::vector<ExternalIdType> point_ids_filter_{};
+  };
+
+
+  /*!
+   * @brief Asserts that the given mesh internals are consistent and valid.
+   *
+   * Mostly used for internal consistency checks and unit tests.
+   */
+  template <unsigned dim>
+  void assert_valid(const RawMesh<dim>& mesh);
 
   /*!
    * Print a summary of the mesh to the given output stream (details according to @p verbose )

--- a/src/core/io/src/4C_io_meshreader.cpp
+++ b/src/core/io/src/4C_io_meshreader.cpp
@@ -570,7 +570,7 @@ namespace
       auto& mesh = *mesh_reader.mesh_on_rank_zero;
 
       // Clean up specific data
-      std::ranges::for_each(mesh.cell_blocks, [](auto& eb) { eb.second.specific_data.reset(); });
+      std::ranges::for_each(mesh.cell_blocks(), [](auto& eb) { eb.second.specific_data.reset(); });
 
       Core::IO::InputParameterContainer data;
       input.match_section(mesh_reader.section_name, data);
@@ -581,7 +581,7 @@ namespace
       Core::Elements::ElementDefinition element_definition;
 
       std::vector<int> skipped_blocks;
-      for (auto& [eb_id, eb] : mesh.cell_blocks)
+      for (auto& [eb_id, eb] : mesh.cell_blocks())
       {
         // Look into the input file to find out which elements we need to assign to this block.
         const int eb_id_copy = eb_id;  // work around compiler warning in clang18
@@ -758,7 +758,6 @@ void Core::IO::MeshReader::read_and_partition()
               "Unsupported mesh file format {}. Currently supported are '.e', '.exo', and '.exii'.",
               this_file_path.extension().string());
         }
-        MeshInput::assert_valid(*mesh);
         MeshInput::print(*mesh, std::cout, verbosity);
       }
       mesh_reader->mesh_on_rank_zero = mesh;

--- a/src/core/io/src/4C_io_meshreader.hpp
+++ b/src/core/io/src/4C_io_meshreader.hpp
@@ -29,7 +29,7 @@ namespace Core::IO
   namespace MeshInput
   {
     template <unsigned dim>
-    struct Mesh;
+    class Mesh;
   }
 
   namespace Internal

--- a/src/core/io/src/4C_io_vtu_reader.cpp
+++ b/src/core/io/src/4C_io_vtu_reader.cpp
@@ -338,12 +338,12 @@ namespace
   }
 }  // namespace
 
-Core::IO::MeshInput::Mesh<3> Core::IO::VTU::read_vtu_file(const std::filesystem::path& vtu_file)
+Core::IO::MeshInput::RawMesh<3> Core::IO::VTU::read_vtu_file(const std::filesystem::path& vtu_file)
 {
   FOUR_C_ASSERT_ALWAYS(
       std::filesystem::exists(vtu_file), "File {} does not exist.", vtu_file.string());
 
-  Core::IO::MeshInput::Mesh<3> mesh{};
+  Core::IO::MeshInput::RawMesh<3> mesh{};
 
   // Read the VTU file
   vtkSmartPointer<vtkXMLUnstructuredGridReader> reader =
@@ -445,11 +445,12 @@ Core::IO::MeshInput::Mesh<3> Core::IO::VTU::read_vtu_file(const std::filesystem:
     }
   }
 
+  MeshInput::assert_valid(mesh);
   return mesh;
 }
 
 #else
-Core::IO::MeshInput::Mesh<3> Core::IO::VTU::read_vtu_file(const std::filesystem::path& vtu_file)
+Core::IO::MeshInput::RawMesh<3> Core::IO::VTU::read_vtu_file(const std::filesystem::path& vtu_file)
 {
   FOUR_C_THROW(
       "You have to enable VTK to support vtu mesh file input. Reconfigure 4C with the CMake option "

--- a/src/core/io/src/4C_io_vtu_reader.hpp
+++ b/src/core/io/src/4C_io_vtu_reader.hpp
@@ -30,9 +30,9 @@ namespace Core::IO::VTU
    *    only contain elements of the same cell-type.
    *
    * @param vtu_file (in) : Path to the file
-   * @return Core::IO::MeshInput::Mesh
+   * @return Core::IO::MeshInput::RawMesh
    */
-  Core::IO::MeshInput::Mesh<3> read_vtu_file(const std::filesystem::path& vtu_file);
+  Core::IO::MeshInput::RawMesh<3> read_vtu_file(const std::filesystem::path& vtu_file);
 }  // namespace Core::IO::VTU
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/io/tests/4C_io_exodus_test.cpp
+++ b/src/core/io/tests/4C_io_exodus_test.cpp
@@ -17,7 +17,7 @@ namespace
 
   TEST(Exodus, MeshCubeHex)
   {
-    Core::IO::MeshInput::Mesh mesh = Core::IO::Exodus::read_exodus_file(
+    Core::IO::MeshInput::RawMesh mesh = Core::IO::Exodus::read_exodus_file(
         TESTING::get_support_file_path("test_files/exodus/cube.exo"));
 
     EXPECT_EQ(mesh.cell_blocks.size(), 2);
@@ -55,6 +55,7 @@ namespace
     EXPECT_EQ(*mesh.point_sets.at(1).name, "node_set_top");
 
     std::stringstream ss;
-    Core::IO::MeshInput::print(mesh, ss, Core::IO::MeshInput::VerbosityLevel::full);
+    Core::IO::MeshInput::print(Core::IO::MeshInput::Mesh<3>::create_view(mesh), ss,
+        Core::IO::MeshInput::VerbosityLevel::full);
   }
 }  // namespace

--- a/src/core/io/tests/4C_io_mesh_test.cpp
+++ b/src/core/io/tests/4C_io_mesh_test.cpp
@@ -1,0 +1,67 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "4C_io_mesh.hpp"
+
+namespace
+{
+  using namespace FourC;
+  using namespace Core::IO::MeshInput;
+
+
+  void fill_test_mesh(RawMesh<3>& mesh)
+  {
+    // 27 points in a 3x3x3 grid from 0 to 1 in each direction
+    mesh.points = {{0.0, 0.0, 0.0}, {0.5, 0.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 0.5, 0.0},
+        {0.5, 0.5, 0.0}, {1.0, 0.5, 0.0}, {0.0, 1.0, 0.0}, {0.5, 1.0, 0.0}, {1.0, 1.0, 0.0},
+        {0.0, 0.0, 0.5}, {0.5, 0.0, 0.5}, {1.0, 0.0, 0.5}, {0.0, 0.5, 0.5}, {0.5, 0.5, 0.5},
+        {1.0, 0.5, 0.5}, {0.0, 1.0, 0.5}, {0.5, 1.0, 0.5}, {1.0, 1.0, 0.5}, {0.0, 0.0, 1.0},
+        {0.5, 0.0, 1.0}, {1.0, 0.0, 1.0}, {0.0, 0.5, 1}, {0.5, 0.5, 1}, {1.0, 0.5, 1},
+        {0.0, 1.0, 1}, {0.5, 1.0, 1.0}, {1.0, 1.0, 1.0}};
+
+    CellBlock<3> block1(Core::FE::CellType::hex8);
+    block1.add_cell(std::array{0, 1, 4, 3, 9, 10, 13, 12});
+    mesh.cell_blocks.emplace(1, block1);
+
+    CellBlock<3> block2(Core::FE::CellType::hex8);
+    block2.add_cell(std::array{1, 2, 5, 4, 10, 11, 14, 13});
+    mesh.cell_blocks.emplace(2, block2);
+
+    mesh.point_sets[10].point_ids = {0, 1, 3, 4};
+    mesh.point_sets[20].point_ids = {22, 23, 25, 26};
+
+    mesh.point_data["test_data"] = std::vector<double>(mesh.points.size(), 1.0);
+
+    assert_valid(mesh);
+  }
+
+  TEST(Mesh, MeshFiltering)
+  {
+    Core::IO::MeshInput::RawMesh<3> raw_mesh;
+    fill_test_mesh(raw_mesh);
+
+    Core::IO::MeshInput::Mesh<3> mesh(std::move(raw_mesh));
+    EXPECT_EQ(mesh.cell_blocks().size(), 2);
+
+    auto filtered_mesh = mesh.filter_by_cell_block_ids({1});
+
+    EXPECT_EQ(filtered_mesh.cell_blocks().size(), 1);
+    EXPECT_EQ(filtered_mesh.points().size(), 8);
+    EXPECT_EQ(filtered_mesh.point_sets().size(), 1);
+
+
+    EXPECT_TRUE(filtered_mesh.has_point_data("test_data"));
+
+    for (auto pd : filtered_mesh.points_with_data())
+    {
+      EXPECT_EQ(std::get<double>(pd.data("test_data")), 1.0);
+      EXPECT_EQ(pd.data_as<double>("test_data"), 1.0);
+    }
+  }
+}  // namespace

--- a/src/core/io/tests/4C_io_vtu_test.cpp
+++ b/src/core/io/tests/4C_io_vtu_test.cpp
@@ -23,7 +23,7 @@ namespace
   using namespace FourC;
 
   template <Core::FE::CellType celltype, unsigned dim>
-  double evaluate_jacobian_determinant(Core::IO::MeshInput::Mesh<3>& mesh,
+  double evaluate_jacobian_determinant(Core::IO::MeshInput::RawMesh<3>& mesh,
       std::span<const int> connectivities, const Core::LinAlg::Tensor<double, dim>& xi)
   {
     Core::Elements::ElementNodes<celltype, dim> element_nodes;
@@ -48,7 +48,7 @@ namespace
     GTEST_SKIP() << "Skipping test: 4C vtu-input requires VTK support";
 #endif
     constexpr auto celltype = Core::FE::CellType::hex8;
-    Core::IO::MeshInput::Mesh<3> mesh =
+    Core::IO::MeshInput::RawMesh<3> mesh =
         Core::IO::VTU::read_vtu_file(TESTING::get_support_file_path("test_files/vtu/hex8.vtu"));
 
     EXPECT_EQ(mesh.cell_blocks.size(), 2);
@@ -71,7 +71,7 @@ namespace
 #ifndef FOUR_C_WITH_VTK
     GTEST_SKIP() << "Skipping test: 4C vtu-input requires VTK support";
 #endif
-    Core::IO::MeshInput::Mesh<3> mesh = Core::IO::VTU::read_vtu_file(
+    Core::IO::MeshInput::RawMesh<3> mesh = Core::IO::VTU::read_vtu_file(
         TESTING::get_support_file_path("test_files/vtu/hex8_point_data.vtu"));
 
     ASSERT_EQ(mesh.points.size(), 16);
@@ -184,7 +184,7 @@ namespace
 #ifndef FOUR_C_WITH_VTK
     GTEST_SKIP() << "Skipping test: 4C vtu-input requires VTK support";
 #endif
-    Core::IO::MeshInput::Mesh<3> mesh = Core::IO::VTU::read_vtu_file(
+    Core::IO::MeshInput::RawMesh<3> mesh = Core::IO::VTU::read_vtu_file(
         TESTING::get_support_file_path("test_files/vtu/hex8_cell_data.vtu"));
 
     ASSERT_EQ(mesh.cell_blocks.size(), 2);
@@ -294,7 +294,7 @@ namespace
     GTEST_SKIP() << "Skipping test: 4C vtu-input requires VTK support";
 #endif
     constexpr auto celltype = Core::FE::CellType::hex20;
-    Core::IO::MeshInput::Mesh<3> mesh =
+    Core::IO::MeshInput::RawMesh<3> mesh =
         Core::IO::VTU::read_vtu_file(TESTING::get_support_file_path("test_files/vtu/hex20.vtu"));
 
     EXPECT_EQ(mesh.cell_blocks.size(), 2);
@@ -318,7 +318,7 @@ namespace
     GTEST_SKIP() << "Skipping test: 4C vtu-input requires VTK support";
 #endif
     constexpr auto celltype = Core::FE::CellType::hex27;
-    Core::IO::MeshInput::Mesh<3> mesh =
+    Core::IO::MeshInput::RawMesh<3> mesh =
         Core::IO::VTU::read_vtu_file(TESTING::get_support_file_path("test_files/vtu/hex27.vtu"));
 
     EXPECT_EQ(mesh.cell_blocks.size(), 2);
@@ -343,7 +343,7 @@ namespace
     GTEST_SKIP() << "Skipping test: 4C vtu-input requires VTK support";
 #endif
     constexpr auto celltype = Core::FE::CellType::tet4;
-    Core::IO::MeshInput::Mesh<3> mesh =
+    Core::IO::MeshInput::RawMesh<3> mesh =
         Core::IO::VTU::read_vtu_file(TESTING::get_support_file_path("test_files/vtu/tet4.vtu"));
 
     EXPECT_EQ(mesh.cell_blocks.size(), 1);
@@ -375,7 +375,7 @@ namespace
     GTEST_SKIP() << "Skipping test: 4C vtu-input requires VTK support";
 #endif
     constexpr auto celltype = Core::FE::CellType::tet10;
-    Core::IO::MeshInput::Mesh<3> mesh =
+    Core::IO::MeshInput::RawMesh<3> mesh =
         Core::IO::VTU::read_vtu_file(TESTING::get_support_file_path("test_files/vtu/tet10.vtu"));
 
     EXPECT_EQ(mesh.cell_blocks.size(), 1);
@@ -408,7 +408,7 @@ namespace
     GTEST_SKIP() << "Skipping test: 4C vtu-input requires VTK support";
 #endif
     constexpr auto celltype = Core::FE::CellType::wedge6;
-    Core::IO::MeshInput::Mesh<3> mesh =
+    Core::IO::MeshInput::RawMesh<3> mesh =
         Core::IO::VTU::read_vtu_file(TESTING::get_support_file_path("test_files/vtu/wedge6.vtu"));
 
     EXPECT_EQ(mesh.cell_blocks.size(), 1);
@@ -431,7 +431,7 @@ namespace
     GTEST_SKIP() << "Skipping test: 4C vtu-input requires VTK support";
 #endif
     constexpr auto celltype = Core::FE::CellType::wedge15;
-    Core::IO::MeshInput::Mesh<3> mesh =
+    Core::IO::MeshInput::RawMesh<3> mesh =
         Core::IO::VTU::read_vtu_file(TESTING::get_support_file_path("test_files/vtu/wedge15.vtu"));
 
     EXPECT_EQ(mesh.cell_blocks.size(), 1);
@@ -454,7 +454,7 @@ namespace
     GTEST_SKIP() << "Skipping test: 4C vtu-input requires VTK support";
 #endif
     constexpr auto celltype = Core::FE::CellType::pyramid5;
-    Core::IO::MeshInput::Mesh<3> mesh =
+    Core::IO::MeshInput::RawMesh<3> mesh =
         Core::IO::VTU::read_vtu_file(TESTING::get_support_file_path("test_files/vtu/pyramid5.vtu"));
 
     EXPECT_EQ(mesh.cell_blocks.size(), 1);

--- a/src/core/utils/src/stl_extension/4C_utils_owner_or_view.hpp
+++ b/src/core/utils/src/stl_extension/4C_utils_owner_or_view.hpp
@@ -47,7 +47,7 @@ namespace Core::Utils
     /**
      * Construct non-owning view on @p ptr.
      */
-    OwnerOrView(T* ptr) : obj_(ptr, [](T*) {}) {}
+    explicit OwnerOrView(T* ptr) : obj_(ptr, [](T*) {}) {}
 
     /**
      * Const-propagating dereference operator.
@@ -68,6 +68,14 @@ namespace Core::Utils
      * Non-const pointer operator.
      */
     T* operator->() { return obj_.get(); }
+
+    /**
+     * Get the raw pointer to the object.
+     *
+     * @note This function does not propagate constness and instead follows the constness of the
+     * type T. This is consistent with std::unique_ptr<T>::get().
+     */
+    T* get() const { return obj_.get(); }
 
    private:
     /**

--- a/src/global_data/4C_global_data_read.cpp
+++ b/src/global_data/4C_global_data_read.cpp
@@ -1472,7 +1472,7 @@ namespace
     {
       if (const auto* external_mesh = mesh_reader.get_external_mesh_on_rank_zero(); external_mesh)
       {
-        const auto& node_sets_from_mesh = external_mesh->point_sets;
+        const auto& node_sets_from_mesh = external_mesh->point_sets();
         for (const auto& [id, node_set] : node_sets_from_mesh)
         {
           const auto& set = node_set.point_ids;
@@ -1498,7 +1498,7 @@ namespace
     {
       if (const auto* external_mesh = mesh_reader.get_external_mesh_on_rank_zero(); external_mesh)
       {
-        for (const auto& [id, eb] : external_mesh->cell_blocks)
+        for (const auto& [id, eb] : external_mesh->cell_blocks())
         {
           std::set<int> nodes;
           for (const auto& cell : eb.cells())


### PR DESCRIPTION
This PR introduces a distinctions between `RawMesh` which is close to a mesh file, and `Mesh` which is an abstraction on top of `RawMesh`. This enables us to implement filtering operations on a mesh, e.g., filtering by the `cell_block_id`. Filtering is useful for all kinds of coupled physics, where one mesh file contains all the info, but we do not constantly want to check which pieces we need from the mesh. Instead, we filter the mesh once and then process the whole (filtered) mesh.
