### PR TITLE
Fix assembly order for scatra-x-interactions

### DIFF
--- a/src/scatra/4C_scatra_timint_implicit.cpp
+++ b/src/scatra/4C_scatra_timint_implicit.cpp
@@ -2657,7 +2657,7 @@ void ScaTra::ScaTraTimIntImpl::evaluate_solution_depending_conditions(
  *----------------------------------------------------------------------------*/
 int ScaTra::ScaTraTimIntImpl::get_max_dof_set_number() const
 {
-  return std::max({nds_disp_, nds_growth_, nds_micro_, nds_pres_, nds_scatra_, nds_thermo_,
+  return std::max({0, nds_disp_, nds_growth_, nds_micro_, nds_pres_, nds_scatra_, nds_thermo_,
       nds_two_tensor_quantity_, nds_vel_, nds_wss_});
 }
 

--- a/src/ssi/4C_ssi_coupling.cpp
+++ b/src/ssi/4C_ssi_coupling.cpp
@@ -27,7 +27,7 @@ void SSI::SSICouplingMatchingVolume::init(const int ndim,
 {
   set_is_setup(false);
 
-  int scatra_dofset_counter = 0;
+  int scatra_dofset_counter = ssi_base->scatra_field()->get_max_dof_set_number();
   int structure_dofset_counter = 0;
 
   auto scatra_integrator = ssi_base->scatra_field();
@@ -184,7 +184,7 @@ void SSI::SSICouplingNonMatchingBoundary::init(const int ndim,
 {
   set_is_setup(false);
 
-  int scatra_dofset_counter = 0;
+  int scatra_dofset_counter = ssi_base->scatra_field()->get_max_dof_set_number();
   int structure_dofset_counter = 0;
 
   auto scatra_integrator = ssi_base->scatra_field();
@@ -326,7 +326,7 @@ void SSI::SSICouplingNonMatchingVolume::init(const int ndim,
 {
   set_is_setup(false);
 
-  int scatra_dofset_counter = 0;
+  int scatra_dofset_counter = ssi_base->scatra_field()->get_max_dof_set_number();
   int structure_dofset_counter = 0;
 
   auto scatra_integrator = ssi_base->scatra_field();
@@ -452,7 +452,7 @@ void SSI::SSICouplingMatchingVolumeAndBoundary::init(const int ndim,
 {
   set_is_setup(false);
 
-  int scatra_dofset_counter = 0;
+  int scatra_dofset_counter = ssi_base->scatra_field()->get_max_dof_set_number();
   int structure_dofset_counter = 0;
 
   auto scatra_integrator = ssi_base->scatra_field();

--- a/src/ssi/4C_ssi_manifold_utils.cpp
+++ b/src/ssi/4C_ssi_manifold_utils.cpp
@@ -436,7 +436,7 @@ void SSI::ScaTraManifoldScaTraFluxEvaluator::evaluate_bulk_side(
       auto matrix_scatra_structure_cond_slave_side_disp_evaluate =
           std::make_shared<Core::LinAlg::SparseMatrix>(*full_map_scatra_, 27, false, true);
 
-      Core::FE::AssembleStrategy strategyscatra(0, 1,
+      Core::FE::AssembleStrategy strategyscatra(0, scatra_->scatra_field()->nds_disp(),
           matrix_scatra_structure_cond_slave_side_disp_evaluate, nullptr, nullptr, nullptr,
           nullptr);
 

--- a/src/ssi/4C_ssi_monolithic_evaluate_OffDiag.cpp
+++ b/src/ssi/4C_ssi_monolithic_evaluate_OffDiag.cpp
@@ -80,7 +80,8 @@ void SSI::ScatraStructureOffDiagCoupling::evaluate_off_diag_block_scatra_structu
   Core::FE::AssembleStrategy strategyscatrastructure(
       0,  // row assembly based on number of dofset associated with scalar transport dofs on
           // scalar transport discretization
-      1,  // column assembly based on number of dofset associated with structural dofs on scalar
+      scatra_field()->nds_disp(),  // column assembly based on number of dofset associated with
+                                   // structural dofs on scalar
       // transport discretization
       scatrastructureblock,  // scatra-structure matrix block
       nullptr,               // no additional matrices or vectors
@@ -118,7 +119,8 @@ void SSI::ScatraManifoldStructureOffDiagCoupling::
   Core::FE::AssembleStrategy strategyscatrastructure(
       0,  // row assembly based on number of dofset associated with scalar transport dofs on
           // scalar transport discretization
-      1,  // column assembly based on number of dofset associated with structural dofs on scalar
+      scatra_field()->nds_disp(),  // column assembly based on number of dofset associated with
+                                   // structural dofs on scalar
       // transport discretization
       scatramanifoldstructureblock,  // scatra-structure matrix block
       nullptr,                       // no additional matrices or vectors
@@ -379,8 +381,9 @@ void SSI::ScatraStructureOffDiagCoupling::
   Core::FE::AssembleStrategy strategyscatras2istructure(
       0,  // row assembly based on number of dofset associated with scalar transport dofs on
           // scalar transport discretization
-      1,  // column assembly based on number of dofset associated with structural dofs on
-      // structural discretization
+      scatra_field()->nds_disp(),  // column assembly based on number of dofset associated with
+                                   // structural dofs on
+      // scalar transport discretization
       scatra_slave_flux_structure_slave_dofs_on_scatra_slave_matrix,
       scatra_master_flux_on_scatra_slave_structure_slave_dofs_on_scatra_slave_matrix,
       // no additional vectors
@@ -615,10 +618,10 @@ void SSI::ScatraStructureOffDiagCoupling::
   Core::FE::AssembleStrategy strategyscatrastructures2i(
       0,  // row assembly based on number of dofset associated with scalar transport dofs on
           // scalar transport discretization
-      1,  // column assembly based on number of dofset associated with structural dofs on
-          // structural discretization
-      evaluate_matrix,  // auxiliary system matrix
-      nullptr,          // no additional matrices of vectors
+      scatra_field()->nds_disp(),  // column assembly based on number of dofset associated with
+                                   // structural dofs on scalar transport discretization
+      evaluate_matrix,             // auxiliary system matrix
+      nullptr,                     // no additional matrices of vectors
       nullptr, nullptr, nullptr);
 
   // evaluate scatra-scatra interface coupling

--- a/src/ssti/4C_ssti_monolithic_evaluate_OffDiag.cpp
+++ b/src/ssti/4C_ssti_monolithic_evaluate_OffDiag.cpp
@@ -68,15 +68,15 @@ void SSTI::ThermoStructureOffDiagCoupling::evaluate_off_diag_block_thermo_struct
   thermo_->scatra_field()->add_time_integration_specific_vectors();
 
   // create strategy for assembly of thermo-structure matrix block
-  Core::FE::AssembleStrategy strategyscatrastructure(
+  Core::FE::AssembleStrategy strategythermostructure(
       0,  // row assembly based on number of dofset associated with thermo dofs on thermo
           // discretization
-      1,  // column assembly based on number of dofset associated with structural dofs on thermo
-          // discretization
-      thermostructuredomain,  // thermo-structure matrix block
+      thermo_->scatra_field()->nds_disp(),  // column assembly based on number of dofset associated
+                                            // with structural dofs on thermo discretization
+      thermostructuredomain,                // thermo-structure matrix block
       nullptr, nullptr, nullptr, nullptr);
 
-  thermo_->scatra_field()->discretization()->evaluate(eleparams, strategyscatrastructure);
+  thermo_->scatra_field()->discretization()->evaluate(eleparams, strategythermostructure);
 
   thermo_->scatra_field()->discretization()->clear_state();
 }
@@ -171,7 +171,7 @@ void SSTI::ThermoStructureOffDiagCoupling::evaluate_off_diag_block_structure_the
   structure_->discretization()->set_state("displacement", *structure_->dispnp());
 
   // create strategy for assembly of structure-thermo matrix block
-  Core::FE::AssembleStrategy strategystructurescatra(
+  Core::FE::AssembleStrategy strategystructurethermo(
       0,  // row assembly based on number of dofset associated with structure dofs on structural
           // discretization
       2,  // column assembly based on number of dofset associated with thermo dofs on structural
@@ -179,7 +179,7 @@ void SSTI::ThermoStructureOffDiagCoupling::evaluate_off_diag_block_structure_the
       structurethermodomain,  // structure-thermo matrix block
       nullptr, nullptr, nullptr, nullptr);
 
-  structure_->discretization()->evaluate(eleparams, strategystructurescatra);
+  structure_->discretization()->evaluate(eleparams, strategystructurethermo);
 
   // need to scale structurethermoblock_ with 'timefac' to getcorrect implementation
   structurethermodomain->scale(1.0 - structure_->tim_int_param());
@@ -308,11 +308,11 @@ void SSTI::ThermoStructureOffDiagCoupling::evaluate_thermo_structure_interface_s
   }
 
   // create strategy for assembly of auxiliary system matrix
-  Core::FE::AssembleStrategy strategyscatrastructures2i(
+  Core::FE::AssembleStrategy strategythermostructures2i(
       0,  // row assembly based on number of dofset associated with thermo dofs on
           // thermo discretization
-      1,  // column assembly based on number of dofset associated with structural dofs on
-          // thermo discretization
+      thermo_->scatra_field()->nds_disp(),  // column assembly based on number of dofset associated
+                                            // with structural dofs on thermo discretization
       evaluate_matrix, nullptr, nullptr, nullptr, nullptr);
 
   // evaluate interface coupling
@@ -327,7 +327,7 @@ void SSTI::ThermoStructureOffDiagCoupling::evaluate_thermo_structure_interface_s
           *kinetics_slave_cond.second);
       // evaluate the condition
       thermo_->scatra_field()->discretization()->evaluate_condition(
-          condparams, strategyscatrastructures2i, "S2IKinetics", kinetics_slave_cond.first);
+          condparams, strategythermostructures2i, "S2IKinetics", kinetics_slave_cond.first);
     }
   }
 

--- a/src/sti/4C_sti_monolithic_evaluate_OffDiag.cpp
+++ b/src/sti/4C_sti_monolithic_evaluate_OffDiag.cpp
@@ -76,10 +76,10 @@ void STI::ScatraThermoOffDiagCoupling::evaluate_off_diag_block_scatra_thermo_dom
   Core::FE::AssembleStrategy strategyscatrathermo(
       0,  // row assembly based on number of dofset associated with scatra dofs on scatra
           // discretization
-      2,  // column assembly based on number of dofset associated with thermo dofs on scatra
-          // discretization
-      scatrathermoblock,  // scatra-thermo matrix block
-      nullptr,            // no additional matrices or vectors
+      scatra_field()->nds_thermo(),  // column assembly based on number of dofset associated with
+                                     // thermo dofs on scatra discretization
+      scatrathermoblock,             // scatra-thermo matrix block
+      nullptr,                       // no additional matrices or vectors
       nullptr, nullptr, nullptr);
 
   // assemble scatra-thermo matrix block
@@ -136,10 +136,10 @@ void STI::ScatraThermoOffDiagCoupling::evaluate_off_diag_block_thermo_scatra_dom
   Core::FE::AssembleStrategy strategythermoscatra(
       0,  // row assembly based on number of dofset associated with thermo dofs on thermo
           // discretization
-      2,  // column assembly based on number of dofset associated with scatra dofs on thermo
-          // discretization
-      thermoscatrablock,  // thermo-scatra matrix block
-      nullptr,            // no additional matrices or vectors
+      thermo_field()->nds_scatra(),  // column assembly based on number of dofset associated with
+                                     // scatra dofs on thermo discretization
+      thermoscatrablock,             // thermo-scatra matrix block
+      nullptr,                       // no additional matrices or vectors
       nullptr, nullptr, nullptr);
 
   // assemble thermo-scatra matrix block
@@ -297,12 +297,12 @@ void STI::ScatraThermoOffDiagCouplingMatchingNodes::evaluate_scatra_thermo_inter
 
   // create strategy for assembly of auxiliary system matrix
   Core::FE::AssembleStrategy strategyscatrathermos2i(
-      0,            // row assembly based on number of dofset associated with scatra dofs on scatra
-                    // discretization
-      2,            // column assembly based on number of dofset associated with thermo dofs on
-                    // scatra discretization
-      slavematrix,  // auxiliary system matrix
-      nullptr,      // no additional matrices of vectors
+      0,  // row assembly based on number of dofset associated with scatra dofs on scatra
+          // discretization
+      scatra_field()->nds_thermo(),  // column assembly based on number of dofset associated with
+                                     // thermo dofs on scatra discretization
+      slavematrix,                   // auxiliary system matrix
+      nullptr,                       // no additional matrices of vectors
       nullptr, nullptr, nullptr);
 
   // evaluate scatra-scatra interface kinetics
@@ -479,13 +479,13 @@ void STI::ScatraThermoOffDiagCouplingMatchingNodes::evaluate_off_diag_block_ther
 
   // create strategy for assembly of auxiliary system matrices
   Core::FE::AssembleStrategy strategythermoscatras2i(
-      0,             // row assembly based on number of dofset associated with thermo dofs on
-                     // thermo discretization
-      2,             // column assembly based on number of dofset associated with scatra dofs on
-                     // thermo discretization
-      slavematrix,   // auxiliary system matrix for slave side
-      mastermatrix,  // auxiliary system matrix for master side
-      nullptr,       // no additional matrices of vectors
+      0,  // row assembly based on number of dofset associated with thermo dofs on
+          // thermo discretization
+      thermo_field()->nds_scatra(),  // column assembly based on number of dofset associated with
+                                     // scatra dofs on thermo discretization
+      slavematrix,                   // auxiliary system matrix for slave side
+      mastermatrix,                  // auxiliary system matrix for master side
+      nullptr,                       // no additional matrices of vectors
       nullptr, nullptr);
 
   // evaluate scatra-scatra interface kinetics


### PR DESCRIPTION
Fixes a bug regarding the assembly order for scatra interactions with other fields, identified by @c-p-schmidt and me.

- Referenced the correct dofset index for the respective fields on the scatra integrator. This
replaces the hardcoded, assumed order and fixes
hereby an ordering bug.
- Fixed the determination of the maximum dofset within the scatra integrator, to be at least 0.

<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
