### PR TITLE
Consolidate writing of TimeMonitor

### DIFF
--- a/apps/global_full/4C_global_full_io.cpp
+++ b/apps/global_full/4C_global_full_io.cpp
@@ -14,6 +14,7 @@
 #include "4C_io_pstream.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>
+#include <Teuchos_TimeMonitor.hpp>
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -296,6 +297,13 @@ void parse_restart_definition(const std::vector<std::string>& inout, const int i
   {
     FOUR_C_THROW("You need to specify a restart step when using restartfrom.");
   }
+}
+
+void write_timemonitor(MPI_Comm comm)
+{
+  std::shared_ptr<const Teuchos::Comm<int>> TeuchosComm =
+      Core::Communication::to_teuchos_comm<int>(comm);
+  Teuchos::TimeMonitor::summarize(Teuchos::Ptr(TeuchosComm.get()), std::cout, false, true, false);
 }
 
 

--- a/apps/global_full/4C_global_full_io.hpp
+++ b/apps/global_full/4C_global_full_io.hpp
@@ -75,6 +75,11 @@ std::vector<std::string> parse_input_output_files(const int argc, char** argv, c
 void parse_restart_definition(const std::vector<std::string>& inout, int in_out_args,
     std::string& restart_file_identifier, const std::string& outfile_identifier, int restart_group,
     CommandlineArguments& arguments);
+
+/**
+ * \brief Writes the Teuchos::TimeMonitor information to std::cout
+ */
+void write_timemonitor(MPI_Comm comm);
 FOUR_C_NAMESPACE_CLOSE
 
 #endif

--- a/apps/global_full/4C_global_full_main.cpp
+++ b/apps/global_full/4C_global_full_main.cpp
@@ -486,6 +486,7 @@ void run(CommandlineArguments& arguments)
 
   entrypoint_switch();
 
+  write_timemonitor(arguments.comms.local_comm());
 
   const double tc = walltime_in_seconds() - t0;
   if (Core::Communication::my_mpi_rank(arguments.comms.global_comm()) == 0)

--- a/src/art_net/4C_art_net_timint.cpp
+++ b/src/art_net/4C_art_net_timint.cpp
@@ -109,14 +109,6 @@ void Arteries::TimInt::integrate(
   prepare_time_loop();
 
   time_loop(CoupledTo3D, CouplingParams);
-
-  // print the results of time measurements
-  if (!coupledTo3D_)
-  {
-    Teuchos::TimeMonitor::summarize();
-  }
-
-  return;
 }  // ArtNetExplicitTimeInt::Integrate
 
 //<><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>//

--- a/src/ehl/4C_ehl_dyn.cpp
+++ b/src/ehl/4C_ehl_dyn.cpp
@@ -14,7 +14,6 @@
 #include "4C_global_data.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>
-#include <Teuchos_TimeMonitor.hpp>
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -132,9 +131,6 @@ void ehl_dyn()
 
   // 4.2.- Solve the whole problem
   ehl->timeloop();
-
-  // 4.3.- Summarize the performance measurements
-  Teuchos::TimeMonitor::summarize();
 
   // 5. - perform the result test
   ehl->test_results(comm);

--- a/src/elch/4C_elch_dyn.cpp
+++ b/src/elch/4C_elch_dyn.cpp
@@ -20,7 +20,6 @@
 #include "4C_utils_enum.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>
-#include <Teuchos_TimeMonitor.hpp>
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -227,9 +226,6 @@ void elch_dyn(int restart)
         // solve the whole electrochemistry problem
         elch.time_loop();
 
-        // summarize the performance measurements
-        Teuchos::TimeMonitor::summarize();
-
         // perform the result test
         elch.test_results();
       }
@@ -271,9 +267,6 @@ void elch_dyn(int restart)
 
         // solve the whole electrochemistry problem
         elch.time_loop();
-
-        // summarize the performance measurements
-        Teuchos::TimeMonitor::summarize();
 
         // perform the result test
         elch.test_results();

