### PR TITLE
Sort the reference sections case insensitive

### DIFF
--- a/utilities/four_c_python/src/four_c_documentation/make_documentation.py
+++ b/utilities/four_c_python/src/four_c_documentation/make_documentation.py
@@ -626,13 +626,14 @@ def create_markdown_documentation(
         ),
     ]
 
-    obj = All_Of.from_4C_metadata(fourc_metadata["sections"])
-
     for doc in reference_documents:
         doc.content = f"({doc.linkanchor})=\n\n" + f"# {doc.title}\n\n"
         doc.content += f"{set_missing_description(doc.description)}\n\n"
 
-    for section in obj:
+    obj = All_Of.from_4C_metadata(fourc_metadata["sections"])
+    sorted_entries = sorted(list(obj), key=lambda e: getattr(e, "name", "").lower())
+
+    for section in sorted_entries:
         for doc in reference_documents:
             if any(re.match(pattern, section.name) for pattern in doc.pattern):
                 doc.content += create_section_markdown(


### PR DESCRIPTION
## Description and Context

According to the discussion #930, the new standard for the input parameters seems to be `snake_case`, opposite to the `SCREAMING CASE WITH SPACES` we have so far.

A side effect is that in the reference documentation, the section with capital letters come first, before the lower case sections, which is probably not wanted (at least I find that odd).
Therefore this PR first makes a case insensitive sort before writing the sections to file.

## Related Issues and Pull Requests
Discussion #930