### PR TITLE
Add interface to write control files

### DIFF
--- a/src/core/io/src/4C_io.hpp
+++ b/src/core/io/src/4C_io.hpp
@@ -349,18 +349,6 @@ namespace Core::IO
      */
     void write_redundant_int_vector(const std::string name, std::vector<int>& vectorint);
 
-    /// overwrite result files
-    void overwrite_result_file();
-
-    /// creating new result files
-    void new_result_file(int numb_run);
-
-    /// creating new result files for the mlmc
-    void new_result_file(std::string name_appendix, int numb_run);
-
-    /// creating new result files using the provided name
-    void new_result_file(std::string name);
-
     //@}
 
     //!@name Data management


### PR DESCRIPTION
Construction of the control file (containing info about 4C's results) is essentially impossible to understand. This PR introduces an interface for writing to this file. I believe we can and should replace the control file format with YAML or JSON to make our lives even easier (we have a hand-written parser in C for this file type :confused: ), but this is not yet part of this PR. 

@c-p-schmidt @isteinbrecher Correct me if I am wrong, but I think the control file will survive the deletion of the old output, since it contains general data and also info about restarts written to HDF5.