--- a/src/fluid/4C_fluid_implicit_integration.cpp
+++ b/src/fluid/4C_fluid_implicit_integration.cpp
@@ -550,12 +550,6 @@ void FLD::FluidImplicitTimeInt::integrate()
 
   // TimeLoop() calls solve_stationary_problem() in stationary case
   time_loop();
-
-  // print the results of time measurements
-  std::shared_ptr<const Teuchos::Comm<int>> TeuchosComm =
-      Core::Communication::to_teuchos_comm<int>(discret_->get_comm());
-  Teuchos::TimeMonitor::summarize(Teuchos::Ptr(TeuchosComm.get()), std::cout, false, true, false);
-
 }  // FluidImplicitTimeInt::Integrate
 
 //<><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>//

--- a/src/fluid_turbulence/4C_fluid_turbulence_turbulent_flow_algorithm.cpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_turbulent_flow_algorithm.cpp
@@ -11,7 +11,7 @@
 #include "4C_linalg_utils_sparse_algebra_create.hpp"
 #include "4C_utils_exceptions.hpp"
 
-#include <Teuchos_TimeMonitor.hpp>
+#include <Teuchos_ParameterList.hpp>
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -116,11 +116,6 @@ void FLD::TurbulentFlowAlgorithm::time_loop()
     std::cout << "#     -> problem ready for restart              #" << std::endl;
     std::cout << "#-----------------------------------------------#\n" << std::endl;
   }
-
-  // summarize the performance measurements
-  Teuchos::TimeMonitor::summarize();
-
-  return;
 }
 
 

--- a/src/fluid_xfluid/4C_fluid_xfluid.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid.cpp
@@ -48,8 +48,6 @@
 #include "4C_xfem_xfluid_timeInt_base.hpp"
 #include "4C_xfem_xfluid_timeInt_std_SemiLagrange.hpp"
 
-#include <Teuchos_Time.hpp>
-
 FOUR_C_NAMESPACE_OPEN
 
 /*----------------------------------------------------------------------*
@@ -2242,9 +2240,6 @@ void FLD::XFluid::time_loop()
         maxtime_, stepmax_);
 
   FluidImplicitTimeInt::time_loop();
-
-  // print the results of time measurements
-  Teuchos::TimeMonitor::summarize();
 }
 
 

--- a/src/fpsi/4C_fpsi_dyn.cpp
+++ b/src/fpsi/4C_fpsi_dyn.cpp
@@ -14,8 +14,6 @@
 #include "4C_global_data.hpp"
 #include "4C_inpar_fpsi.hpp"
 
-#include <Teuchos_TimeMonitor.hpp>
-
 FOUR_C_NAMESPACE_OPEN
 
 /*------------------------------------------------------------------------------------------------*
@@ -104,13 +102,11 @@ void fpsi_drt()
   fpsi->setup_solver();
   // 4.2.- Solve the whole problem
   fpsi->timeloop();
-  Teuchos::TimeMonitor::summarize();
 
   // 5. - perform the result test
   fpsi->test_results(comm);
 
 
-  return;
 }  // fpsi_drt()
 
 /*----------------------------------------------------------------------*/

--- a/src/fs3i/4C_fs3i_dyn.cpp
+++ b/src/fs3i/4C_fs3i_dyn.cpp
@@ -17,8 +17,6 @@
 #include "4C_global_data.hpp"
 #include "4C_utils_enum.hpp"
 
-#include <Teuchos_TimeMonitor.hpp>
-
 FOUR_C_NAMESPACE_OPEN
 
 
@@ -77,10 +75,6 @@ void fs3i_dyn()
   fs3i->timeloop();
 
   fs3i->test_results(comm);
-
-  std::shared_ptr<const Teuchos::Comm<int>> TeuchosComm =
-      Core::Communication::to_teuchos_comm<int>(comm);
-  Teuchos::TimeMonitor::summarize(Teuchos::Ptr(TeuchosComm.get()), std::cout, false, true, false);
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/fsi/src/4C_fsi_dyn.cpp
+++ b/src/fsi/src/4C_fsi_dyn.cpp
@@ -62,7 +62,7 @@
 #include "4C_utils_result_test.hpp"
 #include "4C_xfem_discretization.hpp"
 
