### PR TITLE
Introduce `NOX::Nln::Vector` to replace `::NOX::Epetra::Vector`

### DIFF
--- a/src/cardiovascular0d/4C_cardiovascular0d_nox_nln_linearsystem.cpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_nox_nln_linearsystem.cpp
@@ -11,6 +11,7 @@
 #include "4C_linear_solver_method_linalg.hpp"
 #include "4C_solver_nonlin_nox_interface_jacobian.hpp"
 #include "4C_solver_nonlin_nox_interface_required.hpp"
+#include "4C_solver_nonlin_nox_vector.hpp"
 
 #include <Teuchos_ParameterList.hpp>
 
@@ -24,7 +25,7 @@ NOX::Nln::Cardiovascular0D::LinearSystem::LinearSystem(Teuchos::ParameterList& p
     const Teuchos::RCP<::NOX::Epetra::Interface::Required>& iReq,
     const Teuchos::RCP<::NOX::Epetra::Interface::Jacobian>& iJac,
     const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& M, const ::NOX::Epetra::Vector& cloneVector,
+    const Teuchos::RCP<Core::LinAlg::SparseOperator>& M, const NOX::Nln::Vector& cloneVector,
     const std::shared_ptr<NOX::Nln::Scaling> scalingObject)
     : NOX::Nln::LinearSystem(
           printParams, linearSolverParams, solvers, iReq, iJac, J, M, cloneVector, scalingObject)
@@ -40,7 +41,7 @@ NOX::Nln::Cardiovascular0D::LinearSystem::LinearSystem(Teuchos::ParameterList& p
     const Teuchos::RCP<::NOX::Epetra::Interface::Required>& iReq,
     const Teuchos::RCP<::NOX::Epetra::Interface::Jacobian>& iJac,
     const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& M, const ::NOX::Epetra::Vector& cloneVector)
+    const Teuchos::RCP<Core::LinAlg::SparseOperator>& M, const NOX::Nln::Vector& cloneVector)
     : NOX::Nln::LinearSystem(
           printParams, linearSolverParams, solvers, iReq, iJac, J, M, cloneVector)
 {
@@ -54,7 +55,7 @@ NOX::Nln::Cardiovascular0D::LinearSystem::LinearSystem(Teuchos::ParameterList& p
     const std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>& solvers,
     const Teuchos::RCP<::NOX::Epetra::Interface::Required>& iReq,
     const Teuchos::RCP<::NOX::Epetra::Interface::Jacobian>& iJac,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& J, const ::NOX::Epetra::Vector& cloneVector,
+    const Teuchos::RCP<Core::LinAlg::SparseOperator>& J, const NOX::Nln::Vector& cloneVector,
     const std::shared_ptr<NOX::Nln::Scaling> scalingObject)
     : NOX::Nln::LinearSystem(
           printParams, linearSolverParams, solvers, iReq, iJac, J, cloneVector, scalingObject)
@@ -69,7 +70,7 @@ NOX::Nln::Cardiovascular0D::LinearSystem::LinearSystem(Teuchos::ParameterList& p
     const std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>& solvers,
     const Teuchos::RCP<::NOX::Epetra::Interface::Required>& iReq,
     const Teuchos::RCP<::NOX::Epetra::Interface::Jacobian>& iJac,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& J, const ::NOX::Epetra::Vector& cloneVector)
+    const Teuchos::RCP<Core::LinAlg::SparseOperator>& J, const NOX::Nln::Vector& cloneVector)
     : NOX::Nln::LinearSystem(printParams, linearSolverParams, solvers, iReq, iJac, J, cloneVector)
 {
   // empty constructor

--- a/src/cardiovascular0d/4C_cardiovascular0d_nox_nln_linearsystem.hpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_nox_nln_linearsystem.hpp
@@ -31,7 +31,7 @@ namespace NOX
             const Teuchos::RCP<::NOX::Epetra::Interface::Jacobian>& iJac,
             const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
             const Teuchos::RCP<Core::LinAlg::SparseOperator>& M,
-            const ::NOX::Epetra::Vector& cloneVector,
+            const NOX::Nln::Vector& cloneVector,
             const std::shared_ptr<NOX::Nln::Scaling> scalingObject);
 
         //! Constructor without scaling object
@@ -42,7 +42,7 @@ namespace NOX
             const Teuchos::RCP<::NOX::Epetra::Interface::Jacobian>& iJac,
             const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
             const Teuchos::RCP<Core::LinAlg::SparseOperator>& M,
-            const ::NOX::Epetra::Vector& cloneVector);
+            const NOX::Nln::Vector& cloneVector);
 
         //! Constructor without preconditioner
         LinearSystem(Teuchos::ParameterList& printParams,
@@ -51,7 +51,7 @@ namespace NOX
             const Teuchos::RCP<::NOX::Epetra::Interface::Required>& iReq,
             const Teuchos::RCP<::NOX::Epetra::Interface::Jacobian>& iJac,
             const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
-            const ::NOX::Epetra::Vector& cloneVector,
+            const NOX::Nln::Vector& cloneVector,
             const std::shared_ptr<NOX::Nln::Scaling> scalingObject);
 
         //! Constructor without preconditioner and scaling object
@@ -61,7 +61,7 @@ namespace NOX
             const Teuchos::RCP<::NOX::Epetra::Interface::Required>& iReq,
             const Teuchos::RCP<::NOX::Epetra::Interface::Jacobian>& iJac,
             const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
-            const ::NOX::Epetra::Vector& cloneVector);
+            const NOX::Nln::Vector& cloneVector);
 
         //! sets the options of the underlying solver
         Core::LinAlg::SolverParams set_solver_options(Teuchos::ParameterList& p,

--- a/src/constraint/4C_constraint_lagpenconstraint_noxinterface.cpp
+++ b/src/constraint/4C_constraint_lagpenconstraint_noxinterface.cpp
@@ -13,8 +13,6 @@
 #include "4C_linalg_vector.hpp"
 #include "4C_solver_nonlin_nox_aux.hpp"
 
-#include <NOX_Epetra_Vector.H>
-
 FOUR_C_NAMESPACE_OPEN
 
 /*----------------------------------------------------------------------------*

--- a/src/constraint/4C_constraint_nox_nln_lagpenconstraint_linearsystem.cpp
+++ b/src/constraint/4C_constraint_nox_nln_lagpenconstraint_linearsystem.cpp
@@ -11,6 +11,7 @@
 #include "4C_linear_solver_method_linalg.hpp"
 #include "4C_solver_nonlin_nox_interface_jacobian.hpp"
 #include "4C_solver_nonlin_nox_interface_required.hpp"
+#include "4C_solver_nonlin_nox_vector.hpp"
 
 #include <Teuchos_ParameterList.hpp>
 
@@ -26,7 +27,7 @@ NOX::Nln::LAGPENCONSTRAINT::LinearSystem::LinearSystem(Teuchos::ParameterList& p
     const NOX::Nln::CONSTRAINT::ReqInterfaceMap& iConstr,
     const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
     const NOX::Nln::CONSTRAINT::PrecInterfaceMap& iConstrPrec,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& M, const ::NOX::Epetra::Vector& cloneVector,
+    const Teuchos::RCP<Core::LinAlg::SparseOperator>& M, const NOX::Nln::Vector& cloneVector,
     const std::shared_ptr<NOX::Nln::Scaling> scalingObject)
     : NOX::Nln::LinearSystem(
           printParams, linearSolverParams, solvers, iReq, iJac, J, M, cloneVector, scalingObject),
@@ -45,7 +46,7 @@ NOX::Nln::LAGPENCONSTRAINT::LinearSystem::LinearSystem(Teuchos::ParameterList& p
     const NOX::Nln::CONSTRAINT::ReqInterfaceMap& iConstr,
     const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
     const NOX::Nln::CONSTRAINT::PrecInterfaceMap& iConstrPrec,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& M, const ::NOX::Epetra::Vector& cloneVector)
+    const Teuchos::RCP<Core::LinAlg::SparseOperator>& M, const NOX::Nln::Vector& cloneVector)
     : NOX::Nln::LinearSystem(
           printParams, linearSolverParams, solvers, iReq, iJac, J, M, cloneVector),
       i_constr_(iConstr),

--- a/src/constraint/4C_constraint_nox_nln_lagpenconstraint_linearsystem.hpp
+++ b/src/constraint/4C_constraint_nox_nln_lagpenconstraint_linearsystem.hpp
@@ -34,7 +34,7 @@ namespace NOX
             const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
             const NOX::Nln::CONSTRAINT::PrecInterfaceMap& iConstrPrec,
             const Teuchos::RCP<Core::LinAlg::SparseOperator>& M,
-            const ::NOX::Epetra::Vector& cloneVector,
+            const NOX::Nln::Vector& cloneVector,
             const std::shared_ptr<NOX::Nln::Scaling> scalingObject);
 
         //! Constructor without scaling object
@@ -46,7 +46,7 @@ namespace NOX
             const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
             const NOX::Nln::CONSTRAINT::PrecInterfaceMap& iConstrPrec,
             const Teuchos::RCP<Core::LinAlg::SparseOperator>& M,
-            const ::NOX::Epetra::Vector& cloneVector);
+            const NOX::Nln::Vector& cloneVector);
 
         //! Sets the options of the underlying solver
         Core::LinAlg::SolverParams set_solver_options(Teuchos::ParameterList& p,

--- a/src/contact/src/4C_contact_meshtying_noxinterface.cpp
+++ b/src/contact/src/4C_contact_meshtying_noxinterface.cpp
@@ -11,8 +11,6 @@
 #include "4C_linalg_vector.hpp"
 #include "4C_solver_nonlin_nox_aux.hpp"
 
-#include <NOX_Epetra_Vector.H>
-
 FOUR_C_NAMESPACE_OPEN
 
 /*----------------------------------------------------------------------------*

--- a/src/contact/src/4C_contact_nox_nln_contact_linearsystem.cpp
+++ b/src/contact/src/4C_contact_nox_nln_contact_linearsystem.cpp
@@ -17,6 +17,7 @@
 #include "4C_solver_nonlin_nox_aux.hpp"
 #include "4C_solver_nonlin_nox_interface_jacobian.hpp"
 #include "4C_solver_nonlin_nox_interface_required.hpp"
+#include "4C_solver_nonlin_nox_vector.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -29,7 +30,7 @@ NOX::Nln::CONTACT::LinearSystem::LinearSystem(Teuchos::ParameterList& printParam
     const NOX::Nln::CONSTRAINT::ReqInterfaceMap& iConstr,
     const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
     const NOX::Nln::CONSTRAINT::PrecInterfaceMap& iConstrPrec,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& M, const ::NOX::Epetra::Vector& cloneVector,
+    const Teuchos::RCP<Core::LinAlg::SparseOperator>& M, const NOX::Nln::Vector& cloneVector,
     const std::shared_ptr<NOX::Nln::Scaling> scalingObject)
     : NOX::Nln::LinearSystem(
           printParams, linearSolverParams, solvers, iReq, iJac, J, M, cloneVector, scalingObject),
@@ -49,7 +50,7 @@ NOX::Nln::CONTACT::LinearSystem::LinearSystem(Teuchos::ParameterList& printParam
     const NOX::Nln::CONSTRAINT::ReqInterfaceMap& iConstr,
     const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
     const NOX::Nln::CONSTRAINT::PrecInterfaceMap& iConstrPrec,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& M, const ::NOX::Epetra::Vector& cloneVector)
+    const Teuchos::RCP<Core::LinAlg::SparseOperator>& M, const NOX::Nln::Vector& cloneVector)
     : NOX::Nln::LinearSystem(
           printParams, linearSolverParams, solvers, iReq, iJac, J, M, cloneVector),
       i_constr_(iConstr),

--- a/src/contact/src/4C_contact_nox_nln_contact_linearsystem.hpp
+++ b/src/contact/src/4C_contact_nox_nln_contact_linearsystem.hpp
@@ -40,7 +40,7 @@ namespace NOX
             const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
             const NOX::Nln::CONSTRAINT::PrecInterfaceMap& iConstrPrec,
             const Teuchos::RCP<Core::LinAlg::SparseOperator>& M,
-            const ::NOX::Epetra::Vector& cloneVector,
+            const NOX::Nln::Vector& cloneVector,
             const std::shared_ptr<NOX::Nln::Scaling> scalingObject);
 
         //! Constructor without scaling object
@@ -52,7 +52,7 @@ namespace NOX
             const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
             const NOX::Nln::CONSTRAINT::PrecInterfaceMap& iConstrPrec,
             const Teuchos::RCP<Core::LinAlg::SparseOperator>& M,
-            const ::NOX::Epetra::Vector& cloneVector);
+            const NOX::Nln::Vector& cloneVector);
 
         //! Sets the options of the underlying solver
         Core::LinAlg::SolverParams set_solver_options(Teuchos::ParameterList& p,

--- a/src/contact/src/4C_contact_nox_nln_meshtying_linearsystem.cpp
+++ b/src/contact/src/4C_contact_nox_nln_meshtying_linearsystem.cpp
@@ -16,6 +16,7 @@
 #include "4C_solver_nonlin_nox_aux.hpp"
 #include "4C_solver_nonlin_nox_interface_jacobian.hpp"
 #include "4C_solver_nonlin_nox_interface_required.hpp"
+#include "4C_solver_nonlin_nox_vector.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -28,7 +29,7 @@ NOX::Nln::MeshTying::LinearSystem::LinearSystem(Teuchos::ParameterList& printPar
     const NOX::Nln::CONSTRAINT::ReqInterfaceMap& iConstr,
     const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
     const NOX::Nln::CONSTRAINT::PrecInterfaceMap& iConstrPrec,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& M, const ::NOX::Epetra::Vector& cloneVector,
+    const Teuchos::RCP<Core::LinAlg::SparseOperator>& M, const NOX::Nln::Vector& cloneVector,
     const std::shared_ptr<NOX::Nln::Scaling> scalingObject)
     : NOX::Nln::LinearSystem(
           printParams, linearSolverParams, solvers, iReq, iJac, J, M, cloneVector, scalingObject),
@@ -47,7 +48,7 @@ NOX::Nln::MeshTying::LinearSystem::LinearSystem(Teuchos::ParameterList& printPar
     const NOX::Nln::CONSTRAINT::ReqInterfaceMap& iConstr,
     const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
     const NOX::Nln::CONSTRAINT::PrecInterfaceMap& iConstrPrec,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& M, const ::NOX::Epetra::Vector& cloneVector)
+    const Teuchos::RCP<Core::LinAlg::SparseOperator>& M, const NOX::Nln::Vector& cloneVector)
     : NOX::Nln::LinearSystem(
           printParams, linearSolverParams, solvers, iReq, iJac, J, M, cloneVector),
       i_constr_(iConstr),

--- a/src/contact/src/4C_contact_nox_nln_meshtying_linearsystem.hpp
+++ b/src/contact/src/4C_contact_nox_nln_meshtying_linearsystem.hpp
@@ -40,7 +40,7 @@ namespace NOX
             const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
             const NOX::Nln::CONSTRAINT::PrecInterfaceMap& iConstrPrec,
             const Teuchos::RCP<Core::LinAlg::SparseOperator>& M,
-            const ::NOX::Epetra::Vector& cloneVector,
+            const NOX::Nln::Vector& cloneVector,
             const std::shared_ptr<NOX::Nln::Scaling> scalingObject);
 
         //! Constructor without scaling object
@@ -52,7 +52,7 @@ namespace NOX
             const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
             const NOX::Nln::CONSTRAINT::PrecInterfaceMap& iConstrPrec,
             const Teuchos::RCP<Core::LinAlg::SparseOperator>& M,
-            const ::NOX::Epetra::Vector& cloneVector);
+            const NOX::Nln::Vector& cloneVector);
 
         //! Sets the options of the underlying solver
         Core::LinAlg::SolverParams set_solver_options(Teuchos::ParameterList& p,

--- a/src/contact/src/4C_contact_noxinterface.cpp
+++ b/src/contact/src/4C_contact_noxinterface.cpp
@@ -11,9 +11,9 @@
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
 #include "4C_linalg_vector.hpp"
 #include "4C_solver_nonlin_nox_aux.hpp"
+#include "4C_solver_nonlin_nox_vector.hpp"
 #include "4C_utils_enum.hpp"
 
-#include <NOX_Epetra_Vector.H>
 #include <Teuchos_RCPStdSharedPtrConversions.hpp>
 
 FOUR_C_NAMESPACE_OPEN
@@ -83,7 +83,7 @@ double CONTACT::NoxInterface::get_constraint_rhs_norms(const Core::LinAlg::Vecto
   constrRhs_red->replace_map(strategy().slave_dof_row_map(true));
 
   double constrNorm = -1.0;
-  Teuchos::RCP<const ::NOX::Epetra::Vector> constrRhs_nox = Teuchos::null;
+  Teuchos::RCP<const NOX::Nln::Vector> constrRhs_nox = Teuchos::null;
   switch (checkQuantity)
   {
     case NOX::Nln::StatusTest::quantity_contact_normal:
@@ -223,7 +223,7 @@ double CONTACT::NoxInterface::get_previous_lagrange_multiplier_norms(
   std::shared_ptr<Core::LinAlg::Vector<double>> zold_ptr =
       std::make_shared<Core::LinAlg::Vector<double>>(*strategy().lagrange_multiplier_np(true));
   zold_ptr->update(-1.0, *strategy().lagrange_multiplier_increment(), 1.0);
-  std::shared_ptr<::NOX::Epetra::Vector> zold_nox_ptr = nullptr;
+  std::shared_ptr<NOX::Nln::Vector> zold_nox_ptr = nullptr;
   switch (checkQuantity)
   {
     case NOX::Nln::StatusTest::quantity_contact_normal:

--- a/src/fsi/src/monolithic/4C_fsi_monolithic.cpp
+++ b/src/fsi/src/monolithic/4C_fsi_monolithic.cpp
@@ -30,6 +30,7 @@
 #include "4C_linear_solver_method.hpp"
 #include "4C_linear_solver_method_linalg.hpp"
 #include "4C_linear_solver_method_parameters.hpp"
+#include "4C_solver_nonlin_nox_vector.hpp"
 #include "4C_structure_aux.hpp"
 
 #include <NOX_Direction_UserDefinedFactory.H>
@@ -627,8 +628,8 @@ void FSI::Monolithic::time_step(
       std::make_shared<Core::LinAlg::Vector<double>>(*dof_row_map(), true);
   initial_guess(initial_guess_v);
 
-  ::NOX::Epetra::Vector noxSoln(Teuchos::rcpFromRef(initial_guess_v->get_ref_of_epetra_vector()),
-      ::NOX::Epetra::Vector::CreateView);
+  NOX::Nln::Vector noxSoln(Teuchos::rcpFromRef(initial_guess_v->get_ref_of_epetra_vector()),
+      NOX::Nln::Vector::MemoryType::View);
 
   // Create the linear system
   std::shared_ptr<NOX::Nln::LinearSystemBase> linSys =
@@ -1113,7 +1114,7 @@ void FSI::BlockMonolithic::create_system_matrix(
 /*----------------------------------------------------------------------------*/
 /*----------------------------------------------------------------------------*/
 std::shared_ptr<NOX::Nln::LinearSystemBase> FSI::BlockMonolithic::create_linear_system(
-    Teuchos::ParameterList& nlParams, ::NOX::Epetra::Vector& noxSoln,
+    Teuchos::ParameterList& nlParams, NOX::Nln::Vector& noxSoln,
     std::shared_ptr<::NOX::Utils> utils)
 {
   Teuchos::ParameterList& printParams = nlParams.sublist("Printing");

--- a/src/fsi/src/monolithic/4C_fsi_monolithic.hpp
+++ b/src/fsi/src/monolithic/4C_fsi_monolithic.hpp
@@ -57,6 +57,8 @@ namespace NOX
     class AdaptiveNewtonNormF;
     class Group;
   }  // namespace FSI
+
+  class Vector;
 }  // namespace NOX
 
 namespace TimeStepping
