### PR TITLE
Avoid shared_ptr on DiscretReader/Writer

### DIFF
--- a/src/adapter/4C_adapter_scatra_fluid_coupling_algorithm.cpp
+++ b/src/adapter/4C_adapter_scatra_fluid_coupling_algorithm.cpp
@@ -233,7 +233,7 @@ void Adapter::ScaTraFluidCouplingAlgorithm::read_restart(int step)
   if (fluid_field()->turbulence_statistic_manager() != nullptr)
   {
     Core::IO::DiscretizationReader reader(
-        scatra_field()->discretization(), Global::Problem::instance()->input_control_file(), step);
+        *scatra_field()->discretization(), Global::Problem::instance()->input_control_file(), step);
     fluid_field()->turbulence_statistic_manager()->read_restart_scatra(reader, step);
   }
 }

--- a/src/adapter/4C_adapter_str_timeada.cpp
+++ b/src/adapter/4C_adapter_str_timeada.cpp
@@ -131,7 +131,7 @@ void Adapter::StructureTimeAda::setup_time_ada()
     stm_->read_restart(restart);
     timeinitial_ = stm_->time_old();
     timestepinitial_ = stm_->step_old();
-    Core::IO::DiscretizationReader ioreader(stm_->discretization(),
+    Core::IO::DiscretizationReader ioreader(*stm_->discretization(),
         Global::Problem::instance()->input_control_file(), timestepinitial_);
     stepsizepre_ = ioreader.read_double("next_delta_time");
     time_ = timeinitial_;

--- a/src/ale/4C_ale.cpp
+++ b/src/ale/4C_ale.cpp
@@ -499,7 +499,7 @@ void ALE::Ale::output_restart(bool& datawritten)
 void ALE::Ale::read_restart(const int step)
 {
   Core::IO::DiscretizationReader reader(
-      discret_, Global::Problem::instance()->input_control_file(), step);
+      *discret_, Global::Problem::instance()->input_control_file(), step);
   time_ = reader.read_double("time");
   step_ = reader.read_int("step");
 

--- a/src/art_net/4C_art_net_explicitintegration.cpp
+++ b/src/art_net/4C_art_net_explicitintegration.cpp
@@ -47,7 +47,7 @@ Arteries::ArtNetExplicitTimeInt::ArtNetExplicitTimeInt(
   if (restart_step > 0)
   {
     Core::IO::DiscretizationReader reader(
-        discret_, Global::Problem::instance()->input_control_file(), restart_step);
+        *discret_, Global::Problem::instance()->input_control_file(), restart_step);
 
     time_ = reader.read_double("time");
   }
@@ -766,7 +766,7 @@ void Arteries::ArtNetExplicitTimeInt::read_restart(int step, bool coupledTo3D)
 {
   coupledTo3D_ = coupledTo3D;
   Core::IO::DiscretizationReader reader(
-      discret_, Global::Problem::instance()->input_control_file(), step);
+      *discret_, Global::Problem::instance()->input_control_file(), step);
 
   time_ = reader.read_double("time");
 

--- a/src/art_net/4C_art_net_impl_stationary.cpp
+++ b/src/art_net/4C_art_net_impl_stationary.cpp
@@ -53,7 +53,7 @@ Arteries::ArtNetImplStationary::ArtNetImplStationary(
   if (restart_step > 0)
   {
     Core::IO::DiscretizationReader reader(
-        discret_, Global::Problem::instance()->input_control_file(), restart_step);
+        *discret_, Global::Problem::instance()->input_control_file(), restart_step);
 
     time_ = reader.read_double("time");
   }
@@ -645,7 +645,7 @@ void Arteries::ArtNetImplStationary::read_restart(int step, bool coupledTo3D)
 {
   coupledTo3D_ = coupledTo3D;
   Core::IO::DiscretizationReader reader(
-      discret_, Global::Problem::instance()->input_control_file(), step);
+      *discret_, Global::Problem::instance()->input_control_file(), step);
 
   if (step != reader.read_int("step")) FOUR_C_THROW("Time step on file not equal to given step");
 

--- a/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator.cpp
@@ -119,7 +119,7 @@ void Solid::ModelEvaluator::BeamInteraction::setup()
   ia_discret_ = discloner->create_matching_discretization(
       *discret_ptr_, "ia_structure", true, true, false, true);
   // create discretization writer
-  ia_discret_->set_writer(std::make_shared<Core::IO::DiscretizationWriter>(ia_discret_,
+  ia_discret_->set_writer(std::make_shared<Core::IO::DiscretizationWriter>(*ia_discret_,
       Global::Problem::instance()->output_control_file(),
       Global::Problem::instance()->spatial_approximation_type()));
 
@@ -846,14 +846,14 @@ void Solid::ModelEvaluator::BeamInteraction::read_restart(Core::IO::Discretizati
     (*some_iter)->pre_read_restart();
 
   // read interaction discretization
-  Core::IO::DiscretizationReader ia_reader(ia_discret_, input_control_file, stepn);
+  Core::IO::DiscretizationReader ia_reader(*ia_discret_, input_control_file, stepn);
   // includes fill_complete()
   ia_reader.read_history_data(stepn);
 
   // rebuild bin discret correctly in case crosslinker were present
   // Fixme: do just read history data like with ia discret
   // read correct nodes
-  Core::IO::DiscretizationReader bin_reader(bindis_, input_control_file, stepn);
+  Core::IO::DiscretizationReader bin_reader(*bindis_, input_control_file, stepn);
   bin_reader.read_nodes_only(stepn);
   bindis_->fill_complete(Core::FE::OptionsFillComplete::none());
 

--- a/src/core/binstrategy/4C_binstrategy.cpp
+++ b/src/core/binstrategy/4C_binstrategy.cpp
@@ -113,13 +113,13 @@ Core::Binstrategy::BinningStrategy::BinningStrategy(const Teuchos::ParameterList
   auto spatial_approximation_type = Teuchos::getIntegralValue<Core::FE::ShapeFunctionType>(
       binning_params, "spatial_approximation_type");
   bindis_->set_writer(std::make_shared<Core::IO::DiscretizationWriter>(
-      bindis_, output_control, spatial_approximation_type));
+      *bindis_, output_control, spatial_approximation_type));
   bindis_->fill_complete(Core::FE::OptionsFillComplete::none());
 
   visbindis_ = std::make_shared<Core::FE::Discretization>("bins", comm_, 3);
   // create discretization writer
   visbindis_->set_writer(std::make_shared<Core::IO::DiscretizationWriter>(
-      visbindis_, output_control, spatial_approximation_type));
+      *visbindis_, output_control, spatial_approximation_type));
 
   // try to read valid input
   domain_bounding_box_corner_positions_.put_scalar(1.0e12);

--- a/src/core/io/src/4C_io.hpp
+++ b/src/core/io/src/4C_io.hpp
@@ -64,8 +64,8 @@ namespace Core::IO
   {
    public:
     /// construct reader for a given discretization to read a particular time step
-    DiscretizationReader(std::shared_ptr<Core::FE::Discretization> dis,
-        std::shared_ptr<Core::IO::InputControl> input, int step);
+    DiscretizationReader(
+        Core::FE::Discretization& dis, std::shared_ptr<Core::IO::InputControl> input, int step);
 
     /// destructor
     ~DiscretizationReader() = default;
@@ -165,9 +165,6 @@ namespace Core::IO
         std::shared_ptr<std::vector<int>>& intvec, const std::string name);
 
    protected:
-    /// empty constructor (only used for the construction of derived classes)
-    DiscretizationReader();
-
     /// find control file entry to given time step
     void find_result_group(int step, MAP* file);
 
@@ -193,7 +190,7 @@ namespace Core::IO
     std::shared_ptr<HDFReader> open_files(const char* filestring, MAP* result_step);
 
     //! my discretization
-    std::shared_ptr<Core::FE::Discretization> dis_;
+    Core::FE::Discretization& dis_;
 
     /// my input control file
     std::shared_ptr<Core::IO::InputControl> input_;
@@ -224,18 +221,15 @@ namespace Core::IO
      * @param[in] output_control        output control file
      * @param[in] shape_function_type   shape function type of the underlying fe discretization
      */
-    DiscretizationWriter(std::shared_ptr<Core::FE::Discretization> dis,
+    DiscretizationWriter(Core::FE::Discretization& dis,
         std::shared_ptr<OutputControl> output_control,
         const Core::FE::ShapeFunctionType shape_function_type);
 
-    /** \brief copy constructor
-     *
-     *  \param[in] writer  copy the writer of same type
-     *  \param[in] output  use this control object if provided
-     *  \parma[in] type    copy type
-     */
-    DiscretizationWriter(const Core::IO::DiscretizationWriter& writer,
-        const std::shared_ptr<OutputControl>& control, enum CopyType type);
+    DiscretizationWriter(const DiscretizationWriter& other) = delete;
+    DiscretizationWriter operator=(const DiscretizationWriter& other) = delete;
+    DiscretizationWriter(DiscretizationWriter&& other) = delete;
+    DiscretizationWriter operator=(DiscretizationWriter&& other) = delete;
+
 
     /// cleanup, close hdf5 files
     ~DiscretizationWriter();
@@ -369,9 +363,6 @@ namespace Core::IO
     [[nodiscard]] const Core::FE::Discretization& get_discretization() const;
 
    protected:
-    /// empty constructor (only used for the construction of derived classes)
-    DiscretizationWriter();
-
     /// access the MPI_Comm object
     [[nodiscard]] MPI_Comm get_comm() const;
 
@@ -387,7 +378,7 @@ namespace Core::IO
     void create_result_file(const int step);
 
     //! my discretization
-    std::shared_ptr<Core::FE::Discretization> dis_;
+    Core::FE::Discretization& dis_;
 
     int step_;
     double time_;

--- a/src/ehl/4C_ehl_base.cpp
+++ b/src/ehl/4C_ehl_base.cpp
@@ -107,7 +107,7 @@ void EHL::Base::read_restart(int restart)
     mortaradapter_->integrate(structure_->dispnp(), dt());
     heightold_ = mortaradapter_->nodal_gap();
 
-    Core::IO::DiscretizationReader reader(lubrication_->lubrication_field()->discretization(),
+    Core::IO::DiscretizationReader reader(*lubrication_->lubrication_field()->discretization(),
         Global::Problem::instance()->input_control_file(), restart);
     mortaradapter_->read_restart(reader);
   }

--- a/src/elch/4C_elch_moving_boundary_algorithm.cpp
+++ b/src/elch/4C_elch_moving_boundary_algorithm.cpp
@@ -386,7 +386,7 @@ void ElCh::MovingBoundaryAlgorithm::read_restart(int step)
 
   // finally read isdispn which was written to the fluid restart data
   Core::IO::DiscretizationReader reader(
-      fluid_field()->discretization(), Global::Problem::instance()->input_control_file(), step);
+      *fluid_field()->discretization(), Global::Problem::instance()->input_control_file(), step);
   reader.read_vector(idispn_, "idispn");
   // read same result into vector isdispnp_ as a 'good guess'
   reader.read_vector(idispnp_, "idispn");

--- a/src/fluid/4C_fluid_discret_extractor.cpp
+++ b/src/fluid/4C_fluid_discret_extractor.cpp
@@ -427,7 +427,7 @@ FLD::FluidDiscretExtractor::FluidDiscretExtractor(std::shared_ptr<Core::FE::Disc
         std::make_shared<Core::DOFSets::TransparentDofSet>(parentdiscret_, true));
 
     // set discretization writer
-    childdiscret_->set_writer(std::make_shared<Core::IO::DiscretizationWriter>(childdiscret_,
+    childdiscret_->set_writer(std::make_shared<Core::IO::DiscretizationWriter>(*childdiscret_,
         Global::Problem::instance()->output_control_file(),
         Global::Problem::instance()->spatial_approximation_type()));
 

--- a/src/fluid/4C_fluid_implicit_integration.cpp
+++ b/src/fluid/4C_fluid_implicit_integration.cpp
@@ -3748,7 +3748,7 @@ void FLD::FluidImplicitTimeInt::output_external_forces()
 void FLD::FluidImplicitTimeInt::read_restart(int step)
 {
   Core::IO::DiscretizationReader reader(
-      discret_, Global::Problem::instance()->input_control_file(), step);
+      *discret_, Global::Problem::instance()->input_control_file(), step);
   time_ = reader.read_double("time");
   step_ = reader.read_int("step");
 

--- a/src/fluid/4C_fluid_timint_ost.cpp
+++ b/src/fluid/4C_fluid_timint_ost.cpp
@@ -272,7 +272,7 @@ void FLD::TimIntOneStepTheta::read_restart(int step)
   FLD::FluidImplicitTimeInt::read_restart(step);
 
   Core::IO::DiscretizationReader reader(
-      discret_, Global::Problem::instance()->input_control_file(), step);
+      *discret_, Global::Problem::instance()->input_control_file(), step);
   // check whether external forces were written
   const int have_fexternal = reader.read_int("have_fexternal");
   if (have_fexternal != -1)

--- a/src/fluid/4C_fluid_timint_poro.cpp
+++ b/src/fluid/4C_fluid_timint_poro.cpp
@@ -71,7 +71,7 @@ void FLD::TimIntPoro::assemble_mat_and_rhs()
 void FLD::TimIntPoro::read_restart(int step)
 {
   Core::IO::DiscretizationReader reader(
-      discret_, Global::Problem::instance()->input_control_file(), step);
+      *discret_, Global::Problem::instance()->input_control_file(), step);
   reader.read_vector(gridv_, "gridv");
 }
 

--- a/src/fluid/4C_fluid_timint_red.cpp
+++ b/src/fluid/4C_fluid_timint_red.cpp
@@ -73,7 +73,7 @@ void FLD::TimIntRedModels::init()
     // Check if one-dimensional artery network problem exist
     if (ART_timeInt_ != nullptr)
     {
-      Core::IO::DiscretizationWriter output_redD(ART_timeInt_->discretization(),
+      Core::IO::DiscretizationWriter output_redD(*ART_timeInt_->discretization(),
           Global::Problem::instance()->output_control_file(),
           Global::Problem::instance()->spatial_approximation_type());
       discret_->clear_state();
@@ -92,7 +92,7 @@ void FLD::TimIntRedModels::init()
     // Check if one-dimensional artery network problem exist
     if (airway_imp_timeInt_ != nullptr)
     {
-      Core::IO::DiscretizationWriter output_redD(airway_imp_timeInt_->discretization(),
+      Core::IO::DiscretizationWriter output_redD(*airway_imp_timeInt_->discretization(),
           Global::Problem::instance()->output_control_file(),
           Global::Problem::instance()->spatial_approximation_type());
       discret_->clear_state();
@@ -262,7 +262,7 @@ void FLD::TimIntRedModels::output_reduced_d()
 void FLD::TimIntRedModels::read_restart(int step)
 {
   Core::IO::DiscretizationReader reader(
-      discret_, Global::Problem::instance()->input_control_file(), step);
+      *discret_, Global::Problem::instance()->input_control_file(), step);
 
   vol_surf_flow_bc_->read_restart(reader);
 

--- a/src/fluid_xfluid/4C_fluid_xfluid.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid.cpp
@@ -5080,7 +5080,7 @@ void FLD::XFluid::read_restart(int step)
 {
   //-------- fluid discretization
   Core::IO::DiscretizationReader reader(
-      discret_, Global::Problem::instance()->input_control_file(), step);
+      *discret_, Global::Problem::instance()->input_control_file(), step);
   time_ = reader.read_double("time");
   step_ = reader.read_int("step");
 

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_fluidfluidmonolithic_fluidsplit.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_fluidfluidmonolithic_fluidsplit.cpp
@@ -159,7 +159,7 @@ void FSI::FluidFluidMonolithicFluidSplit::read_restart(int step)
         std::make_shared<Core::LinAlg::Vector<double>>(
             *(fluid_field()->x_fluid_fluid_map_extractor()->fluid_map()), true);
     Core::IO::DiscretizationReader reader = Core::IO::DiscretizationReader(
-        fluid_field()->discretization(), Global::Problem::instance()->input_control_file(), step);
+        *fluid_field()->discretization(), Global::Problem::instance()->input_control_file(), step);
     reader.read_vector(lambdaemb, "fsilambda");
     // Insert into vector containing the whole merged fluid DOF
     std::shared_ptr<Core::LinAlg::Vector<double>> lambdafull =

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_fluidfluidmonolithic_fluidsplit_nonox.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_fluidfluidmonolithic_fluidsplit_nonox.cpp
@@ -735,7 +735,7 @@ void FSI::FluidFluidMonolithicFluidSplitNoNOX::read_restart(int step)
         std::make_shared<Core::LinAlg::Vector<double>>(
             *(fluid_field()->x_fluid_fluid_map_extractor()->fluid_map()), true);
     Core::IO::DiscretizationReader reader = Core::IO::DiscretizationReader(
-        fluid_field()->discretization(), Global::Problem::instance()->input_control_file(), step);
+        *fluid_field()->discretization(), Global::Problem::instance()->input_control_file(), step);
     reader.read_vector(lambdaemb, "fsilambda");
     // Insert into vector containing the whole merged fluid DOF
     std::shared_ptr<Core::LinAlg::Vector<double>> lambdafull =

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_fluidfluidmonolithic_structuresplit_nonox.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_fluidfluidmonolithic_structuresplit_nonox.cpp
@@ -726,7 +726,7 @@ void FSI::FluidFluidMonolithicStructureSplitNoNOX::read_restart(int step)
     std::shared_ptr<Core::LinAlg::Vector<double>> lambdafull =
         std::make_shared<Core::LinAlg::Vector<double>>(*structure_field()->dof_row_map(), true);
     Core::IO::DiscretizationReader reader =
-        Core::IO::DiscretizationReader(structure_field()->discretization(),
+        Core::IO::DiscretizationReader(*structure_field()->discretization(),
             Global::Problem::instance()->input_control_file(), step);
     reader.read_vector(lambdafull, "fsilambda");
     lambda_ = structure_field()->interface()->extract_fsi_cond_vector(*lambdafull);

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_monolithicfluidsplit.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_monolithicfluidsplit.cpp
@@ -1309,7 +1309,7 @@ void FSI::MonolithicFluidSplit::read_restart(int step)
     std::shared_ptr<Core::LinAlg::Vector<double>> lambdafull =
         std::make_shared<Core::LinAlg::Vector<double>>(*fluid_field()->dof_row_map(), true);
     Core::IO::DiscretizationReader reader = Core::IO::DiscretizationReader(
-        fluid_field()->discretization(), Global::Problem::instance()->input_control_file(), step);
+        *fluid_field()->discretization(), Global::Problem::instance()->input_control_file(), step);
     reader.read_vector(lambdafull, "fsilambda");
     lambdaold_ = fluid_field()->interface()->extract_fsi_cond_vector(*lambdafull);
     // Note: the above is normally enough. However, we can use the restart in order to periodically

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_monolithicstructuresplit.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_monolithicstructuresplit.cpp
@@ -255,7 +255,7 @@ void FSI::MonolithicStructureSplit::setup_system()
       std::shared_ptr<Core::LinAlg::Vector<double>> lambdafullfluid =
           std::make_shared<Core::LinAlg::Vector<double>>(*fluid_field()->dof_row_map(), true);
       Core::IO::DiscretizationReader reader =
-          Core::IO::DiscretizationReader(fluid_field()->discretization(),
+          Core::IO::DiscretizationReader(*fluid_field()->discretization(),
               Global::Problem::instance()->input_control_file(), restart);
       reader.read_vector(lambdafullfluid, "fsilambda");
 
@@ -1190,7 +1190,7 @@ void FSI::MonolithicStructureSplit::read_restart(int step)
     std::shared_ptr<Core::LinAlg::Vector<double>> lambdafull =
         std::make_shared<Core::LinAlg::Vector<double>>(*structure_field()->dof_row_map(), true);
     Core::IO::DiscretizationReader reader =
-        Core::IO::DiscretizationReader(structure_field()->discretization(),
+        Core::IO::DiscretizationReader(*structure_field()->discretization(),
             Global::Problem::instance()->input_control_file(), step);
     reader.read_vector(lambdafull, "fsilambda");
     lambdaold_ = structure_field()->interface()->extract_fsi_cond_vector(*lambdafull);

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_fluidsplit.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_fluidsplit.cpp
@@ -1518,7 +1518,7 @@ void FSI::MortarMonolithicFluidSplit::read_restart(int step)
     std::shared_ptr<Core::LinAlg::Vector<double>> lambdafull =
         std::make_shared<Core::LinAlg::Vector<double>>(*fluid_field()->dof_row_map(), true);
     Core::IO::DiscretizationReader reader =
-        Core::IO::DiscretizationReader(fluid_field()->discretization(), input_control_file, step);
+        Core::IO::DiscretizationReader(*fluid_field()->discretization(), input_control_file, step);
     reader.read_vector(lambdafull, "fsilambda");
     lambdaold_ = fluid_field()->interface()->extract_fsi_cond_vector(*lambdafull);
     // Note: the above is normally enough. However, we can use the restart in order to periodically
@@ -1531,7 +1531,7 @@ void FSI::MortarMonolithicFluidSplit::read_restart(int step)
   if (aleproj_ != Inpar::FSI::ALEprojection_none)
   {
     Core::IO::DiscretizationReader reader =
-        Core::IO::DiscretizationReader(fluid_field()->discretization(), input_control_file, step);
+        Core::IO::DiscretizationReader(*fluid_field()->discretization(), input_control_file, step);
     reader.read_vector(iprojdisp_, "slideALE");
     reader.read_vector(iprojdispinc_, "slideALEincr");
     slideale_->read_restart(reader);

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_fluidsplit_sp.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_fluidsplit_sp.cpp
@@ -1288,7 +1288,7 @@ void FSI::MortarMonolithicFluidSplitSaddlePoint::read_restart(int step)
   std::shared_ptr<Core::LinAlg::Vector<double>> lambdafull =
       std::make_shared<Core::LinAlg::Vector<double>>(*fluid_field()->dof_row_map(), true);
   Core::IO::DiscretizationReader reader = Core::IO::DiscretizationReader(
-      fluid_field()->discretization(), Global::Problem::instance()->input_control_file(), step);
+      *fluid_field()->discretization(), Global::Problem::instance()->input_control_file(), step);
   reader.read_vector(lambdafull, "fsilambda");
   auto lag_mult_old_on_fluid_map = fluid_field()->interface()->extract_fsi_cond_vector(*lambdafull);
 

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_structuresplit.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_structuresplit.cpp
@@ -1347,7 +1347,7 @@ void FSI::MortarMonolithicStructureSplit::read_restart(int step)
     std::shared_ptr<Core::LinAlg::Vector<double>> lambdafull =
         std::make_shared<Core::LinAlg::Vector<double>>(*structure_field()->dof_row_map(), true);
     Core::IO::DiscretizationReader reader = Core::IO::DiscretizationReader(
-        structure_field()->discretization(), input_control_file, step);
+        *structure_field()->discretization(), input_control_file, step);
     reader.read_vector(lambdafull, "fsilambda");
     lambdaold_ = structure_field()->interface()->extract_fsi_cond_vector(*lambdafull);
     // Note: the above is normally enough. However, we can use the restart in order to periodically
@@ -1363,7 +1363,7 @@ void FSI::MortarMonolithicStructureSplit::read_restart(int step)
   if (aleproj_ != Inpar::FSI::ALEprojection_none)
   {
     Core::IO::DiscretizationReader reader =
-        Core::IO::DiscretizationReader(fluid_field()->discretization(), input_control_file, step);
+        Core::IO::DiscretizationReader(*fluid_field()->discretization(), input_control_file, step);
     reader.read_vector(iprojdisp_, "slideALE");
     reader.read_vector(iprojdispinc_, "slideALEincr");
     slideale_->read_restart(reader);

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_slidingmonolithic_fluidsplit.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_slidingmonolithic_fluidsplit.cpp
@@ -1514,7 +1514,7 @@ void FSI::SlidingMonolithicFluidSplit::read_restart(int step)
     std::shared_ptr<Core::LinAlg::Vector<double>> lambdafull =
         std::make_shared<Core::LinAlg::Vector<double>>(*fluid_field()->dof_row_map(), true);
     Core::IO::DiscretizationReader reader =
-        Core::IO::DiscretizationReader(fluid_field()->discretization(), input_control_file, step);
+        Core::IO::DiscretizationReader(*fluid_field()->discretization(), input_control_file, step);
     reader.read_vector(lambdafull, "fsilambda");
     lambdaold_ = fluid_field()->interface()->extract_fsi_cond_vector(*lambdafull);
     // Note: the above is normally enough. However, we can use the restart in order to periodically
@@ -1527,7 +1527,7 @@ void FSI::SlidingMonolithicFluidSplit::read_restart(int step)
   if (aleproj_ != Inpar::FSI::ALEprojection_none)
   {
     Core::IO::DiscretizationReader reader =
-        Core::IO::DiscretizationReader(fluid_field()->discretization(), input_control_file, step);
+        Core::IO::DiscretizationReader(*fluid_field()->discretization(), input_control_file, step);
     reader.read_vector(iprojdisp_, "slideALE");
     reader.read_vector(iprojdispinc_, "slideALEincr");
     slideale_->read_restart(reader);

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_slidingmonolithic_structuresplit.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_slidingmonolithic_structuresplit.cpp
@@ -1315,7 +1315,7 @@ void FSI::SlidingMonolithicStructureSplit::read_restart(int step)
     std::shared_ptr<Core::LinAlg::Vector<double>> lambdafull =
         std::make_shared<Core::LinAlg::Vector<double>>(*structure_field()->dof_row_map(), true);
     Core::IO::DiscretizationReader reader = Core::IO::DiscretizationReader(
-        structure_field()->discretization(), input_control_file, step);
+        *structure_field()->discretization(), input_control_file, step);
     reader.read_vector(lambdafull, "fsilambda");
     lambdaold_ = structure_field()->interface()->extract_fsi_cond_vector(*lambdafull);
     // Note: the above is normally enough. However, we can use the restart in order to periodically
@@ -1331,7 +1331,7 @@ void FSI::SlidingMonolithicStructureSplit::read_restart(int step)
   if (aleproj_ != Inpar::FSI::ALEprojection_none)
   {
     Core::IO::DiscretizationReader reader =
-        Core::IO::DiscretizationReader(fluid_field()->discretization(), input_control_file, step);
+        Core::IO::DiscretizationReader(*fluid_field()->discretization(), input_control_file, step);
     reader.read_vector(iprojdisp_, "slideALE");
     reader.read_vector(iprojdispinc_, "slideALEincr");
     slideale_->read_restart(reader);

--- a/src/fsi/src/partitioned/4C_fsi_partitioned.cpp
+++ b/src/fsi/src/partitioned/4C_fsi_partitioned.cpp
@@ -907,14 +907,14 @@ void FSI::Partitioned::read_restart(int step)
       if (std::dynamic_pointer_cast<Adapter::FBIFluidMB>(mb_fluid_field()) != nullptr)
       {
         Core::IO::DiscretizationReader reader(
-            mb_fluid_field()->fluid_field()->discretization(), input_control_file, step);
+            *mb_fluid_field()->fluid_field()->discretization(), input_control_file, step);
         omega = reader.read_double("omega");
       }
       else if (std::dynamic_pointer_cast<Adapter::FluidAle>(mb_fluid_field()) != nullptr)
       {
         std::shared_ptr<Adapter::FluidAle> fluidale =
             std::dynamic_pointer_cast<Adapter::FluidAle>(mb_fluid_field());
-        Core::IO::DiscretizationReader reader(std::const_pointer_cast<Core::FE::Discretization>(
+        Core::IO::DiscretizationReader reader(*std::const_pointer_cast<Core::FE::Discretization>(
                                                   fluidale->ale_field()->discretization()),
             input_control_file, step);
         omega = reader.read_double("omega");

--- a/src/fsi_xfem/4C_fsi_xfem_monolithic.cpp
+++ b/src/fsi_xfem/4C_fsi_xfem_monolithic.cpp
@@ -2549,7 +2549,7 @@ void FSI::MonolithicXFEM::read_restart(int step)
   // read Lagrange multiplier (ie forces onto the structure, Robin-type forces
   // consisting of fluid forces and the Nitsche penalty term contribution)
   Core::IO::DiscretizationReader reader = Core::IO::DiscretizationReader(
-      structure_poro()->discretization(), Global::Problem::instance()->input_control_file(), step);
+      *structure_poro()->discretization(), Global::Problem::instance()->input_control_file(), step);
   for (auto coupit = coup_man_.begin(); coupit != coup_man_.end(); ++coupit)
     coupit->second->read_restart(reader);
   //

--- a/src/global_data/4C_global_data_read.cpp
+++ b/src/global_data/4C_global_data_read.cpp
@@ -844,7 +844,8 @@ std::unique_ptr<Core::IO::MeshReader> Global::read_discretization(
   // global data.
   for (const auto& dis : problem.discretization_range() | std::views::values)
   {
-    dis->set_writer(std::make_unique<Core::IO::DiscretizationWriter>(dis, output_control, distype));
+    dis->set_writer(
+        std::make_unique<Core::IO::DiscretizationWriter>(*dis, output_control, distype));
   }
 
   if (read_mesh)  // now read and allocate!
@@ -1107,7 +1108,7 @@ void Global::read_micro_fields(Global::Problem& problem, const std::filesystem::
 
         // create discretization writer - in constructor set into and owned by corresponding
         // discret
-        dis_micro->set_writer(std::make_shared<Core::IO::DiscretizationWriter>(dis_micro,
+        dis_micro->set_writer(std::make_shared<Core::IO::DiscretizationWriter>(*dis_micro,
             micro_problem->output_control_file(), micro_problem->spatial_approximation_type()));
 
         micro_problem->add_dis(micro_dis_name, dis_micro);
@@ -1239,7 +1240,7 @@ void Global::read_microfields_np_support(Global::Problem& problem)
     std::shared_ptr<Core::FE::Discretization> structdis_micro =
         std::make_shared<Core::FE::Discretization>("structure", subgroupcomm, problem.n_dim());
 
-    structdis_micro->set_writer(std::make_shared<Core::IO::DiscretizationWriter>(structdis_micro,
+    structdis_micro->set_writer(std::make_shared<Core::IO::DiscretizationWriter>(*structdis_micro,
         micro_problem->output_control_file(), micro_problem->spatial_approximation_type()));
 
     micro_problem->add_dis("structure", structdis_micro);

--- a/src/lubrication/src/4C_lubrication_timint_stat.cpp
+++ b/src/lubrication/src/4C_lubrication_timint_stat.cpp
@@ -114,7 +114,7 @@ void Lubrication::TimIntStationary::update(const int num)
 void Lubrication::TimIntStationary::read_restart(int step)
 {
   Core::IO::DiscretizationReader reader(
-      discret_, Global::Problem::instance()->input_control_file(), step);
+      *discret_, Global::Problem::instance()->input_control_file(), step);
   time_ = reader.read_double("time");
   step_ = reader.read_int("step");
 

--- a/src/mat/4C_mat_micromaterialgp_static.cpp
+++ b/src/mat/4C_mat_micromaterialgp_static.cpp
@@ -198,7 +198,7 @@ void Mat::MicroMaterialGP::new_result_file(
 
     // initialize writer for restart output
     micro_output_ = std::make_shared<Core::IO::DiscretizationWriter>(
-        microdis, microcontrol, microproblem->spatial_approximation_type());
+        *microdis, microcontrol, microproblem->spatial_approximation_type());
     micro_output_->set_output(microcontrol);
     micro_output_->write_mesh(step_, time_);
 

--- a/src/mat/4C_mat_scatra_multiscale_gp.cpp
+++ b/src/mat/4C_mat_scatra_multiscale_gp.cpp
@@ -479,7 +479,7 @@ void Mat::ScatraMultiScaleGP::new_result_file()
             adaptname);
 
     micro_output_ = std::make_shared<Core::IO::DiscretizationWriter>(
-        microdis, microcontrol, microproblem->spatial_approximation_type());
+        *microdis, microcontrol, microproblem->spatial_approximation_type());
     micro_output_->set_output(microcontrol);
     micro_output_->write_mesh(
         step_, Discret::Elements::ScaTraEleParameterTimInt::instance("scatra")->time());
@@ -617,12 +617,12 @@ void Mat::ScatraMultiScaleGP::read_restart()
   if (inputcontrol == nullptr)
   {
     reader = std::make_shared<Core::IO::DiscretizationReader>(
-        microtimint->discretization(), Global::Problem::instance()->input_control_file(), step_);
+        *microtimint->discretization(), Global::Problem::instance()->input_control_file(), step_);
   }
   else
   {
     reader = std::make_shared<Core::IO::DiscretizationReader>(
-        microtimint->discretization(), inputcontrol, step_);
+        *microtimint->discretization(), inputcontrol, step_);
   }
 
   if (is_ale_)

--- a/src/mortar/src/4C_mortar_interface.cpp
+++ b/src/mortar/src/4C_mortar_interface.cpp
@@ -258,7 +258,7 @@ void Mortar::Interface::create_interface_discretization(
 
   // Prepare discretization writer
   idiscret_->set_writer(std::make_shared<Core::IO::DiscretizationWriter>(
-      idiscret_, output_control, spatial_approximation_type));
+      *idiscret_, output_control, spatial_approximation_type));
   FOUR_C_ASSERT(idiscret_->writer(), "Setup of discretization writer failed.");
 }
 

--- a/src/particle/src/engine/4C_particle_engine.cpp
+++ b/src/particle/src/engine/4C_particle_engine.cpp
@@ -870,7 +870,7 @@ std::shared_ptr<Core::IO::DiscretizationReader> PARTICLEENGINE::ParticleEngine::
     int restartstep) const
 {
   return std::make_shared<Core::IO::DiscretizationReader>(
-      binstrategy_->bin_discret(), Global::Problem::instance()->input_control_file(), restartstep);
+      *binstrategy_->bin_discret(), Global::Problem::instance()->input_control_file(), restartstep);
 }
 
 int PARTICLEENGINE::ParticleEngine::get_number_of_particles() const

--- a/src/particle/src/wall/4C_particle_wall.cpp
+++ b/src/particle/src/wall/4C_particle_wall.cpp
@@ -452,7 +452,7 @@ void PARTICLEWALL::WallHandlerBase::create_wall_discretization()
 
   // create wall discretization writer
   walldiscretization_->set_writer(std::make_shared<Core::IO::DiscretizationWriter>(
-      walldiscretization_, Global::Problem::instance()->output_control_file(),
+      *walldiscretization_, Global::Problem::instance()->output_control_file(),
       Global::Problem::instance()->spatial_approximation_type()));
 }
 

--- a/src/pasi/4C_pasi_partitioned_twowaycoup.cpp
+++ b/src/pasi/4C_pasi_partitioned_twowaycoup.cpp
@@ -84,7 +84,7 @@ void PaSI::PasiPartTwoWayCoup::read_restart(int restartstep)
   // call base class read restart
   PaSI::PartitionedAlgo::read_restart(restartstep);
 
-  Core::IO::DiscretizationReader reader(structurefield_->discretization(),
+  Core::IO::DiscretizationReader reader(*structurefield_->discretization(),
       Global::Problem::instance()->input_control_file(), restartstep);
   if (restartstep != reader.read_int("step"))
     FOUR_C_THROW("Time step on file not equal to given step");
@@ -611,7 +611,7 @@ void PaSI::PasiPartTwoWayCoupDispRelaxAitken::read_restart(int restartstep)
   // call base class read restart
   PaSI::PasiPartTwoWayCoupDispRelax::read_restart(restartstep);
 
-  Core::IO::DiscretizationReader reader(structurefield_->discretization(),
+  Core::IO::DiscretizationReader reader(*structurefield_->discretization(),
       Global::Problem::instance()->input_control_file(), restartstep);
   if (restartstep != reader.read_int("step"))
     FOUR_C_THROW("Time step on file not equal to given step");

--- a/src/poroelast/4C_poroelast_monolithicsplit_nopenetration.cpp
+++ b/src/poroelast/4C_poroelast_monolithicsplit_nopenetration.cpp
@@ -668,7 +668,7 @@ void PoroElast::MonolithicSplitNoPenetration::read_restart(const int step)
   if (step)
   {
     // get the structure reader (this is where the lagrange multiplier was saved)
-    Core::IO::DiscretizationReader reader(structure_field()->discretization(),
+    Core::IO::DiscretizationReader reader(*structure_field()->discretization(),
         Global::Problem::instance()->input_control_file(), structure_field()->step());
     std::shared_ptr<Core::LinAlg::Vector<double>> fulllambda =
         std::make_shared<Core::LinAlg::Vector<double>>(*structure_field()->dof_row_map());

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_algorithm.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_algorithm.cpp
@@ -124,7 +124,7 @@ PoroPressureBased::PorofluidAlgorithm::PorofluidAlgorithm(
   if (restart_step > 0)
   {
     Core::IO::DiscretizationReader reader(
-        discret_, Global::Problem::instance()->input_control_file(), restart_step);
+        *discret_, Global::Problem::instance()->input_control_file(), restart_step);
 
     time_ = reader.read_double("time");
   }
@@ -2091,7 +2091,7 @@ void PoroPressureBased::PorofluidAlgorithm::read_restart(const int step)
 
   std::shared_ptr<Core::IO::DiscretizationReader> reader(nullptr);
   reader = std::make_shared<Core::IO::DiscretizationReader>(
-      discret_, Global::Problem::instance()->input_control_file(), step);
+      *discret_, Global::Problem::instance()->input_control_file(), step);
 
   time_ = reader->read_double("time");
   step_ = reader->read_int("step");

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_partitioned.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_partitioned.cpp
@@ -458,7 +458,7 @@ void PoroPressureBased::PorofluidElastPartitionedAlgorithm::read_restart(int res
     // call base class
     PoroPressureBased::PorofluidElastAlgorithm::read_restart(restart);
 
-    Core::IO::DiscretizationReader reader(porofluid_algo()->discretization(),
+    Core::IO::DiscretizationReader reader(*porofluid_algo()->discretization(),
         Global::Problem::instance()->input_control_file(), restart);
     if (restart != reader.read_int("step"))
       FOUR_C_THROW("Time step on file not equal to given step");

--- a/src/red_airways/4C_red_airways_implicitintegration.cpp
+++ b/src/red_airways/4C_red_airways_implicitintegration.cpp
@@ -1563,7 +1563,7 @@ void Airway::RedAirwayImplicitTimeInt::read_restart(int step, bool coupledTo3D)
 {
   coupledTo3D_ = coupledTo3D;
   Core::IO::DiscretizationReader reader(
-      discret_, Global::Problem::instance()->input_control_file(), step);
+      *discret_, Global::Problem::instance()->input_control_file(), step);
   time_ = reader.read_double("time");
 
   if (coupledTo3D_)

--- a/src/scatra/4C_scatra_timint_bdf2.cpp
+++ b/src/scatra/4C_scatra_timint_bdf2.cpp
@@ -306,10 +306,10 @@ void ScaTra::TimIntBDF2::read_restart(const int step, std::shared_ptr<Core::IO::
   if (input == nullptr)
   {
     reader = std::make_shared<Core::IO::DiscretizationReader>(
-        discret_, Global::Problem::instance()->input_control_file(), step);
+        *discret_, Global::Problem::instance()->input_control_file(), step);
   }
   else
-    reader = std::make_shared<Core::IO::DiscretizationReader>(discret_, input, step);
+    reader = std::make_shared<Core::IO::DiscretizationReader>(*discret_, input, step);
   time_ = reader->read_double("time");
   step_ = reader->read_int("step");
 

--- a/src/scatra/4C_scatra_timint_cardiac_monodomain_scheme.cpp
+++ b/src/scatra/4C_scatra_timint_cardiac_monodomain_scheme.cpp
@@ -89,9 +89,9 @@ void ScaTra::TimIntCardiacMonodomainOST::read_restart(
   std::shared_ptr<Core::IO::DiscretizationReader> reader(nullptr);
   if (input == nullptr)
     reader = std::make_shared<Core::IO::DiscretizationReader>(
-        discret_, Global::Problem::instance()->input_control_file(), step);
+        *discret_, Global::Problem::instance()->input_control_file(), step);
   else
-    reader = std::make_shared<Core::IO::DiscretizationReader>(discret_, input, step);
+    reader = std::make_shared<Core::IO::DiscretizationReader>(*discret_, input, step);
 
   // Cardiac Monodomain specific
   reader->read_vector(activation_time_np_, "activation_time_np");
@@ -189,9 +189,9 @@ void ScaTra::TimIntCardiacMonodomainBDF2::read_restart(
   std::shared_ptr<Core::IO::DiscretizationReader> reader(nullptr);
   if (input == nullptr)
     reader = std::make_shared<Core::IO::DiscretizationReader>(
-        discret_, Global::Problem::instance()->input_control_file(), step);
+        *discret_, Global::Problem::instance()->input_control_file(), step);
   else
-    reader = std::make_shared<Core::IO::DiscretizationReader>(discret_, input, step);
+    reader = std::make_shared<Core::IO::DiscretizationReader>(*discret_, input, step);
 
   // Cardiac Monodomain specific
   reader->read_vector(activation_time_np_, "activation_time_np");
@@ -275,7 +275,7 @@ void ScaTra::TimIntCardiacMonodomainGenAlpha::read_restart(
   TimIntGenAlpha::read_restart(step, input);
 
   Core::IO::DiscretizationReader reader(
-      discret_, Global::Problem::instance()->input_control_file(), step);
+      *discret_, Global::Problem::instance()->input_control_file(), step);
 
   // Cardiac Monodomain specific
   reader.read_vector(activation_time_np_, "activation_time_np");

--- a/src/scatra/4C_scatra_timint_elch_scheme.cpp
+++ b/src/scatra/4C_scatra_timint_elch_scheme.cpp
@@ -151,9 +151,9 @@ void ScaTra::ScaTraTimIntElchOST::read_restart(
   std::shared_ptr<Core::IO::DiscretizationReader> reader(nullptr);
   if (input == nullptr)
     reader = std::make_shared<Core::IO::DiscretizationReader>(
-        discret_, Global::Problem::instance()->input_control_file(), step);
+        *discret_, Global::Problem::instance()->input_control_file(), step);
   else
-    reader = std::make_shared<Core::IO::DiscretizationReader>(discret_, input, step);
+    reader = std::make_shared<Core::IO::DiscretizationReader>(*discret_, input, step);
 
   // Initialize Nernst-BC
   init_nernst_bc();
@@ -435,9 +435,9 @@ void ScaTra::ScaTraTimIntElchBDF2::read_restart(
   std::shared_ptr<Core::IO::DiscretizationReader> reader(nullptr);
   if (input == nullptr)
     reader = std::make_shared<Core::IO::DiscretizationReader>(
-        discret_, Global::Problem::instance()->input_control_file(), step);
+        *discret_, Global::Problem::instance()->input_control_file(), step);
   else
-    reader = std::make_shared<Core::IO::DiscretizationReader>(discret_, input, step);
+    reader = std::make_shared<Core::IO::DiscretizationReader>(*discret_, input, step);
 
   // Initialize Nernst-BC
   init_nernst_bc();
@@ -731,9 +731,9 @@ void ScaTra::ScaTraTimIntElchGenAlpha::read_restart(
   std::shared_ptr<Core::IO::DiscretizationReader> reader(nullptr);
   if (input == nullptr)
     reader = std::make_shared<Core::IO::DiscretizationReader>(
-        discret_, Global::Problem::instance()->input_control_file(), step);
+        *discret_, Global::Problem::instance()->input_control_file(), step);
   else
-    reader = std::make_shared<Core::IO::DiscretizationReader>(discret_, input, step);
+    reader = std::make_shared<Core::IO::DiscretizationReader>(*discret_, input, step);
 
   // Initialize Nernst-BC
   init_nernst_bc();
@@ -967,9 +967,9 @@ void ScaTra::ScaTraTimIntElchStationary::read_restart(
   std::shared_ptr<Core::IO::DiscretizationReader> reader(nullptr);
   if (input == nullptr)
     reader = std::make_shared<Core::IO::DiscretizationReader>(
-        discret_, Global::Problem::instance()->input_control_file(), step);
+        *discret_, Global::Problem::instance()->input_control_file(), step);
   else
-    reader = std::make_shared<Core::IO::DiscretizationReader>(discret_, input, step);
+    reader = std::make_shared<Core::IO::DiscretizationReader>(*discret_, input, step);
 
   // Initialize Nernst-BC
   init_nernst_bc();

--- a/src/scatra/4C_scatra_timint_genalpha.cpp
+++ b/src/scatra/4C_scatra_timint_genalpha.cpp
@@ -394,10 +394,10 @@ void ScaTra::TimIntGenAlpha::read_restart(
   if (input == nullptr)
   {
     reader = std::make_shared<Core::IO::DiscretizationReader>(
-        discret_, Global::Problem::instance()->input_control_file(), step);
+        *discret_, Global::Problem::instance()->input_control_file(), step);
   }
   else
-    reader = std::make_shared<Core::IO::DiscretizationReader>(discret_, input, step);
+    reader = std::make_shared<Core::IO::DiscretizationReader>(*discret_, input, step);
 
   time_ = reader->read_double("time");
   step_ = reader->read_int("step");

--- a/src/scatra/4C_scatra_timint_hdg.cpp
+++ b/src/scatra/4C_scatra_timint_hdg.cpp
@@ -394,7 +394,7 @@ void ScaTra::TimIntHDG::collect_runtime_output_data()
 void ScaTra::TimIntHDG::read_restart(const int step, std::shared_ptr<Core::IO::InputControl> input)
 {
   Core::IO::DiscretizationReader reader(
-      discret_, Global::Problem::instance()->input_control_file(), step);
+      *discret_, Global::Problem::instance()->input_control_file(), step);
 
   time_ = reader.read_double("time");
   step_ = reader.read_int("step");

--- a/src/scatra/4C_scatra_timint_implicit.cpp
+++ b/src/scatra/4C_scatra_timint_implicit.cpp
@@ -205,7 +205,7 @@ ScaTra::ScaTraTimIntImpl::ScaTraTimIntImpl(std::shared_ptr<Core::FE::Discretizat
   if (restart_step > 0)
   {
     Core::IO::DiscretizationReader reader(
-        discret_, Global::Problem::instance()->input_control_file(), restart_step);
+        *discret_, Global::Problem::instance()->input_control_file(), restart_step);
 
     time_ = reader.read_double("time");
   }

--- a/src/scatra/4C_scatra_timint_loma_genalpha.cpp
+++ b/src/scatra/4C_scatra_timint_loma_genalpha.cpp
@@ -294,9 +294,9 @@ void ScaTra::TimIntLomaGenAlpha::read_restart(
   std::shared_ptr<Core::IO::DiscretizationReader> reader(nullptr);
   if (input == nullptr)
     reader = std::make_shared<Core::IO::DiscretizationReader>(
-        discret_, Global::Problem::instance()->input_control_file(), step);
+        *discret_, Global::Problem::instance()->input_control_file(), step);
   else
-    reader = std::make_shared<Core::IO::DiscretizationReader>(discret_, input, step);
+    reader = std::make_shared<Core::IO::DiscretizationReader>(*discret_, input, step);
 
   // thermodynamic pressure at time n+1
   thermpressnp_ = reader->read_double("thermpressnp");

--- a/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
+++ b/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
@@ -3248,11 +3248,11 @@ void ScaTra::MeshtyingStrategyS2I::read_restart(
     // initialize reader
     std::shared_ptr<Core::IO::DiscretizationReader> reader(nullptr);
     if (input == nullptr)
-      reader = std::make_shared<Core::IO::DiscretizationReader>(
-          scatratimint_->discretization(), Global::Problem::instance()->input_control_file(), step);
+      reader = std::make_shared<Core::IO::DiscretizationReader>(*scatratimint_->discretization(),
+          Global::Problem::instance()->input_control_file(), step);
     else
       reader = std::make_shared<Core::IO::DiscretizationReader>(
-          scatratimint_->discretization(), input, step);
+          *scatratimint_->discretization(), input, step);
 
     // read state vector of discrete scatra-scatra interface layer thicknesses
     reader->read_vector(growthn_, "growthn");

--- a/src/scatra/4C_scatra_timint_ost.cpp
+++ b/src/scatra/4C_scatra_timint_ost.cpp
@@ -330,10 +330,10 @@ void ScaTra::TimIntOneStepTheta::read_restart(
   if (input == nullptr)
   {
     reader = std::make_shared<Core::IO::DiscretizationReader>(
-        discret_, Global::Problem::instance()->input_control_file(), step);
+        *discret_, Global::Problem::instance()->input_control_file(), step);
   }
   else
-    reader = std::make_shared<Core::IO::DiscretizationReader>(discret_, input, step);
+    reader = std::make_shared<Core::IO::DiscretizationReader>(*discret_, input, step);
 
   time_ = reader->read_double("time");
   step_ = reader->read_int("step");

--- a/src/scatra/4C_scatra_timint_stat.cpp
+++ b/src/scatra/4C_scatra_timint_stat.cpp
@@ -180,10 +180,10 @@ void ScaTra::TimIntStationary::read_restart(
   if (input == nullptr)
   {
     reader = std::make_shared<Core::IO::DiscretizationReader>(
-        discret_, Global::Problem::instance()->input_control_file(), step);
+        *discret_, Global::Problem::instance()->input_control_file(), step);
   }
   else
-    reader = std::make_shared<Core::IO::DiscretizationReader>(discret_, input, step);
+    reader = std::make_shared<Core::IO::DiscretizationReader>(*discret_, input, step);
 
   time_ = reader->read_double("time");
   step_ = reader->read_int("step");

--- a/src/ssi/4C_ssi_partitioned_1wc.cpp
+++ b/src/ssi/4C_ssi_partitioned_1wc.cpp
@@ -83,7 +83,7 @@ void SSI::SSIPart1WC::do_scatra_step()
     int diffsteps = structure_field()->dt() / scatra_field()->dt();
     if (scatra_field()->step() % diffsteps == 0)
     {
-      Core::IO::DiscretizationReader reader(scatra_field()->discretization(),
+      Core::IO::DiscretizationReader reader(*scatra_field()->discretization(),
           Global::Problem::instance()->input_control_file(), scatra_field()->step());
 
       // check if this is a cardiac monodomain problem

--- a/src/stru_multi/4C_stru_multi_microstatic.cpp
+++ b/src/stru_multi/4C_stru_multi_microstatic.cpp
@@ -884,7 +884,7 @@ void MultiScale::MicroStatic::read_restart(const int step,
 {
   std::shared_ptr<Core::IO::InputControl> inputcontrol =
       std::make_shared<Core::IO::InputControl>(name, true);
-  Core::IO::DiscretizationReader reader(discret_, inputcontrol, step);
+  Core::IO::DiscretizationReader reader(*discret_, inputcontrol, step);
   double time = reader.read_double("time");
   int rstep = reader.read_int("step");
   if (rstep != step) FOUR_C_THROW("Time step on file not equal to given step");
@@ -926,7 +926,7 @@ void MultiScale::MicroStatic::read_restart(const int step,
 double MultiScale::MicroStatic::get_time_to_step(const int step, const std::string& name)
 {
   std::shared_ptr<Core::IO::InputControl> inputcontrol(new Core::IO::InputControl(name, true));
-  Core::IO::DiscretizationReader reader(discret_, inputcontrol, step);
+  Core::IO::DiscretizationReader reader(*discret_, inputcontrol, step);
   return reader.read_double("time");
 }
 

--- a/src/structure/4C_structure_timint.cpp
+++ b/src/structure/4C_structure_timint.cpp
@@ -1694,7 +1694,7 @@ void Solid::TimInt::reset_step()
 void Solid::TimInt::read_restart(const int step)
 {
   Core::IO::DiscretizationReader reader(
-      discret_, Global::Problem::instance()->input_control_file(), step);
+      *discret_, Global::Problem::instance()->input_control_file(), step);
   if (step != reader.read_int("step")) FOUR_C_THROW("Time step on file not equal to given step");
 
   step_ = step;
@@ -1754,7 +1754,7 @@ void Solid::TimInt::set_restart(int step, double time,
 void Solid::TimInt::read_restart_state()
 {
   Core::IO::DiscretizationReader reader(
-      discret_, Global::Problem::instance()->input_control_file(), step_);
+      *discret_, Global::Problem::instance()->input_control_file(), step_);
 
   reader.read_vector(disn_, "displacement");
   dis_->update_steps(*disn_);
@@ -1797,7 +1797,7 @@ void Solid::TimInt::read_restart_constraint()
   if (conman_->have_constraint())
   {
     Core::IO::DiscretizationReader reader(
-        discret_, Global::Problem::instance()->input_control_file(), step_);
+        *discret_, Global::Problem::instance()->input_control_file(), step_);
     double uzawatemp = reader.read_double("uzawaparameter");
     consolv_->set_uzawa_parameter(uzawatemp);
 
@@ -1812,7 +1812,7 @@ void Solid::TimInt::read_restart_cardiovascular0_d()
   if (cardvasc0dman_->have_cardiovascular0_d())
   {
     Core::IO::DiscretizationReader reader(
-        discret_, Global::Problem::instance()->input_control_file(), step_);
+        *discret_, Global::Problem::instance()->input_control_file(), step_);
     cardvasc0dman_->read_restart(reader, (*time_)[0]);
   }
 }
@@ -1824,7 +1824,7 @@ void Solid::TimInt::read_restart_spring_dashpot()
   if (springman_->have_spring_dashpot())
   {
     Core::IO::DiscretizationReader reader(
-        discret_, Global::Problem::instance()->input_control_file(), step_);
+        *discret_, Global::Problem::instance()->input_control_file(), step_);
     springman_->read_restart(reader, (*time_)[0]);
   }
 }
@@ -1842,7 +1842,7 @@ void Solid::TimInt::read_restart_contact_meshtying()
   // in and contact / meshtying managers choose the correct state.
   //**********************************************************************
   Core::IO::DiscretizationReader reader(
-      discret_, Global::Problem::instance()->input_control_file(), step_);
+      *discret_, Global::Problem::instance()->input_control_file(), step_);
 
   if (have_contact_meshtying()) cmtbridge_->read_restart(reader, (*dis_)(0), zeros_);
 }
@@ -1854,7 +1854,7 @@ void Solid::TimInt::read_restart_beam_contact()
   if (have_beam_contact())
   {
     Core::IO::DiscretizationReader reader(
-        discret_, Global::Problem::instance()->input_control_file(), step_);
+        *discret_, Global::Problem::instance()->input_control_file(), step_);
     beamcman_->read_restart(reader);
   }
 }

--- a/src/structure/4C_structure_timint_genalpha.cpp
+++ b/src/structure/4C_structure_timint_genalpha.cpp
@@ -829,7 +829,7 @@ void Solid::TimIntGenAlpha::update_step_element()
 void Solid::TimIntGenAlpha::read_restart_force()
 {
   Core::IO::DiscretizationReader reader(
-      discret_, Global::Problem::instance()->input_control_file(), step_);
+      *discret_, Global::Problem::instance()->input_control_file(), step_);
   reader.read_vector(fext_, "fexternal");
   reader.read_vector(fint_, "fint");
   reader.read_vector(finert_, "finert");

--- a/src/structure/4C_structure_timint_ost.cpp
+++ b/src/structure/4C_structure_timint_ost.cpp
@@ -693,7 +693,7 @@ void Solid::TimIntOneStepTheta::update_step_element()
 void Solid::TimIntOneStepTheta::read_restart_force()
 {
   Core::IO::DiscretizationReader reader(
-      discret_, Global::Problem::instance()->input_control_file(), step_);
+      *discret_, Global::Problem::instance()->input_control_file(), step_);
   reader.read_vector(fext_, "fexternal");
   reader.read_vector(fint_, "fint");
   reader.read_vector(finert_, "finert");

--- a/src/structure_new/src/4C_structure_new_timint_base.cpp
+++ b/src/structure_new/src/4C_structure_new_timint_base.cpp
@@ -728,7 +728,7 @@ void Solid::TimeInt::Base::read_restart(const int stepn)
 
   // create an input/output reader
   Core::IO::DiscretizationReader ioreader(
-      discretization(), Global::Problem::instance()->input_control_file(), stepn);
+      *discretization(), Global::Problem::instance()->input_control_file(), stepn);
   dataglobalstate_->get_step_n() = stepn;
   dataglobalstate_->get_step_np() = stepn + 1;
   dataglobalstate_->get_multi_time() =

--- a/src/thermo/src/implicit/4C_thermo_timint.cpp
+++ b/src/thermo/src/implicit/4C_thermo_timint.cpp
@@ -338,7 +338,7 @@ void Thermo::TimInt::reset_step()
 void Thermo::TimInt::read_restart(const int step)
 {
   Core::IO::DiscretizationReader reader(
-      discret_, Global::Problem::instance()->input_control_file(), step);
+      *discret_, Global::Problem::instance()->input_control_file(), step);
   if (step != reader.read_int("step")) FOUR_C_THROW("Time step on file not equal to given step");
 
   step_ = step;
@@ -358,7 +358,7 @@ void Thermo::TimInt::read_restart(const int step)
 void Thermo::TimInt::read_restart_state()
 {
   Core::IO::DiscretizationReader reader(
-      discret_, Global::Problem::instance()->input_control_file(), step_);
+      *discret_, Global::Problem::instance()->input_control_file(), step_);
   reader.read_vector(tempn_, "temperature");
   temp_.update_steps(*tempn_);
   reader.read_vector(raten_, "rate");

--- a/src/thermo/src/implicit/4C_thermo_timint_genalpha.cpp
+++ b/src/thermo/src/implicit/4C_thermo_timint_genalpha.cpp
@@ -432,7 +432,7 @@ void Thermo::TimIntGenAlpha::read_restart_force()
 {
   // read the vectors that were written in WriteRestartForce()
   Core::IO::DiscretizationReader reader(
-      discret_, Global::Problem::instance()->input_control_file(), step_);
+      *discret_, Global::Problem::instance()->input_control_file(), step_);
   reader.read_vector(fext_, "fexternal");
   reader.read_vector(fint_, "fint");
   reader.read_vector(fcap_, "fcap");

--- a/src/thermo/src/implicit/4C_thermo_timint_ost.cpp
+++ b/src/thermo/src/implicit/4C_thermo_timint_ost.cpp
@@ -348,7 +348,7 @@ void Thermo::TimIntOneStepTheta::update_step_element()
 void Thermo::TimIntOneStepTheta::read_restart_force()
 {
   Core::IO::DiscretizationReader reader(
-      discret_, Global::Problem::instance()->input_control_file(), step_);
+      *discret_, Global::Problem::instance()->input_control_file(), step_);
   reader.read_vector(fext_, "fexternal");
   reader.read_vector(fint_, "fint");
   reader.read_vector(fcap_, "fcap");

--- a/src/xfem/4C_xfem_coupling_fpi_mesh.cpp
+++ b/src/xfem/4C_xfem_coupling_fpi_mesh.cpp
@@ -575,7 +575,7 @@ void XFEM::MeshCouplingFPI::read_restart(const int step)
 
   //-------- boundary discretization
   Core::IO::DiscretizationReader boundaryreader(
-      cutter_dis_, Global::Problem::instance()->input_control_file(), step);
+      *cutter_dis_, Global::Problem::instance()->input_control_file(), step);
 
   const double time = boundaryreader.read_double("time");
   //  const int    step = boundaryreader.ReadInt("step");

--- a/src/xfem/4C_xfem_coupling_levelset.cpp
+++ b/src/xfem/4C_xfem_coupling_levelset.cpp
@@ -201,7 +201,7 @@ void XFEM::LevelSetCoupling::prepare_cutter_output()
 
   if (cutter_output_ == nullptr)
   {
-    cutter_dis_->set_writer(std::make_shared<Core::IO::DiscretizationWriter>(cutter_dis_,
+    cutter_dis_->set_writer(std::make_shared<Core::IO::DiscretizationWriter>(*cutter_dis_,
         Global::Problem::instance()->output_control_file(),
         Global::Problem::instance()->spatial_approximation_type()));
   }
@@ -343,7 +343,7 @@ void XFEM::LevelSetCoupling::read_restart(const int step, const int lsc_idx)
 
   //-------- boundary discretization
   Core::IO::DiscretizationReader boundaryreader(
-      cutter_dis_, Global::Problem::instance()->input_control_file(), step);
+      *cutter_dis_, Global::Problem::instance()->input_control_file(), step);
 
   const double time = boundaryreader.read_double("time");
 

--- a/src/xfem/4C_xfem_coupling_mesh.cpp
+++ b/src/xfem/4C_xfem_coupling_mesh.cpp
@@ -163,7 +163,7 @@ void XFEM::MeshCoupling::prepare_cutter_output()
 
   if (!mark_geometry_)  // Do not write for marked geometry!
   {
-    cutter_dis_->set_writer(std::make_shared<Core::IO::DiscretizationWriter>(cutter_dis_,
+    cutter_dis_->set_writer(std::make_shared<Core::IO::DiscretizationWriter>(*cutter_dis_,
         Global::Problem::instance()->output_control_file(),
         Global::Problem::instance()->spatial_approximation_type()));
     cutter_output_ = cutter_dis_->writer();
@@ -1662,7 +1662,7 @@ void XFEM::MeshCouplingFSI::read_restart(const int step)
 
   //-------- boundary discretization
   Core::IO::DiscretizationReader boundaryreader(
-      cutter_dis_, Global::Problem::instance()->input_control_file(), step);
+      *cutter_dis_, Global::Problem::instance()->input_control_file(), step);
 
   const double time = boundaryreader.read_double("time");
   //  const int    step = boundaryreader.ReadInt("step");
@@ -2646,7 +2646,7 @@ void XFEM::MeshCouplingFluidFluid::read_restart(const int step)
 
   //-------- boundary discretization
   Core::IO::DiscretizationReader boundaryreader(
-      cutter_dis_, Global::Problem::instance()->input_control_file(), step);
+      *cutter_dis_, Global::Problem::instance()->input_control_file(), step);
 
   const double time = boundaryreader.read_double("time");
   //  const int    step = boundaryreader.ReadInt("step");


### PR DESCRIPTION
Reader and writer should obviously not _own_ a Discretization but just use it/refer to it.

Related to #413

Helps #1407 