### PR TITLE
Publish clang18 compile time report

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: deploy
 
 on:
   workflow_run:
-    workflows: [documentation, coverage]
+    workflows: [documentation, coverage, nightly_tests]
     types: [completed]
     branches: [main]
 
@@ -38,6 +38,12 @@ jobs:
           workflow: coverage.yml
           name: 4C_coverage_report
           path: ${{ github.workspace }}/coverage_report
+          branch: ${{ github.event.repository.default_branch }}
+      - uses: dawidd6/action-download-artifact@v11
+        with:
+          workflow: nightly_tests.yml
+          name: clang18_compile_time_report
+          path: ${{ github.workspace }}
           branch: ${{ github.event.repository.default_branch }}
       - uses: actions/upload-pages-artifact@v4
         id: deployment

--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -160,6 +160,35 @@ jobs:
           number-of-chunks: 15
           junit-report-artifact-name: clang18_test_report.xml
 
+  clang18_compile_time_report:
+    needs: clang18_build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout Catapult repo
+        run: | # version from 2025-10-13
+          git clone https://chromium.googlesource.com/catapult --depth 1
+          cd catapult
+          git fetch origin 2f71f97f0b2d6f885dbeac39a7460863b10a14c0 --depth 1
+          git checkout FETCH_HEAD
+      - name: Download aggregated ninja trace
+        uses: actions/download-artifact@v5
+        with:
+          name: clang18_build-time-trace
+          path: ${{ github.workspace }}
+      - name: Generate compile time trace for clang 18 build
+        run: |
+          catapult/tracing/bin/trace2html $GITHUB_WORKSPACE/clang18_build_trace.json --output=$GITHUB_WORKSPACE/clang18_compile_time_report.html
+      - name: Upload trace
+        uses: actions/upload-artifact@v4
+        with:
+          name: clang18_compile_time_report
+          path: |
+            ${{ github.workspace }}/clang18_compile_time_report.html
+          retention-days: 90
+
   clang18_test:
     needs: clang18_build
     runs-on: ubuntu-latest

--- a/doc/documentation/src/developer_guide/compile_time_trace.rst
+++ b/doc/documentation/src/developer_guide/compile_time_trace.rst
@@ -1,0 +1,17 @@
+.. _compiletimetracereport:
+
+Clang Time Tracing
+==================
+
+Overview
+--------
+
+Clang's *time tracing* feature records detailed timing information during the
+compilation process. This helps identify slow compilation units and
+bottlenecks in the build system.
+
+In our project, a full time tracing run is executed **once per night** as part
+of nightly testing. The latest nightly Clang time tracing report is published
+automatically and can be viewed here:
+
+`View Nightly Time Trace Report <https://4c-multiphysics.github.io/4C/clang18_compile_time_report.html>`_

--- a/doc/documentation/src/developer_guide/developmentguide.rst
+++ b/doc/documentation/src/developer_guide/developmentguide.rst
@@ -13,6 +13,7 @@ Developer guide
     debugging_profiling
     doxygen
     coverage_report
+    compile_time_trace
     developer_ccache
     developer_cluster
     petra_object_model


### PR DESCRIPTION
Generate a static html report of your clang18 nightly job and publish it on our Github pages.