-#include <Teuchos_TimeMonitor.hpp>
+#include <Teuchos_ParameterList.hpp>
 
 #include <functional>
 #include <set>
@@ -355,7 +355,6 @@ void fsi_immersed_drt()
 
   // do the actual testing
   Global::Problem::instance()->test_all(comm);
-  Teuchos::TimeMonitor::summarize(std::cout, false, true, false);
 }
 /*----------------------------------------------------------------------*/
 // entry point for FSI using ALE in discretization management
@@ -676,8 +675,6 @@ void fsi_ale_drt()
       break;
     }
   }
-
-  Teuchos::TimeMonitor::summarize(std::cout, false, true, false);
 }
 
 /*----------------------------------------------------------------------*/
@@ -831,8 +828,6 @@ void xfsi_drt()
       break;
     }
   }
-
-  Teuchos::TimeMonitor::summarize();
 }
 
 /*----------------------------------------------------------------------*/
@@ -953,7 +948,6 @@ void xfpsi_drt()
       break;
     }
   }
-  Teuchos::TimeMonitor::summarize();
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/levelset/4C_levelset_dyn.cpp
+++ b/src/levelset/4C_levelset_dyn.cpp
@@ -115,14 +115,8 @@ void levelset_dyn(int restart)
   // enter time loop
   levelsetalgo->time_loop();
 
-  // summarize performance measurements
-  Teuchos::TimeMonitor::summarize();
-
   // perform result test if required
   std::dynamic_pointer_cast<ScaTra::LevelSetAlgorithm>(levelsetalgo)->test_results();
-
-  return;
-
 }  // end of levelset_dyn()
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/loma/4C_loma_dyn.cpp
+++ b/src/loma/4C_loma_dyn.cpp
@@ -16,8 +16,8 @@
 #include "4C_scatra_utils_clonestrategy.hpp"
 #include "4C_utils_enum.hpp"
 
+#include <Teuchos_ParameterList.hpp>
 #include <Teuchos_StandardParameterEntryValidators.hpp>
-#include <Teuchos_TimeMonitor.hpp>
 
 #include <iostream>
 #include <string>
@@ -185,9 +185,6 @@ void loma_dyn(int restart)
 
       // enter LOMA algorithm
       loma.time_loop();
-
-      // summarize performance measurements
-      Teuchos::TimeMonitor::summarize();
 
       // perform result test if required
       problem->add_field_test(loma.fluid_field()->create_field_test());

--- a/src/lubrication/src/4C_lubrication_timint_implicit.cpp
+++ b/src/lubrication/src/4C_lubrication_timint_implicit.cpp
@@ -389,11 +389,6 @@ void Lubrication::TimIntImpl::time_loop()
     output();
 
   }  // while
-
-  // print the results of time measurements
-  Teuchos::TimeMonitor::summarize();
-
-  return;
 }  // TimIntImpl::TimeLoop
 
 

--- a/src/particle/src/algorithm/4C_particle_algorithm_sim.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_sim.cpp
@@ -11,7 +11,7 @@
 #include "4C_global_data.hpp"
 #include "4C_particle_algorithm.hpp"
 
-#include <Teuchos_RCPStdSharedPtrConversions.hpp>
+#include <Teuchos_ParameterList.hpp>
 
 #include <memory>
 
@@ -62,11 +62,6 @@ void particle_drt()
     // perform all tests
     problem->test_all(comm);
   }
