### PR TITLE
Remove instantiation of `::NOX::Epetra::LinearSystemAztecOO`

### DIFF
--- a/src/fsi/src/partitioned/4C_fsi_partitioned.cpp
+++ b/src/fsi/src/partitioned/4C_fsi_partitioned.cpp
@@ -603,14 +603,10 @@ Teuchos::RCP<::NOX::Epetra::LinearSystem> FSI::Partitioned::create_linear_system
     {
       // if no Jacobian has been set this better be the fix point
       // method.
-      if (dirParams.get("Method", "Newton") != "User Defined")
-      {
-        if (Core::Communication::my_mpi_rank(get_comm()) == 0)
-          utils.out() << "Warning: No Jacobian for solver " << dirParams.get("Method", "Newton")
-                      << "\n";
-      }
-      linSys = Teuchos::make_rcp<::NOX::Epetra::LinearSystemAztecOO>(
-          printParams, lsParams, interface, noxSoln);
+      FOUR_C_ASSERT(dirParams.get("Method", "Newton") == "User Defined",
+          "No Jacobian for solver '{}'", dirParams.get("Method", "Newton"));
+
+      linSys = Teuchos::null;
     }
     else
     {


### PR DESCRIPTION
## Description and Context
It looks like that the default scenario for `FSI::Partitioned` is such that if a child class does not specify `create_linear_system()` directly, then the partitioning scheme does not need _this_ particular linear system object at all and we can return `null`.

Let's see if this assumption is correct and how many test break.
