### PR TITLE
ArborX: Add a wrapper for ArborX bvh

### DIFF
--- a/src/core/geometric_search/src/4C_geometric_search_access_traits.hpp
+++ b/src/core/geometric_search/src/4C_geometric_search_access_traits.hpp
@@ -12,8 +12,8 @@
 
 #include "4C_geometric_search_bounding_volume.hpp"
 
-#ifdef FOUR_C_WITH_ARBORX
-#include <ArborX.hpp>
+#include <utility>
+#include <vector>
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -36,6 +36,8 @@ namespace Core::GeometricSearch
 
 FOUR_C_NAMESPACE_CLOSE
 
+#ifdef FOUR_C_WITH_ARBORX
+#include <ArborX.hpp>
 
 namespace ArborX
 {
@@ -57,8 +59,9 @@ namespace ArborX
     {
       // We are interested in the gid of the primitive, not the id in the bounding volume vector,
       // thus we attach the gid here.
-      return ArborX::PairValueIndex{placeholder.bounding_volumes_[i].second.bounding_volume_,
-          placeholder.bounding_volumes_[i].first};
+      return ArborX::PairValueIndex{
+          .value = placeholder.bounding_volumes_[i].second.bounding_volume_,
+          .index = placeholder.bounding_volumes_[i].first};
     }
 
     static KOKKOS_FUNCTION auto get(

--- a/src/core/geometric_search/src/4C_geometric_search_bvh.cpp
+++ b/src/core/geometric_search/src/4C_geometric_search_bvh.cpp
@@ -22,6 +22,45 @@ FOUR_C_NAMESPACE_OPEN
 
 namespace Core::GeometricSearch
 {
+#ifdef FOUR_C_WITH_ARBORX
+  template <class Predicates>
+  auto BoundingVolumeHierarchy::query(Predicates const& predicates) const
+  {
+    using MemorySpace = typename ArborXBoundingVolumeHierarchy::memory_space;
+
+    Kokkos::View<int*, MemorySpace> indices_full("indices_full", 0);
+    Kokkos::View<int*, MemorySpace> offset_full("offset_full", 0);
+
+    auto get_indices_callback =
+        KOKKOS_LAMBDA(const auto predicate, const auto& value, const auto& out)->void
+    {
+      out(value.index);
+    };
+
+    // Perform the collision check.
+    arborx_bounding_volume_hierarchy_.query(execution_,
+        BoundingVolumeVectorPlaceholder<PredicatesTag>{predicates}, get_indices_callback,
+        indices_full, offset_full);
+
+    // Create the vector with the pairs.
+    std::vector<CollisionSearchResult> pairs;
+    pairs.reserve(indices_full.size());
+    for (size_t i_offset = 0; i_offset < offset_full.size() - 1; i_offset++)
+    {
+      const int gid_predicate = predicates[i_offset].first;
+      for (int j = offset_full[i_offset]; j < offset_full[i_offset + 1]; j++)
+      {
+        pairs.emplace_back(CollisionSearchResult{
+            .gid_predicate = gid_predicate,
+            .gid_primitive = indices_full[j],
+        });
+      }
+    }
+
+    return pairs;
+  }
+#endif
+
   std::vector<CollisionSearchResult> collision_search(
       const std::vector<std::pair<int, BoundingVolume>>& primitives,
       const std::vector<std::pair<int, BoundingVolume>>& predicates, MPI_Comm comm,
@@ -47,40 +86,12 @@ namespace Core::GeometricSearch
     }
     else
     {
-      using memory_space = Kokkos::HostSpace;
-      Kokkos::DefaultExecutionSpace execution_space{};
-
       // Build tree structure containing all primitives.
-      ArborX::BoundingVolumeHierarchy bounding_volume_hierarchy{
-          execution_space, BoundingVolumeVectorPlaceholder<PrimitivesTag>{primitives}};
+      BoundingVolumeHierarchy bounding_volume_hierarchy(
+          BoundingVolumeVectorPlaceholder<PrimitivesTag>{primitives});
 
-      Kokkos::View<int*, memory_space> indices_full("indices_full", 0);
-      Kokkos::View<int*, memory_space> offset_full("offset_full", 0);
-
-      auto get_indices_callback =
-          KOKKOS_LAMBDA(const auto predicate, const auto& value, const auto& out)->void
-      {
-        out(value.index);
-      };
-
-      // Perform the collision check.
-      bounding_volume_hierarchy.query(execution_space,
-          BoundingVolumeVectorPlaceholder<PredicatesTag>{predicates}, get_indices_callback,
-          indices_full, offset_full);
-
-      // Create the vector with the pairs.
-      pairs.reserve(indices_full.size());
-      for (size_t i_offset = 0; i_offset < offset_full.size() - 1; i_offset++)
-      {
-        const int gid_predicate = predicates[i_offset].first;
-        for (int j = offset_full[i_offset]; j < offset_full[i_offset + 1]; j++)
-        {
-          pairs.emplace_back(CollisionSearchResult{
-              .gid_predicate = gid_predicate,
-              .gid_primitive = indices_full[j],
-          });
-        }
-      }
+      // Search for collisions between predicates and primitives.
+      pairs = bounding_volume_hierarchy.query(predicates);
     }
 
     if (verbosity == Core::IO::verbose)


### PR DESCRIPTION
## Description and Context

Add a wrapper to the ArborX bounding volume hierarchy class, so we reuse exiting BVHs for multiple queries. Up until now, we always created the BHV and only performed a single query.