@@ -405,7 +407,7 @@ namespace FSI
 
     /// setup solver for global block system
     virtual std::shared_ptr<NOX::Nln::LinearSystemBase> create_linear_system(
-        Teuchos::ParameterList& nlParams, ::NOX::Epetra::Vector& noxSoln,
+        Teuchos::ParameterList& nlParams, NOX::Nln::Vector& noxSoln,
         std::shared_ptr<::NOX::Utils> utils) = 0;
 
     //! setup of NOX convergence tests
@@ -1055,7 +1057,7 @@ namespace FSI
     /// setup solver for global block system
     std::shared_ptr<NOX::Nln::LinearSystemBase> create_linear_system(
         Teuchos::ParameterList& nlParams,    ///< parameter list
-        ::NOX::Epetra::Vector& noxSoln,      ///< solution vector in NOX format
+        NOX::Nln::Vector& noxSoln,           ///< solution vector in NOX format
         std::shared_ptr<::NOX::Utils> utils  ///< NOX utils
         ) override;
 

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_group.cpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_group.cpp
@@ -15,7 +15,7 @@ FOUR_C_NAMESPACE_OPEN
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 NOX::FSI::Group::Group(FourC::FSI::MonolithicInterface& mfsi, Teuchos::ParameterList& printParams,
-    const Teuchos::RCP<::NOX::Epetra::Interface::Required>& i, const ::NOX::Epetra::Vector& x,
+    const Teuchos::RCP<::NOX::Epetra::Interface::Required>& i, const NOX::Nln::Vector& x,
     const Teuchos::RCP<NOX::Nln::LinearSystemBase>& linSys)
     : NOX::Nln::GroupBase(printParams, i, x, linSys), mfsi_(mfsi)
 {

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_group.hpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_group.hpp
@@ -32,7 +32,7 @@ namespace NOX
       Group(FourC::FSI::MonolithicInterface& mfsi,                    ///< monolithic FSI interface
           Teuchos::ParameterList& printParams,                        ///< printing parameters
           const Teuchos::RCP<::NOX::Epetra::Interface::Required>& i,  ///< NOX interface
-          const ::NOX::Epetra::Vector& x,                             ///< initial guess
+          const NOX::Nln::Vector& x,                                  ///< initial guess
           const Teuchos::RCP<NOX::Nln::LinearSystemBase>& linSys      ///< linear system
       );
 

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem.cpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem.cpp
@@ -13,6 +13,7 @@
 #include "4C_linalg_serialdensevector.hpp"
 #include "4C_linalg_vector.hpp"
 #include "4C_linear_solver_method_linalg.hpp"
+#include "4C_solver_nonlin_nox_vector.hpp"
 
 #include <Epetra_CrsMatrix.h>
 #include <Epetra_Operator.h>
@@ -28,9 +29,8 @@ FOUR_C_NAMESPACE_OPEN
 NOX::FSI::LinearSystem::LinearSystem(Teuchos::ParameterList& printParams,
     Teuchos::ParameterList& linearSolverParams,
     const std::shared_ptr<::NOX::Epetra::Interface::Jacobian>& iJac,
-    const std::shared_ptr<Core::LinAlg::SparseOperator>& J,
-    const ::NOX::Epetra::Vector& cloneVector, std::shared_ptr<Core::LinAlg::Solver> solver,
-    const std::shared_ptr<NOX::Nln::Scaling> s)
+    const std::shared_ptr<Core::LinAlg::SparseOperator>& J, const NOX::Nln::Vector& cloneVector,
+    std::shared_ptr<Core::LinAlg::Solver> solver, const std::shared_ptr<NOX::Nln::Scaling> s)
     : utils_(printParams),
       jac_interface_ptr_(iJac),
       jac_ptr_(J),
