### PR TITLE
Avoid shared_ptr on OutputControl

### DIFF
--- a/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator.cpp
@@ -120,7 +120,7 @@ void Solid::ModelEvaluator::BeamInteraction::setup()
       *discret_ptr_, "ia_structure", true, true, false, true);
   // create discretization writer
   ia_discret_->set_writer(std::make_shared<Core::IO::DiscretizationWriter>(*ia_discret_,
-      Global::Problem::instance()->output_control_file(),
+      *Global::Problem::instance()->output_control_file(),
       Global::Problem::instance()->spatial_approximation_type()));
 
   // init data container

--- a/src/core/binstrategy/4C_binstrategy.cpp
+++ b/src/core/binstrategy/4C_binstrategy.cpp
@@ -113,13 +113,13 @@ Core::Binstrategy::BinningStrategy::BinningStrategy(const Teuchos::ParameterList
   auto spatial_approximation_type = Teuchos::getIntegralValue<Core::FE::ShapeFunctionType>(
       binning_params, "spatial_approximation_type");
   bindis_->set_writer(std::make_shared<Core::IO::DiscretizationWriter>(
-      *bindis_, output_control, spatial_approximation_type));
+      *bindis_, *output_control, spatial_approximation_type));
   bindis_->fill_complete(Core::FE::OptionsFillComplete::none());
 
   visbindis_ = std::make_shared<Core::FE::Discretization>("bins", comm_, 3);
   // create discretization writer
   visbindis_->set_writer(std::make_shared<Core::IO::DiscretizationWriter>(
-      *visbindis_, output_control, spatial_approximation_type));
+      *visbindis_, *output_control, spatial_approximation_type));
 
   // try to read valid input
   domain_bounding_box_corner_positions_.put_scalar(1.0e12);

--- a/src/core/io/src/4C_io.hpp
+++ b/src/core/io/src/4C_io.hpp
@@ -221,8 +221,7 @@ namespace Core::IO
      * @param[in] output_control        output control file
      * @param[in] shape_function_type   shape function type of the underlying fe discretization
      */