-
-  // print summary statistics for all timers
-  std::shared_ptr<const Teuchos::Comm<int>> TeuchosComm =
-      Core::Communication::to_teuchos_comm<int>(comm);
-  Teuchos::TimeMonitor::summarize(Teuchos::Ptr(TeuchosComm.get()), std::cout, false, true, false);
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/pasi/4C_pasi_dyn.cpp
+++ b/src/pasi/4C_pasi_dyn.cpp
@@ -16,6 +16,7 @@
 #include "4C_pasi_partitioned_twowaycoup.hpp"
 #include "4C_pasi_utils.hpp"
 
+#include <Teuchos_ParameterList.hpp>
 #include <Teuchos_StandardParameterEntryValidators.hpp>
 
 FOUR_C_NAMESPACE_OPEN
@@ -101,11 +102,6 @@ void pasi_dyn()
 
   // perform result tests
   algo->test_results(comm);
-
-  // print summary statistics for all timers
-  std::shared_ptr<const Teuchos::Comm<int>> TeuchosComm =
-      Core::Communication::to_teuchos_comm<int>(comm);
-  Teuchos::TimeMonitor::summarize(Teuchos::Ptr(TeuchosComm.get()), std::cout, false, true, false);
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/poroelast/4C_poroelast_dyn.cpp
+++ b/src/poroelast/4C_poroelast_dyn.cpp
@@ -12,7 +12,7 @@
 #include "4C_poroelast_utils_clonestrategy.hpp"
 #include "4C_poroelast_utils_setup.hpp"
 
-#include <Teuchos_TimeMonitor.hpp>
+#include <Teuchos_ParameterList.hpp>
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -53,9 +53,6 @@ void poroelast_drt()
 
   // solve the whole problem
   poroalgo->time_loop();
-
-  // summarize the performance measurements
-  Teuchos::TimeMonitor::summarize();
 
   // perform the result test
   poroalgo->test_results(comm);

--- a/src/poroelast_scatra/4C_poroelast_scatra_dyn.cpp
+++ b/src/poroelast_scatra/4C_poroelast_scatra_dyn.cpp
@@ -13,7 +13,7 @@
 #include "4C_poroelast_scatra_utils_setup.hpp"
 #include "4C_poroelast_utils_clonestrategy.hpp"
 
-#include <Teuchos_TimeMonitor.hpp>
+#include <Teuchos_ParameterList.hpp>
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -54,9 +54,6 @@ void poro_scatra_drt()
 
   // 4.2.- Solve the whole problem
   poro_scatra->timeloop();
-
-  // 4.3.- Summarize the performance measurements
-  Teuchos::TimeMonitor::summarize();
 
   // 5. - perform the result test
   poro_scatra->test_results(comm);

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_algorithm.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_algorithm.cpp
@@ -510,8 +510,6 @@ void PoroPressureBased::PorofluidAlgorithm::time_loop()
 
     output();
   }
-
-  Teuchos::TimeMonitor::summarize();
 }
 
 

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_dyn.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_dyn.cpp
@@ -17,7 +17,6 @@
 #include "4C_porofluid_pressure_based_utils.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>
-#include <Teuchos_TimeMonitor.hpp>
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -143,14 +142,9 @@ void porofluid_pressure_based_dyn(int restart)
   // 4.- Run of the actual problem.
   algo->time_loop();
 
-  // 4.3.- Summarize the performance measurements
-  Teuchos::TimeMonitor::summarize();
-
   // perform the result test if required
   problem->add_field_test(algo->create_field_test());
   problem->test_all(comm);
-
-  return;
 
 }  // poromultiphase_dyn
 

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_dyn.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_dyn.cpp
@@ -14,7 +14,6 @@
 #include "4C_porofluid_pressure_based_utils.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>
-#include <Teuchos_TimeMonitor.hpp>
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -105,9 +104,6 @@ void porofluid_elast_dyn(int restart)
 
   // Solve the whole problem
   algo->time_loop();
-
-  // Summarize the performance measurements
-  Teuchos::TimeMonitor::summarize();
 
   // perform the result test if required
   algo->create_field_test();

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_dyn.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_dyn.cpp
@@ -13,7 +13,6 @@
 #include "4C_porofluid_pressure_based_elast_scatra_utils.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>