@@ -40,7 +40,7 @@ NOX::FSI::LinearSystem::LinearSystem(Teuchos::ParameterList& printParams,
       solver_(solver),
       timer_("", true)
 {
-  tmp_vector_ptr_ = std::make_shared<::NOX::Epetra::Vector>(cloneVector);
+  tmp_vector_ptr_ = std::make_shared<NOX::Nln::Vector>(cloneVector);
 
   reset(linearSolverParams);
 }
@@ -59,7 +59,7 @@ void NOX::FSI::LinearSystem::reset(Teuchos::ParameterList& linearSolverParams)
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 bool NOX::FSI::LinearSystem::apply_jacobian(
-    const ::NOX::Epetra::Vector& input, ::NOX::Epetra::Vector& result) const
+    const NOX::Nln::Vector& input, NOX::Nln::Vector& result) const
 {
   jac_ptr_->SetUseTranspose(false);
   int status = jac_ptr_->Apply(input.getEpetraVector(), result.getEpetraVector());
@@ -71,7 +71,7 @@ bool NOX::FSI::LinearSystem::apply_jacobian(
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 bool NOX::FSI::LinearSystem::apply_jacobian_transpose(
-    const ::NOX::Epetra::Vector& input, ::NOX::Epetra::Vector& result) const
+    const NOX::Nln::Vector& input, NOX::Nln::Vector& result) const
 {
   jac_ptr_->SetUseTranspose(true);
   int status = jac_ptr_->Apply(input.getEpetraVector(), result.getEpetraVector());
@@ -84,7 +84,7 @@ bool NOX::FSI::LinearSystem::apply_jacobian_transpose(
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 bool NOX::FSI::LinearSystem::apply_jacobian_inverse(
-    Teuchos::ParameterList& p, const ::NOX::Epetra::Vector& input, ::NOX::Epetra::Vector& result)
+    Teuchos::ParameterList& p, const NOX::Nln::Vector& input, NOX::Nln::Vector& result)
 {
   // Zero out the delta X of the linear problem if requested by user.
   if (zero_initial_guess_) result.init(0.0);
@@ -128,7 +128,7 @@ bool NOX::FSI::LinearSystem::apply_jacobian_inverse(
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-bool NOX::FSI::LinearSystem::compute_jacobian(const ::NOX::Epetra::Vector& x)
+bool NOX::FSI::LinearSystem::compute_jacobian(const NOX::Nln::Vector& x)
 {
   bool success = jac_interface_ptr_->computeJacobian(x.getEpetraVector(), *jac_ptr_);
   return success;

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem.hpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem.hpp
@@ -19,7 +19,6 @@
 #include <NOX_Common.H>
 #include <NOX_Epetra_Interface_Jacobian.H>
 #include <NOX_Epetra_Interface_Required.H>
-#include <NOX_Epetra_Vector.H>
 #include <NOX_Utils.H>
 #include <Teuchos_Time.hpp>
 
@@ -43,8 +42,8 @@ namespace NOX::FSI
         const std::shared_ptr<::NOX::Epetra::Interface::Jacobian>&
             iJac,  ///< NOX interface to Jacobian
         const std::shared_ptr<Core::LinAlg::SparseOperator>&
-            J,                                     ///< the Jacobian or stiffness matrix
-        const ::NOX::Epetra::Vector& cloneVector,  ///< initial guess of the solution process
+            J,                                ///< the Jacobian or stiffness matrix
+        const NOX::Nln::Vector& cloneVector,  ///< initial guess of the solution process
         std::shared_ptr<Core::LinAlg::Solver>
             structure_solver,  ///< (used-defined) linear algebraic solver
         const std::shared_ptr<NOX::Nln::Scaling> scalingObject =
@@ -54,20 +53,19 @@ namespace NOX::FSI
     void reset(Teuchos::ParameterList& linearSolverParams);
 
     /// Applies Jacobian to the given input vector and puts the answer in the result.
-    bool apply_jacobian(
-        const ::NOX::Epetra::Vector& input, ::NOX::Epetra::Vector& result) const override;
+    bool apply_jacobian(const NOX::Nln::Vector& input, NOX::Nln::Vector& result) const override;
 
     /// Applies Jacobian-Transpose to the given input vector and puts the answer in the result.
     bool apply_jacobian_transpose(
-        const ::NOX::Epetra::Vector& input, ::NOX::Epetra::Vector& result) const override;
+        const NOX::Nln::Vector& input, NOX::Nln::Vector& result) const override;
 
     /// Applies the inverse of the Jacobian matrix to the given input vector and puts the answer
     /// in result.
-    bool apply_jacobian_inverse(Teuchos::ParameterList& params, const ::NOX::Epetra::Vector& input,
-        ::NOX::Epetra::Vector& result) override;
+    bool apply_jacobian_inverse(Teuchos::ParameterList& params, const NOX::Nln::Vector& input,
+        NOX::Nln::Vector& result) override;
 
     /// Evaluates the Jacobian based on the solution vector x.
-    bool compute_jacobian(const ::NOX::Epetra::Vector& x) override;
+    bool compute_jacobian(const NOX::Nln::Vector& x) override;
 
     /// Return Jacobian operator.
     Teuchos::RCP<const Epetra_Operator> get_jacobian_operator() const override;
@@ -85,7 +83,7 @@ namespace NOX::FSI
     mutable std::shared_ptr<Epetra_Operator> jac_ptr_;
     mutable std::shared_ptr<Core::LinAlg::SparseOperator> operator_;
     std::shared_ptr<NOX::Nln::Scaling> scaling_;
-    mutable std::shared_ptr<::NOX::Epetra::Vector> tmp_vector_ptr_;
+    mutable std::shared_ptr<NOX::Nln::Vector> tmp_vector_ptr_;
 
     bool output_solve_details_;
     bool zero_initial_guess_;

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.hpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.hpp
@@ -18,7 +18,6 @@
 #include <NOX_Epetra_Interface_Jacobian.H>
 #include <NOX_Epetra_Interface_Required.H>
 #include <NOX_Epetra_Scaling.H>
-#include <NOX_Epetra_Vector.H>
 #include <NOX_Utils.H>
 #include <Teuchos_Time.hpp>
 
@@ -58,7 +57,7 @@ namespace NOX
           Teuchos::ParameterList& linearSolverParams,
           const Teuchos::RCP<::NOX::Epetra::Interface::Required>& iReq,
           const Teuchos::RCP<::NOX::Epetra::Interface::Jacobian>& iJac,
-          const Teuchos::RCP<Epetra_Operator>& J, const ::NOX::Epetra::Vector& cloneVector,
+          const Teuchos::RCP<Epetra_Operator>& J, const NOX::Nln::Vector& cloneVector,
           const Teuchos::RCP<::NOX::Epetra::Scaling> scalingObject = Teuchos::null);
 
       //! Reset the linear solver parameters.
@@ -72,8 +71,7 @@ namespace NOX
         where \f$J\f$ is the Jacobian, \f$u\f$ is the input vector,
         and \f$v\f$ is the result vector.  Returns true if successful.
       */
-      bool apply_jacobian(
-          const ::NOX::Epetra::Vector& input, ::NOX::Epetra::Vector& result) const override;
+      bool apply_jacobian(const NOX::Nln::Vector& input, NOX::Nln::Vector& result) const override;
 
       /*!
         \brief Applies Jacobian-Transpose to the given input vector and puts the answer in the
@@ -86,7 +84,7 @@ namespace NOX
 
       */
       bool apply_jacobian_transpose(
-          const ::NOX::Epetra::Vector& input, ::NOX::Epetra::Vector& result) const override;
+          const NOX::Nln::Vector& input, NOX::Nln::Vector& result) const override;
 
       /*!
         \brief Applies the inverse of the Jacobian matrix to the given
@@ -99,11 +97,11 @@ namespace NOX
 
         The parameter list contains the linear solver options.
       */
-      bool apply_jacobian_inverse(Teuchos::ParameterList& params,
-          const ::NOX::Epetra::Vector& input, ::NOX::Epetra::Vector& result) override;
+      bool apply_jacobian_inverse(Teuchos::ParameterList& params, const NOX::Nln::Vector& input,
+          NOX::Nln::Vector& result) override;
 
       //! Evaluates the Jacobian based on the solution vector x.
-      bool compute_jacobian(const ::NOX::Epetra::Vector& x) override;
+      bool compute_jacobian(const NOX::Nln::Vector& x) override;
 
       //! Return Jacobian operator
       Teuchos::RCP<const Epetra_Operator> get_jacobian_operator() const override;
@@ -120,8 +118,7 @@ namespace NOX
         GMRES methods, Num. Lin. Alg. Appl., 1 (1994),
         pp. 369--386. http://citeseer.ist.psu.edu/vandervorst91gmresr.html
        */
-      int solve_gcr(
-          const ::NOX::Epetra::Vector& b, ::NOX::Epetra::Vector& x, int& maxit, double& tol);
+      int solve_gcr(const NOX::Nln::Vector& b, NOX::Nln::Vector& x, int& maxit, double& tol);
 
       /// GMRES solver
       /*!
@@ -133,8 +130,8 @@ namespace NOX
         Linear Systems: Building Blocks for Iterative Methods, SIAM
         (1993)
       */
-      int solve_gmres(const ::NOX::Epetra::Vector& b, ::NOX::Epetra::Vector& x, int& max_iter,
-          double& tol, int m);
+      int solve_gmres(
+          const NOX::Nln::Vector& b, NOX::Nln::Vector& x, int& max_iter, double& tol, int m);
 
       /// helper for GMRES
       void apply_plane_rotation(double& dx, double& dy, double& cs, double& sn);
@@ -161,7 +158,7 @@ namespace NOX
       Teuchos::RCP<::NOX::Epetra::Scaling> scaling;
 
       //! An extra temporary vector, only allocated if needed.
-      mutable std::shared_ptr<::NOX::Epetra::Vector> tmpVectorPtr;
+      mutable std::shared_ptr<NOX::Nln::Vector> tmpVectorPtr;
 
       mutable double conditionNumberEstimate;
 
@@ -182,9 +179,9 @@ namespace NOX
       //! Total time spent in apply_jacobian_inverse() (sec.).
       mutable double timeApplyJacbianInverse;
 
-      std::vector<std::shared_ptr<::NOX::Epetra::Vector>> u_;
+      std::vector<std::shared_ptr<NOX::Nln::Vector>> u_;
 
-      std::vector<std::shared_ptr<::NOX::Epetra::Vector>> c_;
+      std::vector<std::shared_ptr<NOX::Nln::Vector>> c_;
     };
 
   }  // namespace FSI

--- a/src/fsi/src/partitioned/4C_fsi_partitioned.cpp
+++ b/src/fsi/src/partitioned/4C_fsi_partitioned.cpp
@@ -28,6 +28,7 @@
 #include "4C_inpar_fsi.hpp"
 #include "4C_io_control.hpp"
 #include "4C_solver_nonlin_nox_group_base.hpp"
+#include "4C_solver_nonlin_nox_vector.hpp"
 #include "4C_structure_aux.hpp"
 #include "4C_utils_enum.hpp"
 
