### PR TITLE
ArborX: Move print out of pure collision search

### DIFF
--- a/src/beaminteraction/src/4C_beaminteraction_submodel_evaluator_beamcontact.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_submodel_evaluator_beamcontact.cpp
@@ -964,8 +964,8 @@ void BeamInteraction::SubmodelEvaluator::BeamContact::find_and_store_neighboring
     }
 
     // Get colliding pairs.
-    const auto& collision_pairs = collision_search(other_bounding_boxes, beam_bounding_boxes,
-        discret().get_comm(), geometric_search_params_ptr_->verbosity_);
+    const auto& collision_pairs = collision_search_print_results(other_bounding_boxes,
+        beam_bounding_boxes, discret().get_comm(), geometric_search_params_ptr_->verbosity_);
 
     // Create the beam-to-xxx pair pointers according to the search.
     for (const auto& pair : collision_pairs)

--- a/src/core/geometric_search/src/4C_geometric_search_bvh.cpp
+++ b/src/core/geometric_search/src/4C_geometric_search_bvh.cpp
@@ -24,8 +24,7 @@ namespace Core::GeometricSearch
 {
   std::vector<CollisionSearchResult> collision_search(
       const std::vector<std::pair<int, BoundingVolume>>& primitives,
-      const std::vector<std::pair<int, BoundingVolume>>& predicates, MPI_Comm comm,
-      const Core::IO::Verbositylevel verbosity)
+      const std::vector<std::pair<int, BoundingVolume>>& predicates)
   {
 #ifndef FOUR_C_WITH_ARBORX
     FOUR_C_THROW(
@@ -83,16 +82,23 @@ namespace Core::GeometricSearch
       }
     }
 
-    if (verbosity == Core::IO::verbose)
-    {
-      Core::GeometricSearch::GeometricSearchInfo info = {static_cast<int>(primitives.size()),
-          static_cast<int>(predicates.size()), static_cast<int>(pairs.size())};
-      Core::GeometricSearch::print_geometric_search_details(comm, info);
-    }
-
     return pairs;
 
 #endif
+  }
+
+  std::vector<CollisionSearchResult> collision_search_print_results(
+      const std::vector<std::pair<int, BoundingVolume>>& primitives,
+      const std::vector<std::pair<int, BoundingVolume>>& predicates, const MPI_Comm comm,
+      const Core::IO::Verbositylevel verbosity)
+  {
+    auto pairs = collision_search(primitives, predicates);
+    print_geometric_search_details(comm,
+        {.primitive_size = primitives.size(),
+            .predicate_size = predicates.size(),
+            .coupling_pair_size = pairs.size()},
+        verbosity);
+    return pairs;
   }
 }  // namespace Core::GeometricSearch
 

--- a/src/core/geometric_search/src/4C_geometric_search_bvh.hpp
+++ b/src/core/geometric_search/src/4C_geometric_search_bvh.hpp
@@ -43,8 +43,6 @@ namespace Core::GeometricSearch
    *
    * @param primitives Bounding volumes to search for intersections
    * @param predicates Bounding volumes to intersect with
-   * @param comm Communicator object of the discretization
-   * @param verbosity Enabling printout of the geometric search information
    * @return pairs Vector of the found interaction pairs
    *
    * D. Lebrun-Grandie, A. Prokopenko, B. Turcksin, and S. R. Slattery. 2020.
@@ -54,7 +52,20 @@ namespace Core::GeometricSearch
    */
   std::vector<CollisionSearchResult> collision_search(
       const std::vector<std::pair<int, BoundingVolume>>& primitives,
-      const std::vector<std::pair<int, BoundingVolume>>& predicates, MPI_Comm comm,
+      const std::vector<std::pair<int, BoundingVolume>>& predicates);
+
+  /*! \brief Performs a local collision search between two sets of bounding volumes and prints the
+   * results.
+   *
+   * @param primitives Bounding volumes to search for intersections
+   * @param predicates Bounding volumes to intersect with
+   * @param comm Communicator object of the discretization
+   * @param verbosity Enabling printout of the geometric search information
+   * @return pairs Vector of the found interaction pairs
+   */
+  std::vector<CollisionSearchResult> collision_search_print_results(
+      const std::vector<std::pair<int, BoundingVolume>>& primitives,
+      const std::vector<std::pair<int, BoundingVolume>>& predicates, const MPI_Comm comm,
       const Core::IO::Verbositylevel verbosity);
 
 }  // namespace Core::GeometricSearch

