### PR TITLE
Add postprocessor deprecation warning

### DIFF
--- a/cmake/functions/four_c_testing_functions.cmake
+++ b/cmake/functions/four_c_testing_functions.cmake
@@ -674,10 +674,10 @@ function(
 
   # define macros for serial and parallel runs
   set(RUNPOSTFILTER_SER
-      ${FOUR_C_ENABLE_ADDRESS_SANITIZER_TEST_OPTIONS}\ ./post_ensight\ --file=${test_directory}/xxx${IDENTIFIER}\ --output=${test_directory}/xxx${IDENTIFIER}_SER_${name_of_input_file}\ --stress=${stresstype}\ --strain=${straintype}\ --start=${startstep}
+      ${FOUR_C_ENABLE_ADDRESS_SANITIZER_TEST_OPTIONS}\ ./post_ensight\ --postprocessor_deprecation_warning_off\ --file=${test_directory}/xxx${IDENTIFIER}\ --output=${test_directory}/xxx${IDENTIFIER}_SER_${name_of_input_file}\ --stress=${stresstype}\ --strain=${straintype}\ --start=${startstep}
       )
   set(RUNPOSTFILTER_PAR
-      ${MPIEXEC_EXECUTABLE}\ ${_mpiexec_all_args_for_testing}\ -np\ ${num_proc}\ ./post_ensight\ --file=${test_directory}/xxx${IDENTIFIER}\ --output=${test_directory}/xxx${IDENTIFIER}_PAR_${name_of_input_file}\ --stress=${stresstype}\ --strain=${straintype}\ --start=${startstep}
+      ${MPIEXEC_EXECUTABLE}\ ${_mpiexec_all_args_for_testing}\ -np\ ${num_proc}\ ./post_ensight\ --postprocessor_deprecation_warning_off\ --file=${test_directory}/xxx${IDENTIFIER}\ --output=${test_directory}/xxx${IDENTIFIER}_PAR_${name_of_input_file}\ --stress=${stresstype}\ --strain=${straintype}\ --start=${startstep}
       )
 
   # remove file ending of input file for reference file


### PR DESCRIPTION
## Description and Context

The post processor will be deleted in the near future. To raise awareness for users that might not know that, this PR adds a deprecation warning that pops up when using the post processor. The warning requires the user to press enter to continue. For automated simulation runs the warning can be deactivated with the flag `--postprocessor_deprecation_warning_off`.

## Related Issues and Pull Requests

#211