### PR TITLE
Aggregate compile time trace in build job

### DIFF
--- a/.github/actions/analyze_compile_time_tracing/action.yml
+++ b/.github/actions/analyze_compile_time_tracing/action.yml
@@ -1,0 +1,63 @@
+name: Analyze compile time tracing output
+description: Analyze the compile time tracing output and optionally remove all individual files
+inputs:
+  build-directory:
+    description: Path to the build directory
+    required: true
+  aggregated-tracing-file:
+    description: Path to the output file with the aggregated tracing information
+    required: true
+  report-summary-file:
+    description: Path to the output file with the report summary
+    required: true
+  cleanup-individual-files:
+    description: Remove individual ninja tracing files after aggregation
+    required: false
+    default: "false"
+runs:
+  using: composite
+  steps:
+    # Analyze compile time with ClangBuildAnalyzer
+    - uses: actions/checkout@v5
+      with:
+        repository: aras-p/ClangBuildAnalyzer
+        ref: bae0cb488cce944bfc3da9850a69ad621701ebef # version 1.6.0
+        path: ClangBuildAnalyzer
+    - shell: bash
+      name: Build ClangBuildAnalyzer
+      run: |
+        cd $GITHUB_WORKSPACE/ClangBuildAnalyzer
+        cmake -B build -S . -DCMAKE_BUILD_TYPE=Release
+        cmake --build build
+    - shell: bash
+      name: Analyze compile time
+      run: |
+        $GITHUB_WORKSPACE/ClangBuildAnalyzer/build/ClangBuildAnalyzer --all $BUILD_DIRECTORY time_trace.bin
+        $GITHUB_WORKSPACE/ClangBuildAnalyzer/build/ClangBuildAnalyzer --analyze time_trace.bin > $SUMMARY_FILE
+        cat $SUMMARY_FILE
+      env:
+        BUILD_DIRECTORY: ${{ inputs.build-directory }}
+        SUMMARY_FILE: ${{ inputs.report-summary-file }}
+
+    # Aggregate individual tracing files with ninjatracing
+    - uses: actions/checkout@v5
+      with:
+        repository: nico/ninjatracing
+        ref: a669e3644cf22b29cbece31dbed2cfbf34e5f48e # no releases for this repo, this is a stable commit
+        path: ${{ github.workspace }}/ninjatracing
+    - shell: bash
+      name: Aggregate trace
+      run: |
+        $GITHUB_WORKSPACE/ninjatracing/ninjatracing -e $BUILD_DIRECTORY/.ninja_log > $TRACING_FILE
+      env:
+        BUILD_DIRECTORY: ${{ inputs.build-directory }}
+        TRACING_FILE: ${{ inputs.aggregated-tracing-file }}
+
+    # Optionally cleanup individual tracing files
+    - name: Cleanup individual tracing files
+      if: ${{ inputs.cleanup-individual-files == 'true' }}
+      shell: bash
+      run: |
+        find $BUILD_DIRECTORY -name '*.cpp.json' -type f -delete
+      env:
+        BUILD_DIRECTORY: ${{ inputs.build-directory }}

--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -113,6 +113,12 @@ jobs:
           build-directory: ${{ github.workspace }}/build
           use-ccache: "false"
           additional-cmake-flags: "-DFOUR_C_CXX_FLAGS=-ftime-trace"
+      - uses: ./.github/actions/analyze_compile_time_tracing
+        with:
+          build-directory: ${{ github.workspace }}/build
+          aggregated-tracing-file: ${{ github.workspace }}/clang18_build_trace.json
+          report-summary-file: ${{ github.workspace }}/clang18_compile_time_report.txt
+          cleanup-individual-files: "true"
       - uses: ./.github/actions/upload_directory
         name: Upload 4C build
         with:
@@ -133,6 +139,19 @@ jobs:
           path: |
             ${{ github.workspace }}/build/4C_metadata.yaml
           retention-days: 30
+      - name: Upload compile time tracing summary
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.job }}-time-trace-summary
+          path: |
+            ${{ github.workspace }}/clang18_compile_time_report.txt
+      - name: Upload Compile time Trace
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.job }}-time-trace
+          path: |
+            ${{ github.workspace }}/clang18_build_trace.json
+          retention-days: 30
       - uses: ./.github/actions/chunk_test_suite
         id: set-matrix
         with:
@@ -140,56 +159,6 @@ jobs:
           source-directory: ${{ github.workspace }}
           number-of-chunks: 15
           junit-report-artifact-name: clang18_test_report.xml
-
-  clang18_analyze_compile_time:
-    needs: clang18_build
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - uses: actions/checkout@v5
-      - uses: actions/checkout@v5
-        with:
-          repository: aras-p/ClangBuildAnalyzer
-          ref: bae0cb488cce944bfc3da9850a69ad621701ebef # version 1.6.0
-          path: ClangBuildAnalyzer
-      - uses: actions/checkout@v5
-        with:
-          repository: nico/ninjatracing
-          ref: a669e3644cf22b29cbece31dbed2cfbf34e5f48e # no releases for this repo, this is a stable commit
-          path: ninjatracing
-      - name: Build ClangBuildAnalyzer
-        run: |
-          cd $GITHUB_WORKSPACE/ClangBuildAnalyzer
-          cmake -B build -S . -DCMAKE_BUILD_TYPE=Release
-          cmake --build build
-      - uses: ./.github/actions/download_directory
-        with:
-          name: clang18_build
-          destination: ${{ github.workspace }}/build
-      - name: Analyze compile time
-        run: |
-          $GITHUB_WORKSPACE/ClangBuildAnalyzer/build/ClangBuildAnalyzer --all $GITHUB_WORKSPACE/build time_trace.bin
-          $GITHUB_WORKSPACE/ClangBuildAnalyzer/build/ClangBuildAnalyzer --analyze time_trace.bin > $GITHUB_WORKSPACE/clang18_compile_time_report.txt
-          cat $GITHUB_WORKSPACE/clang18_compile_time_report.txt
-      - name: Aggregate trace
-        run: |
-          $GITHUB_WORKSPACE/ninjatracing/ninjatracing -e $GITHUB_WORKSPACE/build/.ninja_log > $GITHUB_WORKSPACE/clang18_compile_time_trace.json
-      - name: Upload report
-        uses: actions/upload-artifact@v4
-        with:
-          name: clang18_compile_time_report.txt
-          path: |
-            ${{ github.workspace }}/clang18_compile_time_report.txt
-          retention-days: 90
-      - name: Upload trace
-        uses: actions/upload-artifact@v4
-        with:
-          name: clang18_compile_time_trace.json
-          path: |
-            ${{ github.workspace }}/clang18_compile_time_trace.json
-          retention-days: 90
 
   clang18_test:
     needs: clang18_build


### PR DESCRIPTION
Directly aggregate the compile time trace in the build job and clean all other time-trace json files to avoid running out of storage.

Closes #1361 

Let's see whether this works: https://github.com/amgebauer/4C/actions/runs/18407082001/job/52449454062