### PR TITLE
Use own structure for beam-to-solid penalty law data

### DIFF
--- a/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_mortar_manager_contact.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_mortar_manager_contact.cpp
@@ -66,7 +66,8 @@ BeamInteraction::BeamToSolidMortarManagerContact::get_penalty_regularization(
 
       // The -1 here is due to the way the lagrange multipliers are defined in the coupling
       // constraints.
-      const fad_type local_lambda = -1.0 * penalty_force(scaled_gap, *beam_to_solid_contact_params);
+      const fad_type local_lambda =
+          -1.0 * penalty_force(scaled_gap, beam_to_solid_contact_params->get_penalty_law());
       lambda->replace_local_value(lid, Core::FADUtils::cast_to_double(local_lambda));
       lambda_lin_constraint->replace_local_value(lid, local_lambda.dx(0));
       lambda_lin_kappa->replace_local_value(lid, local_lambda.dx(1));

--- a/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_surface_contact_pair.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_surface_contact_pair.cpp
@@ -120,8 +120,8 @@ void BeamInteraction::BeamToSolidSurfaceContactPairGapVariation<ScalarType, Beam
       }
 
       // Get the contact force.
-      ScalarType force =
-          penalty_force(gap, *this->params()->beam_to_solid_surface_contact_params());
+      ScalarType force = penalty_force(
+          gap, this->params()->beam_to_solid_surface_contact_params()->get_penalty_law());
 
       // Add the Gauss point contributions to the pair force vector.
       gap_variation_times_normal.scale(
@@ -221,7 +221,8 @@ void BeamInteraction::BeamToSolidSurfaceContactPairPotential<ScalarType, Beam,
 
       // Get the contact force.
       potential += projected_gauss_point.get_gauss_weight() * segment_jacobian *
-                   penalty_potential(gap, *this->params()->beam_to_solid_surface_contact_params());
+                   penalty_potential(gap,
+                       this->params()->beam_to_solid_surface_contact_params()->get_penalty_law());
     }
   }
 

--- a/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_surface_contact_pair_base.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_surface_contact_pair_base.cpp
@@ -154,7 +154,8 @@ void BeamInteraction::BeamToSolidSurfaceContactPairBase<ScalarType, Beam, Surfac
 
     u_beam = r_beam;
     u_beam -= X_beam;