--- a/src/core/geometric_search/src/4C_geometric_search_distributed_tree.cpp
+++ b/src/core/geometric_search/src/4C_geometric_search_distributed_tree.cpp
@@ -24,8 +24,7 @@ namespace Core::GeometricSearch
 {
   std::vector<GlobalCollisionSearchResult> global_collision_search(
       const std::vector<std::pair<int, BoundingVolume>>& primitives,
-      const std::vector<std::pair<int, BoundingVolume>>& predicates, MPI_Comm comm,
-      const Core::IO::Verbositylevel verbosity)
+      const std::vector<std::pair<int, BoundingVolume>>& predicates, const MPI_Comm comm)
   {
 #ifndef FOUR_C_WITH_ARBORX
     FOUR_C_THROW(
@@ -77,15 +76,22 @@ namespace Core::GeometricSearch
       }
     }
 
-    if (verbosity == Core::IO::verbose)
-    {
-      Core::GeometricSearch::GeometricSearchInfo info = {static_cast<int>(primitives.size()),
-          static_cast<int>(predicates.size()), static_cast<int>(pairs.size())};
-      Core::GeometricSearch::print_geometric_search_details(comm, info);
-    }
-
     return pairs;
 #endif
+  }
+
+  std::vector<GlobalCollisionSearchResult> global_collision_search_print_results(
+      const std::vector<std::pair<int, BoundingVolume>>& primitives,
+      const std::vector<std::pair<int, BoundingVolume>>& predicates, const MPI_Comm comm,
+      const Core::IO::Verbositylevel verbosity)
+  {
+    auto pairs = global_collision_search(primitives, predicates, comm);
+    print_geometric_search_details(comm,
+        {.primitive_size = primitives.size(),
+            .predicate_size = predicates.size(),
+            .coupling_pair_size = pairs.size()},
+        verbosity);
+    return pairs;
   }
 }  // namespace Core::GeometricSearch
 

--- a/src/core/geometric_search/src/4C_geometric_search_distributed_tree.hpp
+++ b/src/core/geometric_search/src/4C_geometric_search_distributed_tree.hpp
@@ -45,7 +45,6 @@ namespace Core::GeometricSearch
    * @param primitives Bounding volumes to search for intersections
    * @param predicates Bounding volumes to intersect with
    * @param comm Communicator object of the discretization
-   * @param verbosity Enabling printout of the geometric search information
    * @return Collision pairs found with their global and local IDs
    *
    * D. Lebrun-Grandie, A. Prokopenko, B. Turcksin, and S. R. Slattery. 2020.
@@ -55,7 +54,20 @@ namespace Core::GeometricSearch
    */
   std::vector<GlobalCollisionSearchResult> global_collision_search(
       const std::vector<std::pair<int, BoundingVolume>>& primitives,
-      const std::vector<std::pair<int, BoundingVolume>>& predicates, MPI_Comm comm,
+      const std::vector<std::pair<int, BoundingVolume>>& predicates, const MPI_Comm comm);
+
+  /*! \brief Performs a global collision search between two sets of bounding volumes and prints the
+   * results.
+   *
+   * @param primitives Bounding volumes to search for intersections
+   * @param predicates Bounding volumes to intersect with
+   * @param comm Communicator object of the discretization
+   * @param verbosity Enabling printout of the geometric search information
+   * @return Collision pairs found with their global and local IDs
+   */
+  std::vector<GlobalCollisionSearchResult> global_collision_search_print_results(
+      const std::vector<std::pair<int, BoundingVolume>>& primitives,
+      const std::vector<std::pair<int, BoundingVolume>>& predicates, const MPI_Comm comm,
       const Core::IO::Verbositylevel verbosity);
 
 }  // namespace Core::GeometricSearch

