### PR TITLE
Add evaluation context to material interface

### DIFF
--- a/src/ale/4C_ale_ale2.hpp
+++ b/src/ale/4C_ale_ale2.hpp
@@ -28,7 +28,10 @@ namespace Core::FE
 {
   class Discretization;
 }  // namespace Core::FE
-
+namespace Mat
+{
+  struct EvaluationContext;
+}  // namespace Mat
 namespace Discret
 {
   namespace Elements
@@ -363,6 +366,7 @@ namespace Discret
           const int numeps,                                     ///< number of strains
           std::shared_ptr<const Core::Mat::Material> material,  ///< the material data
           Teuchos::ParameterList& params,                       ///< element parameter list
+          const Mat::EvaluationContext& context,                ///< context for material evaluation
           int gp                                                ///< Integration point
       );
 
@@ -371,6 +375,7 @@ namespace Discret
           Core::LinAlg::SerialDenseMatrix& C,             ///< material tensor (output)
           const Core::LinAlg::SerialDenseVector& strain,  ///< strain state (input)
           Teuchos::ParameterList& params,                 ///< parameter list
+          const Mat::EvaluationContext& context,          ///< context for material evaluation
           int gp                                          ///< Integration point
       );
 
@@ -378,7 +383,8 @@ namespace Discret
           Core::LinAlg::Matrix<6, 6>* cmat,                         ///< material tensor (output)
           const Core::LinAlg::Matrix<6, 1>* glstrain,               ///< strain state (input)
           Teuchos::ParameterList& params,                           ///< parameter list
-          int gp                                                    ///< Integration point
+          const Mat::EvaluationContext& context,  ///< context for material evaluation
+          int gp                                  ///< Integration point
       );
 
       //! Transform Green-Lagrange notation from 2D to 3D

--- a/src/fluid_ele/4C_fluid_ele_calc_poro.cpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_poro.cpp
@@ -6538,7 +6538,9 @@ void Discret::Elements::FluidEleCalcPoro<distype>::compute_mixture_strong_residu
 
     Core::LinAlg::Matrix<6, 1> stress_view = Core::LinAlg::make_stress_like_voigt_view(stress);
     Core::LinAlg::Matrix<6, 6> cmat_view = Core::LinAlg::make_stress_like_voigt_view(cmat);
-    struct_mat_->evaluate(nullptr, glstrain, params, stress, cmat, gp, Base::eid_);
+
+    Mat::EvaluationContext context{};  // We have nothing available
+    struct_mat_->evaluate(nullptr, glstrain, params, context, stress, cmat, gp, Base::eid_);
 
     static Core::LinAlg::Matrix<6, nsd_> E_X(Core::LinAlg::Initialization::zero);
     E_X.clear();

--- a/src/mat/4C_mat_aaaneohooke.cpp
+++ b/src/mat/4C_mat_aaaneohooke.cpp
@@ -157,7 +157,8 @@ void Mat::AAAneohooke::unpack(Core::Communication::UnpackBuffer& buffer)
  */
 void Mat::AAAneohooke::evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
     const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-    const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+    const Teuchos::ParameterList& params, const EvaluationContext& context,
