### PR TITLE
Remove a few unnecessary shared_ptrs

### DIFF
--- a/src/cardiovascular0d/4C_cardiovascular0d_mor_pod.cpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_mor_pod.cpp
@@ -97,16 +97,14 @@ Cardiovascular0D::ProperOrthogonalDecomposition::reduce_diagonal(Core::LinAlg::S
   if (err) FOUR_C_THROW("Multiplication M * V failed.");
 
   // left multiply V^T * (M * V)
-  std::shared_ptr<Core::LinAlg::MultiVector<double>> M_red_mvec =
-      std::make_shared<Core::LinAlg::MultiVector<double>>(*structmapr_, M_tmp.num_vectors(), true);
-  multiply_multi_vectors(
-      *projmatrix_, 'T', M_tmp, 'N', *redstructmapr_, *structrimpo_, *M_red_mvec);
+  Core::LinAlg::MultiVector<double> M_red_mvec(*structmapr_, M_tmp.num_vectors(), true);
+  multiply_multi_vectors(*projmatrix_, 'T', M_tmp, 'N', *redstructmapr_, *structrimpo_, M_red_mvec);
 
   // convert Core::LinAlg::MultiVector<double> to Core::LinAlg::SparseMatrix
   std::shared_ptr<Core::LinAlg::SparseMatrix> M_red =
       std::make_shared<Core::LinAlg::SparseMatrix>(*structmapr_, 0, false, true);
   Core::LinAlg::multi_vector_to_linalg_sparse_matrix(
-      *M_red_mvec, *structmapr_, *structmapr_, *M_red);
+      M_red_mvec, *structmapr_, *structmapr_, *M_red);
 
   return M_red;
 }
@@ -117,17 +115,15 @@ std::shared_ptr<Core::LinAlg::SparseMatrix>
 Cardiovascular0D::ProperOrthogonalDecomposition::reduce_off_diagonal(Core::LinAlg::SparseMatrix& M)
 {
   // right multiply M * V
-  std::shared_ptr<Core::LinAlg::MultiVector<double>> M_tmp =
-      std::make_shared<Core::LinAlg::MultiVector<double>>(
-          M.domain_map(), projmatrix_->num_vectors(), true);
-  int err = M.multiply(true, *projmatrix_, *M_tmp);
+  Core::LinAlg::MultiVector<double> M_tmp(M.domain_map(), projmatrix_->num_vectors(), true);
+  int err = M.multiply(true, *projmatrix_, M_tmp);
   if (err) FOUR_C_THROW("Multiplication V^T * M failed.");
 
   // convert Core::LinAlg::MultiVector<double> to Core::LinAlg::SparseMatrix
-  std::shared_ptr<Core::LinAlg::Map> rangemap = std::make_shared<Core::LinAlg::Map>(M.domain_map());
+  Core::LinAlg::Map rangemap(M.domain_map());
   std::shared_ptr<Core::LinAlg::SparseMatrix> M_red =
-      std::make_shared<Core::LinAlg::SparseMatrix>(*rangemap, 0, false, true);
-  Core::LinAlg::multi_vector_to_linalg_sparse_matrix(*M_tmp, *rangemap, *structmapr_, *M_red);
+      std::make_shared<Core::LinAlg::SparseMatrix>(rangemap, 0, false, true);
+  Core::LinAlg::multi_vector_to_linalg_sparse_matrix(M_tmp, rangemap, *structmapr_, *M_red);
 
   return M_red;
 }