--- a/src/core/geometric_search/src/4C_geometric_search_utils.cpp
+++ b/src/core/geometric_search/src/4C_geometric_search_utils.cpp
@@ -12,49 +12,54 @@
 #include "4C_io_pstream.hpp"
 #include "4C_linalg_fixedsizematrix.hpp"
 #include "4C_linalg_utils_densematrix_inverse.hpp"
-#include "4C_utils_fad.hpp"
+
+#include <cstddef>
 
 FOUR_C_NAMESPACE_OPEN
 
 namespace Core::GeometricSearch
 {
-  void print_geometric_search_details(MPI_Comm comm, const GeometricSearchInfo info)
+  void print_geometric_search_details(
+      const MPI_Comm comm, const GeometricSearchInfo info, const Core::IO::Verbositylevel verbosity)
   {
-    const int numproc = Core::Communication::num_mpi_ranks(comm);
-    const int myrank = Core::Communication::my_mpi_rank(comm);
-
-    std::vector<int> primitive_size(numproc, 0), my_primitive_size(numproc, 0);
-    std::vector<int> predicate_size(numproc, 0), my_predicate_size(numproc, 0);
-    std::vector<int> coupling_pair_size(numproc, 0), my_coupling_pair_size(numproc, 0);
-
-    my_primitive_size[myrank] = info.primitive_size;
-    my_predicate_size[myrank] = info.predicate_size;
-    my_coupling_pair_size[myrank] = info.coupling_pair_size;
-
-    primitive_size = Core::Communication::sum_all(my_primitive_size, comm);
-    predicate_size = Core::Communication::sum_all(my_predicate_size, comm);
-    coupling_pair_size = Core::Communication::sum_all(my_coupling_pair_size, comm);
-
-    if (myrank == 0)
+    if (verbosity == Core::IO::verbose)
     {
-      Core::IO::cout(Core::IO::verbose) << "\n   Collision search:" << Core::IO::endl;
-      Core::IO::cout(Core::IO::verbose)
-          << "   +-----+------------+------------+--------------+" << Core::IO::endl;
-      Core::IO::cout(Core::IO::verbose)
-          << "   | PID | primitives | predicates |  found pairs |" << Core::IO::endl;
-      Core::IO::cout(Core::IO::verbose)
-          << "   +-----+------------+------------+--------------+" << Core::IO::endl;
+      const int numproc = Core::Communication::num_mpi_ranks(comm);
+      const int myrank = Core::Communication::my_mpi_rank(comm);
 
-      for (int npid = 0; npid < numproc; ++npid)
+      std::vector<size_t> primitive_size(numproc, 0), my_primitive_size(numproc, 0);
+      std::vector<size_t> predicate_size(numproc, 0), my_predicate_size(numproc, 0);
+      std::vector<size_t> coupling_pair_size(numproc, 0), my_coupling_pair_size(numproc, 0);
+
+      my_primitive_size[myrank] = info.primitive_size;
+      my_predicate_size[myrank] = info.predicate_size;
+      my_coupling_pair_size[myrank] = info.coupling_pair_size;
+
+      primitive_size = Core::Communication::sum_all(my_primitive_size, comm);
+      predicate_size = Core::Communication::sum_all(my_predicate_size, comm);
+      coupling_pair_size = Core::Communication::sum_all(my_coupling_pair_size, comm);
+
+      if (myrank == 0)
       {
-        Core::IO::cout(Core::IO::verbose)
-            << "   | " << std::setw(3) << npid << " | " << std::setw(10) << primitive_size[npid]
-            << " | " << std::setw(10) << predicate_size[npid] << " | " << std::setw(12)
-            << coupling_pair_size[npid] << " | " << Core::IO::endl;
+        Core::IO::cout(Core::IO::verbose) << "\n   Collision search:" << Core::IO::endl;
         Core::IO::cout(Core::IO::verbose)
             << "   +-----+------------+------------+--------------+" << Core::IO::endl;
+        Core::IO::cout(Core::IO::verbose)
+            << "   | PID | primitives | predicates |  found pairs |" << Core::IO::endl;
+        Core::IO::cout(Core::IO::verbose)
+            << "   +-----+------------+------------+--------------+" << Core::IO::endl;
+
+        for (int npid = 0; npid < numproc; ++npid)
+        {
+          Core::IO::cout(Core::IO::verbose)
+              << "   | " << std::setw(3) << npid << " | " << std::setw(10) << primitive_size[npid]
+              << " | " << std::setw(10) << predicate_size[npid] << " | " << std::setw(12)
+              << coupling_pair_size[npid] << " | " << Core::IO::endl;
+          Core::IO::cout(Core::IO::verbose)
+              << "   +-----+------------+------------+--------------+" << Core::IO::endl;
+        }
+        Core::IO::cout(Core::IO::verbose) << Core::IO::endl;
       }
-      Core::IO::cout(Core::IO::verbose) << Core::IO::endl;
     }
   }
 

--- a/src/core/geometric_search/src/4C_geometric_search_utils.hpp
+++ b/src/core/geometric_search/src/4C_geometric_search_utils.hpp
@@ -11,6 +11,7 @@
 #include "4C_config.hpp"
 
 #include "4C_geometric_search_bounding_volume.hpp"
+#include "4C_io_pstream.hpp"
 
 #include <mpi.h>
 
@@ -24,14 +25,15 @@ namespace Core::GeometricSearch
    */
   struct GeometricSearchInfo
   {
-    int primitive_size;
-    int predicate_size;
-    int coupling_pair_size;
+    size_t primitive_size;
+    size_t predicate_size;
+    size_t coupling_pair_size;
   };
 
   /*! \brief Prints details on the geometric search algorithm
    */
-  void print_geometric_search_details(MPI_Comm comm, const GeometricSearchInfo info);
+  void print_geometric_search_details(const MPI_Comm comm, const GeometricSearchInfo info,
+      const Core::IO::Verbositylevel verbosity);
 
   /*! \brief Get the polyhedron representation of a k-DOP
    *

--- a/src/core/geometric_search/tests/4C_geometric_search_distributed_test.np3.cpp
+++ b/src/core/geometric_search/tests/4C_geometric_search_distributed_test.np3.cpp
@@ -29,7 +29,6 @@ namespace
     GeometricSearchDistributed()
     {
       comm_ = MPI_COMM_WORLD;
-      verbosity_ = Core::IO::minimal;
       my_rank_ = Core::Communication::my_mpi_rank(comm_);
     }
 
@@ -37,7 +36,6 @@ namespace
     std::vector<std::pair<int, Core::GeometricSearch::BoundingVolume>> primitives_, predicates_;
     MPI_Comm comm_;
     int my_rank_;
-    Core::IO::Verbositylevel verbosity_;
   };
 
   /**
@@ -72,7 +70,7 @@ namespace
     }
 
     const auto pairs =
-        Core::GeometricSearch::global_collision_search(primitives_, predicates_, comm_, verbosity_);
+        Core::GeometricSearch::global_collision_search(primitives_, predicates_, comm_);
 
     // The order of the results we get are is not deterministic. Therefore, we save the reference
     // results in a map, with the colliding GIDs being the keys. Thus the ordering of the pairs in
@@ -155,7 +153,7 @@ namespace
     }
 
     const auto pairs =
-        Core::GeometricSearch::global_collision_search(primitives_, predicates_, comm_, verbosity_);
+        Core::GeometricSearch::global_collision_search(primitives_, predicates_, comm_);
 
     if (my_rank_ == 1)
     {
@@ -186,7 +184,7 @@ namespace
     EXPECT_EQ(predicates_.size(), 0);
 
     const auto pairs =
-        Core::GeometricSearch::global_collision_search(primitives_, predicates_, comm_, verbosity_);
+        Core::GeometricSearch::global_collision_search(primitives_, predicates_, comm_);
 
     EXPECT_EQ(pairs.size(), 0);
   }

--- a/src/core/geometric_search/tests/4C_geometric_search_test.cpp
+++ b/src/core/geometric_search/tests/4C_geometric_search_test.cpp
@@ -24,12 +24,10 @@ namespace
   class GeometricSearch : public ::testing::Test
   {
    public:
-    GeometricSearch() { verbosity_ = Core::IO::minimal; }
+    GeometricSearch() = default;
 
    protected:
     std::vector<std::pair<int, Core::GeometricSearch::BoundingVolume>> primitives_, predicates_;
-    MPI_Comm comm_{MPI_COMM_WORLD};
-    Core::IO::Verbositylevel verbosity_;
   };
 
   /**
@@ -48,8 +46,7 @@ namespace
     EXPECT_EQ(primitives_.size(), 2);
     EXPECT_EQ(predicates_.size(), 1);
 
-    const auto pairs =
-        Core::GeometricSearch::collision_search(primitives_, predicates_, comm_, verbosity_);
+    const auto pairs = Core::GeometricSearch::collision_search(primitives_, predicates_);
 
     EXPECT_EQ(pairs.size(), 1);
     EXPECT_EQ(pairs[0].gid_primitive, 0);
@@ -71,8 +68,7 @@ namespace
     EXPECT_EQ(primitives_.size(), 0);
     EXPECT_EQ(predicates_.size(), 3);
 
-    const auto& pairs =
-        Core::GeometricSearch::collision_search(primitives_, predicates_, comm_, verbosity_);
+    const auto& pairs = Core::GeometricSearch::collision_search(primitives_, predicates_);
 
     EXPECT_EQ(pairs.size(), 0);
   }
@@ -92,8 +88,7 @@ namespace
     EXPECT_EQ(primitives_.size(), 3);
     EXPECT_EQ(predicates_.size(), 0);
 
-    const auto& pairs =
-        Core::GeometricSearch::collision_search(primitives_, predicates_, comm_, verbosity_);
+    const auto& pairs = Core::GeometricSearch::collision_search(primitives_, predicates_);
 
     EXPECT_EQ(pairs.size(), 0);
   }
@@ -106,8 +101,7 @@ namespace
     EXPECT_EQ(primitives_.size(), 0);
     EXPECT_EQ(predicates_.size(), 0);
 
-    const auto pairs =
-        Core::GeometricSearch::collision_search(primitives_, predicates_, comm_, verbosity_);
+    const auto pairs = Core::GeometricSearch::collision_search(primitives_, predicates_);
 
     EXPECT_EQ(pairs.size(), 0);
   }

--- a/src/core/rebalance/src/4C_rebalance_graph_based.cpp
+++ b/src/core/rebalance/src/4C_rebalance_graph_based.cpp
@@ -354,7 +354,7 @@ std::shared_ptr<const Core::LinAlg::Graph> Core::Rebalance::build_monolithic_nod
         element.user_element()->get_bounding_volume(dis, zero_vector, params)));
   }
 
-  auto result = Core::GeometricSearch::global_collision_search(
+  auto result = Core::GeometricSearch::global_collision_search_print_results(
       bounding_boxes, bounding_boxes, dis.get_comm(), params.verbosity_);
 
   // 2. Get nodal connectivity of each element


### PR DESCRIPTION
## Description and Context

Improve the interface of the ArborX collision search. We now have "pure" collusion search functions and ones that also print the result. This has the nice effect that we are now not required any more to pass a communicator to a pure local operation (the communicator was only used for printing the results). For now we only use the functions which also perform the printout, but this will change in the near future.