+    Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
     Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID)
 {
   // map in GetParameter can now calculate LID, so we do not need it here       05/2017 birzle
@@ -306,8 +307,8 @@ void Mat::AAAneohooke::evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgra
 /*----------------------------------------------------------------------*
  |  calculate strain energy                                hemmler 02/17|
  *----------------------------------------------------------------------*/
-double Mat::AAAneohooke::strain_energy(
-    const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain, int gp, int eleGID) const
+double Mat::AAAneohooke::strain_energy(const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
+    const EvaluationContext& context, int gp, int eleGID) const
 {
   // material parameters for isochoric part
   const double youngs = params_->get_parameter(params_->young, eleGID);  // Young's modulus

--- a/src/mat/4C_mat_aaaneohooke.hpp
+++ b/src/mat/4C_mat_aaaneohooke.hpp
@@ -177,12 +177,13 @@ namespace Mat
     // THE material routine
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
     /// evaluate strain energy function
     [[nodiscard]] double strain_energy(const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        int gp, int eleGID) const override;
+        const EvaluationContext& context, int gp, int eleGID) const override;
 
     /// Return quick accessible material parameter data
     Core::Mat::PAR::Parameter* parameter() const override { return params_; }

--- a/src/mat/4C_mat_constraintmixture.hpp
+++ b/src/mat/4C_mat_constraintmixture.hpp
@@ -245,7 +245,8 @@ namespace Mat
     /// Evaluate material
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
     /// Return density

--- a/src/mat/4C_mat_crystal_plasticity.cpp
+++ b/src/mat/4C_mat_crystal_plasticity.cpp
@@ -530,7 +530,8 @@ void Mat::CrystalPlasticity::update()
  *-------------------------------------------------------------------------------*/
 void Mat::CrystalPlasticity::evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
     const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-    const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+    const Teuchos::ParameterList& params, const EvaluationContext& context,
+    Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
     Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID)
 {
   // simulation parameters
@@ -538,7 +539,8 @@ void Mat::CrystalPlasticity::evaluate(const Core::LinAlg::Tensor<double, 3, 3>* 
   if (eleGID == -1) FOUR_C_THROW("no element provided in material");
 
   // extract time increment
-  dt_ = params.get<double>("delta time");
+  FOUR_C_ASSERT(context.time_step_size, "Time step size not given in evaluation context.");
+  dt_ = *context.time_step_size;
 
   // get current deformation gradient
   (*deform_grad_current_)[gp] = Core::LinAlg::make_matrix(*defgrad);

--- a/src/mat/4C_mat_crystal_plasticity.hpp
+++ b/src/mat/4C_mat_crystal_plasticity.hpp
@@ -242,7 +242,8 @@ namespace Mat
     //! evaluate material law
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
     //! transform Miller Bravais index notation of hexagonal lattices to Miller index notation

--- a/src/mat/4C_mat_damage.cpp
+++ b/src/mat/4C_mat_damage.cpp
@@ -270,7 +270,8 @@ void Mat::Damage::update()
 //  evaluate material (public)
 void Mat::Damage::evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
     const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-    const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+    const Teuchos::ParameterList& params, const EvaluationContext& context,
+    Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
     Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID)
 {
   const Core::LinAlg::Matrix<3, 3> defgrd_mat = Core::LinAlg::make_matrix_view(*defgrad);

--- a/src/mat/4C_mat_damage.hpp
+++ b/src/mat/4C_mat_damage.hpp
@@ -160,7 +160,8 @@ namespace Mat
     //! evaluate material
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
     //! evaluate material using Lemaitre material model

--- a/src/mat/4C_mat_elasthyper.cpp
+++ b/src/mat/4C_mat_elasthyper.cpp
@@ -313,7 +313,7 @@ void Mat::ElastHyper::evaluate_fiber_vecs(const double newgamma,
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 double Mat::ElastHyper::strain_energy(const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-    const int gp, const int eleGID) const
+    const EvaluationContext& context, const int gp, const int eleGID) const
 {
   Core::LinAlg::SymmetricTensor<double, 3, 3> C_strain{};
   static Core::LinAlg::Matrix<3, 1> prinv(Core::LinAlg::Initialization::zero);
@@ -342,7 +342,8 @@ double Mat::ElastHyper::strain_energy(const Core::LinAlg::SymmetricTensor<double
 /*----------------------------------------------------------------------*/
 void Mat::ElastHyper::evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
     const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-    const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+    const Teuchos::ParameterList& params, const EvaluationContext& context,
+    Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
     Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID)
 {
   bool checkpolyconvexity = (params_ != nullptr and params_->polyconvex_ != 0);
@@ -376,7 +377,7 @@ double Mat::ElastHyper::evaluate_cauchy_n_dir_and_derivatives(
     const Core::LinAlg::Tensor<double, 3>& dir, Core::LinAlg::Matrix<3, 1>* d_cauchyndir_dn,
     Core::LinAlg::Matrix<3, 1>* d_cauchyndir_ddir, Core::LinAlg::Matrix<9, 1>* d_cauchyndir_dF,
     Core::LinAlg::Matrix<9, 9>* d2_cauchyndir_dF2, Core::LinAlg::Matrix<9, 3>* d2_cauchyndir_dF_dn,
-    Core::LinAlg::Matrix<9, 3>* d2_cauchyndir_dF_ddir, int gp, int eleGID,
+    Core::LinAlg::Matrix<9, 3>* d2_cauchyndir_dF_ddir, const EvaluationContext& context, int eleGID,
     const double* concentration, const double* temp, double* d_cauchyndir_dT,
     Core::LinAlg::Matrix<9, 1>* d2_cauchyndir_dF_dT)
 {
@@ -415,7 +416,8 @@ double Mat::ElastHyper::evaluate_cauchy_n_dir_and_derivatives(
   dPI.clear();
   ddPII.clear();
   dddPIII.clear();
-  evaluate_cauchy_derivs(prinv, gp, eleGID, dPI, ddPII, dddPIII, temp);
+  constexpr int dummy_gp_id = -1;
+  evaluate_cauchy_derivs(prinv, dummy_gp_id, eleGID, dPI, ddPII, dddPIII, temp);
 
   const double prefac = 2.0 / std::sqrt(prinv(2));
 

--- a/src/mat/4C_mat_elasthyper.hpp
+++ b/src/mat/4C_mat_elasthyper.hpp
@@ -212,8 +212,8 @@ namespace Mat
     virtual double get_young();
 
     /// evaluate strain energy function
-    [[nodiscard]] double strain_energy(
-        const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain, int gp,
+    [[nodiscard]] double strain_energy(const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
+        const EvaluationContext& context, int gp,
         int eleGID  ///< Element GID
     ) const override;
 
@@ -230,7 +230,8 @@ namespace Mat
      */
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
     double evaluate_cauchy_n_dir_and_derivatives(const Core::LinAlg::Tensor<double, 3, 3>& defgrd,
@@ -238,8 +239,8 @@ namespace Mat
         Core::LinAlg::Matrix<3, 1>* d_cauchyndir_dn, Core::LinAlg::Matrix<3, 1>* d_cauchyndir_ddir,
         Core::LinAlg::Matrix<9, 1>* d_cauchyndir_dF, Core::LinAlg::Matrix<9, 9>* d2_cauchyndir_dF2,
         Core::LinAlg::Matrix<9, 3>* d2_cauchyndir_dF_dn,
-        Core::LinAlg::Matrix<9, 3>* d2_cauchyndir_dF_ddir, int gp, int eleGID,
-        const double* concentration, const double* temp, double* d_cauchyndir_dT,
+        Core::LinAlg::Matrix<9, 3>* d2_cauchyndir_dF_ddir, const EvaluationContext& context,
+        int eleGID, const double* concentration, const double* temp, double* d_cauchyndir_dT,
         Core::LinAlg::Matrix<9, 1>* d2_cauchyndir_dF_dT) override;
 
     /**

--- a/src/mat/4C_mat_growthremodel_elasthyper.hpp
+++ b/src/mat/4C_mat_growthremodel_elasthyper.hpp
@@ -210,7 +210,8 @@ namespace Mat
     /// hyperelastic stress response plus elasticity tensor
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp,
         int eleGID) override;  ///< Element ID
 
@@ -233,8 +234,9 @@ namespace Mat
     /// update
     void update(Core::LinAlg::Tensor<double, 3, 3> const& defgrd,  ///< Deformation gradient
         int const gp,                                              ///< Current Gauss-Point
-        const Teuchos::ParameterList& params,  ///< Container for additional information
-        int const eleGID) override;            ///< Element ID
+        const Teuchos::ParameterList& params,
+        const EvaluationContext& context,  ///< Container for additional information
+        int const eleGID) override;        ///< Element ID
 
     /// Return quick accessible material parameter data
     Core::Mat::PAR::Parameter* parameter() const override { return params_; }
@@ -242,8 +244,9 @@ namespace Mat
     /// hyperelastic stress response plus elasticity tensor for membrane element (membrane
     /// formulation)
     void evaluate_membrane(Core::LinAlg::Matrix<3, 3> const&
-                               defgrd_glob,     ///< Deformation gradient in global coordinates
-        const Teuchos::ParameterList& params,   ///< Container for additional information
+                               defgrd_glob,    ///< Deformation gradient in global coordinates
+        const Teuchos::ParameterList& params,  ///< Container for additional information
+        const EvaluationContext& context,
         Core::LinAlg::Matrix<3, 3>& pk2M_glob,  ///< 2nd Piola-Kirchhoff stress global coordinates
         Core::LinAlg::Matrix<6, 6>& cmat_glob,  ///< Elasticity tensor in global coordinates
         int gp,                                 ///< Gauss point
@@ -253,10 +256,10 @@ namespace Mat
     /// formulation)
     double evaluate_membrane_thickness_stretch(
         Core::LinAlg::Matrix<3, 3> const&
-            defgrd_glob,                       ///< Deformation gradient in global coordinates
-        const Teuchos::ParameterList& params,  ///< Container for additional information
-        int gp,                                ///< Gauss point
-        int eleGID) override;                  ///< Element ID
+            defgrd_glob,                           ///< Deformation gradient in global coordinates
+        const Teuchos::ParameterList& params,      ///< Container for additional information
+        const EvaluationContext& context, int gp,  ///< Gauss point
+        int eleGID) override;                      ///< Element ID
 
     /// Return names of visualization data
     void vis_names(std::map<std::string, int>& names) const override;
@@ -273,6 +276,7 @@ namespace Mat
     /// Setup prestretch (optional: setup element axi-, circ-, and rad-directions) for 3D elements
     void setup_g_r_3d(Core::LinAlg::Matrix<3, 3> const* const defgrd,  ///< Deformation gradient
         const Teuchos::ParameterList& params,  ///< Container for additional information
+        const EvaluationContext& context,      ///< Container for additional information
         const double dt,                       ///< Time step size
         const int gp,                          ///< Current Gauss-Point
         const int eleGID);                     ///< Element ID
@@ -281,6 +285,7 @@ namespace Mat
     /// -> membrane
     void setup_g_r_2d(
         const Teuchos::ParameterList& params,  ///< Container for additional information
+        const EvaluationContext& context,      ///< Container for additional information
         const double dt,                       ///< Time step size
         const int gp);                         ///< Current Gauss-Point
 

--- a/src/mat/4C_mat_inelastic_defgrad_factors.cpp
+++ b/src/mat/4C_mat_inelastic_defgrad_factors.cpp
@@ -811,8 +811,8 @@ Mat::InelasticDefgradScalar::InelasticDefgradScalar(Core::Mat::PAR::Parameter* p
 
 /*--------------------------------------------------------------------*
  *--------------------------------------------------------------------*/
-void Mat::InelasticDefgradScalar::pre_evaluate(
-    const Teuchos::ParameterList& params, const int gp, const int eleGID)
+void Mat::InelasticDefgradScalar::pre_evaluate(const Teuchos::ParameterList& params,
+    const EvaluationContext& context, const int gp, const int eleGID)
 {
   // store scalars of current gauss point
   concentrations_ = params.get<std::shared_ptr<std::vector<double>>>("scalars");
@@ -1456,8 +1456,8 @@ Mat::InelasticDefgradLinTempIso::InelasticDefgradLinTempIso(Core::Mat::PAR::Para
 
 /*--------------------------------------------------------------------*
  *--------------------------------------------------------------------*/
-void Mat::InelasticDefgradLinTempIso::pre_evaluate(
-    const Teuchos::ParameterList& params, const int gp, const int eleGID)
+void Mat::InelasticDefgradLinTempIso::pre_evaluate(const Teuchos::ParameterList& params,
+    const EvaluationContext& context, const int gp, const int eleGID)
 {
   temperature_ = params.get<double>("temperature");
 }
@@ -1589,8 +1589,8 @@ Mat::InelasticDefgradNoGrowth::InelasticDefgradNoGrowth(Core::Mat::PAR::Paramete
 
 /*--------------------------------------------------------------------*
  *--------------------------------------------------------------------*/
-void Mat::InelasticDefgradNoGrowth::pre_evaluate(
-    const Teuchos::ParameterList& params, const int gp, const int eleGID)
+void Mat::InelasticDefgradNoGrowth::pre_evaluate(const Teuchos::ParameterList& params,
+    const EvaluationContext& context, const int gp, const int eleGID)
 {
 }
 
@@ -1625,13 +1625,14 @@ Mat::InelasticDefgradTimeFunct::InelasticDefgradTimeFunct(Core::Mat::PAR::Parame
 
 /*--------------------------------------------------------------------*
  *--------------------------------------------------------------------*/
-void Mat::InelasticDefgradTimeFunct::pre_evaluate(
-    const Teuchos::ParameterList& params, const int gp, const int eleGID)
+void Mat::InelasticDefgradTimeFunct::pre_evaluate(const Teuchos::ParameterList& params,
+    const EvaluationContext& context, const int gp, const int eleGID)
 {
   // evaluate function value for current time step.
   auto& funct = Global::Problem::instance()->function_by_id<Core::Utils::FunctionOfTime>(
       parameter()->funct_num());
-  const double time = params.get<double>("total time");
+  FOUR_C_ASSERT(context.total_time, "Time not given in evaluation context.");
+  const double time = *context.total_time;
   funct_value_ = funct.evaluate(time);
 }
 
@@ -1686,7 +1687,8 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::InelasticDefgradTransvIsotrop
 /*--------------------------------------------------------------------*
  *--------------------------------------------------------------------*/
 void Mat::InelasticDefgradTransvIsotropElastViscoplast::pre_evaluate(
-    const Teuchos::ParameterList& params, const int gp, const int eleGID)
+    const Teuchos::ParameterList& params, const EvaluationContext& context, const int gp,
+    const int eleGID)
 {
   // set Gauss Point
   gp_ = gp;
@@ -1695,7 +1697,8 @@ void Mat::InelasticDefgradTransvIsotropElastViscoplast::pre_evaluate(
   ele_gid_ = eleGID;
 
   // set time step
-  time_step_settings_.dt_ = params.get<double>("delta time");
+  FOUR_C_ASSERT(context.time_step_size, "Time step size not given in evaluation context.");
+  time_step_settings_.dt_ = *context.time_step_size;
   // set minimum substep length
   time_step_settings_.min_dt_ =
       time_step_settings_.dt_ / std::pow(2.0, parameter()->max_halve_number());

--- a/src/mat/4C_mat_inelastic_defgrad_factors.hpp
+++ b/src/mat/4C_mat_inelastic_defgrad_factors.hpp
@@ -566,7 +566,8 @@ namespace Mat
      * @param[in] gp      Gauss point
      * @param[in] eleGID  Element ID
      */
-    virtual void pre_evaluate(const Teuchos::ParameterList& params, int gp, int eleGID) = 0;
+    virtual void pre_evaluate(const Teuchos::ParameterList& params,
+        const EvaluationContext& context, int gp, int eleGID) = 0;
 
     /*!
      * @brief set gauss point concentration to parameter class
@@ -647,7 +648,8 @@ namespace Mat
       return Core::Materials::mfi_no_growth;
     }
 
-    void pre_evaluate(const Teuchos::ParameterList& params, int gp, int eleGID) override;
+    void pre_evaluate(const Teuchos::ParameterList& params, const EvaluationContext& context,
+        int gp, int eleGID) override;
 
     void update() override {};
 
@@ -703,7 +705,8 @@ namespace Mat
           Mat::InelasticDefgradFactors::parameter());
     }
 
-    void pre_evaluate(const Teuchos::ParameterList& params, int gp, int eleGID) override;
+    void pre_evaluate(const Teuchos::ParameterList& params, const EvaluationContext& context,
+        int gp, int eleGID) override;
 
     void update() override {};
 
@@ -749,7 +752,8 @@ namespace Mat
 
     Core::Materials::MaterialType material_type() const override = 0;
 
-    void pre_evaluate(const Teuchos::ParameterList& params, int gp, int eleGID) override;
+    void pre_evaluate(const Teuchos::ParameterList& params, const EvaluationContext& context,
+        int gp, int eleGID) override;
 
     void set_concentration_gp(double concentration) override;
 
@@ -1161,7 +1165,8 @@ namespace Mat
           Mat::InelasticDefgradFactors::parameter());
     }
 
-    void pre_evaluate(const Teuchos::ParameterList& params, int gp, int eleGID) override;
+    void pre_evaluate(const Teuchos::ParameterList& params, const EvaluationContext& context,
+        int gp, int eleGID) override;
 
     void update() override {};
 
@@ -1371,7 +1376,8 @@ namespace Mat
     void setup(const int numgp, const Discret::Elements::Fibers& fibers,
         const std::optional<Discret::Elements::CoordinateSystem>& coord_system) override;
 
-    void pre_evaluate(const Teuchos::ParameterList& params, int gp, int eleGID) override;
+    void pre_evaluate(const Teuchos::ParameterList& params, const EvaluationContext& context,
+        int gp, int eleGID) override;
 
     void update() override;
 

--- a/src/mat/4C_mat_iterative_prestress.cpp
+++ b/src/mat/4C_mat_iterative_prestress.cpp
@@ -176,7 +176,8 @@ void Mat::IterativePrestressMaterial::post_setup(const Teuchos::ParameterList& p
 void Mat::IterativePrestressMaterial::update() { child_material_->update(); }
 
 void Mat::IterativePrestressMaterial::update(Core::LinAlg::Tensor<double, 3, 3> const& defgrd,
-    const int gp, const Teuchos::ParameterList& params, const int eleGID)
+    const int gp, const Teuchos::ParameterList& params, const EvaluationContext& context,
+    const int eleGID)
 {
   if (params_->is_prestress_active_)
   {
@@ -186,7 +187,7 @@ void Mat::IterativePrestressMaterial::update(Core::LinAlg::Tensor<double, 3, 3> 
   Core::LinAlg::Tensor<double, 3, 3> elastic_deformation_gradient =
       get_elastic_deformation_gradient(defgrd, prestretch_tensor_[gp]);
 
-  child_material_->update(elastic_deformation_gradient, gp, params, eleGID);
+  child_material_->update(elastic_deformation_gradient, gp, params, context, eleGID);
 }
 
 void Mat::IterativePrestressMaterial::setup(const int numgp,
@@ -222,14 +223,16 @@ bool Mat::IterativePrestressMaterial::evaluate_output_data(
 }
 
 double Mat::IterativePrestressMaterial::strain_energy(
-    const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain, int gp, int eleGID) const
+    const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain, const EvaluationContext& context,
+    int gp, int eleGID) const
 {
   FOUR_C_THROW("Strain energy computation is currently not implemented for prestressing materials");
 }
 
 void Mat::IterativePrestressMaterial::evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
     const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-    const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+    const Teuchos::ParameterList& params, const EvaluationContext& context,
+    Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
     Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID)
 {
   Core::LinAlg::Tensor<double, 3, 3> elastic_deformation_gradient =
@@ -244,7 +247,7 @@ void Mat::IterativePrestressMaterial::evaluate(const Core::LinAlg::Tensor<double
 
 
   // evaluate child material
-  child_material_->evaluate(&elastic_deformation_gradient, elastic_gl_strain, params,
+  child_material_->evaluate(&elastic_deformation_gradient, elastic_gl_strain, params, context,
       elastic_stress, elastic_cmat, gp, eleGID);
 
   // push-forward operation

--- a/src/mat/4C_mat_iterative_prestress.hpp
+++ b/src/mat/4C_mat_iterative_prestress.hpp
@@ -86,12 +86,13 @@ namespace Mat
     [[nodiscard]] double density() const override { return child_material_->density(); }
 
     [[nodiscard]] double strain_energy(const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        int gp, int eleGID) const override;
+        const EvaluationContext& context, int gp, int eleGID) const override;
 
 
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
     void post_setup(const Teuchos::ParameterList& params, int eleGID) override;
@@ -99,7 +100,8 @@ namespace Mat
     void update() override;
 
     void update(Core::LinAlg::Tensor<double, 3, 3> const& defgrd, const int gp,
-        const Teuchos::ParameterList& params, const int eleGID) override;
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        const int eleGID) override;
 
     void vis_names(std::map<std::string, int>& names) const override;
 

--- a/src/mat/4C_mat_membrane_active_strain.cpp
+++ b/src/mat/4C_mat_membrane_active_strain.cpp
@@ -236,8 +236,9 @@ void Mat::MembraneActiveStrain::setup(int numgp, const Discret::Elements::Fibers
  *----------------------------------------------------------------------*/
 void Mat::MembraneActiveStrain::evaluate_membrane(const Core::LinAlg::Matrix<3, 3>& defgrd,
     const Core::LinAlg::Matrix<3, 3>& cauchygreen, const Teuchos::ParameterList& params,
-    const Core::LinAlg::Matrix<3, 3>& Q_trafo, Core::LinAlg::Matrix<3, 1>& stress,
-    Core::LinAlg::Matrix<3, 3>& cmat, const int gp, const int eleGID)
+    const EvaluationContext& context, const Core::LinAlg::Matrix<3, 3>& Q_trafo,
+    Core::LinAlg::Matrix<3, 1>& stress, Core::LinAlg::Matrix<3, 3>& cmat, const int gp,
+    const int eleGID)
 {
   // blank resulting quantities
   stress.clear();
@@ -317,7 +318,7 @@ void Mat::MembraneActiveStrain::evaluate_membrane(const Core::LinAlg::Matrix<3, 
   Core::LinAlg::Matrix<3, 3> cmatpassive_loc(Core::LinAlg::Initialization::zero);
   Core::LinAlg::Matrix<3, 1> S_passive_loc_voigt(Core::LinAlg::Initialization::zero);
   std::dynamic_pointer_cast<Mat::MembraneElastHyper>(matpassive_)
-      ->evaluate_membrane(defgrd_passive_local, cauchygreen_passive_local, params, Q_trafo,
+      ->evaluate_membrane(defgrd_passive_local, cauchygreen_passive_local, params, context, Q_trafo,
           S_passive_loc_voigt, cmatpassive_loc, gp, eleGID);
 
   //******************

--- a/src/mat/4C_mat_membrane_active_strain.hpp
+++ b/src/mat/4C_mat_membrane_active_strain.hpp
@@ -166,7 +166,8 @@ namespace Mat
     /// Standard SO3 evaluate (not meant to be used)
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp,
         int eleGID) override  ///< Element ID
     {
@@ -174,16 +175,17 @@ namespace Mat
     };
 
     void update_membrane(const Core::LinAlg::Matrix<3, 3>& defgrd,
-        const Teuchos::ParameterList& params, const Core::LinAlg::Matrix<3, 3>& Q_trafo, int gp,
-        int eleGID) override
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        const Core::LinAlg::Matrix<3, 3>& Q_trafo, int gp, int eleGID) override
     {
       // nothing to do
     }
 
     void evaluate_membrane(const Core::LinAlg::Matrix<3, 3>& defgrd,
         const Core::LinAlg::Matrix<3, 3>& cauchygreen, const Teuchos::ParameterList& params,
-        const Core::LinAlg::Matrix<3, 3>& Q_trafo, Core::LinAlg::Matrix<3, 1>& stress,
-        Core::LinAlg::Matrix<3, 3>& cmat, int gp, int eleGID) override;
+        const EvaluationContext& context, const Core::LinAlg::Matrix<3, 3>& Q_trafo,
+        Core::LinAlg::Matrix<3, 1>& stress, Core::LinAlg::Matrix<3, 3>& cmat, int gp,
+        int eleGID) override;
 
     /// Update internal variables
     void update() override;

--- a/src/mat/4C_mat_membrane_elasthyper.cpp
+++ b/src/mat/4C_mat_membrane_elasthyper.cpp
@@ -112,8 +112,9 @@ void Mat::MembraneElastHyper::setup(int numgp, const Discret::Elements::Fibers& 
  *----------------------------------------------------------------------*/
 void Mat::MembraneElastHyper::evaluate_membrane(const Core::LinAlg::Matrix<3, 3>& defgrd,
     const Core::LinAlg::Matrix<3, 3>& cauchygreen, const Teuchos::ParameterList& params,
-    const Core::LinAlg::Matrix<3, 3>& Q_trafo, Core::LinAlg::Matrix<3, 1>& stress,
-    Core::LinAlg::Matrix<3, 3>& cmat, const int gp, const int eleGID)
+    const EvaluationContext& context, const Core::LinAlg::Matrix<3, 3>& Q_trafo,
+    Core::LinAlg::Matrix<3, 1>& stress, Core::LinAlg::Matrix<3, 3>& cmat, const int gp,
+    const int eleGID)
 {
   // blank resulting quantities
   stress.clear();

--- a/src/mat/4C_mat_membrane_elasthyper.hpp
+++ b/src/mat/4C_mat_membrane_elasthyper.hpp
@@ -153,16 +153,17 @@ namespace Mat
         const std::optional<Discret::Elements::CoordinateSystem>& coord_system) override;
 
     void update_membrane(const Core::LinAlg::Matrix<3, 3>& defgrd,
-        const Teuchos::ParameterList& params, const Core::LinAlg::Matrix<3, 3>& Q_trafo, int gp,
-        int eleGID) override
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        const Core::LinAlg::Matrix<3, 3>& Q_trafo, int gp, int eleGID) override
     {
       // nothing to do
     }
 
     void evaluate_membrane(const Core::LinAlg::Matrix<3, 3>& defgrd,
         const Core::LinAlg::Matrix<3, 3>& cauchygreen, const Teuchos::ParameterList& params,
-        const Core::LinAlg::Matrix<3, 3>& Q_trafo, Core::LinAlg::Matrix<3, 1>& stress,
-        Core::LinAlg::Matrix<3, 3>& cmat, int gp, int eleGID) override;
+        const EvaluationContext& context, const Core::LinAlg::Matrix<3, 3>& Q_trafo,
+        Core::LinAlg::Matrix<3, 1>& stress, Core::LinAlg::Matrix<3, 3>& cmat, int gp,
+        int eleGID) override;
 
     /// evaluate strain energy function
     virtual void strain_energy(

--- a/src/mat/4C_mat_membrane_material_interfaces.hpp
+++ b/src/mat/4C_mat_membrane_material_interfaces.hpp
@@ -11,6 +11,7 @@
 #include "4C_config.hpp"
 
 #include "4C_linalg_fixedsizematrix.hpp"
+#include "4C_mat_so3_material.hpp"
 #include "4C_utils_parameter_list.fwd.hpp"
 
 FOUR_C_NAMESPACE_OPEN
@@ -44,8 +45,8 @@ namespace Mat
      * @param eleGID (in) : Global element id
      */
     virtual void update_membrane(const Core::LinAlg::Matrix<3, 3>& defgrd,
-        const Teuchos::ParameterList& params, const Core::LinAlg::Matrix<3, 3>& Q_trafo, int gp,
-        int eleGID) = 0;
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        const Core::LinAlg::Matrix<3, 3>& Q_trafo, int gp, int eleGID) = 0;
 
     /*!
      * @brief Evaluate stress response plus elasticity tensor for membranes assuming
@@ -64,8 +65,9 @@ namespace Mat
      */
     virtual void evaluate_membrane(const Core::LinAlg::Matrix<3, 3>& defgrd,
         const Core::LinAlg::Matrix<3, 3>& cauchygreen, const Teuchos::ParameterList& params,
-        const Core::LinAlg::Matrix<3, 3>& Q_trafo, Core::LinAlg::Matrix<3, 1>& stress,
-        Core::LinAlg::Matrix<3, 3>& cmat, int gp, int eleGID) = 0;
+        const EvaluationContext& context, const Core::LinAlg::Matrix<3, 3>& Q_trafo,
+        Core::LinAlg::Matrix<3, 1>& stress, Core::LinAlg::Matrix<3, 3>& cmat, int gp,
+        int eleGID) = 0;
   };
 
   /*!
@@ -94,8 +96,9 @@ namespace Mat
      * @param eleGID (in) : Global element id
      */
     virtual void evaluate_membrane(const Core::LinAlg::Matrix<3, 3>& defgrd,
-        const Teuchos::ParameterList& params, Core::LinAlg::Matrix<3, 3>& stress,
-        Core::LinAlg::Matrix<6, 6>& cmat, int gp, int eleGID) = 0;
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        Core::LinAlg::Matrix<3, 3>& stress, Core::LinAlg::Matrix<6, 6>& cmat, int gp,
+        int eleGID) = 0;
   };
 
   /*!
@@ -126,7 +129,8 @@ namespace Mat
      * @return Adapted stretch in thickness direction
      */
     virtual double evaluate_membrane_thickness_stretch(const Core::LinAlg::Matrix<3, 3>& defgrd,
-        const Teuchos::ParameterList& params, int gp, int eleGID) = 0;
+        const Teuchos::ParameterList& params, const EvaluationContext& context, int gp,
+        int eleGID) = 0;
   };
 
 }  // namespace Mat

--- a/src/mat/4C_mat_micromaterial.hpp
+++ b/src/mat/4C_mat_micromaterial.hpp
@@ -153,7 +153,8 @@ namespace Mat
     /// evaluate micro material on a processor with macro scale
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
     /// evaluate micro material on a processor which only knows about the micro scale (supporting

--- a/src/mat/4C_mat_micromaterial_evaluate.cpp
+++ b/src/mat/4C_mat_micromaterial_evaluate.cpp
@@ -37,7 +37,8 @@ FOUR_C_NAMESPACE_OPEN
 // evaluate for master procs
 void Mat::MicroMaterial::evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
     const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-    const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+    const Teuchos::ParameterList& params, const EvaluationContext& context,
+    Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
     Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID)
 {
   const Core::LinAlg::Matrix<3, 3> defgrd_mat = Core::LinAlg::make_matrix_view(*defgrad);

--- a/src/mat/4C_mat_mixture.cpp
+++ b/src/mat/4C_mat_mixture.cpp
@@ -263,21 +263,22 @@ void Mat::Mixture::update()
 
 // This method is called between two timesteps
 void Mat::Mixture::update(Core::LinAlg::Tensor<double, 3, 3> const& defgrd, const int gp,
-    const Teuchos::ParameterList& params, const int eleGID)
+    const Teuchos::ParameterList& params, const EvaluationContext& context, const int eleGID)
 {
   // Update all constituents
   for (const auto& constituent : *constituents_)
   {
-    constituent->update(defgrd, params, gp, eleGID);
+    constituent->update(defgrd, params, context, gp, eleGID);
   }
 
-  mixture_rule_->update(defgrd, params, gp, eleGID);
+  mixture_rule_->update(defgrd, params, context, gp, eleGID);
 }
 
 // Evaluates the material
 void Mat::Mixture::evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
     const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-    const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+    const Teuchos::ParameterList& params, const EvaluationContext& context,
+    Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
     Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID)
 {
   // check, whether the post_setup method was already called
@@ -288,14 +289,14 @@ void Mat::Mixture::evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
     for (const auto& constituent : *constituents_)
     {
       is_pre_evaluated_[gp] = true;
-      constituent->pre_evaluate(*mixture_rule_, params, gp, eleGID);
+      constituent->pre_evaluate(*mixture_rule_, params, context, gp, eleGID);
     }
 
-    mixture_rule_->pre_evaluate(params, gp, eleGID);
+    mixture_rule_->pre_evaluate(params, context, gp, eleGID);
   }
 
   // Evaluate mixturerule