--- a/src/core/fem/tests/discretization/4C_fem_discretization_nodal_coordinates_test.np3.cpp
+++ b/src/core/fem/tests/discretization/4C_fem_discretization_nodal_coordinates_test.np3.cpp
@@ -74,10 +74,9 @@ namespace
     // build node coordinates based on the node row map of first partial discretization
     {
       std::array<int, 4> nodeList{0, 2, 4, 10};  // GID list of first 4 elements
-      std::shared_ptr<Core::LinAlg::Map> node_row_map =
-          std::make_shared<Core::LinAlg::Map>(-1, nodeList.size(), nodeList.data(), 0, comm_);
+      Core::LinAlg::Map node_row_map(-1, nodeList.size(), nodeList.data(), 0, comm_);
       std::shared_ptr<Core::LinAlg::MultiVector<double>> nodal_test_coordinates =
-          extract_node_coordinates(*test_discretization_, *node_row_map);
+          extract_node_coordinates(*test_discretization_, node_row_map);
 
       const auto& nodal_coordinates = *nodal_test_coordinates;
 

--- a/src/scatra/4C_scatra_timint_implicit_service.cpp
+++ b/src/scatra/4C_scatra_timint_implicit_service.cpp
@@ -842,23 +842,22 @@ void ScaTra::ScaTraTimIntImpl::add_flux_approx_to_parameter_list(Teuchos::Parame
 
   // get the noderowmap
   const Core::LinAlg::Map* noderowmap = discret_->node_row_map();
-  std::shared_ptr<Core::LinAlg::MultiVector<double>> fluxk =
-      std::make_shared<Core::LinAlg::MultiVector<double>>(*noderowmap, 3, true);
+  Core::LinAlg::MultiVector<double> fluxk(*noderowmap, 3, true);
   for (int k = 0; k < num_scal(); ++k)
   {
     const std::string name = "flux_phi_" + std::to_string(k);
-    for (int i = 0; i < fluxk->local_length(); ++i)
+    for (int i = 0; i < fluxk.local_length(); ++i)
     {
       Core::Nodes::Node* actnode = discret_->l_row_node(i);
       int dofgid = discret_->dof(0, actnode, k);
-      fluxk->replace_local_value(i, 0, ((*flux)(0))[(flux->get_map()).lid(dofgid)]);
-      fluxk->replace_local_value(i, 1, ((*flux)(1))[(flux->get_map()).lid(dofgid)]);
-      fluxk->replace_local_value(i, 2, ((*flux)(2))[(flux->get_map()).lid(dofgid)]);
+      fluxk.replace_local_value(i, 0, ((*flux)(0))[(flux->get_map()).lid(dofgid)]);
+      fluxk.replace_local_value(i, 1, ((*flux)(1))[(flux->get_map()).lid(dofgid)]);
+      fluxk.replace_local_value(i, 2, ((*flux)(2))[(flux->get_map()).lid(dofgid)]);
     }
 
     auto tmp = std::make_shared<Core::LinAlg::MultiVector<double>>(
-        *discret_->node_col_map(), fluxk->num_vectors());
-    Core::LinAlg::export_to(*fluxk, *tmp);
+        *discret_->node_col_map(), fluxk.num_vectors());
+    Core::LinAlg::export_to(fluxk, *tmp);
     p.set(name, tmp);
   }
 }