-#include <Teuchos_TimeMonitor.hpp>
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -112,9 +111,6 @@ void porofluid_pressure_based_elast_scatra_dyn(int restart)
 
   // Solve the whole problem
   algo->time_loop();
-
-  // Summarize the performance measurements
-  Teuchos::TimeMonitor::summarize();
 
   // perform the result test if required
   algo->create_field_test();

--- a/src/red_airways/4C_red_airways_implicitintegration.cpp
+++ b/src/red_airways/4C_red_airways_implicitintegration.cpp
@@ -27,6 +27,7 @@
 
 #include <stdio.h>
 #include <Teuchos_StandardParameterEntryValidators.hpp>
+#include <Teuchos_TimeMonitor.hpp>
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -386,13 +387,6 @@ void Airway::RedAirwayImplicitTimeInt::integrate(
 
   // Start time loop
   time_loop(CoupledTo3D, CouplingParams);
-
-  // Print the results of time measurements at the end of the simulation
-  {
-    Teuchos::TimeMonitor::summarize();
-  }
-
-  return;
 }  // RedAirwayImplicitTimeInt::Integrate
 
 

--- a/src/reduced_lung/src/4C_reduced_lung_main.cpp
+++ b/src/reduced_lung/src/4C_reduced_lung_main.cpp
@@ -26,7 +26,6 @@
 #include "4C_utils_function_of_time.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>
-#include <Teuchos_TimeMonitor.hpp>
 
 #include <cmath>
 
@@ -771,8 +770,6 @@ namespace ReducedLung
         visualization_writer.write_to_disk(dt * n, n);
       }
     }
-    // Print time monitor
-    Teuchos::TimeMonitor::summarize(std::cout, false, true, false);
   }
 }  // namespace ReducedLung
 

--- a/src/scatra/4C_scatra_dyn.cpp
+++ b/src/scatra/4C_scatra_dyn.cpp
@@ -20,7 +20,6 @@
 #include "4C_utils_parameter_list.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>
-#include <Teuchos_TimeMonitor.hpp>
 
 #include <iostream>
 
@@ -349,9 +348,6 @@ void scatra_dyn(int restart)
 
       // solve the whole scalar transport problem
       algo.time_loop();
-
-      // summarize the performance measurements
-      Teuchos::TimeMonitor::summarize();
 
       // perform the result test
       algo.test_results();

--- a/src/scatra/4C_scatra_timint_implicit.cpp
+++ b/src/scatra/4C_scatra_timint_implicit.cpp
@@ -47,6 +47,8 @@
 #include "4C_utils_function.hpp"
 #include "4C_utils_parameter_list.hpp"
 
+#include <Teuchos_TimeMonitor.hpp>
+
 #include <unordered_set>
 #include <utility>
 
@@ -1584,9 +1586,6 @@ void ScaTra::ScaTraTimIntImpl::time_loop()
     check_and_write_output_and_restart();
 
   }  // while