-  mixture_rule_->evaluate(*defgrad, glstrain, params, stress, cmat, gp, eleGID);
+  mixture_rule_->evaluate(*defgrad, glstrain, params, context, stress, cmat, gp, eleGID);
 }
 
 void Mat::Mixture::register_output_data_names(

--- a/src/mat/4C_mat_mixture.hpp
+++ b/src/mat/4C_mat_mixture.hpp
@@ -187,7 +187,8 @@ namespace Mat
      * @param eleGID Global element id
      */
     void update(const Core::LinAlg::Tensor<double, 3, 3>& defgrd, int gp,
-        const Teuchos::ParameterList& params, int eleGID) override;
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        int eleGID) override;
 
     /// \brief This material law uses the extended update method
     bool uses_extended_update() override { return true; }
@@ -206,7 +207,8 @@ namespace Mat
      */
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) final;
 
     /// \brief Return material mass density given by mixture rule

--- a/src/mat/4C_mat_monolithic_solid_scalar_material.hpp
+++ b/src/mat/4C_mat_monolithic_solid_scalar_material.hpp
@@ -12,6 +12,7 @@
 
 #include "4C_linalg_fixedsizematrix.hpp"
 #include "4C_linalg_symmetric_tensor.hpp"
+#include "4C_mat_so3_material.hpp"
 #include "4C_utils_parameter_list.fwd.hpp"
 
 FOUR_C_NAMESPACE_OPEN
@@ -36,7 +37,8 @@ namespace Mat
     virtual Core::LinAlg::SymmetricTensor<double, 3, 3> evaluate_d_stress_d_scalar(
         const Core::LinAlg::Tensor<double, 3, 3>& defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, int gp, int eleGID) = 0;
+        const Teuchos::ParameterList& params, const EvaluationContext& context, int gp,
+        int eleGID) = 0;
   };
 }  // namespace Mat
 

--- a/src/mat/4C_mat_multiplicative_split_defgrad_elasthyper.hpp
+++ b/src/mat/4C_mat_multiplicative_split_defgrad_elasthyper.hpp
@@ -260,21 +260,23 @@ namespace Mat
 
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
     Core::LinAlg::SymmetricTensor<double, 3, 3> evaluate_d_stress_d_scalar(
         const Core::LinAlg::Tensor<double, 3, 3>& defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, int gp, int eleGID) override;
