### PR TITLE
Make hint to update the virtual environment more convenient

### DIFF
--- a/utilities/code_checks/check_venv
+++ b/utilities/code_checks/check_venv
@@ -45,7 +45,7 @@ expected_hash=$(cat $stored_hash_file)
 # Check if the hash is different from the last one or if the file does not exist
 if [ "$hash" != "$expected_hash"  ]; then
     echo "Your virtual environment is out of date."
-    echo "Please run ./utilities/set_up_dev_env.sh."
+    echo "Please run the following command in your source directory: ./utilities/set_up_dev_env.sh"
     exit 1
 fi
 


### PR DESCRIPTION
## Description and Context
When it is detected that the virtual environment is outdated, you get a hint on which command to run to update it. As it is convenient to just copy it, the "." at the end is annoying because you have to delete it before running the command.
Thus, I suggest removing it to make the procedure a bit more convenient. 

