### PR TITLE
Add vision/mission to documentation main page

### DIFF
--- a/doc/documentation/src/index.rst
+++ b/doc/documentation/src/index.rst
@@ -2,26 +2,21 @@
 |FOURC|
 ========
 
-Mission statement
-=================
+Vision
+======
 
-|FOURC| is a parallel multiphysics research code
-to analyze and solve a plethora of physical problems
-described by ordinary or partial differential equations.
-Its development is driven by challenging research questions and real-world problems,
-for which existing tools do not suffice,
-either due to the lack of capabilities or due to falling short of accuracy or performance.
+We aim to advance the frontiers of computational science and engineering by providing a versatile, extensible and open-source research software framework for the systematic development, analysis, and application of advanced numerical methods for modeling and simulation of complex multiphysics phenomena across scales and disciplines.
 
-|FOURC| not only provides ready-to-use simulation capabilities for a variety of physical models,
-including single fields such as solids and structures, fluids, or scalar transport,
-and multiphysics coupling and interactions between several fields,
-but also a modular software environment for research in mathematical modeling and numerical methods.
-Pre- and post-processing tools facilitate the use of |FOURC| within streamlined application workflows in science and engineering.
-For spatial discretization, |FOURC| mostly relies on finite element methods (FEM, CutFEM).
-It leverages the `Trilinos project <https://trilinos.github.io>`_ for sparse linear algebra, nonlinear solvers, and linear solvers and preconditioners
-to be executed on MPI-parallel computing clusters.
-Through its comprehensive set of physics modules available to all users without coding effort,
-|FOURC| facilitates the advancement of research in all areas of science, engineering, and biomedicine.
+Mission
+=======
+
+|FOURC| Multiphysics is a modular, parallel and open-source simulation environment tailored to the needs of researchers and computational scientists to enable and accelerate research in computational science and engineering. Our mission is to:
+
+- support the formulation and enable the rigorous study of complex single- and multiphysics models across spatial and temporal scales through a variety of physical models, numerical methods, and coupling algorithms with a strong focus on finite element methods and particle methods accompanied by comprehensive documentation, tutorials and a welcoming culture to ensure a low entry barrier;
+- curate and advance a modular and extensible framework to develop mathematical models for challenging real-world problems in science, engineering and biomedicine described by differential equations and to devise and implement novel numerical methods with a clear focus on methodological innovation and practical usability;
+- offer a platform for both simulation practitioners, studying real-world problems through numerical simulation, as well as researchers in numerical modeling and computational methods, aiming at the development of accurate models and innovative numerical methods and their efficient software implementation in the support of complex real-world scenarios;
+- enable parallel and scalable computations on workstations and clusters to increase efficiency and utilization of available hardware resources with a strong focus on medium- and large-scale practical applications;
+- foster a growing international research community in which engineers, scientists, and domain experts can cooperate, contribute, accelerate scientific discovery, and share advances in computational modeling and numerical method development and are committed to open scientific exchange, collaborative development, and sustainable software practices.
 
 Content
 =======


### PR DESCRIPTION
## Description and Context

Following PR #1343, this PR updates the vision and mission statement on the main page of the documentation.

## Related Issues and Pull Requests

Follows PR #1343, https://github.com/4C-multiphysics/website/pull/26