+        const Teuchos::ParameterList& params, const EvaluationContext& context, int gp,
+        int eleGID) override;
 
     double evaluate_cauchy_n_dir_and_derivatives(const Core::LinAlg::Tensor<double, 3, 3>& defgrd,
         const Core::LinAlg::Tensor<double, 3>& n, const Core::LinAlg::Tensor<double, 3>& dir,
         Core::LinAlg::Matrix<3, 1>* d_cauchyndir_dn, Core::LinAlg::Matrix<3, 1>* d_cauchyndir_ddir,
         Core::LinAlg::Matrix<9, 1>* d_cauchyndir_dF, Core::LinAlg::Matrix<9, 9>* d2_cauchyndir_dF2,
         Core::LinAlg::Matrix<9, 3>* d2_cauchyndir_dF_dn,
-        Core::LinAlg::Matrix<9, 3>* d2_cauchyndir_dF_ddir, int gp, int eleGID,
-        const double* concentration, const double* temp, double* d_cauchyndir_dT,
+        Core::LinAlg::Matrix<9, 3>* d2_cauchyndir_dF_ddir, const EvaluationContext& context,
+        int eleGID, const double* concentration, const double* temp, double* d_cauchyndir_dT,
         Core::LinAlg::Matrix<9, 1>* d2_cauchyndir_dF_dT) override;
 
     void evaluate_linearization_od(const Core::LinAlg::Tensor<double, 3, 3>& defgrd,
@@ -433,7 +435,8 @@ namespace Mat
      * @param[in] gp      current gauss point
      * @param[in] eleGID  Element ID
      */
-    void pre_evaluate(const Teuchos::ParameterList& params, int gp, int eleGID) const;
+    void pre_evaluate(const Teuchos::ParameterList& params, const EvaluationContext& context,
+        int gp, int eleGID) const;
 
     /*!
      * @brief set the gauss point concentration to the respective parameter class of the inelastic

--- a/src/mat/4C_mat_muscle_combo.hpp
+++ b/src/mat/4C_mat_muscle_combo.hpp
@@ -174,11 +174,13 @@ namespace Mat
     bool uses_extended_update() override { return true; };
 
     void update(const Core::LinAlg::Tensor<double, 3, 3>& defgrd, int const gp,
-        const Teuchos::ParameterList& params, int const eleGID) override;
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        int const eleGID) override;
 
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
     using ActivationEvaluatorVariant =
@@ -197,8 +199,9 @@ namespace Mat
      * \param[out] Pa Active nominal stress
      * \param[out] derivPa Derivative of active nominal stress w.r.t. the fiber stretch
      */
-    void evaluate_active_nominal_stress(const Teuchos::ParameterList& params, const int eleGID,
-        const double lambdaM, double& intPa, double& Pa, double& derivPa);
+    void evaluate_active_nominal_stress(const Teuchos::ParameterList& params,
+        const EvaluationContext& context, const int eleGID, const double lambdaM, double& intPa,
+        double& Pa, double& derivPa);
 
     /*!
      * \brief Evaluate activation level omegaa and its first and second derivatives w.r.t. the

--- a/src/mat/4C_mat_muscle_giantesio.cpp
+++ b/src/mat/4C_mat_muscle_giantesio.cpp
@@ -368,7 +368,7 @@ void Mat::MuscleGiantesio::setup(int numgp, const Discret::Elements::Fibers& fib
 }
 
 void Mat::MuscleGiantesio::update(Core::LinAlg::Tensor<double, 3, 3> const& defgrd, int const gp,
-    const Teuchos::ParameterList& params, int const eleGID)
+    const Teuchos::ParameterList& params, const EvaluationContext& context, int const eleGID)
 {
   // compute the current fibre stretch using the deformation gradient and the structural tensor
   // right Cauchy Green tensor C= F^T F
@@ -385,7 +385,8 @@ void Mat::MuscleGiantesio::update(Core::LinAlg::Tensor<double, 3, 3> const& defg
 
 void Mat::MuscleGiantesio::evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrd,
     const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-    const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+    const Teuchos::ParameterList& params, const EvaluationContext& context,
+    Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
     Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, const int gp, const int eleGID)
 {
   Core::LinAlg::Matrix<3, 3> defgrd_mat = Core::LinAlg::make_matrix_view(*defgrd);
@@ -402,14 +403,12 @@ void Mat::MuscleGiantesio::evaluate(const Core::LinAlg::Tensor<double, 3, 3>* de
   const double omega0 = params_->omega0_;
 
   // save current simulation time
-  double currentTime = get_or<double>(params, "total time", -1);
-  if (std::abs(currentTime + 1.0) < 1e-14)
-    FOUR_C_THROW("No total time given for muscle Giantesio material!");
+  FOUR_C_ASSERT(context.total_time, "Time not given in evaluation context.");
+  double currentTime = *context.total_time;
 
   // save (time) step size
-  double timeStepSize = get_or<double>(params, "delta time", -1);
-  if (std::abs(timeStepSize + 1.0) < 1e-14)
-    FOUR_C_THROW("No time step size given for muscle Giantesio material!");
+  FOUR_C_ASSERT(context.time_step_size, "Time step size not given in evaluation context.");
+  double timeStepSize = *context.time_step_size;
 
   // compute matrices
   // right Cauchy Green tensor C

--- a/src/mat/4C_mat_muscle_giantesio.hpp
+++ b/src/mat/4C_mat_muscle_giantesio.hpp
@@ -174,11 +174,13 @@ namespace Mat
     bool uses_extended_update() override { return true; };
 
     void update(Core::LinAlg::Tensor<double, 3, 3> const& defgrd, int const gp,
-        const Teuchos::ParameterList& params, int const eleGID) override;
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        int const eleGID) override;
 
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrd,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
    private:

--- a/src/mat/4C_mat_muscle_weickenmeier.hpp
+++ b/src/mat/4C_mat_muscle_weickenmeier.hpp
@@ -180,11 +180,13 @@ namespace Mat
     bool uses_extended_update() override { return true; };
 
     void update(const Core::LinAlg::Tensor<double, 3, 3>& defgrd, int const gp,
-        const Teuchos::ParameterList& params, int const eleGID) override;
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        int const eleGID) override;
 
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
    private:
@@ -196,8 +198,8 @@ namespace Mat
      *  \param[out] Pa Active nominal stress
      *  \param[out] derivPa Derivative of active nominal stress w.r.t. the fiber stretch
      */
-    void evaluate_active_nominal_stress(
-        const Teuchos::ParameterList& params, const double lambdaM, double& Pa, double& derivPa);
+    void evaluate_active_nominal_stress(const Teuchos::ParameterList& params,
+        const Mat::EvaluationContext& context, const double lambdaM, double& Pa, double& derivPa);
 
     /*!
      *  \brief Evaluate activation level omegaa and its derivative w.r.t. the fiber stretch

--- a/src/mat/4C_mat_plastic_VarConstUpdate.hpp
+++ b/src/mat/4C_mat_plastic_VarConstUpdate.hpp
@@ -139,7 +139,8 @@ namespace Mat
     /// (pure virtual in material base class. Not allowed here)
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp,
         int eleGID) override;  ///< Element GID
 
@@ -333,7 +334,7 @@ namespace Mat
         const Core::LinAlg::Matrix<3, 3> defgrd, Core::LinAlg::SymmetricTensor<double, 3, 3>& eeOut,
         Core::LinAlg::Matrix<5, 1>& rhs, Core::LinAlg::Matrix<5, 1>& rhsElast,
         Core::LinAlg::Matrix<6, 6>& dcedlp, Core::LinAlg::Matrix<9, 6>& dFpiDdeltaDp,
-        const Teuchos::ParameterList& params, const int eleGID);
+        const Teuchos::ParameterList& params, const EvaluationContext& context, const int eleGID);
 
 
     virtual void yield_function(const double last_ai, const double norm_dLp,

--- a/src/mat/4C_mat_plasticdruckerprager.hpp
+++ b/src/mat/4C_mat_plasticdruckerprager.hpp
@@ -121,7 +121,8 @@ namespace Mat
      */
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override
     {
       Core::LinAlg::Matrix<6, 1> stress_view = Core::LinAlg::make_stress_like_voigt_view(stress);

--- a/src/mat/4C_mat_plasticelasthyper.hpp
+++ b/src/mat/4C_mat_plasticelasthyper.hpp
@@ -363,11 +363,12 @@ namespace Mat
     /// (pure virtual in material base class. Not allowed here)
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp,
         int eleGID) override  ///< Element GID
     {
-      ElastHyper::evaluate(defgrad, glstrain, params, stress, cmat, gp, eleGID);
+      ElastHyper::evaluate(defgrad, glstrain, params, context, stress, cmat, gp, eleGID);
     }
 
     virtual double strain_energy(

--- a/src/mat/4C_mat_plasticgtn.cpp
+++ b/src/mat/4C_mat_plasticgtn.cpp
@@ -237,7 +237,8 @@ void Mat::PlasticGTN::register_output_data_names(
 
 void Mat::PlasticGTN::evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
     const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-    const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+    const Teuchos::ParameterList& params, const EvaluationContext& context,
+    Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
     Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID)
 {
   Core::LinAlg::Matrix<6, 1> stress_view = Core::LinAlg::make_stress_like_voigt_view(stress);

--- a/src/mat/4C_mat_plasticgtn.hpp
+++ b/src/mat/4C_mat_plasticgtn.hpp
@@ -139,7 +139,8 @@ namespace Mat
 
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
     Core::Mat::PAR::Parameter* parameter() const override { return params_; }

--- a/src/mat/4C_mat_plasticlinelast.cpp
+++ b/src/mat/4C_mat_plasticlinelast.cpp
@@ -270,7 +270,8 @@ void Mat::PlasticLinElast::update()
  *----------------------------------------------------------------------*/
 void Mat::PlasticLinElast::evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
     const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-    const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+    const Teuchos::ParameterList& params, const EvaluationContext& context,
+    Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
     Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID)
 {
   Core::LinAlg::Matrix<6, 1> stress_view = Core::LinAlg::make_stress_like_voigt_view(stress);

--- a/src/mat/4C_mat_plasticlinelast.hpp
+++ b/src/mat/4C_mat_plasticlinelast.hpp
@@ -152,7 +152,8 @@ namespace Mat
     //! evaluate material
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
     //! computes stress

--- a/src/mat/4C_mat_plasticnlnlogneohooke.cpp
+++ b/src/mat/4C_mat_plasticnlnlogneohooke.cpp
@@ -387,7 +387,8 @@ void Mat::PlasticNlnLogNeoHooke::update()
  *----------------------------------------------------------------------*/
 void Mat::PlasticNlnLogNeoHooke::evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
     const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-    const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+    const Teuchos::ParameterList& params, const EvaluationContext& context,
+    Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
     Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID)
 {
   const Core::LinAlg::Matrix<3, 3> defgrd_mat = Core::LinAlg::make_matrix_view(*defgrad);
@@ -409,7 +410,8 @@ void Mat::PlasticNlnLogNeoHooke::evaluate(const Core::LinAlg::Tensor<double, 3, 
 
   const double detF = defgrd_mat.determinant();
 
-  const double dt = params.get<double>("delta time");
+  FOUR_C_ASSERT(context.time_step_size, "Time step size not given in evaluation context.");
+  const double dt = *context.time_step_size;
   // check, if errors are tolerated or should throw a FOUR_C_THROW
   bool error_tol = false;
   if (params.isParameter("tolerate_errors")) error_tol = params.get<bool>("tolerate_errors");

--- a/src/mat/4C_mat_plasticnlnlogneohooke.hpp
+++ b/src/mat/4C_mat_plasticnlnlogneohooke.hpp
@@ -214,7 +214,8 @@ namespace Mat
     //! evaluate material law
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
    private:

--- a/src/mat/4C_mat_robinson.cpp
+++ b/src/mat/4C_mat_robinson.cpp
@@ -320,7 +320,8 @@ void Mat::Robinson::update()
  *----------------------------------------------------------------------*/
 void Mat::Robinson::evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
     const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-    const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+    const Teuchos::ParameterList& params, const EvaluationContext& context,
+    Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
     Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID)
 {
   const Core::LinAlg::Matrix<6, 1> glstrain_mat =
@@ -354,7 +355,8 @@ void Mat::Robinson::evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
   //     --> NO kintype is needed
 
   // get material parameters
-  const double dt_ = params.get<double>("delta time");
+  FOUR_C_ASSERT(context.time_step_size, "Time step size not given in evaluation context.");
+  const double dt_ = *context.time_step_size;
 
   // build Cartesian identity 2-tensor I_{AB}
   Core::LinAlg::Matrix<Mat::NUM_STRESS_3D, 1> id2(Core::LinAlg::Initialization::zero);
@@ -539,7 +541,7 @@ void Mat::Robinson::stress_temperature_modulus_and_deriv(
 Core::LinAlg::SymmetricTensor<double, 3, 3> Mat::Robinson::evaluate_d_stress_d_scalar(
     const Core::LinAlg::Tensor<double, 3, 3>& defgrad,
     const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-    const Teuchos::ParameterList& params, int gp, int eleGID)
+    const Teuchos::ParameterList& params, const EvaluationContext& context, int gp, int eleGID)
 {
   return {};
 }

--- a/src/mat/4C_mat_robinson.hpp
+++ b/src/mat/4C_mat_robinson.hpp
@@ -179,7 +179,8 @@ namespace Mat
 
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
     //! computes Cauchy stress
@@ -362,7 +363,8 @@ namespace Mat
     Core::LinAlg::SymmetricTensor<double, 3, 3> evaluate_d_stress_d_scalar(
         const Core::LinAlg::Tensor<double, 3, 3>& defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, int gp, int eleGID) override;
+        const Teuchos::ParameterList& params, const EvaluationContext& context, int gp,
+        int eleGID) override;
 
     //! return quick accessible material parameter data
     Core::Mat::PAR::Parameter* parameter() const override { return params_; }

--- a/src/mat/4C_mat_scalardepinterp.hpp
+++ b/src/mat/4C_mat_scalardepinterp.hpp
@@ -181,7 +181,8 @@ namespace Mat
     /// hyperelastic stress response plus elasticity tensor
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
     /// setup
@@ -200,7 +201,7 @@ namespace Mat
 
     /// evaluate strain energy function
     [[nodiscard]] double strain_energy(const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const int gp, const int eleGID) const override;
+        const EvaluationContext& context, const int gp, const int eleGID) const override;
 
    private:
     /// my material parameters

--- a/src/mat/4C_mat_so3_material.cpp
+++ b/src/mat/4C_mat_so3_material.cpp
@@ -12,8 +12,8 @@
 FOUR_C_NAMESPACE_OPEN
 
 
-double Mat::So3Material::strain_energy(
-    const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain, int gp, int eleGID) const
+double Mat::So3Material::strain_energy(const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
+    const EvaluationContext& context, int gp, int eleGID) const
 {
   FOUR_C_THROW(
       "Material of type {} does not support calculation of strain energy", this->material_type());
@@ -25,7 +25,7 @@ double Mat::So3Material::evaluate_cauchy_n_dir_and_derivatives(
     const Core::LinAlg::Tensor<double, 3>& dir, Core::LinAlg::Matrix<3, 1>* d_cauchyndir_dn,
     Core::LinAlg::Matrix<3, 1>* d_cauchyndir_ddir, Core::LinAlg::Matrix<9, 1>* d_cauchyndir_dF,
     Core::LinAlg::Matrix<9, 9>* d2_cauchyndir_dF2, Core::LinAlg::Matrix<9, 3>* d2_cauchyndir_dF_dn,
-    Core::LinAlg::Matrix<9, 3>* d2_cauchyndir_dF_ddir, int gp, int eleGID,
+    Core::LinAlg::Matrix<9, 3>* d2_cauchyndir_dF_ddir, const EvaluationContext& context, int eleGID,
     const double* concentration, const double* temp, double* d_cauchyndir_dT,
     Core::LinAlg::Matrix<9, 1>* d2_cauchyndir_dF_dT)
 {

--- a/src/mat/4C_mat_so3_material.hpp
+++ b/src/mat/4C_mat_so3_material.hpp
@@ -25,6 +25,25 @@ FOUR_C_NAMESPACE_OPEN
 
 namespace Mat
 {
+  /**
+   * @brief Context information for material evaluation
+   */
+  struct EvaluationContext
+  {
+    /// Total time (nullptr if not available)
+    const double* total_time;
+
+    /// Timestep size (nullptr if not available)
+    const double* time_step_size;
+
+    /// Parameter coordinates if the evaluation point (nullptr if not available)
+    const Core::LinAlg::Tensor<double, 3>* xi;
+
+    /// Coordinates of the evaluation point in the reference configuration (nullptr if not
+    /// available)
+    const Core::LinAlg::Tensor<double, 3>* ref_coords;
+  };
+
   class So3Material : public Core::Mat::Material
   {
    public:
@@ -48,7 +67,8 @@ namespace Mat
      */
     virtual void evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) = 0;
 
     /*!
@@ -60,7 +80,8 @@ namespace Mat
      * @param[in] eleGID   Global element ID
      */
     [[nodiscard]] virtual double strain_energy(
-        const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain, int gp, int eleGID) const;
+        const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
+        const EvaluationContext& context, int gp, int eleGID) const;
 
     /*!
      * @brief Evaluate the Cauchy stress contracted with normal and direction vector and
@@ -117,8 +138,8 @@ namespace Mat
         Core::LinAlg::Matrix<3, 1>* d_cauchyndir_ddir, Core::LinAlg::Matrix<9, 1>* d_cauchyndir_dF,
         Core::LinAlg::Matrix<9, 9>* d2_cauchyndir_dF2,
         Core::LinAlg::Matrix<9, 3>* d2_cauchyndir_dF_dn,
-        Core::LinAlg::Matrix<9, 3>* d2_cauchyndir_dF_ddir, int gp, int eleGID,
-        const double* concentration, const double* temp, double* d_cauchyndir_dT,
+        Core::LinAlg::Matrix<9, 3>* d2_cauchyndir_dF_ddir, const EvaluationContext& context,
+        int eleGID, const double* concentration, const double* temp, double* d_cauchyndir_dT,
         Core::LinAlg::Matrix<9, 1>* d2_cauchyndir_dF_dT);
 
     /*!
@@ -195,7 +216,7 @@ namespace Mat
      * @param[in] eleGID Global element ID
      */
     virtual void update(const Core::LinAlg::Tensor<double, 3, 3>& defgrd, int const gp,
-        const Teuchos::ParameterList& params, int const eleGID)
+        const Teuchos::ParameterList& params, const EvaluationContext& context, int const eleGID)
     {
     }
 

--- a/src/mat/4C_mat_structporo.hpp
+++ b/src/mat/4C_mat_structporo.hpp
@@ -268,16 +268,17 @@ namespace Mat
 
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override
     {
-      mat_->evaluate(defgrad, glstrain, params, stress, cmat, gp, eleGID);
+      mat_->evaluate(defgrad, glstrain, params, context, stress, cmat, gp, eleGID);
     }
 
     [[nodiscard]] double strain_energy(const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        int gp, int eleGID) const override
+        const EvaluationContext& context, int gp, int eleGID) const override
     {
-      return mat_->strain_energy(glstrain, gp, eleGID);
+      return mat_->strain_energy(glstrain, context, gp, eleGID);
     }
 
     double evaluate_cauchy_n_dir_and_derivatives(const Core::LinAlg::Tensor<double, 3, 3>& defgrd,
@@ -285,13 +286,13 @@ namespace Mat
         Core::LinAlg::Matrix<3, 1>* d_cauchyndir_dn, Core::LinAlg::Matrix<3, 1>* d_cauchyndir_ddir,
         Core::LinAlg::Matrix<9, 1>* d_cauchyndir_dF, Core::LinAlg::Matrix<9, 9>* d2_cauchyndir_dF2,
         Core::LinAlg::Matrix<9, 3>* d2_cauchyndir_dF_dn,
-        Core::LinAlg::Matrix<9, 3>* d2_cauchyndir_dF_ddir, int gp, int eleGID,
-        const double* concentration, const double* temp, double* d_cauchyndir_dT,
+        Core::LinAlg::Matrix<9, 3>* d2_cauchyndir_dF_ddir, const EvaluationContext& context,
+        int eleGID, const double* concentration, const double* temp, double* d_cauchyndir_dT,
         Core::LinAlg::Matrix<9, 1>* d2_cauchyndir_dF_dT) override
     {
       return mat_->evaluate_cauchy_n_dir_and_derivatives(defgrd, n, dir, d_cauchyndir_dn,
           d_cauchyndir_ddir, d_cauchyndir_dF, d2_cauchyndir_dF2, d2_cauchyndir_dF_dn,
-          d2_cauchyndir_dF_ddir, gp, eleGID, concentration, temp, d_cauchyndir_dT,
+          d2_cauchyndir_dF_ddir, context, eleGID, concentration, temp, d_cauchyndir_dT,
           d2_cauchyndir_dF_dT);
     }
 

--- a/src/mat/4C_mat_structporo_reaction.cpp
+++ b/src/mat/4C_mat_structporo_reaction.cpp
@@ -200,11 +200,12 @@ void Mat::StructPoroReaction::reaction(const double porosity, const double J,
  *----------------------------------------------------------------------*/
 void Mat::StructPoroReaction::evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
     const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-    const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+    const Teuchos::ParameterList& params, const EvaluationContext& context,
+    Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
     Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID)
 {
   // call base class
-  StructPoro::evaluate(defgrad, glstrain, params, stress, cmat, gp, eleGID);
+  StructPoro::evaluate(defgrad, glstrain, params, context, stress, cmat, gp, eleGID);
 
   // scale stresses and cmat
   stress *= (1.0 - refporosity_) / (1.0 - params_->init_porosity_);

--- a/src/mat/4C_mat_structporo_reaction.hpp
+++ b/src/mat/4C_mat_structporo_reaction.hpp
@@ -166,7 +166,8 @@ namespace Mat
     /// evaluate material law
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
     //@}

--- a/src/mat/4C_mat_structporo_reaction_ecm.cpp
+++ b/src/mat/4C_mat_structporo_reaction_ecm.cpp
@@ -11,6 +11,7 @@
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
 #include "4C_mat_poro_law.hpp"
+#include "4C_mat_so3_material.hpp"
 #include "4C_utils_enum.hpp"
 
 #include <vector>
@@ -223,7 +224,8 @@ void Mat::StructPoroReactionECM::chem_potential(
   // dummy parameter list
   Teuchos::ParameterList params;
 
-  double psi = mat_->strain_energy(glstrain, gp, EleID);
+  EvaluationContext context{};  // We have nothing available
+  double psi = mat_->strain_energy(glstrain, context, gp, EleID);
 
   // derivative of
   double dpsidphiref = 0.0;

--- a/src/mat/4C_mat_stvenantkirchhoff.cpp
+++ b/src/mat/4C_mat_stvenantkirchhoff.cpp
@@ -104,7 +104,8 @@ void Mat::StVenantKirchhoff::unpack(Core::Communication::UnpackBuffer& buffer)
  *----------------------------------------------------------------------*/
 void Mat::StVenantKirchhoff::evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
     const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-    const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+    const Teuchos::ParameterList& params, const EvaluationContext& context,
+    Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
     Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID)
 {
   cmat = StVenantKirchhoff::evaluate_stress_linearization(params_->youngs_, params_->poissonratio_);
@@ -117,8 +118,8 @@ void Mat::StVenantKirchhoff::evaluate(const Core::LinAlg::Tensor<double, 3, 3>* 
  |  Calculate strain energy                                    gee 10/09|
  *----------------------------------------------------------------------*/
 double Mat::StVenantKirchhoff::strain_energy(
-    const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain, const int gp,
-    const int eleGID) const
+    const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain, const EvaluationContext& context,
+    const int gp, const int eleGID) const
 {
   auto stress =
       StVenantKirchhoff::evaluate_stress(glstrain, params_->youngs_, params_->poissonratio_);

--- a/src/mat/4C_mat_stvenantkirchhoff.hpp
+++ b/src/mat/4C_mat_stvenantkirchhoff.hpp
@@ -126,11 +126,12 @@ namespace Mat
 
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
     [[nodiscard]] double strain_energy(const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        int gp, int eleGID) const override;
+        const EvaluationContext& context, int gp, int eleGID) const override;
     //@}
 
     static constexpr Core::LinAlg::SymmetricTensor<double, 3, 3> evaluate_stress(

--- a/src/mat/4C_mat_superelastic_sma.cpp
+++ b/src/mat/4C_mat_superelastic_sma.cpp
@@ -303,7 +303,8 @@ void Mat::SuperElasticSMA::update()
  *----------------------------------------------------------------------*/
 void Mat::SuperElasticSMA::evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
     const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-    const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+    const Teuchos::ParameterList& params, const EvaluationContext& context,
+    Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
     Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID)
 {
   const Core::LinAlg::Matrix<3, 3> defgrd_mat = Core::LinAlg::make_matrix_view(*defgrad);
@@ -1120,8 +1121,8 @@ bool Mat::SuperElasticSMA::vis_data(
  |  calculate strain energy                                hemmler 11/16|
  *----------------------------------------------------------------------*/
 double Mat::SuperElasticSMA::strain_energy(
-    const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain, const int gp,
-    const int eleGID) const
+    const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain, const EvaluationContext& context,
+    const int gp, const int eleGID) const
 {
   return strainenergy_;
 }

--- a/src/mat/4C_mat_superelastic_sma.hpp
+++ b/src/mat/4C_mat_superelastic_sma.hpp
@@ -206,12 +206,13 @@ namespace Mat
     //! evaluate material law
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
     /// evaluate strain energy function
     [[nodiscard]] double strain_energy(const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        int gp, int eleGID) const override;
+        const EvaluationContext& context, int gp, int eleGID) const override;
 
     //@}
 

--- a/src/mat/4C_mat_thermoplastichyperelast.cpp
+++ b/src/mat/4C_mat_thermoplastichyperelast.cpp
@@ -388,7 +388,7 @@ Core::LinAlg::SymmetricTensor<double, 3, 3>
 Mat::ThermoPlasticHyperElast::evaluate_d_stress_d_scalar(
     const Core::LinAlg::Tensor<double, 3, 3>& defgrad,
     const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-    const Teuchos::ParameterList& params, int gp, int eleGID)
+    const Teuchos::ParameterList& params, const EvaluationContext& context, int gp, int eleGID)
 {
   // obtain the temperature
   const double temperature = [&]()
@@ -432,7 +432,8 @@ Mat::ThermoPlasticHyperElast::evaluate_d_stress_d_scalar(
  *----------------------------------------------------------------------*/
 void Mat::ThermoPlasticHyperElast::evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
     const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-    const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+    const Teuchos::ParameterList& params, const EvaluationContext& context,
+    Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
     Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, const int gp, const int eleGID)
 {
   Core::LinAlg::Matrix<3, 3> defgrd_mat = Core::LinAlg::make_matrix_view(*defgrad);

--- a/src/mat/4C_mat_thermoplastichyperelast.hpp
+++ b/src/mat/4C_mat_thermoplastichyperelast.hpp
@@ -205,7 +205,8 @@ namespace Mat
     Core::LinAlg::SymmetricTensor<double, 3, 3> evaluate_d_stress_d_scalar(
         const Core::LinAlg::Tensor<double, 3, 3>& defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, int gp, int eleGID) override;
+        const Teuchos::ParameterList& params, const EvaluationContext& context, int gp,
+        int eleGID) override;
 
     //! return quick accessible material parameter data
     Core::Mat::PAR::Parameter* parameter() const override { return params_; }
@@ -276,7 +277,8 @@ namespace Mat
     //! evaluate material law
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
     //! evaluate the elasto-plastic tangent

--- a/src/mat/4C_mat_thermoplasticlinelast.cpp
+++ b/src/mat/4C_mat_thermoplasticlinelast.cpp
@@ -329,7 +329,8 @@ void Mat::ThermoPlasticLinElast::update()
  *----------------------------------------------------------------------*/
 void Mat::ThermoPlasticLinElast::evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
     const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-    const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+    const Teuchos::ParameterList& params, const EvaluationContext& context,
+    Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
     Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID)
 {
   Core::LinAlg::Matrix<6, 1> stress_view = Core::LinAlg::make_stress_like_voigt_view(stress);
@@ -839,7 +840,7 @@ void Mat::ThermoPlasticLinElast::stress_temperature_modulus_and_deriv(
 Core::LinAlg::SymmetricTensor<double, 3, 3> Mat::ThermoPlasticLinElast::evaluate_d_stress_d_scalar(
     const Core::LinAlg::Tensor<double, 3, 3>& defgrad,
     const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-    const Teuchos::ParameterList& params, int gp, int eleGID)
+    const Teuchos::ParameterList& params, const EvaluationContext& context, int gp, int eleGID)
 {
   // get the temperature-dependent material tangent
   Core::LinAlg::SymmetricTensor<double, 3, 3> ctemp;

--- a/src/mat/4C_mat_thermoplasticlinelast.hpp
+++ b/src/mat/4C_mat_thermoplasticlinelast.hpp
@@ -162,7 +162,8 @@ namespace Mat
     //! evaluate material
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
     // computes stress
@@ -254,7 +255,8 @@ namespace Mat
     Core::LinAlg::SymmetricTensor<double, 3, 3> evaluate_d_stress_d_scalar(
         const Core::LinAlg::Tensor<double, 3, 3>& defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, int gp, int eleGID) override;
+        const Teuchos::ParameterList& params, const EvaluationContext& context, int gp,
+        int eleGID) override;
 
     //! return quick accessible material parameter data
     Core::Mat::PAR::Parameter* parameter() const override { return params_; }

--- a/src/mat/4C_mat_thermostvenantkirchhoff.cpp
+++ b/src/mat/4C_mat_thermostvenantkirchhoff.cpp
@@ -142,7 +142,8 @@ void Mat::ThermoStVenantKirchhoff::unpack(Core::Communication::UnpackBuffer& buf
  *----------------------------------------------------------------------*/
 void Mat::ThermoStVenantKirchhoff::evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
     const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-    const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+    const Teuchos::ParameterList& params, const EvaluationContext& context,
+    Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
     Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID)
 {
   // fixme this backwards compatibility modification should be moved outside
@@ -179,8 +180,8 @@ void Mat::ThermoStVenantKirchhoff::evaluate(const Core::LinAlg::Tensor<double, 3
  | calculates strain energy                                 seitz 11/15 |
  *----------------------------------------------------------------------*/
 double Mat::ThermoStVenantKirchhoff::strain_energy(
-    const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain, const int gp,
-    const int eleGID) const
+    const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain, const EvaluationContext& context,
+    const int gp, const int eleGID) const
 {
   if (youngs_is_temp_dependent())
     FOUR_C_THROW("Calculation of strain energy only for constant Young's modulus");
@@ -260,7 +261,7 @@ Core::LinAlg::SymmetricTensor<double, 3, 3>
 Mat::ThermoStVenantKirchhoff::evaluate_d_stress_d_scalar(
     const Core::LinAlg::Tensor<double, 3, 3>& defgrad,
     const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-    const Teuchos::ParameterList& params, int gp, int eleGID)
+    const Teuchos::ParameterList& params, const EvaluationContext& context, int gp, int eleGID)
 {
   const double temperature = [&]()
   {

--- a/src/mat/4C_mat_thermostvenantkirchhoff.hpp
+++ b/src/mat/4C_mat_thermostvenantkirchhoff.hpp
@@ -148,12 +148,14 @@ namespace Mat
     //! evaluates stresses for 3d
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
     /// add strain energy
     [[nodiscard]] double strain_energy(
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,  ///< Green-Lagrange strain
+        const EvaluationContext& context,                             ///< evaluation context
         int gp,                                                       ///< Gauss point
         int eleGID                                                    ///< element GID
     ) const override;
@@ -204,7 +206,8 @@ namespace Mat
     Core::LinAlg::SymmetricTensor<double, 3, 3> evaluate_d_stress_d_scalar(
         const Core::LinAlg::Tensor<double, 3, 3>& defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, int gp, int eleGID) override;
+        const Teuchos::ParameterList& params, const EvaluationContext& context, int gp,
+        int eleGID) override;
 
     void stress_temperature_modulus_and_deriv(Core::LinAlg::SymmetricTensor<double, 3, 3>& stm,
         Core::LinAlg::SymmetricTensor<double, 3, 3>& stm_dT, int gp) override;

--- a/src/mat/4C_mat_viscoanisotropic.cpp
+++ b/src/mat/4C_mat_viscoanisotropic.cpp
@@ -387,7 +387,8 @@ void Mat::ViscoAnisotropic::update_fiber_dirs(const int gp, Core::LinAlg::Matrix
  *----------------------------------------------------------------------*/
 void Mat::ViscoAnisotropic::evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
     const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-    const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+    const Teuchos::ParameterList& params, const EvaluationContext& context,
+    Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
     Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID)
 {
   const Core::LinAlg::Matrix<6, 1> glstrain_mat =
@@ -617,7 +618,8 @@ void Mat::ViscoAnisotropic::evaluate(const Core::LinAlg::Tensor<double, 3, 3>* d
   const double tau_fib = params_->relax_[1];  // assume same tau for both fibers
 
   // get time algorithmic parameters
-  double dt = params.get<double>("delta time");
+  FOUR_C_ASSERT(context.time_step_size, "Time step size not given in evaluation context.");
+  double dt = *context.time_step_size;
 
 
   /* Time integration according Zien/Taylor and the viscoNeoHooke */

--- a/src/mat/4C_mat_viscoanisotropic.hpp
+++ b/src/mat/4C_mat_viscoanisotropic.hpp
@@ -156,7 +156,8 @@ namespace Mat
     /// Evaluate material
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
     /// Return density

--- a/src/mat/4C_mat_viscoelasthyper.hpp
+++ b/src/mat/4C_mat_viscoelasthyper.hpp
@@ -177,7 +177,8 @@ namespace Mat
     /// hyperelastic stress response plus elasticity tensor
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp,
         int eleGID) override;  ///< Constitutive matrix
 
@@ -194,8 +195,8 @@ namespace Mat
         Core::LinAlg::Matrix<6, 1>& scg, Core::LinAlg::Matrix<6, 1>& icg,
         Core::LinAlg::Matrix<3, 1>& prinv, Core::LinAlg::Matrix<7, 1>& rateinv,
         Core::LinAlg::Matrix<6, 1>& modrcg, const Teuchos::ParameterList& params,
-        Core::LinAlg::Matrix<6, 1>& scgrate, Core::LinAlg::Matrix<6, 1>& modrcgrate,
-        Core::LinAlg::Matrix<7, 1>& modrateinv, int gp);
+        const EvaluationContext& context, Core::LinAlg::Matrix<6, 1>& scgrate,
+        Core::LinAlg::Matrix<6, 1>& modrcgrate, Core::LinAlg::Matrix<7, 1>& modrateinv, int gp);
 
     /// calculates the factors associated to the viscous laws
     virtual void evaluate_mu_xi(Core::LinAlg::Matrix<3, 1>& inv, Core::LinAlg::Matrix<3, 1>& modinv,
@@ -226,12 +227,14 @@ namespace Mat
     /// tensors are added
     virtual void evaluate_visco_gen_max(Core::LinAlg::Matrix<6, 1>* stress,
         Core::LinAlg::Matrix<6, 6>* cmat, Core::LinAlg::Matrix<6, 1>& Q,
-        Core::LinAlg::Matrix<6, 6>& cmatq, const Teuchos::ParameterList& params, int gp);
+        Core::LinAlg::Matrix<6, 6>& cmatq, const Teuchos::ParameterList& params,
+        const Mat::EvaluationContext& context, int gp);
 
     /// calculates the stress and elasticitiy tensor for the GeneneralizedMax-material
     virtual void evaluate_visco_generalized_gen_max(Core::LinAlg::Matrix<6, 1>& Q,
         Core::LinAlg::Matrix<6, 6>& cmatq, const Teuchos::ParameterList& params,
-        const Core::LinAlg::Matrix<6, 1>* glstrain, int gp, int eleGID);
+        const Mat::EvaluationContext& context, const Core::LinAlg::Matrix<6, 1>* glstrain, int gp,
+        int eleGID);
 
     /// calculates the stress and elasticity tensor for the viscos Fract-material
     /// depending on the viscoelastic material isochoric-principal, isochoric-modified
@@ -239,7 +242,8 @@ namespace Mat
     /// tensors are added
     virtual void evaluate_visco_fract(Core::LinAlg::Matrix<6, 1> stress,
         Core::LinAlg::Matrix<6, 6> cmat, Core::LinAlg::Matrix<6, 1>& Q,
-        Core::LinAlg::Matrix<6, 6>& cmatq, const Teuchos::ParameterList& params, int gp);
+        Core::LinAlg::Matrix<6, 6>& cmatq, const Teuchos::ParameterList& params,
+        const Mat::EvaluationContext& context, int gp);
 
     /// @name Flags to specify the viscous formulations
     //@{

--- a/src/mat/4C_mat_visconeohooke.cpp
+++ b/src/mat/4C_mat_visconeohooke.cpp
@@ -218,7 +218,8 @@ void Mat::ViscoNeoHooke::update()
  *----------------------------------------------------------------------*/
 void Mat::ViscoNeoHooke::evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
     const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-    const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+    const Teuchos::ParameterList& params, const EvaluationContext& context,
+    Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
     Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID)
 {
   const Core::LinAlg::Matrix<6, 1> glstrain_mat =
@@ -237,7 +238,8 @@ void Mat::ViscoNeoHooke::evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defg
   // get time algorithmic parameters
   // NOTE: dt can be zero (in restart of STI) for Generalized Maxwell model
   // there is no special treatment required. Adaptation for Kelvin-Voigt were necessary.
-  double dt = params.get<double>("delta time");
+  FOUR_C_ASSERT(context.time_step_size, "Time step size not given in evaluation context.");
+  double dt = *context.time_step_size;
 
   // compute algorithmic relaxation time
   double tau1 = tau;

--- a/src/mat/4C_mat_visconeohooke.hpp
+++ b/src/mat/4C_mat_visconeohooke.hpp
@@ -146,7 +146,8 @@ namespace Mat
     /// Evaluate material
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
     /// Return density

--- a/src/mat/4C_mat_viscoplastic_no_yield_surface.cpp
+++ b/src/mat/4C_mat_viscoplastic_no_yield_surface.cpp
@@ -172,7 +172,8 @@ void Mat::ViscoPlasticNoYieldSurface::update()
  *----------------------------------------------------------------------*/
 void Mat::ViscoPlasticNoYieldSurface::evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
     const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-    const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+    const Teuchos::ParameterList& params, const EvaluationContext& context,
+    Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
     Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID)
 {
   const Core::LinAlg::Matrix<3, 3> defgrd_mat = Core::LinAlg::make_matrix_view(*defgrad);
@@ -180,7 +181,8 @@ void Mat::ViscoPlasticNoYieldSurface::evaluate(const Core::LinAlg::Tensor<double
   Core::LinAlg::Matrix<6, 6> cmat_view = Core::LinAlg::make_stress_like_voigt_view(cmat);
 
   // read input and history variables
-  const double dt = params.get<double>("delta time");
+  FOUR_C_ASSERT(context.time_step_size, "Time step size not given in evaluation context.");
+  const double dt = *context.time_step_size;
   const Core::LinAlg::Matrix<3, 3>& last_iFv = last_plastic_defgrd_inverse_[gp];
 
   // trial (purely elastic) deformation gradient

--- a/src/mat/4C_mat_viscoplastic_no_yield_surface.hpp
+++ b/src/mat/4C_mat_viscoplastic_no_yield_surface.hpp
@@ -274,7 +274,8 @@ namespace Mat
 
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>* defgrad,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
+        const Teuchos::ParameterList& params, const EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
     /*!

--- a/src/mixture/src/4C_mixture_constituent.cpp
+++ b/src/mixture/src/4C_mixture_constituent.cpp
@@ -143,7 +143,7 @@ void Mixture::MixtureConstituent::unpack_constituent(Core::Communication::Unpack
 
 void Mixture::MixtureConstituent::evaluate_elastic_part(const Core::LinAlg::Tensor<double, 3, 3>& F,
     const Core::LinAlg::Tensor<double, 3, 3>& F_in, const Teuchos::ParameterList& params,
-    Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
+    const Mat::EvaluationContext& context, Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
     Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID)
 {
   FOUR_C_THROW("This constituent cannot handle an additional inelastic part.");

--- a/src/mixture/src/4C_mixture_constituent.hpp
+++ b/src/mixture/src/4C_mixture_constituent.hpp
@@ -27,7 +27,8 @@ FOUR_C_NAMESPACE_OPEN
 namespace Mat
 {
   class Anisotropy;
-}
+  struct EvaluationContext;
+}  // namespace Mat
 
 /*!
  * \brief The mixture namespace holds all mixture specific classes.
@@ -150,7 +151,8 @@ namespace Mixture
      * @param eleGID Global element identifier
      */
     virtual void update(Core::LinAlg::Tensor<double, 3, 3> const& defgrd,
-        const Teuchos::ParameterList& params, const int gp, const int eleGID)
+        const Teuchos::ParameterList& params, const Mat::EvaluationContext& context, const int gp,
+        const int eleGID)
     {
     }
 
@@ -176,7 +178,7 @@ namespace Mixture
      */
     virtual void update_elastic_part(const Core::LinAlg::Tensor<double, 3, 3>& F,
         const Core::LinAlg::Tensor<double, 3, 3>& iFext, const Teuchos::ParameterList& params,
-        const double dt, const int gp, const int eleGID)
+        const Mat::EvaluationContext& context, const double dt, const int gp, const int eleGID)
     {
       // do nothing
     }
@@ -189,8 +191,8 @@ namespace Mixture
      * @param gp (in) : Gauss point
      * @param eleGID (in) : Global element id
      */
-    virtual void pre_evaluate(
-        MixtureRule& mixtureRule, const Teuchos::ParameterList& params, int gp, int eleGID)
+    virtual void pre_evaluate(MixtureRule& mixtureRule, const Teuchos::ParameterList& params,
+        const Mat::EvaluationContext& context, int gp, int eleGID)
     {
       // do nothing in the default case
     }
@@ -244,6 +246,7 @@ namespace Mixture
      */
     virtual void evaluate_elastic_part(const Core::LinAlg::Tensor<double, 3, 3>& F,
         const Core::LinAlg::Tensor<double, 3, 3>& iF_in, const Teuchos::ParameterList& params,
+        const Mat::EvaluationContext& context,
         Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID);
 
@@ -265,7 +268,8 @@ namespace Mixture
      */
     virtual void evaluate(const Core::LinAlg::Tensor<double, 3, 3>& F,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& E_strain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
+        const Teuchos::ParameterList& params, const Mat::EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) = 0;
 
     /// Returns the reference mass density. Needs to be implemented by the deriving class.

--- a/src/mixture/src/4C_mixture_constituent_elasthyper.cpp
+++ b/src/mixture/src/4C_mixture_constituent_elasthyper.cpp
@@ -49,7 +49,8 @@ Core::Materials::MaterialType Mixture::MixtureConstituentElastHyper::material_ty
 // Evaluates the stress of the constituent
 void Mixture::MixtureConstituentElastHyper::evaluate(const Core::LinAlg::Tensor<double, 3, 3>& F,
     const Core::LinAlg::SymmetricTensor<double, 3, 3>& E_strain,
-    const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
+    const Teuchos::ParameterList& params, const Mat::EvaluationContext& context,
+    Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
     Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, const int gp, const int eleGID)
 {
   if (prestress_strategy() != nullptr)
@@ -72,7 +73,8 @@ void Mixture::MixtureConstituentElastHyper::evaluate(const Core::LinAlg::Tensor<
 // Compute the stress resultant with incorporating an elastic and inelastic part of the deformation
 void Mixture::MixtureConstituentElastHyper::evaluate_elastic_part(
     const Core::LinAlg::Tensor<double, 3, 3>& F, const Core::LinAlg::Tensor<double, 3, 3>& iFextin,
-    const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
+    const Teuchos::ParameterList& params, const Mat::EvaluationContext& context,
+    Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
     Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID)
 {
   Core::LinAlg::Tensor<double, 3, 3> iFin = iFextin * prestretch_tensor(gp);

--- a/src/mixture/src/4C_mixture_constituent_elasthyper.hpp
+++ b/src/mixture/src/4C_mixture_constituent_elasthyper.hpp
@@ -64,7 +64,8 @@ namespace Mixture
      */
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>& F,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& E_strain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
+        const Teuchos::ParameterList& params, const Mat::EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
     /*!
@@ -88,6 +89,7 @@ namespace Mixture
      */
     void evaluate_elastic_part(const Core::LinAlg::Tensor<double, 3, 3>& F,
         const Core::LinAlg::Tensor<double, 3, 3>& iFextin, const Teuchos::ParameterList& params,
+        const Mat::EvaluationContext& context,
         Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
   };

--- a/src/mixture/src/4C_mixture_constituent_elasthyper_damage.cpp
+++ b/src/mixture/src/4C_mixture_constituent_elasthyper_damage.cpp
@@ -82,18 +82,22 @@ void Mixture::MixtureConstituentElastHyperDamage::read_element(int numgp,
 // Updates all summands
 void Mixture::MixtureConstituentElastHyperDamage::update(
     Core::LinAlg::Tensor<double, 3, 3> const& defgrd, const Teuchos::ParameterList& params,
-    const int gp, const int eleGID)
+    const Mat::EvaluationContext& context, const int gp, const int eleGID)
 {
-  const auto& reference_coordinates = params.get<Core::LinAlg::Tensor<double, 3>>("gp_coords_ref");
+  FOUR_C_ASSERT(context.ref_coords,
+      "Reference coordinates not set in EvaluationContext, but required for function-based "
+      "mixture rule!");
+  const auto& reference_coordinates = *context.ref_coords;
 
-  double totaltime = params.get<double>("total time");
+  FOUR_C_ASSERT(context.total_time, "Time not given in evaluation context.");
+  double totaltime = *context.total_time;
 
   current_reference_growth_[gp] =
       Global::Problem::instance()
           ->function_by_id<Core::Utils::FunctionOfSpaceTime>(params_->damage_function_id_)
           .evaluate(reference_coordinates.as_span(), totaltime, 0);
 
-  MixtureConstituentElastHyperBase::update(defgrd, params, gp, eleGID);
+  MixtureConstituentElastHyperBase::update(defgrd, params, context, gp, eleGID);
 }
 
 double Mixture::MixtureConstituentElastHyperDamage::get_growth_scalar(int gp) const
@@ -104,7 +108,8 @@ double Mixture::MixtureConstituentElastHyperDamage::get_growth_scalar(int gp) co
 void Mixture::MixtureConstituentElastHyperDamage::evaluate(
     const Core::LinAlg::Tensor<double, 3, 3>& F,
     const Core::LinAlg::SymmetricTensor<double, 3, 3>& E_strain,
-    const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
+    const Teuchos::ParameterList& params, const Mat::EvaluationContext& context,
+    Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
     Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID)
 {
   FOUR_C_THROW("This constituent does not support Evaluation without an elastic part.");
@@ -112,7 +117,8 @@ void Mixture::MixtureConstituentElastHyperDamage::evaluate(
 
 void Mixture::MixtureConstituentElastHyperDamage::evaluate_elastic_part(
     const Core::LinAlg::Tensor<double, 3, 3>& F, const Core::LinAlg::Tensor<double, 3, 3>& iFextin,
-    const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
+    const Teuchos::ParameterList& params, const Mat::EvaluationContext& context,
+    Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
     Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID)
 {
   // Compute total inelastic deformation gradient

--- a/src/mixture/src/4C_mixture_constituent_elasthyper_damage.hpp
+++ b/src/mixture/src/4C_mixture_constituent_elasthyper_damage.hpp
@@ -117,7 +117,8 @@ namespace Mixture
      * @param eleGID Global element identifier
      */
     void update(Core::LinAlg::Tensor<double, 3, 3> const& defgrd,
-        const Teuchos::ParameterList& params, int gp, int eleGID) override;
+        const Teuchos::ParameterList& params, const Mat::EvaluationContext& context, int gp,
+        int eleGID) override;
 
     [[nodiscard]] double get_growth_scalar(int gp) const override;
 
@@ -135,6 +136,7 @@ namespace Mixture
      */
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>& F,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& E, const Teuchos::ParameterList& params,
+        const Mat::EvaluationContext& context,
         Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
@@ -151,6 +153,7 @@ namespace Mixture
      */
     void evaluate_elastic_part(const Core::LinAlg::Tensor<double, 3, 3>& F,
         const Core::LinAlg::Tensor<double, 3, 3>& iFextin, const Teuchos::ParameterList& params,
+        const Mat::EvaluationContext& context,
         Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 

--- a/src/mixture/src/4C_mixture_constituent_elasthyper_elastin_membrane.hpp
+++ b/src/mixture/src/4C_mixture_constituent_elasthyper_elastin_membrane.hpp
@@ -172,7 +172,8 @@ namespace Mixture
      * @param eleGID Global element identifier
      */
     void update(Core::LinAlg::Tensor<double, 3, 3> const& defgrd,
-        const Teuchos::ParameterList& params, int gp, int eleGID) override;
+        const Teuchos::ParameterList& params, const Mat::EvaluationContext& context, int gp,
+        int eleGID) override;
 
     /*!
      * \brief Method that will be called once before the evaluation process. The elastin material
@@ -183,8 +184,8 @@ namespace Mixture
      * \param gp Gauss point
      * \param eleGID Global element id
      */
-    void pre_evaluate(MixtureRule& mixtureRule, const Teuchos::ParameterList& params, int gp,
-        int eleGID) override;
+    void pre_evaluate(MixtureRule& mixtureRule, const Teuchos::ParameterList& params,
+        const Mat::EvaluationContext& context, int gp, int eleGID) override;
 
 
     [[nodiscard]] double get_growth_scalar(int gp) const override;
@@ -203,7 +204,8 @@ namespace Mixture
      */
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>& F,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& E_strain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
+        const Teuchos::ParameterList& params, const Mat::EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
     /*!
@@ -219,6 +221,7 @@ namespace Mixture
      */
     void evaluate_elastic_part(const Core::LinAlg::Tensor<double, 3, 3>& F,
         const Core::LinAlg::Tensor<double, 3, 3>& iFextin, const Teuchos::ParameterList& params,
+        const Mat::EvaluationContext& context,
         Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 

--- a/src/mixture/src/4C_mixture_constituent_elasthyperbase.cpp
+++ b/src/mixture/src/4C_mixture_constituent_elasthyperbase.cpp
@@ -187,9 +187,9 @@ void Mixture::MixtureConstituentElastHyperBase::read_element(int numgp,
 // Updates all summands
 void Mixture::MixtureConstituentElastHyperBase::update(
     Core::LinAlg::Tensor<double, 3, 3> const& defgrd, const Teuchos::ParameterList& params,
-    const int gp, const int eleGID)
+    const Mat::EvaluationContext& context, const int gp, const int eleGID)
 {
-  MixtureConstituent::update(defgrd, params, gp, eleGID);
+  MixtureConstituent::update(defgrd, params, context, gp, eleGID);
 
   // loop map of associated potential summands
   for (auto& summand : potsum_) summand->update();
@@ -198,7 +198,7 @@ void Mixture::MixtureConstituentElastHyperBase::update(
   if (params_->get_prestressing_mat_id() > 0)
   {
     prestress_strategy_->update(cosy_anisotropy_extension_.get_coordinate_system_provider(gp),
-        *this, defgrd, prestretch_[gp], params, gp, eleGID);
+        *this, defgrd, prestretch_[gp], params, context, gp, eleGID);
   }
 }
 
@@ -214,15 +214,15 @@ void Mixture::MixtureConstituentElastHyperBase::setup(
   }
 }
 
-void Mixture::MixtureConstituentElastHyperBase::pre_evaluate(
-    MixtureRule& mixtureRule, const Teuchos::ParameterList& params, int gp, int eleGID)
+void Mixture::MixtureConstituentElastHyperBase::pre_evaluate(MixtureRule& mixtureRule,
+    const Teuchos::ParameterList& params, const Mat::EvaluationContext& context, int gp, int eleGID)
 {
   // do nothing in the default case
   if (params_->get_prestressing_mat_id() > 0)
   {
     prestress_strategy_->evaluate_prestress(mixtureRule,
         cosy_anisotropy_extension_.get_coordinate_system_provider(gp), *this, prestretch_[gp],
-        params, gp, eleGID);
+        params, context, gp, eleGID);
   }
 }
 

--- a/src/mixture/src/4C_mixture_constituent_elasthyperbase.hpp
+++ b/src/mixture/src/4C_mixture_constituent_elasthyperbase.hpp
@@ -114,7 +114,8 @@ namespace Mixture
      * @param eleGID Global element identifier
      */
     void update(Core::LinAlg::Tensor<double, 3, 3> const& defgrd,
-        const Teuchos::ParameterList& params, int gp, int eleGID) override;
+        const Teuchos::ParameterList& params, const Mat::EvaluationContext& context, int gp,
+        int eleGID) override;
 
     /*!
      * \brief Returns a reference to all summands
@@ -149,8 +150,8 @@ namespace Mixture
      * \param gp Gauss point
      * \param eleGID Global element id
      */
-    void pre_evaluate(MixtureRule& mixtureRule, const Teuchos::ParameterList& params, int gp,
-        int eleGID) override;
+    void pre_evaluate(MixtureRule& mixtureRule, const Teuchos::ParameterList& params,
+        const Mat::EvaluationContext& context, int gp, int eleGID) override;
 
     void register_output_data_names(
         std::unordered_map<std::string, int>& names_and_size) const override;

--- a/src/mixture/src/4C_mixture_constituent_full_constrained_mixture_fiber.hpp
+++ b/src/mixture/src/4C_mixture_constituent_full_constrained_mixture_fiber.hpp
@@ -79,15 +79,17 @@ namespace Mixture
     void setup(const Teuchos::ParameterList& params, int eleGID) override;
 
     void update(const Core::LinAlg::Tensor<double, 3, 3>& F, const Teuchos::ParameterList& params,
-        int gp, int eleGID) override;
+        const Mat::EvaluationContext& context, int gp, int eleGID) override;
 
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>& F,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& E_strain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
+        const Teuchos::ParameterList& params, const Mat::EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
     void evaluate_elastic_part(const Core::LinAlg::Tensor<double, 3, 3>& FM,
         const Core::LinAlg::Tensor<double, 3, 3>& iFextin, const Teuchos::ParameterList& params,
+        const Mat::EvaluationContext& context,
         Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 

--- a/src/mixture/src/4C_mixture_constituent_remodelfiber_expl.hpp
+++ b/src/mixture/src/4C_mixture_constituent_remodelfiber_expl.hpp
@@ -11,6 +11,7 @@
 #include "4C_config.hpp"
 
 #include "4C_mat_anisotropy_extension_default.hpp"
+#include "4C_mat_so3_material.hpp"
 #include "4C_material_parameter_base.hpp"
 #include "4C_mixture_constituent.hpp"
 #include "4C_mixture_constituent_remodelfiber_material.hpp"
@@ -77,19 +78,21 @@ namespace Mixture
     void setup(const Teuchos::ParameterList& params, int eleGID) override;
 
     void update(const Core::LinAlg::Tensor<double, 3, 3>& F, const Teuchos::ParameterList& params,
-        int gp, int eleGID) override;
+        const Mat::EvaluationContext& context, int gp, int eleGID) override;
 
     void update_elastic_part(const Core::LinAlg::Tensor<double, 3, 3>& F,
         const Core::LinAlg::Tensor<double, 3, 3>& iFext, const Teuchos::ParameterList& params,
-        double dt, int gp, int eleGID) override;
+        const Mat::EvaluationContext& context, double dt, int gp, int eleGID) override;
 
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>& F,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& E, const Teuchos::ParameterList& params,
+        const Mat::EvaluationContext& context,
         Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
     void evaluate_elastic_part(const Core::LinAlg::Tensor<double, 3, 3>& FM,
         const Core::LinAlg::Tensor<double, 3, 3>& iFextin, const Teuchos::ParameterList& params,
+        const Mat::EvaluationContext& context,
         Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
@@ -113,7 +116,8 @@ namespace Mixture
         int gp, int eleGID) const;
 
     [[nodiscard]] double evaluate_deposition_stretch(double time) const;
-    void update_homeostatic_values(const Teuchos::ParameterList& params, int eleGID);
+    void update_homeostatic_values(
+        const Teuchos::ParameterList& params, double total_time, int eleGID);
 
     void initialize();
 

--- a/src/mixture/src/4C_mixture_constituent_remodelfiber_impl.hpp
+++ b/src/mixture/src/4C_mixture_constituent_remodelfiber_impl.hpp
@@ -75,15 +75,17 @@ namespace Mixture
     void setup(const Teuchos::ParameterList& params, int eleGID) override;
 
     void update(const Core::LinAlg::Tensor<double, 3, 3>& F, const Teuchos::ParameterList& params,
-        int gp, int eleGID) override;
+        const Mat::EvaluationContext& context, int gp, int eleGID) override;
 
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>& F,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& E_strain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
+        const Teuchos::ParameterList& params, const Mat::EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
     void evaluate_elastic_part(const Core::LinAlg::Tensor<double, 3, 3>& FM,
         const Core::LinAlg::Tensor<double, 3, 3>& iFextin, const Teuchos::ParameterList& params,
+        const Mat::EvaluationContext& context,
         Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
@@ -110,7 +112,8 @@ namespace Mixture
         int gp, int eleGID) const;
 
     [[nodiscard]] double evaluate_deposition_stretch(double time) const;
-    void update_homeostatic_values(const Teuchos::ParameterList& params, int eleGID);
+    void update_homeostatic_values(
+        const Teuchos::ParameterList& params, double total_time, int eleGID);
 
     void initialize();
 

--- a/src/mixture/src/4C_mixture_constituent_solidmaterial.cpp
+++ b/src/mixture/src/4C_mixture_constituent_solidmaterial.cpp
@@ -144,17 +144,18 @@ void Mixture::MixtureConstituentSolidMaterial::update() { material_->update(); }
 
 void Mixture::MixtureConstituentSolidMaterial::update(
     Core::LinAlg::Tensor<double, 3, 3> const& defgrd, const Teuchos::ParameterList& params,
-    const int gp, const int eleGID)
+    const Mat::EvaluationContext& context, const int gp, const int eleGID)
 {
-  material_->update(defgrd, gp, params, eleGID);
+  material_->update(defgrd, gp, params, context, eleGID);
 }
 
 void Mixture::MixtureConstituentSolidMaterial::evaluate(const Core::LinAlg::Tensor<double, 3, 3>& F,
     const Core::LinAlg::SymmetricTensor<double, 3, 3>& E_strain,
-    const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
+    const Teuchos::ParameterList& params, const Mat::EvaluationContext& context,
+    Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
     Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, const int gp, const int eleGID)
 {
-  material_->evaluate(&F, E_strain, params, S_stress, cmat, gp, eleGID);
+  material_->evaluate(&F, E_strain, params, context, S_stress, cmat, gp, eleGID);
 }
 
 void Mixture::MixtureConstituentSolidMaterial::register_output_data_names(

--- a/src/mixture/src/4C_mixture_constituent_solidmaterial.hpp
+++ b/src/mixture/src/4C_mixture_constituent_solidmaterial.hpp
@@ -61,13 +61,15 @@ namespace Mixture
         const std::optional<Discret::Elements::CoordinateSystem>& coord_system) override;
 
     void update(Core::LinAlg::Tensor<double, 3, 3> const& defgrd,
-        const Teuchos::ParameterList& params, const int gp, const int eleGID) override;
+        const Teuchos::ParameterList& params, const Mat::EvaluationContext& context, const int gp,
+        const int eleGID) override;
 
     void update() override;
 
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>& F,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& E_strain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
+        const Teuchos::ParameterList& params, const Mat::EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
     void register_output_data_names(

--- a/src/mixture/src/4C_mixture_elastin_membrane_prestress_strategy.hpp
+++ b/src/mixture/src/4C_mixture_elastin_membrane_prestress_strategy.hpp
@@ -12,6 +12,7 @@
 
 #include "4C_linalg_fixedsizematrix.hpp"
 #include "4C_linalg_symmetric_tensor.hpp"
+#include "4C_mat_so3_material.hpp"
 #include "4C_utils_parameter_list.fwd.hpp"
 
 // forward declarations
@@ -20,7 +21,8 @@ FOUR_C_NAMESPACE_OPEN
 namespace Mat
 {
   class CoordinateSystemProvider;
-}
+  struct EvaluationContext;
+}  // namespace Mat
 
 namespace Mixture
 {
@@ -57,7 +59,8 @@ namespace Mixture
     virtual double evaluate_mue_frac(MixtureRule& mixtureRule,
         const std::shared_ptr<const Mat::CoordinateSystemProvider> cosy,
         Mixture::MixtureConstituent& constituent, ElastinMembraneEvaluation& membraneEvaluation,
-        const Teuchos::ParameterList& params, int gp, int eleGID) const = 0;
+        const Teuchos::ParameterList& params, const Mat::EvaluationContext& context, int gp,
+        int eleGID) const = 0;
   };
 
   /*!

--- a/src/mixture/src/4C_mixture_prestress_strategy.hpp
+++ b/src/mixture/src/4C_mixture_prestress_strategy.hpp
@@ -13,6 +13,7 @@
 #include "4C_linalg_fixedsizematrix.hpp"
 #include "4C_linalg_symmetric_tensor.hpp"
 #include "4C_linalg_tensor.hpp"
+#include "4C_mat_so3_material.hpp"
 #include "4C_material_parameter_base.hpp"
 #include "4C_utils_exceptions.hpp"
 #include "4C_utils_parameter_list.fwd.hpp"
@@ -45,7 +46,8 @@ namespace Mat
 namespace Mat
 {
   class CoordinateSystemProvider;
-}
+  struct EvaluationContext;
+}  // namespace Mat
 
 namespace Mixture
 {
@@ -153,7 +155,8 @@ namespace Mixture
     virtual void evaluate_prestress(const MixtureRule& mixtureRule,
         const std::shared_ptr<const Mat::CoordinateSystemProvider> anisotropy,
         Mixture::MixtureConstituent& constituent, Core::LinAlg::SymmetricTensor<double, 3, 3>& G,
-        const Teuchos::ParameterList& params, int gp, int eleGID) = 0;
+        const Teuchos::ParameterList& params, const Mat::EvaluationContext& context, int gp,
+        int eleGID) = 0;
 
     /*!
      * \brief Update prestretch tensor during update
@@ -169,7 +172,7 @@ namespace Mixture
     virtual void update(const std::shared_ptr<const Mat::CoordinateSystemProvider> anisotropy,
         Mixture::MixtureConstituent& constituent, const Core::LinAlg::Tensor<double, 3, 3>& F,
         Core::LinAlg::SymmetricTensor<double, 3, 3>& G, const Teuchos::ParameterList& params,
-        int gp, int eleGID) = 0;
+        const Mat::EvaluationContext& context, int gp, int eleGID) = 0;
   };
 }  // namespace Mixture
 

--- a/src/mixture/src/4C_mixture_prestress_strategy_constant.cpp
+++ b/src/mixture/src/4C_mixture_prestress_strategy_constant.cpp
@@ -52,7 +52,7 @@ void Mixture::ConstantPrestressStrategy::setup(Mixture::MixtureConstituent& cons
 void Mixture::ConstantPrestressStrategy::evaluate_prestress(const MixtureRule& mixtureRule,
     const std::shared_ptr<const Mat::CoordinateSystemProvider> cosy,
     Mixture::MixtureConstituent& constituent, Core::LinAlg::SymmetricTensor<double, 3, 3>& G,
-    const Teuchos::ParameterList& params, int gp, int eleGID)
+    const Teuchos::ParameterList& params, const Mat::EvaluationContext& context, int gp, int eleGID)
 {
   // setup prestretch
   const Core::LinAlg::Matrix<6, 1> prestretch_vector(params_->prestretch_.data(), true);
@@ -63,8 +63,8 @@ void Mixture::ConstantPrestressStrategy::evaluate_prestress(const MixtureRule& m
 void Mixture::ConstantPrestressStrategy::update(
     const std::shared_ptr<const Mat::CoordinateSystemProvider> anisotropy,
     Mixture::MixtureConstituent& constituent, const Core::LinAlg::Tensor<double, 3, 3>& F,
-    Core::LinAlg::SymmetricTensor<double, 3, 3>& G, const Teuchos::ParameterList& params, int gp,
-    int eleGID)
+    Core::LinAlg::SymmetricTensor<double, 3, 3>& G, const Teuchos::ParameterList& params,
+    const Mat::EvaluationContext& context, int gp, int eleGID)
 {
 }
 FOUR_C_NAMESPACE_CLOSE

--- a/src/mixture/src/4C_mixture_prestress_strategy_constant.hpp
+++ b/src/mixture/src/4C_mixture_prestress_strategy_constant.hpp
@@ -61,12 +61,13 @@ namespace Mixture
     void evaluate_prestress(const MixtureRule& mixtureRule,
         const std::shared_ptr<const Mat::CoordinateSystemProvider> cosy,
         Mixture::MixtureConstituent& constituent, Core::LinAlg::SymmetricTensor<double, 3, 3>& G,
-        const Teuchos::ParameterList& params, int gp, int eleGID) override;
+        const Teuchos::ParameterList& params, const Mat::EvaluationContext& context, int gp,
+        int eleGID) override;
 
     void update(const std::shared_ptr<const Mat::CoordinateSystemProvider> anisotropy,
         Mixture::MixtureConstituent& constituent, const Core::LinAlg::Tensor<double, 3, 3>& F,
         Core::LinAlg::SymmetricTensor<double, 3, 3>& G, const Teuchos::ParameterList& params,
-        int gp, int eleGID) override;
+        const Mat::EvaluationContext& context, int gp, int eleGID) override;
 
    private:
     /// Holder for internal parameters

--- a/src/mixture/src/4C_mixture_prestress_strategy_isocyl.hpp
+++ b/src/mixture/src/4C_mixture_prestress_strategy_isocyl.hpp
@@ -11,6 +11,7 @@
 #include "4C_config.hpp"
 
 #include "4C_linalg_fixedsizematrix.hpp"
+#include "4C_mat_so3_material.hpp"
 #include "4C_mixture_elastin_membrane_prestress_strategy.hpp"
 #include "4C_mixture_prestress_strategy.hpp"
 
@@ -18,6 +19,10 @@
 
 FOUR_C_NAMESPACE_OPEN
 
+namespace Mat
+{
+  struct EvaluationContext;
+}
 namespace Mixture
 {
   // forward declaration
@@ -66,17 +71,19 @@ namespace Mixture
     double evaluate_mue_frac(MixtureRule& mixtureRule,
         const std::shared_ptr<const Mat::CoordinateSystemProvider> cosy,
         Mixture::MixtureConstituent& constituent, ElastinMembraneEvaluation& membraneEvaluation,
-        const Teuchos::ParameterList& params, int gp, int eleGID) const override;
+        const Teuchos::ParameterList& params, const Mat::EvaluationContext& context, int gp,
+        int eleGID) const override;
 
     void evaluate_prestress(const MixtureRule& mixtureRule,
         const std::shared_ptr<const Mat::CoordinateSystemProvider> cosy,
         Mixture::MixtureConstituent& constituent, Core::LinAlg::SymmetricTensor<double, 3, 3>& G,
-        const Teuchos::ParameterList& params, int gp, int eleGID) override;
+        const Teuchos::ParameterList& params, const Mat::EvaluationContext& context, int gp,
+        int eleGID) override;
 
     void update(const std::shared_ptr<const Mat::CoordinateSystemProvider> anisotropy,
         Mixture::MixtureConstituent& constituent, const Core::LinAlg::Tensor<double, 3, 3>& F,
         Core::LinAlg::SymmetricTensor<double, 3, 3>& G, const Teuchos::ParameterList& params,
-        int gp, int eleGID) override;
+        const Mat::EvaluationContext& context, int gp, int eleGID) override;
 
    private:
     /// Holder for internal parameters

--- a/src/mixture/src/4C_mixture_prestress_strategy_iterative.cpp
+++ b/src/mixture/src/4C_mixture_prestress_strategy_iterative.cpp
@@ -52,7 +52,7 @@ void Mixture::IterativePrestressStrategy::setup(Mixture::MixtureConstituent& con
 void Mixture::IterativePrestressStrategy::evaluate_prestress(const MixtureRule& mixtureRule,
     const std::shared_ptr<const Mat::CoordinateSystemProvider> cosy,
     Mixture::MixtureConstituent& constituent, Core::LinAlg::SymmetricTensor<double, 3, 3>& G,
-    const Teuchos::ParameterList& params, int gp, int eleGID)
+    const Teuchos::ParameterList& params, const Mat::EvaluationContext& context, int gp, int eleGID)
 {
   // Start with zero prestretch
   G = Core::LinAlg::TensorGenerators::identity<double, 3, 3>;
@@ -61,8 +61,8 @@ void Mixture::IterativePrestressStrategy::evaluate_prestress(const MixtureRule& 
 void Mixture::IterativePrestressStrategy::update(
     const std::shared_ptr<const Mat::CoordinateSystemProvider> anisotropy,
     Mixture::MixtureConstituent& constituent, const Core::LinAlg::Tensor<double, 3, 3>& F,
-    Core::LinAlg::SymmetricTensor<double, 3, 3>& G, const Teuchos::ParameterList& params, int gp,
-    int eleGID)
+    Core::LinAlg::SymmetricTensor<double, 3, 3>& G, const Teuchos::ParameterList& params,
+    const Mat::EvaluationContext& context, int gp, int eleGID)
 {
   // only update prestress if it is active
   if (!params_->is_active_) return;

--- a/src/mixture/src/4C_mixture_prestress_strategy_iterative.hpp
+++ b/src/mixture/src/4C_mixture_prestress_strategy_iterative.hpp
@@ -72,12 +72,13 @@ namespace Mixture
     void evaluate_prestress(const MixtureRule& mixtureRule,
         const std::shared_ptr<const Mat::CoordinateSystemProvider> cosy,
         Mixture::MixtureConstituent& constituent, Core::LinAlg::SymmetricTensor<double, 3, 3>& G,
-        const Teuchos::ParameterList& params, int gp, int eleGID) override;
+        const Teuchos::ParameterList& params, const Mat::EvaluationContext& context, int gp,
+        int eleGID) override;
 
     void update(const std::shared_ptr<const Mat::CoordinateSystemProvider> anisotropy,
         Mixture::MixtureConstituent& constituent, const Core::LinAlg::Tensor<double, 3, 3>& F,
         Core::LinAlg::SymmetricTensor<double, 3, 3>& G, const Teuchos::ParameterList& params,
-        int gp, int eleGID) override;
+        const Mat::EvaluationContext& context, int gp, int eleGID) override;
 
    private:
     /// Holder for internal parameters

--- a/src/mixture/src/4C_mixture_rule.hpp
+++ b/src/mixture/src/4C_mixture_rule.hpp
@@ -13,6 +13,7 @@
 #include "4C_linalg_fixedsizematrix.hpp"
 #include "4C_linalg_symmetric_tensor.hpp"
 #include "4C_linalg_tensor.hpp"
+#include "4C_mat_so3_material.hpp"
 #include "4C_material_parameter_base.hpp"
 #include "4C_solid_3D_ele_fibers.hpp"
 #include "4C_utils_exceptions.hpp"
@@ -43,6 +44,7 @@ namespace Mat
 {
   class Anisotropy;
   class Material;
+  struct EvaluationContext;
   namespace PAR
   {
     class Material;
@@ -171,7 +173,8 @@ namespace Mixture
      * @param eleGID (in) : Global element id
      */
     virtual void update(Core::LinAlg::Tensor<double, 3, 3> const& F,
-        const Teuchos::ParameterList& params, const int gp, const int eleGID)
+        const Teuchos::ParameterList& params, const Mat::EvaluationContext& context, const int gp,
+        const int eleGID)
     {
       // Nothing needs to be updated in this simple mixture rule
     }