-    DiscretizationWriter(Core::FE::Discretization& dis,
-        std::shared_ptr<OutputControl> output_control,
+    DiscretizationWriter(Core::FE::Discretization& dis, OutputControl& output_control,
         const Core::FE::ShapeFunctionType shape_function_type);
 
     DiscretizationWriter(const DiscretizationWriter& other) = delete;
@@ -354,10 +353,7 @@ namespace Core::IO
     //@}
 
     /// get output control
-    [[nodiscard]] std::shared_ptr<OutputControl> output() const { return output_; }
-
-    /// set output control
-    void set_output(std::shared_ptr<OutputControl> output);
+    [[nodiscard]] OutputControl& output() const { return output_; }
 
     /// access discretization
     [[nodiscard]] const Core::FE::Discretization& get_discretization() const;
@@ -400,7 +396,7 @@ namespace Core::IO
     int meshfile_changed_;
 
     //! Control file object
-    std::shared_ptr<OutputControl> output_;
+    OutputControl& output_;
 
     //! do we want binary output
     bool binio_;

--- a/src/fluid/4C_fluid_discret_extractor.cpp
+++ b/src/fluid/4C_fluid_discret_extractor.cpp
@@ -428,7 +428,7 @@ FLD::FluidDiscretExtractor::FluidDiscretExtractor(std::shared_ptr<Core::FE::Disc
 
     // set discretization writer
     childdiscret_->set_writer(std::make_shared<Core::IO::DiscretizationWriter>(*childdiscret_,
-        Global::Problem::instance()->output_control_file(),
+        *Global::Problem::instance()->output_control_file(),
         Global::Problem::instance()->spatial_approximation_type()));
 
     // call fill_complete() to assign the dof

--- a/src/fluid/4C_fluid_implicit_integration.cpp
+++ b/src/fluid/4C_fluid_implicit_integration.cpp
@@ -3690,14 +3690,14 @@ void FLD::FluidImplicitTimeInt::output_to_gmsh(
   if (inflow)
   {
     filename = Core::IO::Gmsh::get_new_file_name_and_delete_old_files("solution_velpres_inflow",
-        discret_->writer()->output()->file_name(), step, 20, screen_out,
+        discret_->writer()->output().file_name(), step, 20, screen_out,
         Core::Communication::my_mpi_rank(discret_->get_comm()));
     // std::ofstream gmshfilecontent(filename.c_str());
   }
   else
   {
     filename = Core::IO::Gmsh::get_new_file_name_and_delete_old_files("solution_velpres",
-        discret_->writer()->output()->file_name(), step, 20, screen_out,
+        discret_->writer()->output().file_name(), step, 20, screen_out,
         Core::Communication::my_mpi_rank(discret_->get_comm()));
     // std::ofstream gmshfilecontent(filename.c_str());
   }

--- a/src/fluid/4C_fluid_timint_red.cpp
+++ b/src/fluid/4C_fluid_timint_red.cpp
@@ -74,7 +74,7 @@ void FLD::TimIntRedModels::init()
     if (ART_timeInt_ != nullptr)
     {
       Core::IO::DiscretizationWriter output_redD(*ART_timeInt_->discretization(),
-          Global::Problem::instance()->output_control_file(),
+          *Global::Problem::instance()->output_control_file(),
           Global::Problem::instance()->spatial_approximation_type());
       discret_->clear_state();
       discret_->set_state("velaf", *zeros_);
@@ -93,7 +93,7 @@ void FLD::TimIntRedModels::init()
     if (airway_imp_timeInt_ != nullptr)
     {
       Core::IO::DiscretizationWriter output_redD(*airway_imp_timeInt_->discretization(),
-          Global::Problem::instance()->output_control_file(),
+          *Global::Problem::instance()->output_control_file(),
           Global::Problem::instance()->spatial_approximation_type());
       discret_->clear_state();
       discret_->set_state("velaf", *zeros_);

--- a/src/fluid_xfluid/4C_fluid_xfluid_outputservice.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid_outputservice.cpp
@@ -414,7 +414,7 @@ void FLD::XFluidOutputServiceGmsh::gmsh_output(
 
   bool screen_out = gmsh_debug_out_screen_;
 
-  auto file_name = discret_->writer()->output()->file_name();
+  auto file_name = discret_->writer()->output().file_name();
 
   // output for Element and Node IDs
   std::ostringstream filename_base_vel;
@@ -1298,7 +1298,7 @@ void FLD::XFluidOutputServiceGmsh::gmsh_output_discretization(
 
   // output for Element and Node IDs
   const std::string filename = Core::IO::Gmsh::get_new_file_name_and_delete_old_files("DISCRET",
-      discret_->writer()->output()->file_name(), step, gmsh_step_diff_, gmsh_debug_out_screen_,
+      discret_->writer()->output().file_name(), step, gmsh_step_diff_, gmsh_debug_out_screen_,
       Core::Communication::my_mpi_rank(discret_->get_comm()));
   std::ofstream gmshfilecontent(filename.c_str());
   gmshfilecontent.setf(std::ios::scientific, std::ios::floatfield);
@@ -1329,7 +1329,7 @@ void FLD::XFluidOutputServiceGmsh::gmsh_output_eos(
 
   // output for Element and Node IDs
   const std::string filename = Core::IO::Gmsh::get_new_file_name_and_delete_old_files("EOS",
-      discret_->writer()->output()->file_name(), step, gmsh_step_diff_, gmsh_debug_out_screen_,
+      discret_->writer()->output().file_name(), step, gmsh_step_diff_, gmsh_debug_out_screen_,
       Core::Communication::my_mpi_rank(discret_->get_comm()));
   std::ofstream gmshfilecontent(filename.c_str());
   gmshfilecontent.setf(std::ios::scientific, std::ios::floatfield);

--- a/src/fs3i/4C_fs3i_biofilm_fsi.cpp
+++ b/src/fs3i/4C_fs3i_biofilm_fsi.cpp
@@ -923,7 +923,7 @@ void FS3I::BiofilmFSI::struct_gmsh_output()
       scatravec_[1]->scatra_field()->discretization();
 
   const std::string filename = Core::IO::Gmsh::get_new_file_name_and_delete_old_files("struct",
-      structdis->writer()->output()->file_name(), step_bio_, 701, false,
+      structdis->writer()->output().file_name(), step_bio_, 701, false,
       Core::Communication::my_mpi_rank(structdis->get_comm()));
   std::ofstream gmshfilecontent(filename.c_str());
 
@@ -974,7 +974,7 @@ void FS3I::BiofilmFSI::fluid_gmsh_output()
       scatravec_[0]->scatra_field()->discretization();
 
   const std::string filenamefluid = Core::IO::Gmsh::get_new_file_name_and_delete_old_files("fluid",
-      fluiddis->writer()->output()->file_name(), step_bio_, 701, false,
+      fluiddis->writer()->output().file_name(), step_bio_, 701, false,
       Core::Communication::my_mpi_rank(fluiddis->get_comm()));
   std::ofstream gmshfilecontent(filenamefluid.c_str());
 

--- a/src/global_data/4C_global_data.hpp
+++ b/src/global_data/4C_global_data.hpp
@@ -137,9 +137,14 @@ namespace Global
     /// set restart step which was read from the command line
     void set_restart_step(int r);
 
-    void set_input_control_file(std::shared_ptr<Core::IO::InputControl>& input)
+    void set_input_control_file(std::shared_ptr<Core::IO::InputControl>&& input)
     {
       inputcontrol_ = input;
+    }
+
+    void set_output_control_file(std::shared_ptr<Core::IO::OutputControl>&& output)
+    {
+      outputcontrol_ = output;
     }
 
     /// manipulate problem type

--- a/src/lubrication/src/4C_lubrication_timint_implicit.cpp
+++ b/src/lubrication/src/4C_lubrication_timint_implicit.cpp
@@ -1118,7 +1118,7 @@ void Lubrication::TimIntImpl::output_to_gmsh(const int step, const double time) 
 
   // create Gmsh postprocessing file
   const std::string filename = Core::IO::Gmsh::get_new_file_name_and_delete_old_files(
-      "solution_field_pressure", discret_->writer()->output()->file_name(), step, 500, screen_out,
+      "solution_field_pressure", discret_->writer()->output().file_name(), step, 500, screen_out,
       Core::Communication::my_mpi_rank(discret_->get_comm()));
   std::ofstream gmshfilecontent(filename.c_str());
   {

--- a/src/mat/4C_mat_micromaterialgp_static.cpp
+++ b/src/mat/4C_mat_micromaterialgp_static.cpp
@@ -190,16 +190,14 @@ void Mat::MicroMaterialGP::new_result_file(
     // in case of restart, the new output file name is already adapted
     if (restart) adaptname = false;
 
-    std::shared_ptr<Core::IO::OutputControl> microcontrol =
-        std::make_shared<Core::IO::OutputControl>(microdis->get_comm(), "Structure",
-            microproblem->spatial_approximation_type(), "micro-input-file-not-known", restartname_,
-            newfilename, ndim, restart, macrocontrol->file_steps(),
-            Global::Problem::instance()->io_params().get<bool>("OUTPUT_BIN"), adaptname);
+    micro_output_control_.emplace(microdis->get_comm(), "Structure",
+        microproblem->spatial_approximation_type(), "micro-input-file-not-known", restartname_,
+        newfilename, ndim, restart, macrocontrol->file_steps(),
+        Global::Problem::instance()->io_params().get<bool>("OUTPUT_BIN"), adaptname);
 
     // initialize writer for restart output
     micro_output_ = std::make_shared<Core::IO::DiscretizationWriter>(
-        *microdis, microcontrol, microproblem->spatial_approximation_type());
-    micro_output_->set_output(microcontrol);
+        *microdis, *micro_output_control_, microproblem->spatial_approximation_type());
     micro_output_->write_mesh(step_, time_);
 
     if (initialize_runtime_output_writer)
@@ -208,7 +206,7 @@ void Mat::MicroMaterialGP::new_result_file(
           std::make_shared<Core::IO::DiscretizationVisualizationWriterMesh>(
               microdis, Core::IO::visualization_parameters_factory(
                             Global::Problem::instance()->io_params().sublist("RUNTIME VTK OUTPUT"),
-                            *microcontrol, time_));
+                            *micro_output_control_, time_));
     }
   }
 }

--- a/src/mat/4C_mat_micromaterialgp_static.hpp
+++ b/src/mat/4C_mat_micromaterialgp_static.hpp
@@ -12,6 +12,7 @@
 
 #include "4C_config.hpp"
 
+#include "4C_io_control.hpp"
 #include "4C_io_discretization_visualization_writer_mesh.hpp"
 #include "4C_linalg_fixedsizematrix.hpp"
 #include "4C_linalg_vector.hpp"
@@ -105,6 +106,8 @@ namespace Mat
 
     /// microstructure runtime output writer
     std::shared_ptr<Core::IO::DiscretizationVisualizationWriterMesh> micro_visualization_writer_;
+
+    std::optional<Core::IO::OutputControl> micro_output_control_;
 
     /// homogenized density
     double density_;

--- a/src/mat/4C_mat_scatra_multiscale_gp.hpp
+++ b/src/mat/4C_mat_scatra_multiscale_gp.hpp
@@ -10,6 +10,7 @@
 
 #include "4C_config.hpp"
 
+#include "4C_io_control.hpp"
 #include "4C_linalg_vector.hpp"
 #include "4C_linear_solver_method_linalg.hpp"
 
@@ -133,6 +134,8 @@ namespace Mat
 
     //! micro-scale visualization writer
     std::shared_ptr<Core::IO::DiscretizationVisualizationWriterMesh> micro_visualization_writer_;
+
+    std::optional<Core::IO::OutputControl> micro_output_control_;
 
     //! file name prefix for restart
     std::string restartname_;

--- a/src/mortar/src/4C_mortar_interface.cpp
+++ b/src/mortar/src/4C_mortar_interface.cpp
@@ -258,7 +258,7 @@ void Mortar::Interface::create_interface_discretization(
 
   // Prepare discretization writer
   idiscret_->set_writer(std::make_shared<Core::IO::DiscretizationWriter>(
-      *idiscret_, output_control, spatial_approximation_type));
+      *idiscret_, *output_control, spatial_approximation_type));
   FOUR_C_ASSERT(idiscret_->writer(), "Setup of discretization writer failed.");
 }
 

--- a/src/particle/src/wall/4C_particle_wall.cpp
+++ b/src/particle/src/wall/4C_particle_wall.cpp
@@ -452,7 +452,7 @@ void PARTICLEWALL::WallHandlerBase::create_wall_discretization()
 
   // create wall discretization writer
   walldiscretization_->set_writer(std::make_shared<Core::IO::DiscretizationWriter>(
-      *walldiscretization_, Global::Problem::instance()->output_control_file(),
+      *walldiscretization_, *Global::Problem::instance()->output_control_file(),
       Global::Problem::instance()->spatial_approximation_type()));
 }
 

--- a/src/scatra/4C_scatra_timint_elch.cpp
+++ b/src/scatra/4C_scatra_timint_elch.cpp
@@ -169,7 +169,7 @@ void ScaTra::ScaTraTimIntElch::setup()
       electrodecrates_.insert(conditioninitpair);
       runtime_csvwriter_soc_.insert(std::make_pair(cond_id, std::nullopt));
       runtime_csvwriter_soc_[cond_id].emplace(
-          myrank_, *disc_writer()->output(), "electrode_soc_" + std::to_string(cond_id));
+          myrank_, disc_writer()->output(), "electrode_soc_" + std::to_string(cond_id));
       runtime_csvwriter_soc_[cond_id]->register_data_vector("SOC", 1, 16);
       runtime_csvwriter_soc_[cond_id]->register_data_vector("CRate", 1, 16);
 
@@ -214,7 +214,7 @@ void ScaTra::ScaTraTimIntElch::setup()
         electrodevoltage_.insert({condid, 0.0});
       }
       // setup csv writer for cell voltage