-    const auto force = penalty_force(gap, *this->params()->beam_to_solid_surface_contact_params());
+    const auto force = penalty_force(
+        gap, this->params()->beam_to_solid_surface_contact_params()->get_penalty_law());
 
     for (unsigned int dim = 0; dim < 3; dim++)
     {

--- a/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_surface_contact_params.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_surface_contact_params.cpp
@@ -22,8 +22,7 @@ FOUR_C_NAMESPACE_OPEN
 BeamInteraction::BeamToSolidSurfaceContactParams::BeamToSolidSurfaceContactParams()
     : BeamToSolidParamsBase(),
       contact_type_(Inpar::BeamToSolid::BeamToSolidSurfaceContact::none),
-      penalty_law_(Inpar::BeamToSolid::BeamToSolidSurfaceContactPenaltyLaw::none),
-      penalty_parameter_g0_(0.0),
+      penalty_law_data_{},
       mortar_contact_configuration_(
           Inpar::BeamToSolid::BeamToSolidSurfaceContactMortarDefinedIn::none),
       output_params_ptr_(nullptr)
@@ -50,11 +49,13 @@ void BeamInteraction::BeamToSolidSurfaceContactParams::init()
     contact_type_ = Teuchos::getIntegralValue<Inpar::BeamToSolid::BeamToSolidSurfaceContact>(
         beam_to_solid_contact_params_list, "CONTACT_TYPE");
 
-    penalty_law_ =
+    penalty_law_data_.type =
         Teuchos::getIntegralValue<Inpar::BeamToSolid::BeamToSolidSurfaceContactPenaltyLaw>(
             beam_to_solid_contact_params_list, "PENALTY_LAW");
-
-    penalty_parameter_g0_ = beam_to_solid_contact_params_list.get<double>("PENALTY_PARAMETER_G0");
+    penalty_law_data_.penalty_parameter =
+        beam_to_solid_contact_params_list.get<double>("PENALTY_PARAMETER");
+    penalty_law_data_.penalty_parameter_g0 =
+        beam_to_solid_contact_params_list.get<double>("PENALTY_PARAMETER_G0");
 
     mortar_contact_configuration_ =
         Teuchos::getIntegralValue<Inpar::BeamToSolid::BeamToSolidSurfaceContactMortarDefinedIn>(

--- a/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_surface_contact_params.hpp
+++ b/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_surface_contact_params.hpp
@@ -12,6 +12,7 @@
 #include "4C_config.hpp"
 
 #include "4C_beaminteraction_beam_to_solid_params_base.hpp"
+#include "4C_beaminteraction_beam_to_solid_utils.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -60,17 +61,9 @@ namespace BeamInteraction
     }
 
     /**
-     * \brief Returns the type of penalty law.
+     * \brief Returns the information for the penalty law.
      */
-    inline Inpar::BeamToSolid::BeamToSolidSurfaceContactPenaltyLaw get_penalty_law() const
-    {
-      return penalty_law_;
-    }
-
-    /**
-     * \brief Returns the regularization parameter of the penalty law.
-     */
-    inline double get_penalty_parameter_g0() const { return penalty_parameter_g0_; }
+    inline const PenaltyLawParameters& get_penalty_law() const { return penalty_law_data_; }
 
     /**
      * \brief Returns the configuration where the mortar contact is defined in.
@@ -95,11 +88,8 @@ namespace BeamInteraction
     //! Type of contact constraints.
     Inpar::BeamToSolid::BeamToSolidSurfaceContact contact_type_;
 
-    //! Type of penalty law.
-    Inpar::BeamToSolid::BeamToSolidSurfaceContactPenaltyLaw penalty_law_;
-
-    //! Regularization parameter for the penalty law.
-    double penalty_parameter_g0_;
+    //! Penalty law parameters
+    PenaltyLawParameters penalty_law_data_;
 
     //! Configuration where the mortar contact is defined
     Inpar::BeamToSolid::BeamToSolidSurfaceContactMortarDefinedIn mortar_contact_configuration_;

--- a/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_utils.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_utils.cpp
@@ -32,36 +32,31 @@ FOUR_C_NAMESPACE_OPEN
  */
 template <typename ScalarType>
 ScalarType BeamInteraction::penalty_force(
-    const ScalarType& gap, const BeamToSolidSurfaceContactParams& contact_params)
+    const ScalarType& gap, const PenaltyLawParameters& penalty_law)
 {
-  const Inpar::BeamToSolid::BeamToSolidSurfaceContactPenaltyLaw penalty_law =
-      contact_params.get_penalty_law();
-  const double penalty_parameter = contact_params.get_penalty_parameter();
-
   ScalarType penalty_force = 0.0;
 
-  switch (penalty_law)
+  switch (penalty_law.type)
   {
     case Inpar::BeamToSolid::BeamToSolidSurfaceContactPenaltyLaw::linear:
     {
       if (gap < 0.0)
       {
-        penalty_force = -gap * penalty_parameter;
+        penalty_force = -gap * penalty_law.penalty_parameter;
       }
       break;
     }
     case Inpar::BeamToSolid::BeamToSolidSurfaceContactPenaltyLaw::linear_quadratic:
     {
-      const double penalty_parameter_g0 = contact_params.get_penalty_parameter_g0();
-
       if (gap < 0.0)
       {
-        penalty_force = 0.5 * (-2.0 * gap + penalty_parameter_g0) * penalty_parameter;
+        penalty_force =
+            0.5 * (-2.0 * gap + penalty_law.penalty_parameter_g0) * penalty_law.penalty_parameter;
       }
-      else if (gap < penalty_parameter_g0)
+      else if (gap < penalty_law.penalty_parameter_g0)
       {
-        penalty_force = 0.5 * std::pow(gap - penalty_parameter_g0, 2) * penalty_parameter /
-                        penalty_parameter_g0;
+        penalty_force = 0.5 * std::pow(gap - penalty_law.penalty_parameter_g0, 2) *
+                        penalty_law.penalty_parameter / penalty_law.penalty_parameter_g0;
       }
       break;
     }
@@ -78,38 +73,33 @@ ScalarType BeamInteraction::penalty_force(
  */
 template <typename ScalarType>
 ScalarType BeamInteraction::penalty_potential(
-    const ScalarType& gap, const BeamToSolidSurfaceContactParams& contact_params)
+    const ScalarType& gap, const PenaltyLawParameters& penalty_law)
 {
-  const Inpar::BeamToSolid::BeamToSolidSurfaceContactPenaltyLaw penalty_law =
-      contact_params.get_penalty_law();
-  const double penalty_parameter = contact_params.get_penalty_parameter();
-
   ScalarType penalty_potential = 0.0;
 
-  switch (penalty_law)
+  switch (penalty_law.type)
   {
     case Inpar::BeamToSolid::BeamToSolidSurfaceContactPenaltyLaw::linear:
     {
       if (gap < 0.0)
       {
-        penalty_potential = 0.5 * std::pow(gap, 2) * penalty_parameter;
+        penalty_potential = 0.5 * std::pow(gap, 2) * penalty_law.penalty_parameter;
       }
       break;
     }
     case Inpar::BeamToSolid::BeamToSolidSurfaceContactPenaltyLaw::linear_quadratic:
     {
-      const double penalty_parameter_g0 = contact_params.get_penalty_parameter_g0();
-
       if (gap < 0.0)
       {
-        penalty_potential = penalty_parameter / 6.0 *
-                            (3.0 * std::pow(gap, 2) - 3.0 * gap * penalty_parameter_g0 +
-                                std::pow(penalty_parameter_g0, 2));
+        penalty_potential = penalty_law.penalty_parameter / 6.0 *
+                            (3.0 * std::pow(gap, 2) - 3.0 * gap * penalty_law.penalty_parameter_g0 +
+                                std::pow(penalty_law.penalty_parameter_g0, 2));
       }
-      else if (gap < penalty_parameter_g0)
+      else if (gap < penalty_law.penalty_parameter_g0)
       {
-        penalty_potential = penalty_parameter / (6.0 * penalty_parameter_g0) *
-                            std::pow(penalty_parameter_g0 - gap, 3);
+        penalty_potential = penalty_law.penalty_parameter /
+                            (6.0 * penalty_law.penalty_parameter_g0) *
+                            std::pow(penalty_law.penalty_parameter_g0 - gap, 3);
       }
       break;
     }
@@ -846,11 +836,11 @@ namespace BeamInteraction
   using line_to_surface_patch_scalar_type_fixed_size_hermite_nurbs_9 =
       line_to_surface_patch_scalar_type_fixed_size<t_hermite, t_nurbs9>;
 
-#define initialize_template_penalty(scalar_type)                   \
-  template scalar_type penalty_force<scalar_type>(                 \
-      const scalar_type&, const BeamToSolidSurfaceContactParams&); \
-  template scalar_type penalty_potential<scalar_type>(             \
-      const scalar_type&, const BeamToSolidSurfaceContactParams&);
+#define initialize_template_penalty(scalar_type)        \
+  template scalar_type penalty_force<scalar_type>(      \
+      const scalar_type&, const PenaltyLawParameters&); \
+  template scalar_type penalty_potential<scalar_type>(  \
+      const scalar_type&, const PenaltyLawParameters&);
 
   initialize_template_penalty(double);
   initialize_template_penalty(fad_type_1st_order_2_variables);

--- a/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_utils.hpp
+++ b/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_utils.hpp
@@ -14,6 +14,7 @@
 #include "4C_beaminteraction_calc_utils.hpp"
 #include "4C_geometry_pair_element.hpp"
 #include "4C_geometry_pair_element_faces.hpp"
+#include "4C_inpar_beam_to_solid.hpp"
 #include "4C_linalg_fevector.hpp"
 
 #include <memory>
@@ -72,13 +73,23 @@ namespace BeamInteraction
       typename Core::FADUtils::HigherOrderFadType<1, Sacado::ELRFad::SLFad<double, 2>>::type;
 
   /**
+   * \brief Structure containing all parameters required for beam-to-solid penalty laws
+   */
+  struct PenaltyLawParameters
+  {
+    Inpar::BeamToSolid::BeamToSolidSurfaceContactPenaltyLaw type{
+        Inpar::BeamToSolid::BeamToSolidSurfaceContactPenaltyLaw::none};
+    double penalty_parameter = 0.0;
+    double penalty_parameter_g0 = 0.0;
+  };
+
+  /**
    * \brief Evaluate the penalty force depending on the gap function.
    * @param gap (in) Gap function value.
    * @return Penalty force.
    */
   template <typename ScalarType>
-  ScalarType penalty_force(
-      const ScalarType& gap, const BeamToSolidSurfaceContactParams& contact_params);
+  ScalarType penalty_force(const ScalarType& gap, const PenaltyLawParameters& penalty_law);
 
   /**
    * \brief Evaluate the penalty potential depending on the gap function.
@@ -86,8 +97,7 @@ namespace BeamInteraction
    * @return Penalty potential.
    */
   template <typename ScalarType>
-  ScalarType penalty_potential(
-      const ScalarType& gap, const BeamToSolidSurfaceContactParams& contact_params);
+  ScalarType penalty_potential(const ScalarType& gap, const PenaltyLawParameters& penalty_law);
 
   /**
    * \brief Get the number of Lagrange multiplicator values corresponding to the beam nodes and beam


### PR DESCRIPTION
## Description and Context

Add a lightweight data structure for the beam-to-solid penalty laws that can just be passed over instead of passing a larger parameters object. This will enable easy usage of the penalty laws from within multiple different beam-to-solid interactions.