@@ -192,7 +195,8 @@ namespace Mixture
      * @param gp (in) : Gauss point
      * @param eleGID (in) : Global element id
      */
-    virtual void pre_evaluate(const Teuchos::ParameterList& params, const int gp, const int eleGID)
+    virtual void pre_evaluate(const Teuchos::ParameterList& params,
+        const Mat::EvaluationContext& context, const int gp, const int eleGID)
     {
       // do nothing in the default case
     }
@@ -211,7 +215,7 @@ namespace Mixture
      */
     virtual void evaluate(const Core::LinAlg::Tensor<double, 3, 3>& F,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& E, const Teuchos::ParameterList& params,
-        Core::LinAlg::SymmetricTensor<double, 3, 3>& S,
+        const Mat::EvaluationContext& context, Core::LinAlg::SymmetricTensor<double, 3, 3>& S,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) = 0;
 
     /*!

--- a/src/mixture/src/4C_mixture_rule_function.hpp
+++ b/src/mixture/src/4C_mixture_rule_function.hpp
@@ -59,7 +59,7 @@ namespace Mixture
 
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>& F,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& E, const Teuchos::ParameterList& params,
-        Core::LinAlg::SymmetricTensor<double, 3, 3>& S,
+        const Mat::EvaluationContext& context, Core::LinAlg::SymmetricTensor<double, 3, 3>& S,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
     [[nodiscard]] double return_mass_density() const override

--- a/src/mixture/src/4C_mixture_rule_growthremodel.hpp
+++ b/src/mixture/src/4C_mixture_rule_growthremodel.hpp
@@ -98,11 +98,12 @@ namespace Mixture
     void setup(const Teuchos::ParameterList& params, int eleGID) override;
 
     void update(Core::LinAlg::Tensor<double, 3, 3> const& F, const Teuchos::ParameterList& params,
-        int gp, int eleGID) override;
+        const Mat::EvaluationContext& context, int gp, int eleGID) override;
 
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>& F,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& E_strain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
+        const Teuchos::ParameterList& params, const Mat::EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
     /*!

--- a/src/mixture/src/4C_mixture_rule_simple.cpp
+++ b/src/mixture/src/4C_mixture_rule_simple.cpp
@@ -54,7 +54,8 @@ void Mixture::SimpleMixtureRule::setup(const Teuchos::ParameterList& params, int
 
 void Mixture::SimpleMixtureRule::evaluate(const Core::LinAlg::Tensor<double, 3, 3>& F,
     const Core::LinAlg::SymmetricTensor<double, 3, 3>& E_strain,
-    const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
+    const Teuchos::ParameterList& params, const Mat::EvaluationContext& context,
+    Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
     Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, const int gp, const int eleGID)
 {
   // define temporary matrices
@@ -68,7 +69,7 @@ void Mixture::SimpleMixtureRule::evaluate(const Core::LinAlg::Tensor<double, 3, 
     MixtureConstituent& constituent = *constituents()[i];
     cstress = {};
     ccmat = {};
-    constituent.evaluate(F, E_strain, params, cstress, ccmat, gp, eleGID);
+    constituent.evaluate(F, E_strain, params, context, cstress, ccmat, gp, eleGID);
 
     // Add stress contribution to global stress
     // In this basic mixture rule, the mass fractions do not change

--- a/src/mixture/src/4C_mixture_rule_simple.hpp
+++ b/src/mixture/src/4C_mixture_rule_simple.hpp
@@ -68,7 +68,8 @@ namespace Mixture
 
     void evaluate(const Core::LinAlg::Tensor<double, 3, 3>& F,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& E_strain,
-        const Teuchos::ParameterList& params, Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
+        const Teuchos::ParameterList& params, const Mat::EvaluationContext& context,
+        Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
     void setup(const Teuchos::ParameterList& params, int eleGID) override;

--- a/src/shell7p/4C_shell7p_ele_calc_lib.hpp
+++ b/src/shell7p/4C_shell7p_ele_calc_lib.hpp
@@ -158,7 +158,8 @@ namespace Discret::Elements::Shell
    */
   template <int dim>
   Stress<Mat::NUM_STRESS_3D> evaluate_material_stress_cartesian_system(Mat::So3Material& material,
-      const Strains& strains, Teuchos::ParameterList& params, int gp, int eleGID)
+      const Strains& strains, Teuchos::ParameterList& params, const Mat::EvaluationContext& context,
+      int gp, int eleGID)
   {
     if (dim != 3) FOUR_C_THROW("stop: this currently only works for 3D");
     Discret::Elements::Shell::Stress<Mat::NUM_STRESS_3D> stress;
@@ -172,8 +173,7 @@ namespace Discret::Elements::Shell
     Core::LinAlg::SymmetricTensor<double, 3, 3> gl_strain =
         Core::LinAlg::make_symmetric_tensor_from_stress_like_voigt_matrix(gl_stress);
 
-
-    material.evaluate(&defgrd, gl_strain, params, pk2, cmat, gp, eleGID);
+    material.evaluate(&defgrd, gl_strain, params, context, pk2, cmat, gp, eleGID);
 
     stress.pk2_ = {Core::LinAlg::make_stress_like_voigt_view(pk2), false};
     stress.cmat_ = {Core::LinAlg::make_stress_like_voigt_view(cmat), false};

--- a/src/solid_3D_ele/4C_solid_3D_ele_calc_lib.hpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_calc_lib.hpp
@@ -834,10 +834,11 @@ namespace Discret::Elements
       const Core::LinAlg::Tensor<double, Core::FE::dim<celltype>, Core::FE::dim<celltype>>& defgrd,
       const Core::LinAlg::SymmetricTensor<double, Core::FE::dim<celltype>, Core::FE::dim<celltype>>&
           gl_strain,
-      Teuchos::ParameterList& params, const int gp, const int eleGID)
+      Teuchos::ParameterList& params, const Mat::EvaluationContext& context, const int gp,
+      const int eleGID)
   {
     Stress<celltype> stress{};
-    material.evaluate(&defgrd, gl_strain, params, stress.pk2_, stress.cmat_, gp, eleGID);
+    material.evaluate(&defgrd, gl_strain, params, context, stress.pk2_, stress.cmat_, gp, eleGID);
     return stress;
   }
 