--- a/src/structure/4C_structure_timint_genalpha.cpp
+++ b/src/structure/4C_structure_timint_genalpha.cpp
@@ -410,7 +410,7 @@ void Solid::TimIntGenAlpha::evaluate_force_stiff_residual(Teuchos::ParameterList
   Teuchos::ParameterList psprdash;
   psprdash.set("time_fac", gamma_ / (beta_ * (*dt_)[0]));
   psprdash.set("dt", (*dt_)[0]);  // needed only for cursurfnormal option!!
-  apply_force_stiff_spring_dashpot(stiff_, fintn_, disn_, veln_, predict, psprdash);
+  apply_force_stiff_spring_dashpot(stiff_, fintn_, disn_, *veln_, predict, psprdash);
 
   // total internal mid-forces F_{int;n+1-alpha_f} ----> TR-like
   // F_{int;n+1-alpha_f} := (1.-alphaf) * F_{int;n+1} + alpha_f * F_{int;n}

--- a/src/structure/4C_structure_timint_impl.cpp
+++ b/src/structure/4C_structure_timint_impl.cpp
@@ -980,16 +980,15 @@ void Solid::TimIntImpl::apply_force_stiff_cardiovascular0_d(const double time,
 void Solid::TimIntImpl::apply_force_stiff_spring_dashpot(
     std::shared_ptr<Core::LinAlg::SparseOperator> stiff,
     std::shared_ptr<Core::LinAlg::Vector<double>> fint,
-    std::shared_ptr<Core::LinAlg::Vector<double>> disn,
-    std::shared_ptr<Core::LinAlg::Vector<double>> veln, bool predict,
-    Teuchos::ParameterList psprdash)
+    std::shared_ptr<Core::LinAlg::Vector<double>> disn, Core::LinAlg::Vector<double>& veln,
+    bool predict, Teuchos::ParameterList psprdash)
 {
   psprdash.set("total time", time());
   if (springman_->have_spring_dashpot())
   {
     auto stiff_sparse = std::dynamic_pointer_cast<Core::LinAlg::SparseMatrix>(stiff);
     if (stiff_sparse == nullptr) FOUR_C_THROW("Cannot cast stiffness matrix to sparse matrix!");
-    springman_->stiffness_and_internal_forces(stiff_sparse, fint, disn, *veln, psprdash);
+    springman_->stiffness_and_internal_forces(stiff_sparse, fint, disn, veln, psprdash);
   }
 
   return;

--- a/src/structure/4C_structure_timint_impl.hpp
+++ b/src/structure/4C_structure_timint_impl.hpp
@@ -329,7 +329,7 @@ namespace Solid
         std::shared_ptr<Core::LinAlg::SparseOperator> stiff,  //!< stiffness is modified
         std::shared_ptr<Core::LinAlg::Vector<double>> fint,   //!< internal forces are modified
         std::shared_ptr<Core::LinAlg::Vector<double>> dis,    //!< current displacement state
-        std::shared_ptr<Core::LinAlg::Vector<double>> vel,    //!< current velocity state
+        Core::LinAlg::Vector<double>& vel,                    //!< current velocity state
         bool predict,                                         //!< flag indicating predictor step
         Teuchos::ParameterList
             psprdash  //!< parameter list containing scale factors for matrix entries

--- a/src/structure/4C_structure_timint_ost.cpp
+++ b/src/structure/4C_structure_timint_ost.cpp
@@ -323,7 +323,7 @@ void Solid::TimIntOneStepTheta::evaluate_force_stiff_residual(Teuchos::Parameter
   Teuchos::ParameterList psprdash;
   psprdash.set("time_fac", 1. / (theta_ * (*dt_)[0]));
   psprdash.set("dt", (*dt_)[0]);  // needed only for cursurfnormal option!!
-  apply_force_stiff_spring_dashpot(stiff_, fintn_, disn_, veln_, predict, psprdash);
+  apply_force_stiff_spring_dashpot(stiff_, fintn_, disn_, *veln_, predict, psprdash);
 
   // apply forces and stiffness due to constraints
   Teuchos::ParameterList pcon;

--- a/src/structure/4C_structure_timint_statics.cpp
+++ b/src/structure/4C_structure_timint_statics.cpp
@@ -221,7 +221,7 @@ void Solid::TimIntStatics::evaluate_force_stiff_residual(Teuchos::ParameterList&
 
   // add forces and stiffness due to spring dashpot condition
   Teuchos::ParameterList psprdash;
-  apply_force_stiff_spring_dashpot(stiff_, fintn_, disn_, veln_, predict, psprdash);
+  apply_force_stiff_spring_dashpot(stiff_, fintn_, disn_, *veln_, predict, psprdash);
 
   // ************************** (3) INERTIAL FORCES ***************************
   // This is statics, so there are no inertial forces.

--- a/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.cpp
+++ b/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.cpp
@@ -1136,8 +1136,7 @@ void NOX::Nln::GROUP::PrePostOp::TimeInt::RotVecUpdater::run_pre_compute_x(
   // cast the const away so that the new x vector can be set after the update
   NOX::Nln::Group& curr_grp_mutable = const_cast<NOX::Nln::Group&>(curr_grp);
 
-  std::shared_ptr<Core::LinAlg::Vector<double>> xnew =
-      std::make_shared<Core::LinAlg::Vector<double>>(xold.Map(), true);
+  Core::LinAlg::Vector<double> xnew(xold.Map(), true);
 
   /* we do the multiplicative update only for those entries which belong to
    * rotation (pseudo-)vectors */
@@ -1174,12 +1173,12 @@ void NOX::Nln::GROUP::PrePostOp::TimeInt::RotVecUpdater::run_pre_compute_x(
   }
 
   // first update entire x vector in an additive manner
-  xnew->update(1.0, xold, step, dir, 0.0);
+  xnew.update(1.0, xold, step, dir, 0.0);
 
   // now replace the rotvec entries by the correct value computed before
-  Core::LinAlg::assemble_my_vector(0.0, *xnew, 1.0, x_rotvec);
+  Core::LinAlg::assemble_my_vector(0.0, xnew, 1.0, x_rotvec);
 
-  NOX::Nln::Vector wrapper(Teuchos::make_rcp<Epetra_Vector>(xnew->get_ref_of_epetra_vector()),
+  NOX::Nln::Vector wrapper(Teuchos::make_rcp<Epetra_Vector>(xnew.get_ref_of_epetra_vector()),
       NOX::Nln::Vector::MemoryType::View);
   curr_grp_mutable.setX(wrapper);
 


### PR DESCRIPTION
I expected that we could remove a couple of shared_ptrs as a result of #1422 and #1421. Apparently, that is not the case, or at least my tool was not able to remove them. Still, here is a little bit of cleanup that dropped out of this attempt.