### PR TITLE
CMake: error on _ROOT vars that aren't directories

### DIFF
--- a/cmake/functions/four_c_configure_dependency.cmake
+++ b/cmake/functions/four_c_configure_dependency.cmake
@@ -260,6 +260,14 @@ function(four_c_configure_dependency _package_name)
     endif()
 
     if(FOUR_C_${_package_name_sanitized}_ROOT)
+      # Sanity check: root should be a directory and should exist
+      if(NOT IS_DIRECTORY ${FOUR_C_${_package_name_sanitized}_ROOT})
+        message(
+          FATAL_ERROR "FOUR_C_${_package_name_sanitized}_ROOT is set to "
+                      "${FOUR_C_${_package_name_sanitized}_ROOT} which is not a directory"
+          )
+      endif()
+
       # Translate the ROOT variable into the case style that fits to the package name.
       # This variable is automatically understood by CMake's find_XXX functions.
       set(${_package_name}_ROOT ${FOUR_C_${_package_name_sanitized}_ROOT})


### PR DESCRIPTION
We can help users by telling them that the `FOUR _C_<package>_ROOT` variables need to refer to directories. This is especially useful for `FOUR_C_PYTHON_ROOT` where one might pass the `python` executable.

FYI @shervas @lkoeglmeier @c-p-schmidt 