@@ -1165,26 +1166,6 @@ namespace Discret::Elements
           error_result.integrated_volume += integration_factor;
         });
     return error_result;
-  }
-
-  /*!
-   * @brief Evaluates the Gauss point coordinates in reference configuration
-   * and adds those to the parameter list
-   *
-   * @tparam celltype : Cell type
-   * @param nodal_coordinates (in) : Reference and current coordinates of the nodes of the element
-   * @param shape_functions_gp (in) : Shape functions evaluated at the Gauss point
-   * @param params (in/out) : ParameterList the quantities are added to
-   */
-  template <Core::FE::CellType celltype>
-  void evaluate_gp_coordinates_and_add_to_parameter_list(
-      const ElementNodes<celltype>& nodal_coordinates,
-      const ShapeFunctionsAndDerivatives<celltype>& shape_functions_gp,
-      Teuchos::ParameterList& params)
-  {
-    auto gp_ref_coord = evaluate_reference_coordinate<celltype>(
-        nodal_coordinates.reference_coordinates, shape_functions_gp.shapefunctions_);
-    params.set("gp_coords_ref", gp_ref_coord);
   }
 
   /*!

--- a/src/solid_3D_ele/4C_solid_3D_ele_surface_traceestimate.cpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_surface_traceestimate.cpp
@@ -144,8 +144,14 @@ void Discret::Elements::SolidSurface::trace_estimate_vol_matrix(
       *scalar_values_at_xi = Core::FE::interpolate_to_xi<dt_vol>(xi, parent_scalar);
       params.set("scalars", scalar_values_at_xi);
     }
+
+    Core::LinAlg::Tensor<double, 3> xi_t = {{xi(0), xi(1), xi(2)}};
+    Mat::EvaluationContext context{.total_time = nullptr,  // Do not have the time here
+        .time_step_size = nullptr,                         // Do not have the time-step here
+        .xi = &xi_t,
+        .ref_coords = nullptr};
     std::dynamic_pointer_cast<Mat::So3Material>(parent_element()->material())
-        ->evaluate(&defgrd, glstrain, params, stress, cmat, gp, parent_element()->id());
+        ->evaluate(&defgrd, glstrain, params, context, stress, cmat, gp, parent_element()->id());
     bc.multiply_tn(bop, Core::LinAlg::make_stress_like_voigt_view(cmat));
     vol.multiply(ip.ip().qwgt[gp] * jac, bc, bop, 1.);
   }
@@ -211,8 +217,14 @@ void Discret::Elements::SolidSurface::trace_estimate_surf_matrix(
       *scalar_values_at_xi = Core::FE::interpolate_to_xi<dt_vol>(xi, parent_scalar);
       params.set("scalars", scalar_values_at_xi);
     }
+
+    Core::LinAlg::Tensor<double, 3> xi_t = {{xi(0), xi(1), xi(2)}};
+    Mat::EvaluationContext context{.total_time = nullptr,  // Do not have the time here
+        .time_step_size = nullptr,                         // Do not have the time-step here
+        .xi = &xi_t,
+        .ref_coords = nullptr};
     std::dynamic_pointer_cast<Mat::So3Material>(parent_element()->material())
-        ->evaluate(&defgrd, glstrain, params, stress, cmat, gp, parent_element()->id());
+        ->evaluate(&defgrd, glstrain, params, context, stress, cmat, gp, parent_element()->id());
 
     double normalfac = 1.0;
     if (shape() == Core::FE::CellType::nurbs9)

--- a/src/w1/4C_w1.hpp
+++ b/src/w1/4C_w1.hpp
@@ -645,7 +645,8 @@ namespace Discret
           const int numeps,                                     ///< number of strains
           std::shared_ptr<const Core::Mat::Material> material,  ///< the material data
           Teuchos::ParameterList& params,                       ///< element parameter list
-          int gp                                                ///< Gauss point
+          const Mat::EvaluationContext& context,
+          int gp  ///< Gauss point
       );
 
       /// Stress and constitutive matrix mapper from 3d to 2d
@@ -655,7 +656,8 @@ namespace Discret
           Core::LinAlg::SerialDenseMatrix& C,             ///< elasticity matrix
           const Core::LinAlg::SerialDenseVector& strain,  ///< Green-Lagrange strain vector
           Teuchos::ParameterList& params,                 ///< element parameter list
-          int gp                                          ///< Gauss point
+          const Mat::EvaluationContext& context,
+          int gp  ///< Gauss point
       );
 
       /// Generic 3D stress response
@@ -666,7 +668,8 @@ namespace Discret
           const Core::LinAlg::SymmetricTensor<double, 3, 3>&
               glstrain,                    ///< 3D Green-Lagrange strain vector
           Teuchos::ParameterList& params,  ///< element parameter list
-          int gp                           ///< Gauss point
+          const Mat::EvaluationContext& context,
+          int gp  ///< Gauss point
       );
 
       /// Map plane Green-Lagrange strains to 3d
@@ -680,8 +683,9 @@ namespace Discret
       double energy_internal(
           std::shared_ptr<const Core::Mat::Material> material,  ///< element material
           Teuchos::ParameterList& params,                       ///< element parameter list
-          const Core::LinAlg::SerialDenseVector& Ev,            ///< Green-Lagrange strain vector
-          int gp                                                ///< Gauss point
+          const Mat::EvaluationContext& context,
+          const Core::LinAlg::SerialDenseVector& Ev,  ///< Green-Lagrange strain vector
+          int gp                                      ///< Gauss point
       );
 
       /// Kinetic Energy

--- a/src/w1/4C_w1_evaluate.cpp
+++ b/src/w1/4C_w1_evaluate.cpp
@@ -776,6 +776,10 @@ void Discret::Elements::Wall1::w1_nlnstiffmass(const std::vector<int>& lm,
     w1_eassetup(boplin0, F0, xjm0, detJ0, xrefe, xcure, distype);
   }
 
+  const double* total_time =
+      params.isParameter("total time") ? &params.get<double>("total time") : nullptr;
+  const double* time_step_size =
+      params.isParameter("delta time") ? &params.get<double>("delta time") : nullptr;
   /*=================================================== integration loops */
   for (int ip = 0; ip < intpoints.nquad; ++ip)
   {
@@ -841,7 +845,12 @@ void Discret::Elements::Wall1::w1_nlnstiffmass(const std::vector<int>& lm,
       /*-----total deformation gradient, Green-Lagrange-strain E^F -----------*/
       w1_call_defgrad_tot(F_enh, F_tot, F, strain);
       /* call material law----------------------------------------------------*/
-      w1_call_matgeononl(strain, stress, C, numeps, material, params, ip);
+      Core::LinAlg::Tensor<double, 3> xi = {{e1, e2, 0.0}};
+      Mat::EvaluationContext context{.total_time = total_time,
+          .time_step_size = time_step_size,
+          .xi = &xi,
+          .ref_coords = nullptr};
+      w1_call_matgeononl(strain, stress, C, numeps, material, params, context, ip);
 
       // return gp strains (only in case of strain output)
       switch (iostrain)
@@ -902,7 +911,12 @@ void Discret::Elements::Wall1::w1_nlnstiffmass(const std::vector<int>& lm,
     }
     else
     {
-      w1_call_matgeononl(strain, stress, C, numeps, material, params, ip);
+      Core::LinAlg::Tensor<double, 3> xi = {{e1, e2, 0.0}};
+      Mat::EvaluationContext context{.total_time = total_time,
+          .time_step_size = time_step_size,
+          .xi = &xi,
+          .ref_coords = nullptr};
+      w1_call_matgeononl(strain, stress, C, numeps, material, params, context, ip);
 
       // return gp strains (only in case of strain output)
       switch (iostrain)
@@ -1075,6 +1089,10 @@ void Discret::Elements::Wall1::w1_linstiffmass(const std::vector<int>& lm,
     }
   }
 
+  const double* total_time =
+      params.isParameter("total time") ? &params.get<double>("total time") : nullptr;
+  const double* time_step_size =
+      params.isParameter("delta time") ? &params.get<double>("delta time") : nullptr;
   /*=================================================== integration loops */
   for (int ip = 0; ip < intpoints.nquad; ++ip)
   {
@@ -1133,7 +1151,12 @@ void Discret::Elements::Wall1::w1_linstiffmass(const std::vector<int>& lm,
     strain[3] = strain[2];
 
     // material call
-    w1_call_matgeononl(strain, stress, C, numeps, material, params, ip);
+    Core::LinAlg::Tensor<double, 3> xi = {{e1, e2, 0.0}};
+    Mat::EvaluationContext context{.total_time = total_time,
+        .time_step_size = time_step_size,
+        .xi = &xi,
+        .ref_coords = nullptr};
+    w1_call_matgeononl(strain, stress, C, numeps, material, params, context, ip);
 
     // return gp strains (only in case of strain output)
     switch (iostrain)
@@ -1545,6 +1568,10 @@ void Discret::Elements::Wall1::energy(Teuchos::ParameterList& params, const std:
     w1_defgrad(Fuv0, Ev, Xe, xe, boplin0, numnode);  // at t_{n}
   }
 
+  const double* total_time =
+      params.isParameter("total time") ? &params.get<double>("total time") : nullptr;
+  const double* time_step_size =
+      params.isParameter("delta time") ? &params.get<double>("delta time") : nullptr;
   // integration loops over element domain
   for (int ip = 0; ip < intpoints.nquad; ++ip)
   {
@@ -1585,7 +1612,12 @@ void Discret::Elements::Wall1::energy(Teuchos::ParameterList& params, const std:
       w1_call_defgrad_tot(Fenhv, Fm, Fuv, Ev);  // at t_{n}
     }
 
-    internal_energy += fac * energy_internal(material, params, Ev, ip);
+    Core::LinAlg::Tensor<double, 3> xi = {{xi1, xi2, 0.0}};
+    Mat::EvaluationContext context{.total_time = total_time,
+        .time_step_size = time_step_size,
+        .xi = &xi,
+        .ref_coords = nullptr};
+    internal_energy += fac * energy_internal(material, params, context, Ev, ip);
   }  // end loop Gauss points
 
 

--- a/unittests/mat/4C_druckerprager_test.cpp
+++ b/unittests/mat/4C_druckerprager_test.cpp
@@ -16,6 +16,7 @@
 #include "4C_mat_par_bundle.hpp"
 #include "4C_mat_plasticdruckerprager.hpp"
 #include "4C_mat_service.hpp"
+#include "4C_mat_so3_material.hpp"
 #include "4C_material_base.hpp"
 #include "4C_material_parameter_base.hpp"
 #include "4C_unittest_utils_assertions_test.hpp"
@@ -95,7 +96,13 @@ namespace
     FourC::Mat::PlasticDruckerPrager plastic;
     Core::Communication::UnpackBuffer buffer(dataSend);
     plastic.unpack(buffer);
-    plastic.evaluate(nullptr, input_strain, paras, result_stress, result_cmat, 0, 0);
+    double total_time = 0.0;
+    double time_step_size = 1.0;
+    Mat::EvaluationContext context{.total_time = &total_time,
+        .time_step_size = &time_step_size,
+        .xi = {},
+        .ref_coords = nullptr};
+    plastic.evaluate(nullptr, input_strain, paras, context, result_stress, result_cmat, 0, 0);
     FOUR_C_EXPECT_NEAR(result_stress, ref_stress, 1.0e-12);
   };
 
@@ -127,7 +134,13 @@ namespace
     }
     Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3> result_cmat{};
     Core::LinAlg::SymmetricTensor<double, 3, 3> result_stress{};
-    druckprag_->evaluate(nullptr, input_strain, paras, result_stress, result_cmat, 0, 0);
+    double total_time = 0.0;
+    double time_step_size = 1.0;
+    Mat::EvaluationContext context{.total_time = &total_time,
+        .time_step_size = &time_step_size,
+        .xi = {},
+        .ref_coords = nullptr};
+    druckprag_->evaluate(nullptr, input_strain, paras, context, result_stress, result_cmat, 0, 0);
     FOUR_C_EXPECT_NEAR(result_stress, ref_stress, 1.0e-12);
   };
 
@@ -146,7 +159,13 @@ namespace
         (1 - ((1.0 / (2 * (1.0 + 0.25))) * Dgamma / (2.2 * sqrt(3) / 2.5))) * 2.2;
     Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3> result_cmat{};
     Core::LinAlg::SymmetricTensor<double, 3, 3> result_stress{};
-    druckprag_->evaluate(nullptr, input_strain, paras, result_stress, result_cmat, 0, 0);
+    double total_time = 0.0;
+    double time_step_size = 1.0;
+    Mat::EvaluationContext context{.total_time = &total_time,
+        .time_step_size = &time_step_size,
+        .xi = {},
+        .ref_coords = nullptr};
+    druckprag_->evaluate(nullptr, input_strain, paras, context, result_stress, result_cmat, 0, 0);
     FOUR_C_EXPECT_NEAR(result_stress, ref_stress, 1.0e-12);
   };
 