@@ -403,8 +404,8 @@ void FSI::Partitioned::timeloop(const Teuchos::RCP<::NOX::Epetra::Interface::Req
     // Get initial guess
     std::shared_ptr<Core::LinAlg::Vector<double>> soln = initial_guess();
 
-    ::NOX::Epetra::Vector noxSoln(
-        Teuchos::rcpFromRef(soln->get_ref_of_epetra_vector()), ::NOX::Epetra::Vector::CreateView);
+    NOX::Nln::Vector noxSoln(
+        Teuchos::rcpFromRef(soln->get_ref_of_epetra_vector()), NOX::Nln::Vector::MemoryType::View);
 
     // Create the linear system
     Teuchos::RCP<NOX::Nln::LinearSystemBase> linSys =
@@ -490,8 +491,8 @@ void FSI::Partitioned::timeloop(const Teuchos::RCP<::NOX::Epetra::Interface::Req
 /*----------------------------------------------------------------------*/
 Teuchos::RCP<NOX::Nln::LinearSystemBase> FSI::Partitioned::create_linear_system(
     Teuchos::ParameterList& nlParams,
-    const Teuchos::RCP<::NOX::Epetra::Interface::Required>& interface,
-    ::NOX::Epetra::Vector& noxSoln, ::NOX::Utils& utils)
+    const Teuchos::RCP<::NOX::Epetra::Interface::Required>& interface, NOX::Nln::Vector& noxSoln,
+    ::NOX::Utils& utils)
 {
   Teuchos::ParameterList& printParams = nlParams.sublist("Printing");
 

--- a/src/fsi/src/partitioned/4C_fsi_partitioned.hpp
+++ b/src/fsi/src/partitioned/4C_fsi_partitioned.hpp
@@ -216,7 +216,7 @@ namespace FSI
     /// create linear solver framework
     Teuchos::RCP<NOX::Nln::LinearSystemBase> create_linear_system(Teuchos::ParameterList& nlParams,
         const Teuchos::RCP<::NOX::Epetra::Interface::Required>& interface,
-        ::NOX::Epetra::Vector& noxSoln, ::NOX::Utils& utils);
+        NOX::Nln::Vector& noxSoln, ::NOX::Utils& utils);
 
     /// create convergence tests including testing framework
     Teuchos::RCP<::NOX::StatusTest::Combo> create_status_test(

--- a/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_aitken.cpp
+++ b/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_aitken.cpp
@@ -12,11 +12,11 @@
 #include "4C_global_data.hpp"
 #include "4C_io_control.hpp"
 #include "4C_linalg_vector.hpp"
+#include "4C_solver_nonlin_nox_vector.hpp"
 
 #include <NOX_Abstract_Group.H>
 #include <NOX_Abstract_Vector.H>
 #include <NOX_Common.H>
-#include <NOX_Epetra_Vector.H>
 #include <NOX_GlobalData.H>
 #include <NOX_Solver_Generic.H>
 #include <Teuchos_ParameterList.hpp>
@@ -117,8 +117,7 @@ bool NOX::FSI::AitkenRelaxation::compute(::NOX::Abstract::Group& grp, double& st
 
   if (utils_->isPrintType(::NOX::Utils::InnerIteration))
   {
-    utils_->out() << std::setw(3) << "1"
-                  << ":";
+    utils_->out() << std::setw(3) << "1" << ":";
     utils_->out() << " step = " << utils_->sciformat(step);
     utils_->out() << " orth = " << utils_->sciformat(checkOrthogonality);
     utils_->out() << "\n" << ::NOX::Utils::fill(72) << "\n" << std::endl;
@@ -127,7 +126,7 @@ bool NOX::FSI::AitkenRelaxation::compute(::NOX::Abstract::Group& grp, double& st
   // write omega
   double fnorm = grp.getF().norm();
   if (Core::Communication::my_mpi_rank(Core::Communication::unpack_epetra_comm(
-          dynamic_cast<const ::NOX::Epetra::Vector&>(F).getEpetraVector().Comm())) == 0)
+          dynamic_cast<const NOX::Nln::Vector&>(F).getEpetraVector().Comm())) == 0)
   {
     static int count;
     static std::ofstream* out;

--- a/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_jacobian.cpp
+++ b/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_jacobian.cpp
@@ -12,7 +12,6 @@
 
 #include <NOX_Abstract_Group.H>
 #include <NOX_Epetra_Interface_Required.H>
-#include <NOX_Epetra_Vector.H>
 #include <NOX_Utils.H>
 
 #include <iostream>
@@ -21,7 +20,7 @@ FOUR_C_NAMESPACE_OPEN
 
 
 NOX::FSI::FSIMatrixFree::FSIMatrixFree(Teuchos::ParameterList& printParams,
-    const Teuchos::RCP<::NOX::Epetra::Interface::Required>& i, const ::NOX::Epetra::Vector& x)
+    const Teuchos::RCP<::NOX::Epetra::Interface::Required>& i, const NOX::Nln::Vector& x)
     : label("FSI-Matrix-Free"),
       interface(i),
       currentX(x),
@@ -80,12 +79,12 @@ int NOX::FSI::FSIMatrixFree::Apply(const Epetra_MultiVector& X, Epetra_MultiVect
   // the fluid field on the interface displacements.
 
   // Convert X and Y from an Epetra_MultiVector to a Core::LinAlg::Vectors
-  // and NOX::epetra::Vectors.  This is done so we use a consistent
+  // and NOX::Nln::Vectors.  This is done so we use a consistent
   // vector space for norms and inner products.
   Teuchos::RCP<Epetra_Vector> wrappedX = Teuchos::make_rcp<Epetra_Vector>(View, X, 0);
   Teuchos::RCP<Epetra_Vector> wrappedY = Teuchos::make_rcp<Epetra_Vector>(View, Y, 0);
-  ::NOX::Epetra::Vector nevX(wrappedX, ::NOX::Epetra::Vector::CreateView);
-  ::NOX::Epetra::Vector nevY(wrappedY, ::NOX::Epetra::Vector::CreateView);
+  NOX::Nln::Vector nevX(wrappedX, NOX::Nln::Vector::MemoryType::View);
+  NOX::Nln::Vector nevY(wrappedY, NOX::Nln::Vector::MemoryType::View);
 
   // The trial vector x is not guaranteed to be a suitable interface
   // displacement. It might be much too large to fit the ALE

--- a/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_jacobian.hpp
+++ b/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_jacobian.hpp
@@ -10,11 +10,12 @@
 
 #include "4C_config.hpp"
 
+#include "4C_solver_nonlin_nox_vector.hpp"
+
 #include <Epetra_Operator.h>
 #include <NOX_Abstract_Group.H>
 #include <NOX_Epetra_Interface_Jacobian.H>
 #include <NOX_Epetra_Interface_Required.H>
-#include <NOX_Epetra_Vector.H>
 #include <NOX_Utils.H>
 
 #include <memory>
@@ -26,6 +27,11 @@ FOUR_C_NAMESPACE_OPEN
 
 namespace NOX
 {
+  namespace Nln
+  {
+    class Vector;
+  }  // namespace Nln
+
   namespace FSI
   {
     /// Matrix Free Newton Krylov based on an approximation of the residuum derivatives
@@ -37,8 +43,7 @@ namespace NOX
         The vector \c x is used to clone the solution vector.
       */
       FSIMatrixFree(Teuchos::ParameterList& printParams,
-          const Teuchos::RCP<::NOX::Epetra::Interface::Required>& i,
-          const ::NOX::Epetra::Vector& x);
+          const Teuchos::RCP<::NOX::Epetra::Interface::Required>& i, const NOX::Nln::Vector& x);
 
 
       //! If set true, transpose of this operator will be applied.
@@ -115,13 +120,13 @@ namespace NOX
       Teuchos::RCP<::NOX::Epetra::Interface::Required> interface;
 
       //! The current solution vector
-      ::NOX::Epetra::Vector currentX;
+      NOX::Nln::Vector currentX;
 
       //! Perturbed solution vector
-      mutable ::NOX::Epetra::Vector perturbX;
+      mutable NOX::Nln::Vector perturbX;
 
       //! Perturbed solution vector
-      mutable ::NOX::Epetra::Vector perturbY;
+      mutable NOX::Nln::Vector perturbY;
 
       //! Core::LinAlg::Map object used in the returns of the Epetra_Operator derived methods.
       /*! If the user is using Core::LinAlg::Maps, then ::NOX::Epetra::MatrixFree must create an

--- a/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_mpe.cpp
+++ b/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_mpe.cpp
@@ -12,9 +12,9 @@
 #include "4C_linalg_serialdensematrix.hpp"
 #include "4C_linalg_serialdensevector.hpp"
 #include "4C_linalg_vector.hpp"
+#include "4C_solver_nonlin_nox_vector.hpp"
 
 #include <NOX_Abstract_Group.H>
-#include <NOX_Epetra_Vector.H>
 #include <NOX_GlobalData.H>
 #include <Teuchos_ParameterList.hpp>
 #include <Teuchos_RCP.hpp>
@@ -55,7 +55,7 @@ bool NOX::FSI::MinimalPolynomial::compute(
 
   const ::NOX::Abstract::Vector& x = group.getX();
 
-  std::vector<Teuchos::RCP<::NOX::Epetra::Vector>> q;
+  std::vector<Teuchos::RCP<NOX::Nln::Vector>> q;
   Core::LinAlg::SerialDenseMatrix r(kmax_ + 1, kmax_ + 1, true);
   Core::LinAlg::SerialDenseVector c(kmax_ + 1, true);
   Core::LinAlg::SerialDenseVector gamma(kmax_ + 1, true);
@@ -71,10 +71,10 @@ bool NOX::FSI::MinimalPolynomial::compute(
     if (status != ::NOX::Abstract::Group::Ok) throw_error("compute", "Unable to compute F");
 
     // get f = d(k+1) - d(k)
-    const ::NOX::Epetra::Vector& f = dynamic_cast<const ::NOX::Epetra::Vector&>(group.getF());
+    const auto& f = dynamic_cast<const NOX::Nln::Vector&>(group.getF());
 
     // We have to work on the scaled residual here.
-    Teuchos::RCP<::NOX::Epetra::Vector> y = Teuchos::make_rcp<::NOX::Epetra::Vector>(f);
+    Teuchos::RCP<NOX::Nln::Vector> y = Teuchos::make_rcp<NOX::Nln::Vector>(f);
     y->scale(omega_);
 
     // modified Gram-Schmidt
@@ -192,7 +192,7 @@ bool NOX::FSI::MinimalPolynomial::compute(
     xi(j) = xi(j - 1) - gamma(j);
   }
 
-  ::NOX::Epetra::Vector s(dynamic_cast<const ::NOX::Epetra::Vector&>(x));
+  NOX::Nln::Vector s(dynamic_cast<const NOX::Nln::Vector&>(x));
   for (int j = 0; j < k; ++j)
   {
     double hp = 0.;

--- a/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_sd.cpp
+++ b/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_sd.cpp
@@ -12,12 +12,12 @@
 #include "4C_io_control.hpp"
 #include "4C_linalg_vector.hpp"
 #include "4C_solver_nonlin_nox_group.hpp"
+#include "4C_solver_nonlin_nox_vector.hpp"
 
 #include <NOX_Abstract_Group.H>
 #include <NOX_Abstract_Vector.H>
 #include <NOX_Common.H>
 #include <NOX_Epetra_Interface_Required.H>
-#include <NOX_Epetra_Vector.H>
 #include <NOX_GlobalData.H>
 #include <NOX_Solver_Generic.H>
 #include <NOX_Utils.H>
@@ -75,8 +75,7 @@ bool NOX::FSI::SDRelaxation::compute(::NOX::Abstract::Group& newgrp, double& ste
 
   if (utils_->isPrintType(::NOX::Utils::InnerIteration))
   {
-    utils_->out() << std::setw(3) << "1"
-                  << ":";
+    utils_->out() << std::setw(3) << "1" << ":";
     utils_->out() << " step = " << utils_->sciformat(step);
     utils_->out() << " orth = " << utils_->sciformat(checkOrthogonality);
     utils_->out() << "\n" << ::NOX::Utils::fill(72) << "\n" << std::endl;
@@ -85,7 +84,7 @@ bool NOX::FSI::SDRelaxation::compute(::NOX::Abstract::Group& newgrp, double& ste
   // write omega
   double fnorm = oldgrp.getF().norm();
   if (Core::Communication::my_mpi_rank(Core::Communication::unpack_epetra_comm(
-          dynamic_cast<const ::NOX::Epetra::Vector&>(oldgrp.getF()).getEpetraVector().Comm())) == 0)
+          dynamic_cast<const NOX::Nln::Vector&>(oldgrp.getF()).getEpetraVector().Comm())) == 0)
   {
     static int count;
     static std::ofstream* out;
@@ -110,8 +109,8 @@ bool NOX::FSI::SDRelaxation::compute(::NOX::Abstract::Group& newgrp, double& ste
   // Allocate space for vecPtr and grpPtr if necessary
   if (!(vec_ptr_)) vec_ptr_ = dir.clone(::NOX::ShapeCopy);
 
-  const ::NOX::Epetra::Vector& edir = dynamic_cast<const ::NOX::Epetra::Vector&>(dir);
-  ::NOX::Epetra::Vector& evec = dynamic_cast<::NOX::Epetra::Vector&>(*vec_ptr_);
+  const auto& edir = dynamic_cast<const NOX::Nln::Vector&>(dir);
+  auto& evec = dynamic_cast<NOX::Nln::Vector&>(*vec_ptr_);
 
   // we do not want the group to remember this solution
   // and we want to set our own flag

--- a/src/fsi/src/utils/4C_fsi_statustest.cpp
+++ b/src/fsi/src/utils/4C_fsi_statustest.cpp
@@ -10,11 +10,11 @@
 #include "4C_coupling_adapter.hpp"
 #include "4C_coupling_adapter_converter.hpp"
 #include "4C_fsi_nox_newton.hpp"
+#include "4C_solver_nonlin_nox_vector.hpp"
 #include "4C_utils_exceptions.hpp"
 
 #include <NOX_Abstract_Group.H>
 #include <NOX_Abstract_Vector.H>
-#include <NOX_Epetra_Vector.H>
 #include <NOX_Solver_Generic.H>
 
 FOUR_C_NAMESPACE_OPEN
@@ -174,7 +174,7 @@ double NOX::FSI::PartialNormF::compute_norm(const ::NOX::Abstract::Group& grp)
   // extract the block epetra vector
 
   const ::NOX::Abstract::Vector& abstract_f = grp.getF();
-  const ::NOX::Epetra::Vector& f = Teuchos::dyn_cast<const ::NOX::Epetra::Vector>(abstract_f);
+  const auto& f = Teuchos::dyn_cast<const NOX::Nln::Vector>(abstract_f);
 
   Core::LinAlg::Vector<double> f_copy(f.getEpetraVector());
   // extract the inner vector elements we are interested in
@@ -307,8 +307,7 @@ NOX::FSI::GenericNormUpdate::GenericNormUpdate(std::string name, double tol, Sca
 
   update_vector_ptr_->update(1.0, curSoln, -1.0, oldSoln, 0.0);
 
-  compute_norm(
-      std::dynamic_pointer_cast<::NOX::Epetra::Vector>(update_vector_ptr_)->getEpetraVector());
+  compute_norm(std::dynamic_pointer_cast<NOX::Nln::Vector>(update_vector_ptr_)->getEpetraVector());
 
   status_ =
       (norm_update_ < tolerance_) ? ::NOX::StatusTest::Converged : ::NOX::StatusTest::Unconverged;
@@ -320,7 +319,7 @@ NOX::FSI::GenericNormUpdate::GenericNormUpdate(std::string name, double tol, Sca
 /*----------------------------------------------------------------------*/
 double NOX::FSI::GenericNormUpdate::compute_norm(const Epetra_Vector& v)
 {
-  ::NOX::Epetra::Vector vec(v);
+  NOX::Nln::Vector vec(v);
   int n = (scale_type_ == Scaled) ? vec.length() : 0;
 
   switch (norm_type_)

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_constraint_group.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_constraint_group.cpp
@@ -17,7 +17,7 @@ FOUR_C_NAMESPACE_OPEN
  *----------------------------------------------------------------------------*/
 NOX::Nln::CONSTRAINT::Group::Group(Teuchos::ParameterList& printParams,
     Teuchos::ParameterList& grpOptionParams,
-    const Teuchos::RCP<::NOX::Epetra::Interface::Required>& i, const ::NOX::Epetra::Vector& x,
+    const Teuchos::RCP<::NOX::Epetra::Interface::Required>& i, const NOX::Nln::Vector& x,
     const Teuchos::RCP<NOX::Nln::LinearSystemBase>& linSys,
     const NOX::Nln::CONSTRAINT::ReqInterfaceMap& iConstr)
     : NOX::Nln::Group(printParams, grpOptionParams, i, x, linSys),
@@ -161,7 +161,7 @@ Teuchos::RCP<std::vector<double>> NOX::Nln::CONSTRAINT::Group::get_solution_upda
     const std::vector<StatusTest::QuantityType>& chQ,
     Teuchos::RCP<const std::vector<StatusTest::NormUpdate::ScaleType>> scale) const
 {
-  const ::NOX::Epetra::Vector& xOldEpetra = dynamic_cast<const ::NOX::Epetra::Vector&>(xOld);
+  const auto& xOldEpetra = dynamic_cast<const NOX::Nln::Vector&>(xOld);
   if (scale.is_null())
     scale = Teuchos::make_rcp<std::vector<StatusTest::NormUpdate::ScaleType>>(
         chQ.size(), StatusTest::NormUpdate::Unscaled);
@@ -211,7 +211,7 @@ Teuchos::RCP<std::vector<double>> NOX::Nln::CONSTRAINT::Group::get_previous_solu
     const std::vector<StatusTest::QuantityType>& chQ,
     Teuchos::RCP<const std::vector<StatusTest::NormUpdate::ScaleType>> scale) const
 {
-  const ::NOX::Epetra::Vector& xOldEpetra = dynamic_cast<const ::NOX::Epetra::Vector&>(xOld);
+  const auto& xOldEpetra = dynamic_cast<const NOX::Nln::Vector&>(xOld);
   if (scale.is_null())
     scale = Teuchos::make_rcp<std::vector<StatusTest::NormUpdate::ScaleType>>(
         chQ.size(), StatusTest::NormUpdate::Unscaled);
@@ -260,7 +260,7 @@ Teuchos::RCP<std::vector<double>> NOX::Nln::CONSTRAINT::Group::get_solution_upda
     const std::vector<double>& rTol, const std::vector<NOX::Nln::StatusTest::QuantityType>& chQ,
     const std::vector<bool>& disable_implicit_weighting) const
 {
-  const ::NOX::Epetra::Vector& xOldEpetra = dynamic_cast<const ::NOX::Epetra::Vector&>(xOld);
+  const auto& xOldEpetra = dynamic_cast<const NOX::Nln::Vector&>(xOld);
   Teuchos::RCP<std::vector<double>> rms = Teuchos::make_rcp<std::vector<double>>(0);
 
   double rval = -1.0;

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_constraint_group.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_constraint_group.hpp
@@ -36,8 +36,8 @@ namespace NOX
         Group(Teuchos::ParameterList& printParams,  //!< printing parameters
             Teuchos::ParameterList& grpOptionParams,
             const Teuchos::RCP<::NOX::Epetra::Interface::Required>&
-                i,                           //!< basically the NOXified time integrator
-            const ::NOX::Epetra::Vector& x,  //!< current solution vector
+                i,                      //!< basically the NOXified time integrator
+            const NOX::Nln::Vector& x,  //!< current solution vector
             const Teuchos::RCP<NOX::Nln::LinearSystemBase>&
                 linSys,  //!< linear system, matrix and RHS etc.
             const std::map<enum NOX::Nln::SolutionType,

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_group.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_group.hpp
@@ -55,8 +55,8 @@ namespace NOX
       Group(Teuchos::ParameterList& printParams,    //!< printing parameters
           Teuchos::ParameterList& grpOptionParams,  //!< group option parameters
           const Teuchos::RCP<::NOX::Epetra::Interface::Required>&
-              i,                           //!< basically the NOXified user interface
-          const ::NOX::Epetra::Vector& x,  //!< current solution vector
+              i,                      //!< basically the NOXified user interface
+          const NOX::Nln::Vector& x,  //!< current solution vector
           const Teuchos::RCP<NOX::Nln::LinearSystemBase>&
               linSys  //!< linear system, matrix and RHS etc.
       );
@@ -72,7 +72,7 @@ namespace NOX
           ::NOX::CopyType type = ::NOX::DeepCopy) const override;
 
       //! compute/update the current state variables
-      void computeX(const NOX::Nln::Group& grp, const ::NOX::Epetra::Vector& d, double step);
+      void computeX(const NOX::Nln::Group& grp, const NOX::Nln::Vector& d, double step);
       void computeX(const ::NOX::Abstract::Group& grp, const ::NOX::Abstract::Vector& d,
           double step) override;
 
@@ -87,7 +87,7 @@ namespace NOX
       virtual ::NOX::Abstract::Group::ReturnType compute_f_and_jacobian();
 
       //! set right hand side
-      ::NOX::Abstract::Group::ReturnType set_f(Teuchos::RCP<::NOX::Epetra::Vector> Fptr);
+      ::NOX::Abstract::Group::ReturnType set_f(Teuchos::RCP<NOX::Nln::Vector> Fptr);
 
 #if !(FOUR_C_TRILINOS_INTERNAL_VERSION_GE(2025, 4))
       //! set the solution vector to zero
@@ -179,7 +179,7 @@ namespace NOX
       void adjust_pseudo_time_step(double& delta, const double& stepSize,
           const ::NOX::Abstract::Vector& dir, const NOX::Nln::Solver::PseudoTransient& ptcsolver);
       void adjust_pseudo_time_step(double& delta, const double& stepSize,
-          const ::NOX::Epetra::Vector& dir, const NOX::Nln::Solver::PseudoTransient& ptcsolver);
+          const NOX::Nln::Vector& dir, const NOX::Nln::Solver::PseudoTransient& ptcsolver);
 
       // Get element based scaling operator
       Teuchos::RCP<Core::LinAlg::SparseMatrix> get_contributions_from_element_level();

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_group_base.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_group_base.cpp
@@ -15,7 +15,7 @@
 FOUR_C_NAMESPACE_OPEN
 
 NOX::Nln::GroupBase::GroupBase(Teuchos::ParameterList& printParams,
-    const Teuchos::RCP<::NOX::Epetra::Interface::Required>& i, const ::NOX::Epetra::Vector& x,
+    const Teuchos::RCP<::NOX::Epetra::Interface::Required>& i, const NOX::Nln::Vector& x,
     const Teuchos::RCP<NOX::Nln::LinearSystemBase>& linSys)
     : utils(printParams),
       xVector(x, ::NOX::DeepCopy),
@@ -127,14 +127,14 @@ Teuchos::RCP<const ::NOX::Abstract::Vector> NOX::Nln::GroupBase::getNewtonPtr() 
 void NOX::Nln::GroupBase::setX(const ::NOX::Abstract::Vector& y)
 {
   reset_is_valid();
-  xVector = dynamic_cast<const ::NOX::Epetra::Vector&>(y);
+  xVector = dynamic_cast<const NOX::Nln::Vector&>(y);
 }
 
 void NOX::Nln::GroupBase::computeX(
     const ::NOX::Abstract::Group& grp, const ::NOX::Abstract::Vector& d, double step)
 {
   const auto& grp_base = dynamic_cast<const GroupBase&>(grp);
-  const auto& epetra_d = dynamic_cast<const ::NOX::Epetra::Vector&>(d);
+  const auto& epetra_d = dynamic_cast<const NOX::Nln::Vector&>(d);
 
   reset_is_valid();
   xVector.update(1.0, grp_base.xVector, step, epetra_d);
@@ -202,8 +202,8 @@ void NOX::Nln::GroupBase::computeX(
 ::NOX::Abstract::Group::ReturnType NOX::Nln::GroupBase::applyJacobian(
     const ::NOX::Abstract::Vector& input, ::NOX::Abstract::Vector& result) const
 {
-  const auto& epetra_input = dynamic_cast<const ::NOX::Epetra::Vector&>(input);
-  auto& epetra_result = dynamic_cast<::NOX::Epetra::Vector&>(result);
+  const auto& epetra_input = dynamic_cast<const NOX::Nln::Vector&>(input);
+  auto& epetra_result = dynamic_cast<NOX::Nln::Vector&>(result);
 
   if (!isJacobian()) return ::NOX::Abstract::Group::BadDependency;
 
@@ -216,8 +216,8 @@ void NOX::Nln::GroupBase::computeX(
     Teuchos::ParameterList& p, const ::NOX::Abstract::Vector& input,
     ::NOX::Abstract::Vector& result) const
 {
-  const auto& epetra_input = dynamic_cast<const ::NOX::Epetra::Vector&>(input);
-  auto& epetra_result = dynamic_cast<::NOX::Epetra::Vector&>(result);
+  const auto& epetra_input = dynamic_cast<const NOX::Nln::Vector&>(input);
+  auto& epetra_result = dynamic_cast<NOX::Nln::Vector&>(result);
 
   if (!isJacobian()) return ::NOX::Abstract::Group::BadDependency;
 
@@ -234,8 +234,8 @@ void NOX::Nln::GroupBase::computeX(
 ::NOX::Abstract::Group::ReturnType NOX::Nln::GroupBase::applyJacobianTranspose(
     const ::NOX::Abstract::Vector& input, ::NOX::Abstract::Vector& result) const
 {
-  const auto& epetra_input = dynamic_cast<const ::NOX::Epetra::Vector&>(input);
-  auto& epetra_result = dynamic_cast<::NOX::Epetra::Vector&>(result);
+  const auto& epetra_input = dynamic_cast<const NOX::Nln::Vector&>(input);
+  auto& epetra_result = dynamic_cast<NOX::Nln::Vector&>(result);
 
   if (!isJacobian()) return ::NOX::Abstract::Group::BadDependency;
 

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_group_base.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_group_base.hpp
@@ -11,10 +11,10 @@
 #include "4C_config.hpp"
 
 #include "4C_solver_nonlin_nox_linearsystem_base.hpp"
+#include "4C_solver_nonlin_nox_vector.hpp"
 
 #include <NOX_Abstract_Group.H>
 #include <NOX_Epetra_Interface_Required.H>
-#include <NOX_Epetra_Vector.H>
 #include <NOX_Utils.H>
 #include <Teuchos_RCP.hpp>
 
@@ -28,7 +28,7 @@ namespace NOX
     {
      public:
       GroupBase(Teuchos::ParameterList& printParams,
-          const Teuchos::RCP<::NOX::Epetra::Interface::Required>& i, const ::NOX::Epetra::Vector& x,
+          const Teuchos::RCP<::NOX::Epetra::Interface::Required>& i, const NOX::Nln::Vector& x,
           const Teuchos::RCP<NOX::Nln::LinearSystemBase>& linSys);
 
       GroupBase(const NOX::Nln::GroupBase& source, ::NOX::CopyType type);
@@ -133,13 +133,13 @@ namespace NOX
       /** @name Vectors */
       //@{
       //! Solution vector.
-      ::NOX::Epetra::Vector xVector;
+      NOX::Nln::Vector xVector;
       //! Right-hand-side vector (function evaluation).
-      ::NOX::Epetra::Vector RHSVector;
+      NOX::Nln::Vector RHSVector;
       //! Gradient vector (steepest descent vector).
-      ::NOX::Epetra::Vector gradVector;
+      NOX::Nln::Vector gradVector;
       //! Newton direction vector.
-      ::NOX::Epetra::Vector NewtonVector;
+      NOX::Nln::Vector NewtonVector;
       //@}
 
       /** @name IsValid flags

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_inner_statustest_armijo.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_inner_statustest_armijo.cpp
@@ -12,7 +12,6 @@
 #include "4C_utils_exceptions.hpp"
 
 #include <NOX_Abstract_Group.H>
-#include <NOX_Epetra_Vector.H>
 #include <NOX_MeritFunction_Generic.H>
 #include <NOX_Utils.H>
 

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_inner_statustest_upperbound.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_inner_statustest_upperbound.cpp
@@ -13,7 +13,6 @@
 #include "4C_utils_exceptions.hpp"
 
 #include <NOX_Abstract_Vector.H>
-#include <NOX_Epetra_Vector.H>
 #include <NOX_Solver_Generic.H>
 #include <NOX_Utils.H>
 

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_interface_required.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_interface_required.hpp
@@ -13,8 +13,8 @@
 #include "4C_solver_nonlin_nox_enum_lists.hpp"
 #include "4C_utils_exceptions.hpp"
 
+#include <NOX_Abstract_Vector.H>
 #include <NOX_Epetra_Interface_Required.H>  // base class
-#include <NOX_Epetra_Vector.H>
 
 #include <set>
 #include <vector>

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.hpp
@@ -47,6 +47,7 @@ namespace NOX
       class PrePostOperator;
     }  // namespace LinSystem
     class Scaling;
+    class Vector;
 
     class LinearSystem : public NOX::Nln::LinearSystemBase
     {
@@ -60,7 +61,7 @@ namespace NOX
           const Teuchos::RCP<::NOX::Epetra::Interface::Jacobian>& iJac,
           const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
           const Teuchos::RCP<Core::LinAlg::SparseOperator>& preconditioner,
-          const ::NOX::Epetra::Vector& cloneVector,
+          const NOX::Nln::Vector& cloneVector,
           const std::shared_ptr<NOX::Nln::Scaling> scalingObject);
 
       //! Constructor without scaling object
@@ -69,22 +70,20 @@ namespace NOX
           const Teuchos::RCP<::NOX::Epetra::Interface::Jacobian>& iJac,
           const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
           const Teuchos::RCP<Core::LinAlg::SparseOperator>& preconditioner,
-          const ::NOX::Epetra::Vector& cloneVector);
+          const NOX::Nln::Vector& cloneVector);
 
       //! Constructor without preconditioner
       LinearSystem(Teuchos::ParameterList& printParams, Teuchos::ParameterList& linearSolverParams,
           const SolverMap& solvers, const Teuchos::RCP<::NOX::Epetra::Interface::Required>& iReq,
           const Teuchos::RCP<::NOX::Epetra::Interface::Jacobian>& iJac,
-          const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
-          const ::NOX::Epetra::Vector& cloneVector,
+          const Teuchos::RCP<Core::LinAlg::SparseOperator>& J, const NOX::Nln::Vector& cloneVector,
           const std::shared_ptr<NOX::Nln::Scaling> scalingObject);
 
       //! Constructor without preconditioner and scaling object
       LinearSystem(Teuchos::ParameterList& printParams, Teuchos::ParameterList& linearSolverParams,
           const SolverMap& solvers, const Teuchos::RCP<::NOX::Epetra::Interface::Required>& iReq,
           const Teuchos::RCP<::NOX::Epetra::Interface::Jacobian>& iJac,
-          const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
-          const ::NOX::Epetra::Vector& cloneVector);
+          const Teuchos::RCP<Core::LinAlg::SparseOperator>& J, const NOX::Nln::Vector& cloneVector);
 
       //! reset the linear solver parameters
       void reset(Teuchos::ParameterList& p);
@@ -93,31 +92,28 @@ namespace NOX
       void reset_pre_post_operator(Teuchos::ParameterList& p);
 
       //! Evaluate the Jacobian
-      bool compute_jacobian(const ::NOX::Epetra::Vector& x) override;
+      bool compute_jacobian(const NOX::Nln::Vector& x) override;
 
       //! Evaluate the Jacobian and the right hand side based on the solution vector x at once.
-      virtual bool compute_f_and_jacobian(
-          const ::NOX::Epetra::Vector& x, ::NOX::Epetra::Vector& rhs);
+      virtual bool compute_f_and_jacobian(const NOX::Nln::Vector& x, NOX::Nln::Vector& rhs);
 
       bool compute_correction_system(const enum NOX::Nln::CorrectionType type,
-          const ::NOX::Abstract::Group& grp, const ::NOX::Epetra::Vector& x,
-          ::NOX::Epetra::Vector& rhs);
+          const ::NOX::Abstract::Group& grp, const NOX::Nln::Vector& x, NOX::Nln::Vector& rhs);
 
-      bool apply_jacobian_block(const ::NOX::Epetra::Vector& input,
-          Teuchos::RCP<::NOX::Epetra::Vector>& result, unsigned rbid, unsigned cbid) const;
+      bool apply_jacobian_block(const NOX::Nln::Vector& input,
+          Teuchos::RCP<NOX::Nln::Vector>& result, unsigned rbid, unsigned cbid) const;
 
-      bool apply_jacobian(
-          const ::NOX::Epetra::Vector& input, ::NOX::Epetra::Vector& result) const override;
+      bool apply_jacobian(const NOX::Nln::Vector& input, NOX::Nln::Vector& result) const override;
 
       bool apply_jacobian_transpose(
-          const ::NOX::Epetra::Vector& input, ::NOX::Epetra::Vector& result) const override;
+          const NOX::Nln::Vector& input, NOX::Nln::Vector& result) const override;
 
       bool apply_jacobian_inverse(Teuchos::ParameterList& linearSolverParams,
-          const ::NOX::Epetra::Vector& input, ::NOX::Epetra::Vector& result) override;
+          const NOX::Nln::Vector& input, NOX::Nln::Vector& result) override;
 
       //! adjust the pseudo time step (using a least squares approximation)
       void adjust_pseudo_time_step(double& delta, const double& stepSize,
-          const ::NOX::Epetra::Vector& dir, const ::NOX::Epetra::Vector& rhs,
+          const NOX::Nln::Vector& dir, const NOX::Nln::Vector& rhs,
           const NOX::Nln::Solver::PseudoTransient& ptcsolver);
 
       //! ::NOX::Epetra::Interface::Required accessor

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_base.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_base.hpp
@@ -11,7 +11,6 @@
 #include "4C_config.hpp"
 
 #include <Epetra_Operator.h>
-#include <NOX_Epetra_Vector.H>
 #include <NOX_Utils.H>
 #include <Teuchos_ParameterList.hpp>
 
@@ -21,6 +20,8 @@ namespace NOX
 {
   namespace Nln
   {
+    class Vector;
+
     /**
      * \brief Base class for NOX linear systems.
      *
@@ -40,26 +41,26 @@ namespace NOX
        * \brief Applies Jacobian to the given input vector and puts the answer in the result.
        */
       virtual bool apply_jacobian(
-          const ::NOX::Epetra::Vector& input, ::NOX::Epetra::Vector& result) const = 0;
+          const NOX::Nln::Vector& input, NOX::Nln::Vector& result) const = 0;
 
       /**
        * \brief Applies Jacobian-Transpose to the given input vector and puts the answer in the
        *  result.
        */
       virtual bool apply_jacobian_transpose(
-          const ::NOX::Epetra::Vector& input, ::NOX::Epetra::Vector& result) const = 0;
+          const NOX::Nln::Vector& input, NOX::Nln::Vector& result) const = 0;
 
       /**
        * \brief Applies the inverse of the Jacobian matrix to the given input vector and puts the
        * answer in result.
        */
       virtual bool apply_jacobian_inverse(Teuchos::ParameterList& params,
-          const ::NOX::Epetra::Vector& input, ::NOX::Epetra::Vector& result) = 0;
+          const NOX::Nln::Vector& input, NOX::Nln::Vector& result) = 0;
 
       /**
        * \brief Evaluates the Jacobian based on the solution vector x.
        */
-      virtual bool compute_jacobian(const ::NOX::Epetra::Vector& x) = 0;
+      virtual bool compute_jacobian(const NOX::Nln::Vector& x) = 0;
 
       /**
        * \brief Return Jacobian operator

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_factory.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_factory.cpp
@@ -15,13 +15,13 @@
 #include "4C_linear_solver_method_linalg.hpp"
 #include "4C_solver_nonlin_nox_globaldata.hpp"
 #include "4C_solver_nonlin_nox_scaling.hpp"
+#include "4C_solver_nonlin_nox_vector.hpp"
 #include "4C_structure_new_nox_nln_str_linearsystem.hpp"
 #include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 
 #include <NOX_Epetra_Interface_Jacobian.H>
 #include <NOX_Epetra_Interface_Required.H>
-#include <NOX_Epetra_Vector.H>
 #include <Teuchos_ParameterList.hpp>
 
 FOUR_C_NAMESPACE_OPEN
@@ -37,7 +37,7 @@ NOX::Nln::LinSystem::Factory::Factory()
  *----------------------------------------------------------------------------*/
 Teuchos::RCP<NOX::Nln::LinearSystemBase> NOX::Nln::LinSystem::Factory::build_linear_system(
     const NOX::Nln::LinSystem::LinearSystemType& linsystype, NOX::Nln::GlobalData& noxNlnGlobalData,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& jac, ::NOX::Epetra::Vector& cloneVector,
+    const Teuchos::RCP<Core::LinAlg::SparseOperator>& jac, NOX::Nln::Vector& cloneVector,
     const Teuchos::RCP<Core::LinAlg::SparseOperator>& precMat,
     const std::shared_ptr<NOX::Nln::Scaling>& scalingObject) const
 {
@@ -129,7 +129,7 @@ Teuchos::RCP<NOX::Nln::LinearSystemBase> NOX::Nln::LinSystem::Factory::build_lin
  *----------------------------------------------------------------------------*/
 Teuchos::RCP<NOX::Nln::LinearSystemBase> NOX::Nln::LinSystem::build_linear_system(
     const NOX::Nln::LinSystem::LinearSystemType& linsystype, NOX::Nln::GlobalData& noxNlnGlobalData,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& jac, ::NOX::Epetra::Vector& cloneVector,
+    const Teuchos::RCP<Core::LinAlg::SparseOperator>& jac, NOX::Nln::Vector& cloneVector,
     const Teuchos::RCP<Core::LinAlg::SparseOperator>& precMat,
     const std::shared_ptr<NOX::Nln::Scaling>& scalingObject)
 {

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_factory.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_factory.hpp
@@ -33,6 +33,7 @@ namespace NOX
   {
     class GlobalData;
     class Scaling;
+    class Vector;
 
     namespace LinSystem
     {
@@ -46,8 +47,7 @@ namespace NOX
         Teuchos::RCP<NOX::Nln::LinearSystemBase> build_linear_system(
             const NOX::Nln::LinSystem::LinearSystemType& linsystype,
             NOX::Nln::GlobalData& noxNlnGlobalData,
-            const Teuchos::RCP<Core::LinAlg::SparseOperator>& jac,
-            ::NOX::Epetra::Vector& cloneVector,
+            const Teuchos::RCP<Core::LinAlg::SparseOperator>& jac, NOX::Nln::Vector& cloneVector,
             const Teuchos::RCP<Core::LinAlg::SparseOperator>& precMat,
             const std::shared_ptr<NOX::Nln::Scaling>& scalingObject) const;
       };
@@ -60,7 +60,7 @@ namespace NOX
       Teuchos::RCP<NOX::Nln::LinearSystemBase> build_linear_system(
           const NOX::Nln::LinSystem::LinearSystemType& linsystype,
           NOX::Nln::GlobalData& noxNlnGlobalData,
-          const Teuchos::RCP<Core::LinAlg::SparseOperator>& jac, ::NOX::Epetra::Vector& cloneVector,
+          const Teuchos::RCP<Core::LinAlg::SparseOperator>& jac, NOX::Nln::Vector& cloneVector,
           const Teuchos::RCP<Core::LinAlg::SparseOperator>& precMat,
           const std::shared_ptr<NOX::Nln::Scaling>& scalingObject);
     }  // namespace LinSystem

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_problem.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_problem.cpp
@@ -21,9 +21,9 @@
 #include "4C_solver_nonlin_nox_linearsystem_factory.hpp"
 #include "4C_solver_nonlin_nox_scaling.hpp"
 #include "4C_solver_nonlin_nox_singlestep_group.hpp"
+#include "4C_solver_nonlin_nox_vector.hpp"
 
 #include <NOX_Epetra_Interface_Required.H>
-#include <NOX_Epetra_Vector.H>
 #include <NOX_StatusTest_Generic.H>
 #include <Teuchos_ParameterList.hpp>
 
@@ -45,8 +45,7 @@ NOX::Nln::Problem::Problem(const Teuchos::RCP<NOX::Nln::GlobalData>& noxNlnGloba
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 NOX::Nln::Problem::Problem(const Teuchos::RCP<NOX::Nln::GlobalData>& noxNlnGlobalData,
-    const Teuchos::RCP<::NOX::Epetra::Vector>& x,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& A)
+    const Teuchos::RCP<NOX::Nln::Vector>& x, const Teuchos::RCP<Core::LinAlg::SparseOperator>& A)
     : isinit_(false),
       nox_global_data_(noxNlnGlobalData),
       x_vector_(nullptr),
@@ -58,8 +57,8 @@ NOX::Nln::Problem::Problem(const Teuchos::RCP<NOX::Nln::GlobalData>& noxNlnGloba
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-void NOX::Nln::Problem::initialize(const Teuchos::RCP<::NOX::Epetra::Vector>& x,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& A)
+void NOX::Nln::Problem::initialize(
+    const Teuchos::RCP<NOX::Nln::Vector>& x, const Teuchos::RCP<Core::LinAlg::SparseOperator>& A)
 {
   // in the standard case, we use the input rhs and matrix
   // ToDo Check if CreateView is sufficient

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_problem.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_problem.hpp
@@ -40,6 +40,8 @@ namespace NOX
       }  // namespace StatusTest
     }  // namespace Inner
 
+    class Vector;
+
     class Problem
     {
      public:
@@ -48,11 +50,11 @@ namespace NOX
 
       //! standard constructor
       Problem(const Teuchos::RCP<NOX::Nln::GlobalData>& noxNlnGlobalData,
-          const Teuchos::RCP<::NOX::Epetra::Vector>& x,
+          const Teuchos::RCP<NOX::Nln::Vector>& x,
           const Teuchos::RCP<Core::LinAlg::SparseOperator>& A);
 
       //! initialize stuff
-      void initialize(const Teuchos::RCP<::NOX::Epetra::Vector>& x,
+      void initialize(const Teuchos::RCP<NOX::Nln::Vector>& x,
           const Teuchos::RCP<Core::LinAlg::SparseOperator>& A);
 
       //! create the linear system for the NOX framework
@@ -95,7 +97,7 @@ namespace NOX
 
       /** ptr to the state vector RCP. In this way the strong_count is neither lost
        *  nor increased. */
-      const Teuchos::RCP<::NOX::Epetra::Vector>* x_vector_;
+      const Teuchos::RCP<NOX::Nln::Vector>* x_vector_;
 
       /** ptr to the state matrix RCP. In this way the strong_count is neither lost
        *  nor increased. */

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_singlestep_group.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_singlestep_group.cpp
@@ -15,7 +15,7 @@ FOUR_C_NAMESPACE_OPEN
  *----------------------------------------------------------------------------*/
 NOX::Nln::SINGLESTEP::Group::Group(Teuchos::ParameterList& printParams,
     Teuchos::ParameterList& grpOptionParams,
-    const Teuchos::RCP<::NOX::Epetra::Interface::Required>& i, const ::NOX::Epetra::Vector& x,
+    const Teuchos::RCP<::NOX::Epetra::Interface::Required>& i, const NOX::Nln::Vector& x,
     const Teuchos::RCP<NOX::Nln::LinearSystemBase>& linSys)
     : NOX::Nln::Group(printParams, grpOptionParams, i, x, linSys)
 {
@@ -46,7 +46,7 @@ void NOX::Nln::SINGLESTEP::Group::computeX(
   const NOX::Nln::SINGLESTEP::Group* nlngrp =
       dynamic_cast<const NOX::Nln::SINGLESTEP::Group*>(&grp);
   if (nlngrp == nullptr) throw_error("computeX", "dyn_cast to nox_nln_group failed!");
-  const ::NOX::Epetra::Vector& epetrad = dynamic_cast<const ::NOX::Epetra::Vector&>(d);
+  const auto& epetrad = dynamic_cast<const NOX::Nln::Vector&>(d);
 
   computeX(*nlngrp, epetrad, step);
   return;
@@ -55,7 +55,7 @@ void NOX::Nln::SINGLESTEP::Group::computeX(
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 void NOX::Nln::SINGLESTEP::Group::computeX(
-    const NOX::Nln::SINGLESTEP::Group& grp, const ::NOX::Epetra::Vector& d, double step)
+    const NOX::Nln::SINGLESTEP::Group& grp, const NOX::Nln::Vector& d, double step)
 {
   Core::LinAlg::View d_view(const_cast<Epetra_Vector&>(d.getEpetraVector()));
   prePostOperatorPtr_->run_pre_compute_x(grp, d_view, step, *this);

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_singlestep_group.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_singlestep_group.hpp
@@ -29,8 +29,8 @@ namespace NOX
         Group(Teuchos::ParameterList& printParams,  //!< printing parameters
             Teuchos::ParameterList& grpOptionParams,
             const Teuchos::RCP<::NOX::Epetra::Interface::Required>&
-                i,                           //!< basically the NOXified time integrator
-            const ::NOX::Epetra::Vector& x,  //!< current solution vector
+                i,                      //!< basically the NOXified time integrator
+            const NOX::Nln::Vector& x,  //!< current solution vector
             const Teuchos::RCP<NOX::Nln::LinearSystemBase>&
                 linSys  //!< linear system, matrix and RHS etc.
         );
@@ -44,7 +44,7 @@ namespace NOX
 
         //! compute/update the current state variables
         void computeX(
-            const NOX::Nln::SINGLESTEP::Group& grp, const ::NOX::Epetra::Vector& d, double step);
+            const NOX::Nln::SINGLESTEP::Group& grp, const NOX::Nln::Vector& d, double step);
         void computeX(const ::NOX::Abstract::Group& grp, const ::NOX::Abstract::Vector& d,
             double step) override;
 

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_solver_ptc.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_solver_ptc.hpp
@@ -30,6 +30,8 @@ namespace NOX
   namespace Nln
   {
     class LinearSystem;
+    class Vector;
+
     namespace Solver
     {
       /*! \brief Pseudo Transient Continuation (PTC) non-linear solver
@@ -435,8 +437,7 @@ namespace NOX
               Core::LinAlg::Vector<double>& F, const NOX::Nln::Group& grp) override;
 
          protected:
-          Teuchos::RCP<::NOX::Epetra::Vector> eval_pseudo_transient_f_update(
-              const NOX::Nln::Group& grp);
+          Teuchos::RCP<NOX::Nln::Vector> eval_pseudo_transient_f_update(const NOX::Nln::Group& grp);
 
          private:
           //! read-only access

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_vector.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_vector.cpp
@@ -1,0 +1,66 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "4C_solver_nonlin_nox_vector.hpp"
+
+#include "4C_utils_exceptions.hpp"
+
+#include <Epetra_Vector.h>
+
+FOUR_C_NAMESPACE_OPEN
+
+NOX::Nln::Vector::Vector(
+    const Teuchos::RCP<Epetra_Vector>& source, MemoryType memoryType, ::NOX::CopyType type)
+    : ::NOX::Epetra::Vector(source,
+          memoryType == MemoryType::View ? ::NOX::Epetra::Vector::CreateView
+                                         : ::NOX::Epetra::Vector::CreateCopy,
+          type)
+{
+}
+
+NOX::Nln::Vector::Vector(const Epetra_Vector& source, ::NOX::CopyType type)
+    : ::NOX::Epetra::Vector(source, type)
+{
+}
+
+NOX::Nln::Vector::Vector(const NOX::Nln::Vector& source, ::NOX::CopyType type)
+    : ::NOX::Epetra::Vector(source, type)
+{
+}
+
+::NOX::Abstract::Vector& NOX::Nln::Vector::operator=(const Epetra_Vector& source)
+{
+  epetraVec->Scale(1.0, source);
+  return *this;
+}
+
+::NOX::Abstract::Vector& NOX::Nln::Vector::operator=(const NOX::Nln::Vector& source)
+{
+  epetraVec->Scale(1.0, source.getEpetraVector());
+  return *this;
+}
+
+::NOX::Abstract::Vector& NOX::Nln::Vector::operator=(const ::NOX::Abstract::Vector& source)
+{
+  return operator=(dynamic_cast<const NOX::Nln::Vector&>(source));
+}
+
+::NOX::Abstract::Vector& NOX::Nln::Vector::operator=(const ::NOX::Epetra::Vector&)
+{
+  FOUR_C_THROW("This operator= should never be called!");
+
+  return *this;
+}
+
+Teuchos::RCP<::NOX::Abstract::Vector> NOX::Nln::Vector::clone(::NOX::CopyType type) const
+{
+  Teuchos::RCP<::NOX::Abstract::Vector> newVec =
+      Teuchos::rcp(new NOX::Nln::Vector(*epetraVec, type));
+  return newVec;
+}
+
+FOUR_C_NAMESPACE_CLOSE

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_vector.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_vector.hpp
@@ -1,0 +1,58 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef FOUR_C_SOLVER_NONLIN_NOX_VECTOR_HPP
+#define FOUR_C_SOLVER_NONLIN_NOX_VECTOR_HPP
+
+#include "4C_config.hpp"
+
+#include <NOX_Epetra_Vector.H>
+#include <Teuchos_RCP.hpp>
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace NOX
+{
+  namespace Nln
+  {
+    class Vector : public ::NOX::Epetra::Vector
+    {
+     public:
+      enum class MemoryType
+      {
+        View = ::NOX::Epetra::Vector::CreateView,
+        Copy = ::NOX::Epetra::Vector::CreateCopy
+      };
+
+      //! Reproduce ctors of ::NOX::Epetra::Vector
+      Vector(const Teuchos::RCP<Epetra_Vector>& source, MemoryType memoryType = MemoryType::Copy,
+          ::NOX::CopyType type = ::NOX::DeepCopy);
+
+      Vector(const Epetra_Vector& source, ::NOX::CopyType type = ::NOX::DeepCopy);
+
+      Vector(const NOX::Nln::Vector& source, ::NOX::CopyType type = ::NOX::DeepCopy);
+
+      //! Main copy assignment operator
+      ::NOX::Abstract::Vector& operator=(const NOX::Nln::Vector& source);
+
+      //! Overloaded copy assignment operators
+      ::NOX::Abstract::Vector& operator=(const Epetra_Vector& source) override;
+      ::NOX::Abstract::Vector& operator=(const ::NOX::Abstract::Vector& source) override;
+
+      //! This operator is inherited and should not be ever called
+      ::NOX::Abstract::Vector& operator=(const ::NOX::Epetra::Vector&) override;
+
+      //! Clone method
+      Teuchos::RCP<::NOX::Abstract::Vector> clone(
+          ::NOX::CopyType type = ::NOX::DeepCopy) const override;
+    };
+  }  // namespace Nln
+}  // namespace NOX
+
+FOUR_C_NAMESPACE_CLOSE
+
+#endif

--- a/src/structure_new/src/4C_structure_new_integrator.cpp
+++ b/src/structure_new/src/4C_structure_new_integrator.cpp
@@ -16,6 +16,7 @@
 #include "4C_linalg_vector.hpp"
 #include "4C_linear_solver_method_linalg.hpp"
 #include "4C_solver_nonlin_nox_aux.hpp"
+#include "4C_solver_nonlin_nox_vector.hpp"
 #include "4C_structure_new_dbc.hpp"
 #include "4C_structure_new_model_evaluator_data.hpp"
 #include "4C_structure_new_model_evaluator_manager.hpp"
@@ -232,9 +233,9 @@ void Solid::Integrator::compute_mass_matrix_and_init_acc()
 
   // create a copy of the initial displacement vector
   Core::LinAlg::Vector<double> soln(*global_state().dof_row_map_view(), true);
-  // wrap the soln_ptr in a nox_epetra_Vector
-  ::NOX::Epetra::Vector nox_soln(
-      Teuchos::rcpFromRef(soln.get_ref_of_epetra_vector()), ::NOX::Epetra::Vector::CreateView);
+  // wrap the soln_ptr in a NOX::Nln::Vector
+  NOX::Nln::Vector nox_soln(
+      Teuchos::rcpFromRef(soln.get_ref_of_epetra_vector()), NOX::Nln::Vector::MemoryType::View);
 
   // Check if we are using a Newton direction
   std::string dir_str = p_nox.sublist("Direction").get<std::string>("Method");

--- a/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.hpp
+++ b/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.hpp
@@ -26,13 +26,6 @@ namespace Teuchos
 {
   class Time;
 }
-namespace NOX
-{
-  namespace Epetra
-  {
-    class Vector;
-  }  // namespace Epetra
-}  // namespace NOX
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -54,6 +47,11 @@ namespace Core::LinAlg
   class SparseOperator;
   class SparseMatrix;
 }  // namespace Core::LinAlg
+
+namespace NOX::Nln
+{
+  class Vector;
+}  // namespace NOX::Nln
 
 namespace Solid
 {
@@ -222,9 +220,8 @@ namespace Solid
       std::shared_ptr<Core::LinAlg::SparseMatrix> jacobian_displ_block();
 
       /// Create the global solution vector
-      std::shared_ptr<::NOX::Epetra::Vector> create_global_vector() const;
-      std::shared_ptr<::NOX::Epetra::Vector> create_global_vector(
-          const enum VecInitType& vecinittype,
+      std::shared_ptr<NOX::Nln::Vector> create_global_vector() const;
+      std::shared_ptr<NOX::Nln::Vector> create_global_vector(const enum VecInitType& vecinittype,
           const std::shared_ptr<const Solid::ModelEvaluatorManager>& modeleval) const;
 
       /// Create the structural stiffness matrix block

--- a/src/structure_new/src/implicit/4C_structure_new_impl_generic.cpp
+++ b/src/structure_new/src/implicit/4C_structure_new_impl_generic.cpp
@@ -12,6 +12,7 @@
 #include "4C_solver_nonlin_nox_group.hpp"
 #include "4C_solver_nonlin_nox_group_prepostoperator.hpp"
 #include "4C_solver_nonlin_nox_solver_linesearchbased.hpp"
+#include "4C_solver_nonlin_nox_vector.hpp"
 #include "4C_structure_new_model_evaluator_data.hpp"
 #include "4C_structure_new_model_evaluator_manager.hpp"
 #include "4C_structure_new_timint_implicit.hpp"
@@ -24,18 +25,18 @@ namespace
 {
   Epetra_Vector& extract_epetra_vector(::NOX::Abstract::Vector& vec)
   {
-    ::NOX::Epetra::Vector* epetra_vec = dynamic_cast<::NOX::Epetra::Vector*>(&vec);
+    auto* epetra_vec = dynamic_cast<NOX::Nln::Vector*>(&vec);
     FOUR_C_ASSERT(
-        epetra_vec != nullptr, "The given ::NOX::Abstract::Vector is no ::NOX::Epetra::Vector!");
+        epetra_vec != nullptr, "The given ::NOX::Abstract::Vector is no NOX::Nln::Vector!");
 
     return epetra_vec->getEpetraVector();
   }
 
   Core::LinAlg::Vector<double> copy_to_our_vector(const ::NOX::Abstract::Vector& vec)
   {
-    const ::NOX::Epetra::Vector* epetra_vec = dynamic_cast<const ::NOX::Epetra::Vector*>(&vec);
+    const auto* epetra_vec = dynamic_cast<const NOX::Nln::Vector*>(&vec);
     FOUR_C_ASSERT(
-        epetra_vec != nullptr, "The given ::NOX::Abstract::Vector is no ::NOX::Epetra::Vector!");
+        epetra_vec != nullptr, "The given ::NOX::Abstract::Vector is no NOX::Nln::Vector!");
 
     return Core::LinAlg::Vector<double>(epetra_vec->getEpetraVector());
   }
@@ -192,7 +193,7 @@ void NOX::Nln::PrePostOp::IMPLICIT::Generic::run_pre_compute_x(const NOX::Nln::G
     const Core::LinAlg::Vector<double>& dir, const double& step, const NOX::Nln::Group& curr_grp)
 {
   // set the evaluation parameters
-  const auto& xold = dynamic_cast<const ::NOX::Epetra::Vector&>(input_grp.getX()).getEpetraVector();
+  const auto& xold = dynamic_cast<const NOX::Nln::Vector&>(input_grp.getX()).getEpetraVector();
   Core::LinAlg::Vector<double>& dir_mutable = const_cast<Core::LinAlg::Vector<double>&>(dir);
 
   const bool isdefaultstep = (step == default_step_);
@@ -206,8 +207,8 @@ void NOX::Nln::PrePostOp::IMPLICIT::Generic::run_post_compute_x(const NOX::Nln::
     const Core::LinAlg::Vector<double>& dir, const double& step, const NOX::Nln::Group& curr_grp)
 {
   // set the evaluation parameters
-  const auto& xold = dynamic_cast<const ::NOX::Epetra::Vector&>(input_grp.getX()).getEpetraVector();
-  const auto& xnew = dynamic_cast<const ::NOX::Epetra::Vector&>(curr_grp.getX()).getEpetraVector();
+  const auto& xold = dynamic_cast<const NOX::Nln::Vector&>(input_grp.getX()).getEpetraVector();
+  const auto& xnew = dynamic_cast<const NOX::Nln::Vector&>(curr_grp.getX()).getEpetraVector();
 
   bool isdefaultstep = (step == default_step_);
   impl_.model_eval().run_post_compute_x(Core::LinAlg::Vector<double>(xold), dir, step,
@@ -248,7 +249,7 @@ void NOX::Nln::PrePostOp::IMPLICIT::Generic::run_pre_apply_jacobian_inverse(
 
   impl_.model_eval().run_pre_apply_jacobian_inverse(
       rhs_our, result_view, copy_to_our_vector(xold), grp);
-  const ::NOX::Epetra::Vector* epetra_rhs = dynamic_cast<const ::NOX::Epetra::Vector*>(&rhs);
+  const auto* epetra_rhs = dynamic_cast<const NOX::Nln::Vector*>(&rhs);
   const_cast<Epetra_Vector&>(epetra_rhs->getEpetraVector()).Update(1.0, rhs_our, 0.0);
 }
 

--- a/src/structure_new/src/implicit/4C_structure_new_impl_statics.cpp
+++ b/src/structure_new/src/implicit/4C_structure_new_impl_statics.cpp
@@ -12,14 +12,13 @@
 #include "4C_linalg_sparseoperator.hpp"
 #include "4C_linalg_utils_sparse_algebra_create.hpp"
 #include "4C_linalg_vector.hpp"
+#include "4C_solver_nonlin_nox_vector.hpp"
 #include "4C_structure_new_dbc.hpp"
 #include "4C_structure_new_model_evaluator_data.hpp"
 #include "4C_structure_new_model_evaluator_manager.hpp"
 #include "4C_structure_new_model_evaluator_structure.hpp"
 #include "4C_structure_new_predict_generic.hpp"
 #include "4C_structure_new_timint_implicit.hpp"
-
-#include <NOX_Epetra_Vector.H>
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -150,13 +149,13 @@ double Solid::IMPLICIT::Statics::calc_ref_norm_force(
   const std::shared_ptr<Core::LinAlg::Vector<double>> freactnp =
       std::const_pointer_cast<Core::LinAlg::Vector<double>>(global_state().get_freact_np());
 
-  // switch from Core::LinAlg::Vector<double> to ::NOX::Epetra::Vector (view but read-only)
-  const ::NOX::Epetra::Vector fintnp_nox_ptr(
-      Teuchos::rcpFromRef(fintnp->get_ref_of_epetra_vector()), ::NOX::Epetra::Vector::CreateView);
-  const ::NOX::Epetra::Vector fextnp_nox_ptr(
-      Teuchos::rcpFromRef(fextnp->get_ref_of_epetra_vector()), ::NOX::Epetra::Vector::CreateView);
-  const ::NOX::Epetra::Vector freactnp_nox_ptr(
-      Teuchos::rcpFromRef(freactnp->get_ref_of_epetra_vector()), ::NOX::Epetra::Vector::CreateView);
+  // switch from Core::LinAlg::Vector<double> to NOX::Nln::Vector (view but read-only)
+  const NOX::Nln::Vector fintnp_nox_ptr(
+      Teuchos::rcpFromRef(fintnp->get_ref_of_epetra_vector()), NOX::Nln::Vector::MemoryType::View);
+  const NOX::Nln::Vector fextnp_nox_ptr(
+      Teuchos::rcpFromRef(fextnp->get_ref_of_epetra_vector()), NOX::Nln::Vector::MemoryType::View);
+  const NOX::Nln::Vector freactnp_nox_ptr(Teuchos::rcpFromRef(freactnp->get_ref_of_epetra_vector()),
+      NOX::Nln::Vector::MemoryType::View);
 
   // norm of the internal forces
   double fintnorm = fintnp_nox_ptr.norm(type);

--- a/src/structure_new/src/implicit/4C_structure_new_timint_implicitbase.cpp
+++ b/src/structure_new/src/implicit/4C_structure_new_timint_implicitbase.cpp
@@ -9,10 +9,10 @@
 
 #include "4C_linalg_blocksparsematrix.hpp"
 #include "4C_linalg_sparsematrix.hpp"
+#include "4C_solver_nonlin_nox_vector.hpp"
 #include "4C_structure_new_integrator.hpp"
 
 #include <NOX_Abstract_Group.H>
-#include <NOX_Epetra_Vector.H>
 #include <Teuchos_Time.hpp>
 
 FOUR_C_NAMESPACE_OPEN
@@ -29,7 +29,7 @@ Solid::TimeInt::ImplicitBase::ImplicitBase()
 std::shared_ptr<const Core::LinAlg::Vector<double>> Solid::TimeInt::ImplicitBase::get_f() const
 {
   const ::NOX::Abstract::Group& solgrp = get_solution_group();
-  const ::NOX::Epetra::Vector& F = dynamic_cast<const ::NOX::Epetra::Vector&>(solgrp.getF());
+  const auto& F = dynamic_cast<const NOX::Nln::Vector&>(solgrp.getF());
   return get_data_global_state().extract_displ_entries(
       Core::LinAlg::Vector<double>(F.getEpetraVector()));
 }

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_contact.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_contact.cpp
@@ -17,6 +17,7 @@
 #include "4C_solver_nonlin_nox_group.hpp"
 #include "4C_solver_nonlin_nox_group_prepostoperator.hpp"
 #include "4C_solver_nonlin_nox_solver_linesearchbased.hpp"
+#include "4C_solver_nonlin_nox_vector.hpp"
 #include "4C_structure_new_dbc.hpp"
 #include "4C_structure_new_impl_generic.hpp"
 #include "4C_structure_new_model_evaluator_data.hpp"
@@ -745,8 +746,7 @@ void Solid::ModelEvaluator::Contact::run_post_iterate(const ::NOX::Solver::Gener
 {
   check_init_setup();
 
-  const ::NOX::Epetra::Vector& nox_x =
-      dynamic_cast<const ::NOX::Epetra::Vector&>(solver.getSolutionGroup().getX());
+  const auto& nox_x = dynamic_cast<const NOX::Nln::Vector&>(solver.getSolutionGroup().getX());
 
   // displacement vector after the predictor call
   std::shared_ptr<Core::LinAlg::Vector<double>> curr_disp =
@@ -776,8 +776,7 @@ void Solid::ModelEvaluator::Contact::run_pre_apply_jacobian_inverse(
 void Solid::ModelEvaluator::Contact::run_pre_solve(const ::NOX::Solver::Generic& solver)
 {
   check_init_setup();
-  const ::NOX::Epetra::Vector& nox_x =
-      dynamic_cast<const ::NOX::Epetra::Vector&>(solver.getSolutionGroup().getX());
+  const auto& nox_x = dynamic_cast<const NOX::Nln::Vector&>(solver.getSolutionGroup().getX());
 
   // displacement vector after the predictor call
   std::shared_ptr<Core::LinAlg::Vector<double>> curr_disp =
@@ -827,7 +826,7 @@ std::shared_ptr<Core::LinAlg::Vector<double>>
 Solid::ModelEvaluator::Contact::assemble_force_of_models(
     const std::vector<Inpar::Solid::ModelType>* without_these_models, const bool apply_dbc) const
 {
-  std::shared_ptr<::NOX::Epetra::Vector> force_nox = global_state().create_global_vector();
+  std::shared_ptr<NOX::Nln::Vector> force_nox = global_state().create_global_vector();
   {
     Core::LinAlg::View force_view(force_nox->getEpetraVector());
     integrator().assemble_force(force_view, without_these_models);

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_nox.cpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_nox.cpp
@@ -20,7 +20,6 @@
 #include "4C_structure_new_utils.hpp"
 
 #include <NOX_Abstract_Group.H>
-#include <NOX_Epetra_Vector.H>
 #include <NOX_Solver_Generic.H>
 #include <Teuchos_RCPStdSharedPtrConversions.hpp>
 
@@ -92,8 +91,7 @@ Solid::Nln::SOLVER::Nox::Nox(const Teuchos::ParameterList& default_params,
   // -------------------------------------------------------------------------
   // Create NOX control class: NoxProblem()
   // -------------------------------------------------------------------------
-  Teuchos::RCP<::NOX::Epetra::Vector> soln =
-      Teuchos::rcp(data_global_state().create_global_vector());
+  Teuchos::RCP<NOX::Nln::Vector> soln = Teuchos::rcp(data_global_state().create_global_vector());
   Teuchos::RCP<Core::LinAlg::SparseOperator> jac =
       Teuchos::rcp(data_global_state().create_jacobian());
   problem_ = Teuchos::make_rcp<NOX::Nln::Problem>(nlnglobaldata_, soln, jac);

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nox_nln_str_linearsystem.cpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nox_nln_str_linearsystem.cpp
@@ -24,7 +24,7 @@ NOX::Nln::Solid::LinearSystem::LinearSystem(Teuchos::ParameterList& printParams,
     const Teuchos::RCP<::NOX::Epetra::Interface::Required>& iReq,
     const Teuchos::RCP<::NOX::Epetra::Interface::Jacobian>& iJac,
     const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& M, const ::NOX::Epetra::Vector& cloneVector,
+    const Teuchos::RCP<Core::LinAlg::SparseOperator>& M, const NOX::Nln::Vector& cloneVector,
     const std::shared_ptr<NOX::Nln::Scaling> scalingObject)
     : NOX::Nln::LinearSystem(
           printParams, linearSolverParams, solvers, iReq, iJac, J, M, cloneVector, scalingObject)
@@ -40,7 +40,7 @@ NOX::Nln::Solid::LinearSystem::LinearSystem(Teuchos::ParameterList& printParams,
     const Teuchos::RCP<::NOX::Epetra::Interface::Required>& iReq,
     const Teuchos::RCP<::NOX::Epetra::Interface::Jacobian>& iJac,
     const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& M, const ::NOX::Epetra::Vector& cloneVector)
+    const Teuchos::RCP<Core::LinAlg::SparseOperator>& M, const NOX::Nln::Vector& cloneVector)
     : NOX::Nln::LinearSystem(
           printParams, linearSolverParams, solvers, iReq, iJac, J, M, cloneVector)
 {
@@ -54,7 +54,7 @@ NOX::Nln::Solid::LinearSystem::LinearSystem(Teuchos::ParameterList& printParams,
     const std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>& solvers,
     const Teuchos::RCP<::NOX::Epetra::Interface::Required>& iReq,
     const Teuchos::RCP<::NOX::Epetra::Interface::Jacobian>& iJac,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& J, const ::NOX::Epetra::Vector& cloneVector,
+    const Teuchos::RCP<Core::LinAlg::SparseOperator>& J, const NOX::Nln::Vector& cloneVector,
     const std::shared_ptr<NOX::Nln::Scaling> scalingObject)
     : NOX::Nln::LinearSystem(
           printParams, linearSolverParams, solvers, iReq, iJac, J, cloneVector, scalingObject)
@@ -69,7 +69,7 @@ NOX::Nln::Solid::LinearSystem::LinearSystem(Teuchos::ParameterList& printParams,
     const std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>& solvers,
     const Teuchos::RCP<::NOX::Epetra::Interface::Required>& iReq,
     const Teuchos::RCP<::NOX::Epetra::Interface::Jacobian>& iJac,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& J, const ::NOX::Epetra::Vector& cloneVector)
+    const Teuchos::RCP<Core::LinAlg::SparseOperator>& J, const NOX::Nln::Vector& cloneVector)
     : NOX::Nln::LinearSystem(printParams, linearSolverParams, solvers, iReq, iJac, J, cloneVector)
 {
   // empty constructor

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nox_nln_str_linearsystem.hpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nox_nln_str_linearsystem.hpp
@@ -31,7 +31,7 @@ namespace NOX
             const Teuchos::RCP<::NOX::Epetra::Interface::Jacobian>& iJac,
             const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
             const Teuchos::RCP<Core::LinAlg::SparseOperator>& M,
-            const ::NOX::Epetra::Vector& cloneVector,
+            const NOX::Nln::Vector& cloneVector,
             const std::shared_ptr<NOX::Nln::Scaling> scalingObject);
 
         //! Constructor without scaling object
@@ -42,7 +42,7 @@ namespace NOX
             const Teuchos::RCP<::NOX::Epetra::Interface::Jacobian>& iJac,
             const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
             const Teuchos::RCP<Core::LinAlg::SparseOperator>& M,
-            const ::NOX::Epetra::Vector& cloneVector);
+            const NOX::Nln::Vector& cloneVector);
 
         //! Constructor without preconditioner
         LinearSystem(Teuchos::ParameterList& printParams,
@@ -51,7 +51,7 @@ namespace NOX
             const Teuchos::RCP<::NOX::Epetra::Interface::Required>& iReq,
             const Teuchos::RCP<::NOX::Epetra::Interface::Jacobian>& iJac,
             const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
-            const ::NOX::Epetra::Vector& cloneVector,
+            const NOX::Nln::Vector& cloneVector,
             const std::shared_ptr<NOX::Nln::Scaling> scalingObject);
 
         //! Constructor without preconditioner and scaling object
@@ -61,7 +61,7 @@ namespace NOX
             const Teuchos::RCP<::NOX::Epetra::Interface::Required>& iReq,
             const Teuchos::RCP<::NOX::Epetra::Interface::Jacobian>& iJac,
             const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
-            const ::NOX::Epetra::Vector& cloneVector);
+            const NOX::Nln::Vector& cloneVector);
 
 
         //! sets the options of the underlying solver

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_timint_noxinterface.cpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_timint_noxinterface.cpp
@@ -21,8 +21,6 @@
 #include "4C_structure_new_timint_base.hpp"
 #include "4C_structure_new_utils.hpp"
 
-#include <NOX_Epetra_Vector.H>
-
 FOUR_C_NAMESPACE_OPEN
 
 /*----------------------------------------------------------------------------*
@@ -535,8 +533,7 @@ void Solid::TimeInt::NoxInterface::find_constraint_models(const ::NOX::Abstract:
 double Solid::TimeInt::NoxInterface::calc_ref_norm_force()
 {
   check_init_setup();
-  const ::NOX::Epetra::Vector::NormType& nox_normtype =
-      timint_ptr_->get_data_sdyn().get_nox_norm_type();
+  const auto& nox_normtype = timint_ptr_->get_data_sdyn().get_nox_norm_type();
   return int_ptr_->calc_ref_norm_force(nox_normtype);
 }
 

--- a/src/structure_new/src/predict/4C_structure_new_predict_generic.cpp
+++ b/src/structure_new/src/predict/4C_structure_new_predict_generic.cpp
@@ -90,7 +90,7 @@ void Solid::Predict::Generic::post_predict(::NOX::Abstract::Group& grp)
       global_state().get_vel_np(), global_state().get_acc_np(), false);
 
   // Create the new solution vector
-  std::shared_ptr<::NOX::Epetra::Vector> x_vec = global_state().create_global_vector(
+  std::shared_ptr<NOX::Nln::Vector> x_vec = global_state().create_global_vector(
       TimeInt::BaseDataGlobalState::VecInitType::init_current_state, impl_int().model_eval_ptr());
   // resets all isValid flags
   grp.setX(*x_vec);

--- a/src/structure_new/src/predict/4C_structure_new_predict_tangdis.cpp
+++ b/src/structure_new/src/predict/4C_structure_new_predict_tangdis.cpp
@@ -12,6 +12,7 @@
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
 #include "4C_solver_nonlin_nox_group.hpp"
 #include "4C_solver_nonlin_nox_group_prepostoperator.hpp"
+#include "4C_solver_nonlin_nox_vector.hpp"
 #include "4C_structure_new_dbc.hpp"
 #include "4C_structure_new_impl_generic.hpp"
 #include "4C_structure_new_model_evaluator_data.hpp"
@@ -20,7 +21,6 @@
 #include "4C_structure_new_utils.hpp"
 #include "4C_utils_exceptions.hpp"
 
-#include <NOX_Epetra_Vector.H>
 #include <Teuchos_ParameterList.hpp>
 
 FOUR_C_NAMESPACE_OPEN
@@ -73,7 +73,7 @@ void Solid::Predict::TangDis::compute(::NOX::Abstract::Group& grp)
   // We create at this point a new solution vector and initialize it
   // with the values of the last converged time step.
   // ---------------------------------------------------------------------------
-  std::shared_ptr<::NOX::Epetra::Vector> x_ptr = global_state().create_global_vector(
+  std::shared_ptr<NOX::Nln::Vector> x_ptr = global_state().create_global_vector(
       TimeInt::BaseDataGlobalState::VecInitType::last_time_step, impl_int().model_eval_ptr());
   // Set the solution vector in the nox group. This will reset all isValid
   // flags.
@@ -121,8 +121,7 @@ void Solid::Predict::TangDis::compute(::NOX::Abstract::Group& grp)
   Core::LinAlg::export_to(*dbc_incr_ptr_, *dbc_incr_exp_ptr);
   grp_ptr->computeX(*grp_ptr, dbc_incr_exp_ptr->get_ref_of_epetra_vector(), 1.0);
   // Reset the state variables
-  const ::NOX::Epetra::Vector& x_eptra =
-      dynamic_cast<const ::NOX::Epetra::Vector&>(grp_ptr->getX());
+  const auto& x_eptra = dynamic_cast<const NOX::Nln::Vector&>(grp_ptr->getX());
   // set the consistent state in the models (e.g. structure and contact models)
   impl_int().reset_model_states(Core::LinAlg::Vector<double>(x_eptra.getEpetraVector()));
 

--- a/src/structure_new/src/utils/4C_structure_new_dbc.cpp
+++ b/src/structure_new/src/utils/4C_structure_new_dbc.cpp
@@ -16,9 +16,8 @@
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
 #include "4C_linalg_vector.hpp"
 #include "4C_solver_nonlin_nox_linearsystem_prepostoperator.hpp"
+#include "4C_solver_nonlin_nox_vector.hpp"
 #include "4C_structure_new_timint_base.hpp"
-
-#include <NOX_Epetra_Vector.H>
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -496,7 +495,7 @@ void NOX::Nln::LinSystem::PrePostOp::Dbc::run_pre_apply_jacobian_inverse(
     ::NOX::Abstract::Vector& rhs, Core::LinAlg::SparseOperator& jac,
     const NOX::Nln::LinearSystem& linsys)
 {
-  ::NOX::Epetra::Vector& rhs_epetra = dynamic_cast<::NOX::Epetra::Vector&>(rhs);
+  auto& rhs_epetra = dynamic_cast<NOX::Nln::Vector&>(rhs);
   Core::LinAlg::View rhs_view(rhs_epetra.getEpetraVector());
   std::shared_ptr<Core::LinAlg::SparseOperator> jac_ptr = Core::Utils::shared_ptr_from_ref(jac);
   // apply the dirichlet condition and rotate the system if desired


### PR DESCRIPTION
## Description and Context
This is a preliminary PR on the way to completely remove `::NOX:Epetra::Vector`. Here I have created a new class `NOX::Nln::Vector` by inheriting it from the latter. In the next PRs this will be changed and `NOX::Nln::Vector` is planned to implement directly `NOX::Abstract::Vector` interface.

## Related Issues and Pull Requests
#1292, #1077, #1098, #359
