### PR TITLE
Move general condition parameters

### DIFF
--- a/src/core/fem/src/condition/4C_fem_condition_definition.cpp
+++ b/src/core/fem/src/condition/4C_fem_condition_definition.cpp
@@ -35,6 +35,15 @@ Core::Conditions::ConditionDefinition::ConditionDefinition(std::string sectionna
       buildgeometry_(buildgeometry),
       gtype_(gtype)
 {
+  using namespace Core::IO::InputSpecBuilders;
+  // Add common parameters to all conditions.
+
+  add_component(
+      parameter<int>("E", {.description = "ID of the condition. This ID refers to the respective "
+                                          "topological entity of the condition."}));
+  add_component(parameter<Core::Conditions::EntityType>(
+      "ENTITY_TYPE", {.description = "The type of entity that E refers to.",
+                         .default_value = Core::Conditions::EntityType::legacy_id}));
 }
 
 
@@ -85,6 +94,13 @@ void Core::Conditions::ConditionDefinition::read(Core::IO::InputFile& input,
 
     cmap.emplace(id, condition);
   }
+}
+
+
+Core::IO::InputSpec Core::Conditions::ConditionDefinition::spec() const
+{
+  using namespace Core::IO::InputSpecBuilders;
+  return list(section_name(), all_of(specs_), {.description = description_, .required = false});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/fem/src/condition/4C_fem_condition_definition.hpp
+++ b/src/core/fem/src/condition/4C_fem_condition_definition.hpp
@@ -14,13 +14,8 @@
 #include "4C_io_input_parameter_container.hpp"
 #include "4C_io_input_spec.hpp"
 
-#include <Teuchos_Array.hpp>
-
-#include <iostream>
 #include <memory>
 #include <string>
-#include <type_traits>
-#include <variant>
 #include <vector>
 
 FOUR_C_NAMESPACE_OPEN
@@ -69,7 +64,6 @@ namespace Core::Conditions
 
     /// read all conditions from my input file section
     /*!
-      \param problem (i) global problem instance that manages the input
       \param input (i) the input file
       \param cmap (o) the conditions we read here
      */
@@ -82,13 +76,11 @@ namespace Core::Conditions
     /// my condition name
     std::string name() const { return conditionname_; }
 
-    /// my condition description
-    std::string description() const { return description_; }
-
     /// my GeometryType
     Core::Conditions::GeometryType geometry_type() const { return gtype_; }
 
-    const std::vector<Core::IO::InputSpec>& specs() const { return specs_; }
+    /// Get the InputSpec for this ConditionDefinition
+    [[nodiscard]] Core::IO::InputSpec spec() const;
 
    private:
     std::string sectionname_;

--- a/src/global_data/4C_global_data_read.cpp
+++ b/src/global_data/4C_global_data_read.cpp
@@ -103,17 +103,7 @@ namespace
       auto valid_conditions = global_legacy_module_callbacks().conditions();
       for (const auto& cond : valid_conditions)
       {
-        auto condition_spec = all_of({
-            parameter<int>(
-                "E", {.description = "ID of the condition. This ID refers to the respective "
-                                     "topological entity of the condition."}),
-            parameter<Core::Conditions::EntityType>(
-                "ENTITY_TYPE", {.description = "The type of entity that E refers to.",
-                                   .default_value = Core::Conditions::EntityType::legacy_id}),
-            all_of(cond.specs()),
-        });
-        // section_specs.emplace(cond.section_name(), std::move(condition_spec));
-        section_specs.push_back(list(cond.section_name(), condition_spec, {.required = false}));
+        section_specs.emplace_back(cond.spec());
       }
     }
 
@@ -1684,8 +1674,8 @@ void Global::read_conditions(
       {
         const std::vector<int>* nodes = condition->get_nodes();
         if (nodes->size() == 0)
-          FOUR_C_THROW("{} condition {} has no nodal cloud", condition_definition.description(),
-              condition->id());
+          FOUR_C_THROW(
+              "{} condition {} has no nodal cloud", condition_definition.name(), condition->id());
 
         int foundit = 0;
         for (int node : *nodes)


### PR DESCRIPTION
Instead of returning a partial InputSpec, build the whole thing in `ConditionDefinition`.