### PR TITLE
[scatra] Remove temporary vector copy from restart

### DIFF
--- a/src/ssi/4C_ssi_partitioned_1wc.cpp
+++ b/src/ssi/4C_ssi_partitioned_1wc.cpp
@@ -95,12 +95,8 @@ void SSI::SSIPart1WC::do_scatra_step()
         // read phinp from restart file
         std::shared_ptr<Core::LinAlg::MultiVector<double>> phinptemp = reader.read_vector("phinp");
 
-        Core::LinAlg::MultiVector<double> tmp(
-            *scatra_field()->dof_row_map(), phinptemp->num_vectors());
-        std::copy_n(phinptemp->get_values(), phinptemp->local_length(), tmp.get_values());
-
         // update phinp
-        scatra_field()->phinp()->update(1.0, tmp, 0.0);
+        scatra_field()->phinp()->update(1.0, *phinptemp, 0.0);
       }
       else
       {
@@ -111,11 +107,8 @@ void SSI::SSIPart1WC::do_scatra_step()
         // read phinp from restart file
         reader.read_vector(phinptemp, "phinp");
 
-        Core::LinAlg::Vector<double> tmp(*scatra_field()->dof_row_map());
-        std::copy_n(phinptemp->get_values(), phinptemp->local_length(), tmp.get_values());
-
         // update phinp
-        scatra_field()->phinp()->update(1.0, tmp, 0.0);
+        scatra_field()->phinp()->update(1.0, *phinptemp, 0.0);
       }
     }
   }


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
Somehow there's this weird vector copy thing used for partitioned one way coupled ssi. This PR simplifies things.