### PR TITLE
[documentation] Enhance anchors in the reference guide

### DIFF
--- a/doc/documentation/conf.py.in
+++ b/doc/documentation/conf.py.in
@@ -104,6 +104,7 @@ html_theme_options = {
 # so a file named "default.css" will overwrite the builtin "default.css".
 # Since up to now, we don't have these, it's not needed. Uncomment if necessary.
 html_static_path = ["@PROJECT_BINARY_DIR@/doc/tmp/_static", "@_sphinx_OUT_DIR@/reference_docs/_static"]
+html_js_files = ['open_details_on_link.js']
 html_css_files = ['html_extensions.css']
 #
 # for finding headers as internal link targets, we have to set the variable myst_heading_anchors

--- a/doc/documentation/src/_static/open_details_on_link.js
+++ b/doc/documentation/src/_static/open_details_on_link.js
@@ -1,0 +1,19 @@
+(function () {
+    // Scroll to and open section upon clicking a link
+    function openAncestors(id) {
+        if (!id) return;
+        const target = document.getElementById(decodeURIComponent(id));
+        if (!target) return;
+        let el = target;
+        while (el && el !== document.body) {
+            if (el.tagName && el.tagName.toLowerCase() === 'details') el.open = true;
+            el = el.parentElement;
+        }
+        target.scrollIntoView({ block: 'start', behavior: 'instant' });
+    }
+
+    function run() { openAncestors(location.hash.slice(1)); }
+
+    document.addEventListener('DOMContentLoaded', run);
+    window.addEventListener('hashchange', run);
+})();

--- a/doc/documentation/src/tutorial_templates/tutorial_fsi_monolithic.md.j2
+++ b/doc/documentation/src/tutorial_templates/tutorial_fsi_monolithic.md.j2
@@ -162,7 +162,7 @@ They are defined as follows:
 Thereby, `MAT: 1` specifies a Newtonian fluid for the fluid domain, while `MAT 2` defines a St.-Venant-Kirchhoff material for the solid domain. The values correspond to the pressure wave example [^Gerbeau2003a].
 
 ```{note}
-**Link to documentation:** For details, see the 4C documentation: [Newtonian fluid](https://4c-multiphysics.github.io/4C/documentation/materialreference.html#mat-fluid), [St.-Venant-Kirchhoff](https://4c-multiphysics.github.io/4C/documentation/materialreference.html#mat-struct-stvenantkirchhoff)
+**Link to documentation:** For details, see the 4C documentation: {ref}`Newtonian fluid<MATERIALS_MAT_fluid>`, {ref}`St.-Venant-Kirchhoff<MATERIALS_MAT_Struct_StVenantKirchhoff>`.
 ```
 
 ### Geometry and mesh information


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

This PR fixes the material reference links in the monolithic FSI tutorial and introduces an enhancement to the anchors in the reference guide of the documentation.
It introduces dedicated anchors for each option and a small JavaScript utility that automatically opens the corresponding dropdown (`<details>`) when a link with a hash is followed. The anchor uses the name of the `One of` entry.
Previously, the material references were more nested than other references and could not be referenced by a link (e.g. in the documentation).

### Key changes
- Adds globally unique anchors for each `One_of` option across all automatically generated reference files (materials, general, condition, discretization), e.g. `(MATERIALS_MAT_LinElast1D)=` for materials or `(ALEDOMAIN_FLUID_QUAD4)=` for discretization, within the `<details>` environment.
- Includes a small JS script that ensures all ancestor dropdowns open when visiting a link to a specific material.

### Example
A material can be linked like this in `md` now:
```
For details, see the 4C documentation: {ref}`St.-Venant-Kirchhoff<MATERIALS_MAT_Struct_StVenantKirchhoff>`.
```
When clicked, the target page scrolls to the material and automatically expands the relevant dropdown section.
Similarly, element types, conditions, and general parameters can now be referenced in the same way using the generated anchors.


### EDIT: Reason for previously failing pipeline and fix
Initially, this PR only addressed material references. For other reference files (general, condition, discretization), the documentation build failed because duplicate labels were generated for repeated `One of` options. For example, both [ALE GEOMETRY](https://4c-multiphysics.github.io/4C/documentation/reference_guide/discretization_reference.html#ale-geometry) and [ARTERY GEOMETRY](https://4c-multiphysics.github.io/4C/documentation/reference_guide/discretization_reference.html#artery-geometry)) contain `One of` environments within `ELEMENT_BLOCKS` with identical option names, and there is even another nested `One of` layer.

This has been fixed by:
- Prefixing anchors with the surrounding section and option path (e.g. `ALEDOMAIN_FLUID_QUAD4 `) to make all labels unique within a file.
- Propagating this prefix through nested `One of` structures so also nested options get unique, readable labels.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
Part of issue #1280 
Follow up of PR #1360 