### PR TITLE
[LinAlg] Add `Epetra` error check to sparse matrix import methods

### DIFF
--- a/src/core/linalg/src/sparse/4C_linalg_sparsematrix.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_sparsematrix.hpp
@@ -599,16 +599,18 @@ namespace Core::LinAlg
 
     /** \name Import / Export methods */
     //@{
-    int import(const SparseMatrix& A, const Core::LinAlg::Import& importer,
+    void import(const SparseMatrix& A, const Core::LinAlg::Import& importer,
         Epetra_CombineMode combine_mode)
     {
-      return sysmat_->Import(A.epetra_matrix(), importer.get_epetra_import(), combine_mode);
+      CHECK_EPETRA_CALL(
+          sysmat_->Import(A.epetra_matrix(), importer.get_epetra_import(), combine_mode));
     }
 
-    int import(const SparseMatrix& A, const Core::LinAlg::Export& exporter,
+    void import(const SparseMatrix& A, const Core::LinAlg::Export& exporter,
         Epetra_CombineMode combine_mode)
     {
-      return sysmat_->Import(A.epetra_matrix(), exporter.get_epetra_export(), combine_mode);
+      CHECK_EPETRA_CALL(
+          sysmat_->Import(A.epetra_matrix(), exporter.get_epetra_export(), combine_mode));
     }
 
     //@}

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_manipulation.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_manipulation.cpp
@@ -858,9 +858,7 @@ std::shared_ptr<Core::LinAlg::SparseMatrix> Core::LinAlg::redistribute(
   Core::LinAlg::Export exporter(permrowmap, src.row_map());
 
   auto permsrc = std::make_shared<Core::LinAlg::SparseMatrix>(permrowmap, src.max_num_entries());
-  int err = permsrc->import(src, exporter, Insert);
-  if (err) FOUR_C_THROW("Import failed with err={}", err);
-
+  permsrc->import(src, exporter, Insert);
   permsrc->complete(permdomainmap, permrowmap);
   return permsrc;
 }

--- a/src/coupling/src/adapter/4C_coupling_adapter.cpp
+++ b/src/coupling/src/adapter/4C_coupling_adapter.cpp
@@ -765,10 +765,7 @@ std::shared_ptr<Core::LinAlg::SparseMatrix> Coupling::Adapter::Coupling::master_
   // OK. You cannot use the same exporter for different matrices. So we
   // recreate one all the time... This has to be optimized later on.
   Core::LinAlg::Export exporter(*permmasterdofmap_, *masterdofmap_);
-  int err = permsm->import(sm, exporter, Insert);
-
-  if (err) FOUR_C_THROW("Import failed with err={}", err);
-
+  permsm->import(sm, exporter, Insert);
   permsm->complete(sm.domain_map(), *permmasterdofmap_);
 
   return permsm;
@@ -791,10 +788,7 @@ std::shared_ptr<Core::LinAlg::SparseMatrix> Coupling::Adapter::Coupling::slave_t
   // OK. You cannot use the same exporter for different matrices. So we
   // recreate one all the time... This has to be optimized later on.
   Core::LinAlg::Export exporter(*permslavedofmap_, *slavedofmap_);
-  int err = permsm->import(sm, exporter, Insert);
-
-  if (err) FOUR_C_THROW("Import failed with err={}", err);
-
+  permsm->import(sm, exporter, Insert);
   permsm->complete(sm.domain_map(), *permslavedofmap_);
 
   return permsm;
@@ -850,9 +844,7 @@ void Coupling::Adapter::Coupling::setup_coupling_matrices(const Core::LinAlg::Ma
   auto tmp = std::make_shared<Core::LinAlg::SparseMatrix>(slavedomainmap, 1);
 
   Core::LinAlg::Import exporter(slavedomainmap, *perm_slave_dof_map());
-  int err = tmp->import(*matsm_trans_, exporter, Insert);
-  if (err) FOUR_C_THROW("Import failed with err={}", err);
-
+  tmp->import(*matsm_trans_, exporter, Insert);
   tmp->complete(shiftedmastermap, slavedomainmap);
   matsm_trans_ = tmp;
 }

--- a/src/coupling/src/adapter/4C_coupling_adapter_converter.cpp
+++ b/src/coupling/src/adapter/4C_coupling_adapter_converter.cpp
@@ -140,9 +140,7 @@ bool Coupling::Adapter::MatrixLogicalSplitAndTransform::operator()(
       }
 
       auto permsrc = std::make_shared<Core::LinAlg::SparseMatrix>(permsrcmap, 0);
-      int err = permsrc->import(src, *exporter_, Insert);
-      if (err) FOUR_C_THROW("Import failed with err={}", err);
-
+      permsrc->import(src, *exporter_, Insert);
       permsrc->complete(src.domain_map(), permsrcmap);
       esrc = permsrc;
     }

--- a/src/sti/4C_sti_monolithic.cpp
+++ b/src/sti/4C_sti_monolithic.cpp
@@ -569,8 +569,7 @@ void STI::Monolithic::output_matrix_to_file(
   Core::LinAlg::SparseMatrix crsmatrix(fullrowmap, 0);
   if (sparsematrix != nullptr)
   {
-    if (crsmatrix.import(*sparsematrix, Core::LinAlg::Import(fullrowmap, rowmap), Insert))
-      FOUR_C_THROW("Matrix import failed!");
+    crsmatrix.import(*sparsematrix, Core::LinAlg::Import(fullrowmap, rowmap), Insert);
   }
   else
   {
@@ -578,9 +577,8 @@ void STI::Monolithic::output_matrix_to_file(
     {
       for (int j = 0; j < blocksparsematrix->cols(); ++j)
       {
-        if (crsmatrix.import(blocksparsematrix->matrix(i, j),
-                Core::LinAlg::Import(fullrowmap, blocksparsematrix->range_map(i)), Insert))
-          FOUR_C_THROW("Matrix import failed!");
+        crsmatrix.import(blocksparsematrix->matrix(i, j),
+            Core::LinAlg::Import(fullrowmap, blocksparsematrix->range_map(i)), Insert);
       }
     }
   }


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
As PR #1436 seems to change too much and breaks a lot of tests, I propose to do it in a step by step approach.
This PR adds `Epetra` error checks to the import methods of the sparse matrix implementation.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
Part of #1190 