### PR TITLE
Fix failing oldest dependency test

### DIFF
--- a/tests/input_files/sti_mono_3D_tet4_elch_s2i_butlervolmerpeltier_adiabatic_AMG-BGS_4x4.4C.yaml
+++ b/tests/input_files/sti_mono_3D_tet4_elch_s2i_butlervolmerpeltier_adiabatic_AMG-BGS_4x4.4C.yaml
@@ -177,7 +177,7 @@ RESULT DESCRIPTION:
       NODE: 40
       QUANTITY: "phi2"
       VALUE: -7.11975713773337415e-08
-      TOLERANCE: 7.1e-16
+      TOLERANCE: 7.1e-15
   - SCATRA:
       DIS: "thermo"
       NODE: 40


### PR DESCRIPTION
## Description and Context
After merging #1143 the oldest dependency pipeline failed (see e.g. https://github.com/4C-multiphysics/4C/actions/runs/18824515613/job/53707711552). I compared the outputs of two runs, one with the newest supported Trilinos and one with the oldest supported Trilinos. The nonlinear and linear iteration counts are completely identical; however, a slight deviation occurs in the exact residual, which accumulates over time, leading to the failing result check in one quantity.

Thus, I decided that it would be justified to relax that tolerance by a factor of 10, which, at least on my workstation, makes the test pass on both configurations.

## Related Issues and Pull Requests
Follows #1143