@@ -161,7 +180,13 @@ namespace
     for (int i = 0; i < 3; ++i) ref_stress(i, i) = 2.0 - (10. / 15.) * (3. / 5.);
     Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3> result_cmat{};
     Core::LinAlg::SymmetricTensor<double, 3, 3> result_stress{};
-    druckprag_->evaluate(nullptr, input_strain, paras, result_stress, result_cmat, 0, 0);
+    double total_time = 0.0;
+    double time_step_size = 1.0;
+    Mat::EvaluationContext context{.total_time = &total_time,
+        .time_step_size = &time_step_size,
+        .xi = {},
+        .ref_coords = nullptr};
+    druckprag_->evaluate(nullptr, input_strain, paras, context, result_stress, result_cmat, 0, 0);
     FOUR_C_EXPECT_NEAR(result_stress, ref_stress, 1.0e-12);
   };
 
@@ -237,7 +262,13 @@ namespace
     ref_stress(0, 2) = 0.2613249104715;
     Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3> result_cmat{};
     Core::LinAlg::SymmetricTensor<double, 3, 3> result_stress{};
-    druckprag_->evaluate(nullptr, input_strain, paras, result_stress, result_cmat, 0, 0);
+    double total_time = 0.0;
+    double time_step_size = 1.0;
+    Mat::EvaluationContext context{.total_time = &total_time,
+        .time_step_size = &time_step_size,
+        .xi = {},
+        .ref_coords = nullptr};
+    druckprag_->evaluate(nullptr, input_strain, paras, context, result_stress, result_cmat, 0, 0);
     FOUR_C_EXPECT_NEAR(result_stress, ref_stress, 1.0e-12);
   };
 