-
-  // print the results of time measurements
-  Teuchos::TimeMonitor::summarize();
 }
 
 /*----------------------------------------------------------------------*

--- a/src/ssi/4C_ssi_dyn.cpp
+++ b/src/ssi/4C_ssi_dyn.cpp
@@ -156,9 +156,6 @@ void ssi_drt()
   // 4.2.- Solve the whole problem
   ssi->timeloop();
 
-  // 4.3.- Summarize the performance measurements
-  Teuchos::TimeMonitor::summarize();
-
   // 5. - perform the result test
   ssi->test_results(comm);
 }

--- a/src/ssti/4C_ssti_dyn.cpp
+++ b/src/ssti/4C_ssti_dyn.cpp
@@ -16,7 +16,6 @@
 #include "4C_ssti_utils.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>
-#include <Teuchos_TimeMonitor.hpp>
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -50,8 +49,6 @@ void ssti_drt()
   ssti->setup_system();
 
   ssti->timeloop();
-
-  Teuchos::TimeMonitor::summarize();
 
   ssti->test_results(comm);
 }

--- a/src/sti/4C_sti_dyn.cpp
+++ b/src/sti/4C_sti_dyn.cpp
@@ -19,7 +19,6 @@
 #include "4C_sti_resulttest.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>
-#include <Teuchos_TimeMonitor.hpp>
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -181,9 +180,6 @@ void sti_dyn(const int& restartstep  //! time step for restart
 
   // enter time loop and solve scatra-thermo interaction problem
   sti_algorithm->time_loop();
-
-  // summarize performance measurements
-  Teuchos::TimeMonitor::summarize();
 
   // perform result tests
   problem->add_field_test(

--- a/src/structure/4C_structure_dyn_nln_drt.cpp
+++ b/src/structure/4C_structure_dyn_nln_drt.cpp
@@ -22,7 +22,6 @@
 #include "4C_structure_resulttest.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>
-#include <Teuchos_TimeMonitor.hpp>
 
 #include <cstdlib>
 #include <ctime>
@@ -153,15 +152,6 @@ void dyn_nlnstructural_drt()
   // test results
   Global::Problem::instance()->add_field_test(structadapter->create_field_test());
   Global::Problem::instance()->test_all(structdis->get_comm());
-
-  // print monitoring of time consumption
-  std::shared_ptr<const Teuchos::Comm<int>> TeuchosComm =
-      Core::Communication::to_teuchos_comm<int>(structdis->get_comm());
-  Teuchos::TimeMonitor::summarize(Teuchos::Ptr(TeuchosComm.get()), std::cout, false, true, true);
-
-  // time to go home...
-  return;
-
 }  // end of dyn_nlnstructural_drt()
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/thermo/src/4C_thermo_adapter.cpp
+++ b/src/thermo/src/4C_thermo_adapter.cpp
@@ -17,7 +17,6 @@
 #include "4C_utils_enum.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>
-#include <Teuchos_TimeMonitor.hpp>
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -112,8 +111,6 @@ void Thermo::Adapter::integrate()
         FOUR_C_THROW("Solver failed.");
     }
   }
-
-  Teuchos::TimeMonitor::summarize();
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/tsi/4C_tsi_dyn.cpp
+++ b/src/tsi/4C_tsi_dyn.cpp
@@ -20,7 +20,6 @@
 #include "4C_utils_enum.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>
-#include <Teuchos_TimeMonitor.hpp>
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -94,15 +93,10 @@ void tsi_dyn_drt()
   // solve the whole tsi problem
   tsi->time_loop();
 
-  // summarize the performance measurements
-  Teuchos::TimeMonitor::summarize();
-
   // perform the result test
   Global::Problem::instance()->add_field_test(tsi->structure_field()->create_field_test());
   Global::Problem::instance()->add_field_test(tsi->thermo_field()->create_field_test());
   Global::Problem::instance()->test_all(comm);
-
-  return;
 }  // tsi_dyn_drt()
 
 


### PR DESCRIPTION
This PR consolidates the different `TimeMonitor::summarize` calls. The summary is now written once after the problem finishes. Before, each problem type wrote the summary themselves. Some problems called it directly after their timeloop, others after the timeloop and evaluation of the result tests. Now, the summary is called after the timeloop and the result tests. I think this is fine.

Originally, I planned to add an option to write the TimeMonitor as yaml file to make it easier to post-process, e.g., for performance tests (@amgebauer). But there is a bug in [`TimeMonitor::summarizeToYAML`](https://github.com/trilinos/Trilinos/blob/master/packages/teuchos/comm/src/Teuchos_TimeMonitor.cpp#L1171) in `TimeMonitor::report` where the yaml output does not work on multiple cores (I will open an issue for that).

There is one call to `TimeMonitor::summarize` left in https://github.com/4C-multiphysics/4C/blob/main/src/core/fem/src/condition/4C_fem_condition_periodic.cpp#L90. This is a call in some method and not after a timeloop. I don't know enough about it. So, I left it.