-      runtime_csvwriter_cell_voltage_.emplace(myrank_, *disc_writer()->output(), "cell_voltage");
+      runtime_csvwriter_cell_voltage_.emplace(myrank_, disc_writer()->output(), "cell_voltage");
       runtime_csvwriter_cell_voltage_->register_data_vector("CellVoltage", 1, 16);
     }
   }

--- a/src/scatra/4C_scatra_timint_implicit_service.cpp
+++ b/src/scatra/4C_scatra_timint_implicit_service.cpp
@@ -1080,7 +1080,7 @@ void ScaTra::ScaTraTimIntImpl::output_to_gmsh(const int step, const double time)
 
   // create Gmsh postprocessing file
   const std::string filename = Core::IO::Gmsh::get_new_file_name_and_delete_old_files(
-      "solution_field_scalar", disc_writer()->output()->file_name(), step, 500, screen_out,
+      "solution_field_scalar", disc_writer()->output().file_name(), step, 500, screen_out,
       Core::Communication::my_mpi_rank(discret_->get_comm()));
   std::ofstream gmshfilecontent(filename.c_str());
   {
@@ -2319,7 +2319,7 @@ ScaTra::OutputScalarsStrategyBase::OutputScalarsStrategyBase(const ScaTraTimIntI
   else
     filename = "scalarvalues";
 
-  runtime_csvwriter_.emplace(myrank_, *scatratimint->disc_writer()->output(), filename);
+  runtime_csvwriter_.emplace(myrank_, scatratimint->disc_writer()->output(), filename);
 }
 
 /*-------------------------------------------------------------------------*

--- a/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
+++ b/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
@@ -1943,7 +1943,7 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
   master_conditions_.clear();
   runtime_csvwriter_.emplace(
       Core::Communication::my_mpi_rank(scatratimint_->discretization()->get_comm()),
-      *scatratimint_->disc_writer()->output(), "kinetics_interface_flux");
+      scatratimint_->disc_writer()->output(), "kinetics_interface_flux");
 
   for (auto* s2imeshtying_cond : s2imeshtying_conditions)
   {

--- a/src/ssi/4C_ssi_dyn.cpp
+++ b/src/ssi/4C_ssi_dyn.cpp
@@ -145,7 +145,7 @@ void ssi_drt()
     {
       std::string filename = Teuchos::getNumericStringParameter(ssiparams, "SCATRA_FILENAME");
       auto inputscatra = std::make_shared<Core::IO::InputControl>(filename, comm);
-      problem->set_input_control_file(inputscatra);
+      problem->set_input_control_file(std::move(inputscatra));
     }
 
     // 4.- Run of the actual problem.

--- a/src/structure/4C_structure_timint.cpp
+++ b/src/structure/4C_structure_timint.cpp
@@ -1940,7 +1940,7 @@ void Solid::TimInt::write_gmsh_struct_output_step()
   if (not gmsh_out_) return;
 
   const std::string filename = Core::IO::Gmsh::get_file_name(
-      "struct", discret_->writer()->output()->file_name(), stepn_, false, myrank_);
+      "struct", discret_->writer()->output().file_name(), stepn_, false, myrank_);
   std::ofstream gmshfilecontent(filename.c_str());
 
   // add 'View' to Gmsh postprocessing file

--- a/src/structure_new/src/4C_structure_new_timint_base.cpp
+++ b/src/structure_new/src/4C_structure_new_timint_base.cpp
@@ -706,7 +706,7 @@ void Solid::TimeInt::Base::write_gmsh_struct_output_step()
   if (!dataio_->is_gmsh()) return;
 
   const std::string filename =
-      Core::IO::Gmsh::get_file_name("struct", disc_writer()->output()->file_name(),
+      Core::IO::Gmsh::get_file_name("struct", disc_writer()->output().file_name(),
           dataglobalstate_->get_step_np(), false, dataglobalstate_->get_my_rank());
   std::ofstream gmshfilecontent(filename.c_str());
 

--- a/src/structure_new/src/implicit/4C_structure_new_timint_implicit.cpp
+++ b/src/structure_new/src/implicit/4C_structure_new_timint_implicit.cpp
@@ -485,7 +485,7 @@ void Solid::TimeInt::Implicit::print_jacobian_in_matlab_format(
            << nlnsolver_ptr_->get_num_nln_iterations();
 
   std::stringstream filename;
-  filename << get_data_io().get_output_ptr()->output()->file_name() << "_" << filebase.str()
+  filename << get_data_io().get_output_ptr()->output().file_name() << "_" << filebase.str()
            << ".mtl";
 
   if (get_data_global_state().get_my_rank() == 0)

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_data.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_data.cpp
@@ -720,7 +720,7 @@ int Solid::ModelEvaluator::Data::get_step_np() const { return global_state().get
 std::string Solid::ModelEvaluator::ContactData::get_output_file_path() const
 {
   check_init();
-  return in_output().get_output_ptr()->output()->file_name();
+  return in_output().get_output_ptr()->output().file_name();
 }
 
 /*----------------------------------------------------------------------------*

--- a/src/xfem/4C_xfem_coupling_levelset.cpp
+++ b/src/xfem/4C_xfem_coupling_levelset.cpp
@@ -202,7 +202,7 @@ void XFEM::LevelSetCoupling::prepare_cutter_output()
   if (cutter_output_ == nullptr)
   {
     cutter_dis_->set_writer(std::make_shared<Core::IO::DiscretizationWriter>(*cutter_dis_,
-        Global::Problem::instance()->output_control_file(),
+        *Global::Problem::instance()->output_control_file(),
         Global::Problem::instance()->spatial_approximation_type()));
   }
 
@@ -306,7 +306,7 @@ void XFEM::LevelSetCoupling::gmsh_output(const std::string& filename_base, const
   filename_base_fsi << filename_base << "_levelset";
 
   const std::string filename = Core::IO::Gmsh::get_new_file_name_and_delete_old_files(
-      filename_base_fsi.str(), cutter_output_->output()->file_name(), step, gmsh_step_diff,
+      filename_base_fsi.str(), cutter_output_->output().file_name(), step, gmsh_step_diff,
       gmsh_debug_out_screen, myrank_);
 
   std::ofstream gmshfilecontent(filename.c_str());

--- a/src/xfem/4C_xfem_coupling_mesh.cpp
+++ b/src/xfem/4C_xfem_coupling_mesh.cpp
@@ -164,7 +164,7 @@ void XFEM::MeshCoupling::prepare_cutter_output()
   if (!mark_geometry_)  // Do not write for marked geometry!
   {
     cutter_dis_->set_writer(std::make_shared<Core::IO::DiscretizationWriter>(*cutter_dis_,
-        Global::Problem::instance()->output_control_file(),
+        *Global::Problem::instance()->output_control_file(),
         Global::Problem::instance()->spatial_approximation_type()));
     cutter_output_ = cutter_dis_->writer();
     cutter_output_->write_mesh(0, 0.0);
@@ -1719,7 +1719,7 @@ void XFEM::MeshCouplingFSI::gmsh_output(const std::string& filename_base, const 
 
 
   const std::string filename = Core::IO::Gmsh::get_new_file_name_and_delete_old_files(
-      filename_base_fsi.str(), cutter_dis_->writer()->output()->file_name(), step, gmsh_step_diff,
+      filename_base_fsi.str(), cutter_dis_->writer()->output().file_name(), step, gmsh_step_diff,
       gmsh_debug_out_screen, myrank_);
 
   std::ofstream gmshfilecontent(filename.c_str());


### PR DESCRIPTION
Follows #1421. Turns out there are more reference cycles that prevent me from finishing #1407 

~~Does not quite work yet due to micro-macro/nested parallelism hacking the infrastructure.~~