--- a/unittests/mat/4C_inelastic_defgrad_factors_test.cpp
+++ b/unittests/mat/4C_inelastic_defgrad_factors_test.cpp
@@ -15,6 +15,7 @@
 #include "4C_mat_electrode.hpp"
 #include "4C_mat_inelastic_defgrad_factors.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_mat_so3_material.hpp"
 #include "4C_mat_vplast_law.hpp"
 #include "4C_mat_vplast_reform_johnsoncook.hpp"
 #include "4C_solid_3D_ele_fibers.hpp"
@@ -118,7 +119,7 @@ namespace
           params_inelastic_defgrad_lin_scalar_iso_.get());
 
       // call pre_evaluate to set the concentration value
-      lin_scalar_iso_->pre_evaluate(params_lin, 0, 0);
+      lin_scalar_iso_->pre_evaluate(params_lin, {}, 0, 0);
 
       // create InelasticDefgradLinScalarAniso object initialize container for material parameters
       Core::IO::InputParameterContainer inelastic_defgrad_lin_scalar_aniso_data;
@@ -140,7 +141,7 @@ namespace
           params_inelastic_defgrad_lin_scalar_aniso_.get());
 
       // call pre_evaluate to set the concentration value
-      lin_scalar_aniso_->pre_evaluate(params_lin, 0, 0);
+      lin_scalar_aniso_->pre_evaluate(params_lin, {}, 0, 0);
 
       // InelasticDefgradPolyIntercalFracIso object initialize container for required electrode
       // material parameters
@@ -229,7 +230,7 @@ namespace
           params_inelastic_defgrad_poly_intercal_frac_.get());
 
       // call pre_evaluate to set the concentration value
-      poly_intercal_frac_iso_->pre_evaluate(params_poly, 0, 0);
+      poly_intercal_frac_iso_->pre_evaluate(params_poly, {}, 0, 0);
 
       // create InelasticDefgradPolyIntercalFracAniso object initialize container for material
       // parameters
@@ -260,7 +261,7 @@ namespace
           params_inelastic_defgrad_poly_intercal_frac_aniso_.get());
 
       // call pre_evaluate to set the concentration value
-      poly_intercal_frac_aniso_->pre_evaluate(params_poly, 0, 0);
+      poly_intercal_frac_aniso_->pre_evaluate(params_poly, {}, 0, 0);
 
       // create InelasticDefgradLinTempIso object initialize container for material parameters
       Core::IO::InputParameterContainer inelastic_defgrad_temp_iso_data;
@@ -280,7 +281,7 @@ namespace
       Teuchos::ParameterList params_temp{};
       params_temp.set<double>("temperature", 280.0);
       // call pre_evaluate to set the temperature
-      lin_temp_iso_->pre_evaluate(params_temp, 0, 0);
+      lin_temp_iso_->pre_evaluate(params_temp, {}, 0, 0);
 
 
       // create InelasticDefgradTransvIsotropElastViscoplast object initialize container for
@@ -404,11 +405,16 @@ namespace
 
       // parameter list for InelasticDefGradTransvIsotropElastViscoplast
       Teuchos::ParameterList param_list_transv_isotrop_elast_viscoplast{};
-      param_list_transv_isotrop_elast_viscoplast.set<double>("delta time", 1.0e-6);
-      // call pre_evaluate
+      double total_time = 0.2;
+      double time_step_size = 1e-6;
+      Mat::EvaluationContext context{.total_time = &total_time,
+          .time_step_size = &time_step_size,
+          .xi = {},
+          .ref_coords = nullptr};
       transv_isotrop_elast_viscoplast_->pre_evaluate(
-          param_list_transv_isotrop_elast_viscoplast, 0, 0);
-      isotrop_elast_viscoplast_->pre_evaluate(param_list_transv_isotrop_elast_viscoplast, 0, 0);
+          param_list_transv_isotrop_elast_viscoplast, context, 0, 0);
+      isotrop_elast_viscoplast_->pre_evaluate(
+          param_list_transv_isotrop_elast_viscoplast, context, 0, 0);
     }
 
     void set_up_state_quantities_solution()

--- a/unittests/mat/4C_multiplicative_split_defgrad_elasthyper_test.cpp
+++ b/unittests/mat/4C_multiplicative_split_defgrad_elasthyper_test.cpp
@@ -324,7 +324,7 @@ namespace
 
 
       // call pre evaluate to have concentration during actual call
-      multiplicative_split_defgrad_->pre_evaluate(params, 0, 0);
+      multiplicative_split_defgrad_->pre_evaluate(params, {}, 0, 0);
     }
 
     void set_ref_values_evaluated_sdi_fin()
@@ -489,10 +489,17 @@ namespace
     Core::LinAlg::Matrix<3, 1> d_cauchyndir_ddir(Core::LinAlg::Initialization::zero);
     Core::LinAlg::Matrix<9, 1> d_cauchyndir_dF(Core::LinAlg::Initialization::zero);
 
+
+    double total_time = 0.0;
+    double time_step_size = 1.0;
+    Mat::EvaluationContext context{.total_time = &total_time,
+        .time_step_size = &time_step_size,
+        .xi = {},
+        .ref_coords = nullptr};
     const double cauchy_n_dir =
         multiplicative_split_defgrad_->evaluate_cauchy_n_dir_and_derivatives(F_, n, dir,
-            &d_cauchyndir_dn, &d_cauchyndir_ddir, &d_cauchyndir_dF, nullptr, nullptr, nullptr, 0, 0,
-            &concentration, nullptr, nullptr, nullptr);
+            &d_cauchyndir_dn, &d_cauchyndir_ddir, &d_cauchyndir_dF, nullptr, nullptr, nullptr,
+            context, 0, &concentration, nullptr, nullptr, nullptr);
 
     const double cauchy_n_dir_ref(6.019860168755);
     Core::LinAlg::Matrix<3, 1> d_cauchyndir_dn_ref(Core::LinAlg::Initialization::zero);

--- a/unittests/mat/4C_stvenantkirchhoff_test.cpp
+++ b/unittests/mat/4C_stvenantkirchhoff_test.cpp
@@ -78,8 +78,14 @@ namespace
     Teuchos::ParameterList params{};
 
     // Call evaluate function with test strain
+    double total_time = 0.0;
+    double time_step_size = 1.0;
+    Mat::EvaluationContext context{.total_time = &total_time,
+        .time_step_size = &time_step_size,
+        .xi = {},
+        .ref_coords = nullptr};
     stvenantkirchhoff_->evaluate(
-        nullptr, input_glstrain_, params, result_stress, result_cmat, 0, 0);
+        nullptr, input_glstrain_, params, context, result_stress, result_cmat, 0, 0);
 
     // Test member function results using reference stress values
     FOUR_C_EXPECT_NEAR(result_stress, ref_stress_, 1.0e-4);
@@ -98,8 +104,15 @@ namespace
 
     int eleGID = 1;
 
+    double total_time = 0.0;
+    double time_step_size = 1.0;
+    Mat::EvaluationContext context{.total_time = &total_time,
+        .time_step_size = &time_step_size,
+        .xi = {},
+        .ref_coords = nullptr};
+
     // Call evaluate function with test strain
-    double result_psi = stvenantkirchhoff_->strain_energy(input_glstrain_, 0, eleGID);
+    double result_psi = stvenantkirchhoff_->strain_energy(input_glstrain_, context, 0, eleGID);
 
     // test result with respect to reference result
     EXPECT_NEAR(result_psi, ref_strain_energy, 1.0e-4);


### PR DESCRIPTION
This PR adds a struct with the evaluation context for providing the material with very basic information (time, timestep, xi, reference coordinates) without relying on the `ParameterList`.

We don't have basic information always readily available, so that the structs holds only pointers.

Part of #61