### PR TITLE
Fix Vector Operations due to wrong maps in Poro

### DIFF
--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_monolithic.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_monolithic.cpp
@@ -1148,7 +1148,10 @@ void PoroPressureBased::PorofluidElastMonolithicAlgorithm::poro_fd_check()
 
     if (not combined_dbc_map()->my_gid(i)) iterinc->replace_global_value(i, -delta);
 
-    iterinc->replace_global_value(i - 1, 0.0);
+    if (i - 1 >= 0 && i - 1 < dofs && iterinc->get_map().my_gid(i - 1))
+    {
+      iterinc->replace_global_value(i - 1, 0.0);
+    }
 
     if (i != dofs - 1) iterinc->replace_global_value(i + 1, delta);
 

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_monolithic.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_monolithic.cpp
@@ -1173,7 +1173,10 @@ void PoroPressureBased::PorofluidElastScatraMonolithicAlgorithm::poro_multi_phas
 
     if (not combined_dbc_map()->my_gid(i)) iter_inc->replace_global_value(i, -delta);
 
-    iter_inc->replace_global_value(i - 1, 0.0);
+    if (i - 1 >= 0 && i - 1 < dofs && iter_inc->get_map().my_gid(i - 1))
+    {
+      iter_inc->replace_global_value(i - 1, 0.0);
+    }
 
     if (i != dofs - 1) iter_inc->replace_global_value(i + 1, delta);
 


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
Before `CHECK_EPETRA_CALL` can be used within the wrapper, some errors should be removed first. 
To keep this reviewable, this is a sub part of https://github.com/4C-multiphysics/4C/pull/1390, which aims to provide solutions for wrong vector updates/manipulations due to false maps within the subsection `Poro`. 


## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
Part of https://github.com/4C-multiphysics/4C/pull/1390
 See https://github.com/4C-multiphysics/4C/issues/1190 and https://github.com/4C-multiphysics/4C/issues/1121

