### PR TITLE
1134 always build prebuilt 4c image

### DIFF
--- a/.github/workflows/docker_prebuilt_4c.yml
+++ b/.github/workflows/docker_prebuilt_4c.yml
@@ -16,8 +16,7 @@ env:
 jobs:
   build_4c_image:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.repository == '4C-multiphysics/4C'
-      }}
+    if: ${{ github.repository == '4C-multiphysics/4C' }}
     permissions:
       contents: read
       packages: write
@@ -38,6 +37,15 @@ jobs:
           images: ${{ env.IMAGE_NAME }}
           labels: |
             org.opencontainers.image.description=Image containing the built 4C code
+      - name: Create tags
+        id: tags
+        # If the nightly tests are successful the docker image is additionally tagged as `stable`
+        run: |
+          TAGS="${{ env.IMAGE_NAME }}:main"
+          if [[ "${{ github.event.workflow_run.conclusion }}" == 'success' ]]; then
+            TAGS="$TAGS,${{ env.IMAGE_NAME }}:stable"
+          fi
+          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
@@ -45,13 +53,12 @@ jobs:
           context: .
           file: docker/prebuilt_4C/Dockerfile
           push: true
-          tags: ${{ env.IMAGE_NAME }}:main
+          tags: ${{ steps.tags.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
   build_4c_minimal_image:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.repository == '4C-multiphysics/4C'
-      }}
+    if: ${{ github.repository == '4C-multiphysics/4C' }}
     permissions:
       contents: read
       packages: write
@@ -72,6 +79,15 @@ jobs:
           images: ${{ env.IMAGE_NAME }}-minimal
           labels: |
             org.opencontainers.image.description=Image containing the 4C executable
+      - name: Create tags
+        id: tags
+        # If the nightly tests are successful the docker image is additionally tagged as `stable`
+        run: |
+          TAGS="${{ env.IMAGE_NAME }}:main"
+          if [[ "${{ github.event.workflow_run.conclusion }}" == 'success' ]]; then
+            TAGS="$TAGS,${{ env.IMAGE_NAME }}:stable"
+          fi
+          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
@@ -79,5 +95,5 @@ jobs:
           context: docker/prebuilt_4C_minimal
           file: docker/prebuilt_4C_minimal/Dockerfile
           push: true
-          tags: ${{ env.IMAGE_NAME }}-minimal:main
+          tags: ${{ steps.tags.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
The prebuilt 4C docker image is always built and tagged as `main` even
if the tests fail. This better reflects the tag name `main` as the
docker image reflects the current state on main.
If the nightly tests succeed, this image gets the tag `stable`. So, the
tag `stable` reflects the last state where the tests were successful.
See issue https://github.com/4C-multiphysics/4C/issues/1134.

**Breaking change**: This is a breaking change because it changes the behavior of the Docker image. In the `main` image, the tests may not work. The previous `main` tag is now called `stable`. The `stable` image is the last state where the tests were successful.

@sebproell @amgebauer It would also be possible to use the REST API to query if the build in the nightly pipeline was successful. If the build failed, we will now start the Docker build, even though it will also fail. We could save some resources here. What do you think?

FYI @gilrrei 