### PR TITLE
Remove unused fluid output reset

### DIFF
--- a/src/adapter/4C_adapter_fld_fluid.hpp
+++ b/src/adapter/4C_adapter_fld_fluid.hpp
@@ -266,7 +266,7 @@ namespace Adapter
     virtual std::shared_ptr<FLD::Vreman> vreman() = 0;
 
     /// reset state vectors (needed for biofilm simulations)
-    virtual void reset(bool completeReset = false, int numsteps = 1, int iter = -1) = 0;
+    virtual void reset(int numsteps = 1, int iter = -1) = 0;
 
     /// set fluid displacement vector due to biofilm growth
     virtual void set_fld_gr_disp(

--- a/src/adapter/4C_adapter_fld_fluid_fsi.cpp
+++ b/src/adapter/4C_adapter_fld_fluid_fsi.cpp
@@ -517,10 +517,10 @@ void Adapter::FluidFSI::proj_vel_to_div_zero()
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void Adapter::FluidFSI::reset(bool completeReset, int numsteps, int iter)
+void Adapter::FluidFSI::reset(int numsteps, int iter)
 
 {
-  FluidWrapper::reset(completeReset, numsteps, iter);
+  FluidWrapper::reset(numsteps, iter);
   return;
 }
 

--- a/src/adapter/4C_adapter_fld_fluid_fsi.hpp
+++ b/src/adapter/4C_adapter_fld_fluid_fsi.hpp
@@ -155,7 +155,7 @@ namespace Adapter
     void proj_vel_to_div_zero();
 
     /// reset state vectors
-    void reset(bool completeReset = false, int numsteps = 1, int iter = -1) override;
+    void reset(int numsteps = 1, int iter = -1) override;
 
     /// calculate error in comparison to analytical solution
     void calculate_error() override;

--- a/src/adapter/4C_adapter_fld_wrapper.hpp
+++ b/src/adapter/4C_adapter_fld_wrapper.hpp
@@ -469,10 +469,7 @@ namespace Adapter
     {
       return fluid_->create_field_test();
     }
-    void reset(bool completeReset = false, int numsteps = 1, int iter = -1) override
-    {
-      return fluid_->reset(completeReset, numsteps, iter);
-    };
+    void reset(int numsteps = 1, int iter = -1) override { return fluid_->reset(numsteps, iter); };
     void set_fld_gr_disp(std::shared_ptr<Core::LinAlg::Vector<double>> fluid_growth_disp) override
     {
       return fluid_->set_fld_gr_disp(fluid_growth_disp);

--- a/src/fluid/4C_fluid_implicit_integration.hpp
+++ b/src/fluid/4C_fluid_implicit_integration.hpp
@@ -555,7 +555,7 @@ namespace FLD
         std::shared_ptr<const Core::LinAlg::Vector<double>> velpres) override;
 
     /// Reset state vectors
-    void reset(bool completeReset = false, int numsteps = 1, int iter = -1) override;
+    void reset(int numsteps = 1, int iter = -1) override;
 
     /*!
     \brief calculate error between a analytical solution and the

--- a/src/fluid/4C_fluid_timint.hpp
+++ b/src/fluid/4C_fluid_timint.hpp
@@ -694,7 +694,7 @@ namespace FLD
     }
 
     /// reset data for restart of simulation at beginning
-    void reset(bool completeReset = false, int numsteps = 1, int iter = -1) override
+    void reset(int numsteps = 1, int iter = -1) override
     {
       FOUR_C_THROW("reset function not implemented for this fluid adapter");
     };

--- a/src/fluid/4C_fluid_timint_hdg.cpp
+++ b/src/fluid/4C_fluid_timint_hdg.cpp
@@ -434,9 +434,9 @@ std::shared_ptr<std::vector<double>> FLD::TimIntHDG::evaluate_error_compared_to_
 /*------------------------------------------------------------------------------------------------*
  |
  *------------------------------------------------------------------------------------------------*/
-void FLD::TimIntHDG::reset(bool completeReset, int numsteps, int iter)
+void FLD::TimIntHDG::reset(int numsteps, int iter)
 {
-  FluidImplicitTimeInt::reset(completeReset, numsteps, iter);
+  FluidImplicitTimeInt::reset(numsteps, iter);
   const Core::LinAlg::Map* intdofrowmap = discret_->dof_row_map(1);
   intvelnp_ = Core::LinAlg::create_vector(*intdofrowmap, true);
   intvelaf_ = Core::LinAlg::create_vector(*intdofrowmap, true);

--- a/src/fluid/4C_fluid_timint_hdg.hpp
+++ b/src/fluid/4C_fluid_timint_hdg.hpp
@@ -117,7 +117,7 @@ namespace FLD
     /*!
     \brief Reset state vectors
      */
-    void reset(bool completeReset = false, int numsteps = 1, int iter = -1) override;
+    void reset(int numsteps = 1, int iter = -1) override;
 
     /*!
     \brief update configuration and output to file/screen

--- a/src/fluid/4C_fluid_timint_hdg_weak_comp.cpp
+++ b/src/fluid/4C_fluid_timint_hdg_weak_comp.cpp
@@ -624,9 +624,9 @@ FLD::TimIntHDGWeakComp::evaluate_error_compared_to_analytical_sol()
 /*------------------------------------------------------------------------------------------------*
  |
  *------------------------------------------------------------------------------------------------*/
-void FLD::TimIntHDGWeakComp::reset(bool completeReset, int numsteps, int iter)
+void FLD::TimIntHDGWeakComp::reset(int numsteps, int iter)
 {
-  FluidImplicitTimeInt::reset(completeReset, numsteps, iter);
+  FluidImplicitTimeInt::reset(numsteps, iter);
   const Core::LinAlg::Map* intdofrowmap = discret_->dof_row_map(1);
   intvelnp_ = Core::LinAlg::create_vector(*intdofrowmap, true);
   intvelaf_ = Core::LinAlg::create_vector(*intdofrowmap, true);

--- a/src/fluid/4C_fluid_timint_hdg_weak_comp.hpp
+++ b/src/fluid/4C_fluid_timint_hdg_weak_comp.hpp
@@ -128,7 +128,7 @@ namespace FLD
     /*!
     \brief Reset state vectors
      */
-    void reset(bool completeReset = false, int numsteps = 1, int iter = -1) override;
+    void reset(int numsteps = 1, int iter = -1) override;
 
     /*!
     \brief update configuration and output to file/screen

--- a/src/fluid/4C_fluid_timint_stat_hdg.cpp
+++ b/src/fluid/4C_fluid_timint_stat_hdg.cpp
@@ -95,9 +95,9 @@ void FLD::TimIntStationaryHDG::init()
 }
 
 
-void FLD::TimIntStationaryHDG::reset(bool completeReset, int numsteps, int iter)
+void FLD::TimIntStationaryHDG::reset(int numsteps, int iter)
 {
-  FluidImplicitTimeInt::reset(completeReset, numsteps, iter);
+  FluidImplicitTimeInt::reset(numsteps, iter);
   const Core::LinAlg::Map* intdofrowmap = discret_->dof_row_map(1);
   intvelnp_ = Core::LinAlg::create_vector(*intdofrowmap, true);
   if (Core::Communication::my_mpi_rank(discret_->get_comm()) == 0)

--- a/src/fluid/4C_fluid_timint_stat_hdg.hpp
+++ b/src/fluid/4C_fluid_timint_stat_hdg.hpp
@@ -50,7 +50,7 @@ namespace FLD
     /*!
       \brief Reset state vectors
        */
-    void reset(bool completeReset = false, int numsteps = 1, int iter = -1) override;
+    void reset(int numsteps = 1, int iter = -1) override;
 
     void set_old_part_of_righthandside() override;
 


### PR DESCRIPTION
Removing this functionality will allow us to drop more unused functionality from the output writers and controls.