### PR TITLE
[LinAlg] Guard `Epetra` checks with `FOUR_C_ENABLE_ASSERTIONS`

### DIFF
--- a/src/contact/src/4C_contact_lagrange_strategy.cpp
+++ b/src/contact/src/4C_contact_lagrange_strategy.cpp
@@ -26,7 +26,6 @@
 #include "4C_mortar_defines.hpp"
 #include "4C_mortar_utils.hpp"
 #include "4C_structure_new_model_evaluator_contact.hpp"
-#include "4C_utils_epetra_exceptions.hpp"
 
 #include <Teuchos_TimeMonitor.hpp>
 

--- a/src/core/linalg/src/sparse/4C_linalg_fevector.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_fevector.cpp
@@ -72,113 +72,113 @@ Core::LinAlg::MultiVector<T>& Core::LinAlg::FEVector<T>::as_multi_vector()
 template <typename T>
 void Core::LinAlg::FEVector<T>::norm_1(double* Result) const
 {
-  CHECK_EPETRA_CALL(vector_->Norm1(Result));
+  ASSERT_EPETRA_CALL(vector_->Norm1(Result));
 }
 
 template <typename T>
 void Core::LinAlg::FEVector<T>::norm_2(double* Result) const
 {
-  CHECK_EPETRA_CALL(vector_->Norm2(Result));
+  ASSERT_EPETRA_CALL(vector_->Norm2(Result));
 }
 
 template <typename T>
 void Core::LinAlg::FEVector<T>::norm_inf(double* Result) const
 {
-  CHECK_EPETRA_CALL(vector_->NormInf(Result));
+  ASSERT_EPETRA_CALL(vector_->NormInf(Result));
 }
 
 template <typename T>
 void Core::LinAlg::FEVector<T>::min_value(double* Result) const
 {
-  CHECK_EPETRA_CALL(vector_->MinValue(Result));
+  ASSERT_EPETRA_CALL(vector_->MinValue(Result));
 }
 
 template <typename T>
 void Core::LinAlg::FEVector<T>::max_value(double* Result) const
 {
-  CHECK_EPETRA_CALL(vector_->MaxValue(Result));
+  ASSERT_EPETRA_CALL(vector_->MaxValue(Result));
 }
 
 template <typename T>
 void Core::LinAlg::FEVector<T>::mean_value(double* Result) const
 {
-  CHECK_EPETRA_CALL(vector_->MeanValue(Result));
+  ASSERT_EPETRA_CALL(vector_->MeanValue(Result));
 }
 
 template <typename T>
 void Core::LinAlg::FEVector<T>::scale(double ScalarValue)
 {
-  CHECK_EPETRA_CALL(vector_->Scale(ScalarValue));
+  ASSERT_EPETRA_CALL(vector_->Scale(ScalarValue));
 }
 
 template <typename T>
 void Core::LinAlg::FEVector<T>::dot(const Epetra_MultiVector& A, double* Result) const
 {
-  CHECK_EPETRA_CALL(vector_->Dot(A, Result));
+  ASSERT_EPETRA_CALL(vector_->Dot(A, Result));
 }
 
 template <typename T>
 void Core::LinAlg::FEVector<T>::abs(const Epetra_MultiVector& A)
 {
-  CHECK_EPETRA_CALL(vector_->Abs(A));
+  ASSERT_EPETRA_CALL(vector_->Abs(A));
 }
 
 template <typename T>
 void Core::LinAlg::FEVector<T>::scale(double ScalarA, const Epetra_MultiVector& A)
 {
-  CHECK_EPETRA_CALL(vector_->Scale(ScalarA, A));
+  ASSERT_EPETRA_CALL(vector_->Scale(ScalarA, A));
 }
 
 template <typename T>
 void Core::LinAlg::FEVector<T>::update(
     double ScalarA, const Epetra_MultiVector& A, double ScalarThis)
 {
-  CHECK_EPETRA_CALL(vector_->Update(ScalarA, A, ScalarThis));
+  ASSERT_EPETRA_CALL(vector_->Update(ScalarA, A, ScalarThis));
 }
 
 template <typename T>
 void Core::LinAlg::FEVector<T>::update(double ScalarA, const Epetra_MultiVector& A, double ScalarB,
     const Epetra_MultiVector& B, double ScalarThis)
 {
-  CHECK_EPETRA_CALL(vector_->Update(ScalarA, A, ScalarB, B, ScalarThis));
+  ASSERT_EPETRA_CALL(vector_->Update(ScalarA, A, ScalarB, B, ScalarThis));
 }
 
 template <typename T>
 void Core::LinAlg::FEVector<T>::dot(const FEVector& A, double* Result) const
 {
-  CHECK_EPETRA_CALL(vector_->Dot(A, Result));
+  ASSERT_EPETRA_CALL(vector_->Dot(A, Result));
 }
 
 template <typename T>
 void Core::LinAlg::FEVector<T>::abs(const FEVector& A)
 {
-  CHECK_EPETRA_CALL(vector_->Abs(A));
+  ASSERT_EPETRA_CALL(vector_->Abs(A));
 }
 
 template <typename T>
 void Core::LinAlg::FEVector<T>::scale(double ScalarA, const FEVector& A)
 {
-  CHECK_EPETRA_CALL(vector_->Scale(ScalarA, A));
+  ASSERT_EPETRA_CALL(vector_->Scale(ScalarA, A));
 }
 
 template <typename T>
 void Core::LinAlg::FEVector<T>::update(double ScalarA, const FEVector& A, double ScalarThis)
 {
-  CHECK_EPETRA_CALL(vector_->Update(ScalarA, A, ScalarThis));
+  ASSERT_EPETRA_CALL(vector_->Update(ScalarA, A, ScalarThis));
 }
 
 template <typename T>
 void Core::LinAlg::FEVector<T>::update(
     double ScalarA, const FEVector& A, double ScalarB, const FEVector& B, double ScalarThis)
 {
-  CHECK_EPETRA_CALL(
+  ASSERT_EPETRA_CALL(
       vector_->Update(ScalarA, A, ScalarB, B.get_ref_of_epetra_fevector(), ScalarThis));
 }
 
 template <typename T>
 void Core::LinAlg::FEVector<T>::put_scalar(double ScalarConstant)
 {
-  CHECK_EPETRA_CALL(vector_->PutScalar(ScalarConstant));
+  ASSERT_EPETRA_CALL(vector_->PutScalar(ScalarConstant));
 }
 
 template <typename T>
@@ -186,7 +186,7 @@ void Core::LinAlg::FEVector<T>::replace_map(const Map& map)
 {
   multi_vector_view_.invalidate();
   map_.invalidate();
-  CHECK_EPETRA_CALL(vector_->ReplaceMap(map.get_epetra_block_map()));
+  ASSERT_EPETRA_CALL(vector_->ReplaceMap(map.get_epetra_block_map()));
 }
 
 template <typename T>

--- a/src/core/linalg/src/sparse/4C_linalg_fevector.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_fevector.hpp
@@ -14,8 +14,8 @@
 #include "4C_linalg_map.hpp"
 #include "4C_linalg_multi_vector.hpp"
 #include "4C_linalg_transfer.hpp"
+#include "4C_linalg_utils_exceptions.hpp"
 #include "4C_linalg_view.hpp"
-#include "4C_utils_epetra_exceptions.hpp"
 
 #include <Epetra_FEVector.h>
 
@@ -180,106 +180,100 @@ namespace Core::LinAlg
 
     void replace_local_value(int MyRow, int FEVectorIndex, double ScalarValue)
     {
-      CHECK_EPETRA_CALL(vector_->ReplaceMyValue(MyRow, FEVectorIndex, ScalarValue));
+      ASSERT_EPETRA_CALL(vector_->ReplaceMyValue(MyRow, FEVectorIndex, ScalarValue));
     }
 
     void replace_global_value(int GlobalRow, int FEVectorIndex, double ScalarValue)
     {
-      CHECK_EPETRA_CALL(vector_->ReplaceGlobalValue(GlobalRow, FEVectorIndex, ScalarValue));
+      ASSERT_EPETRA_CALL(vector_->ReplaceGlobalValue(GlobalRow, FEVectorIndex, ScalarValue));
     }
 
     void replace_global_values(
         int numIDs, const int* GIDs, const double* values, int vectorIndex = 0)
     {
-      CHECK_EPETRA_CALL(vector_->ReplaceGlobalValues(numIDs, GIDs, values, vectorIndex));
+      ASSERT_EPETRA_CALL(vector_->ReplaceGlobalValues(numIDs, GIDs, values, vectorIndex));
     }
 
     //! Matrix-Matrix multiplication, \e this = ScalarThis*\e this + ScalarAB*A*B.
     void multiply(char TransA, char TransB, double ScalarAB, const Epetra_MultiVector& A,
         const Epetra_MultiVector& B, double ScalarThis)
     {
-      CHECK_EPETRA_CALL(vector_->Multiply(TransA, TransB, ScalarAB, A, B, ScalarThis));
+      ASSERT_EPETRA_CALL(vector_->Multiply(TransA, TransB, ScalarAB, A, B, ScalarThis));
     }
 
     //! Puts element-wise reciprocal values of input Multi-vector in target.
-    void reciprocal(const Epetra_MultiVector& A) { CHECK_EPETRA_CALL(vector_->Reciprocal(A)); }
+    void reciprocal(const Epetra_MultiVector& A) { ASSERT_EPETRA_CALL(vector_->Reciprocal(A)); }
 
     //! Multiply a Core::LinAlg::MultiVector<double> with another, element-by-element.
     void multiply(double ScalarAB, const Epetra_MultiVector& A, const Epetra_MultiVector& B,
-        double ScalarThis)
-    {
-      CHECK_EPETRA_CALL(vector_->Multiply(ScalarAB, A, B, ScalarThis));
-    }
+        double ScalarThis);
 
     //! Imports an Epetra_DistObject using the Core::LinAlg::Import object.
     void import(const Epetra_SrcDistObject& A, const Core::LinAlg::Import& Importer,
-        Epetra_CombineMode CombineMode)
-    {
-      CHECK_EPETRA_CALL(vector_->Import(A, Importer.get_epetra_import(), CombineMode));
-    }
+        Epetra_CombineMode CombineMode);
 
     //! Imports an Epetra_DistObject using the Epetra_Export object.
     void import(const Epetra_SrcDistObject& A, const Epetra_Export& Exporter,
         Epetra_CombineMode CombineMode)
     {
-      CHECK_EPETRA_CALL(vector_->Import(A, Exporter, CombineMode));
+      ASSERT_EPETRA_CALL(vector_->Import(A, Exporter, CombineMode));
     }
 
     void export_to(const Epetra_SrcDistObject& A, const Core::LinAlg::Import& Importer,
         Epetra_CombineMode CombineMode)
     {
-      CHECK_EPETRA_CALL(vector_->Export(A, Importer.get_epetra_import(), CombineMode));
+      ASSERT_EPETRA_CALL(vector_->Export(A, Importer.get_epetra_import(), CombineMode));
     }
 
     void export_to(const Epetra_SrcDistObject& A, const Core::LinAlg::Export& Exporter,
         Epetra_CombineMode CombineMode)
     {
-      CHECK_EPETRA_CALL(vector_->Export(A, Exporter.get_epetra_export(), CombineMode));
+      ASSERT_EPETRA_CALL(vector_->Export(A, Exporter.get_epetra_export(), CombineMode));
     }
 
     void export_to(const Epetra_SrcDistObject& A, const Epetra_Export& Exporter,
         Epetra_CombineMode CombineMode)
     {
-      CHECK_EPETRA_CALL(vector_->Export(A, Exporter, CombineMode));
+      ASSERT_EPETRA_CALL(vector_->Export(A, Exporter, CombineMode));
     }
 
     void complete(Epetra_CombineMode mode = Add, bool reuse_map_and_exporter = false)
     {
-      CHECK_EPETRA_CALL(vector_->GlobalAssemble(mode, reuse_map_and_exporter));
+      ASSERT_EPETRA_CALL(vector_->GlobalAssemble(mode, reuse_map_and_exporter));
     }
 
     void sum_into_global_value(int GlobalRow, int FEVectorIndex, double ScalarValue)
     {
-      CHECK_EPETRA_CALL(vector_->SumIntoGlobalValue(GlobalRow, FEVectorIndex, ScalarValue));
+      ASSERT_EPETRA_CALL(vector_->SumIntoGlobalValue(GlobalRow, FEVectorIndex, ScalarValue));
     }
 
     void sum_into_global_value(long long GlobalRow, int FEVectorIndex, double ScalarValue)
     {
-      CHECK_EPETRA_CALL(vector_->SumIntoGlobalValue(GlobalRow, FEVectorIndex, ScalarValue));
+      ASSERT_EPETRA_CALL(vector_->SumIntoGlobalValue(GlobalRow, FEVectorIndex, ScalarValue));
     }
 
     void sum_into_global_values(int numIDs, const int* GIDs, const int* numValuesPerID,
         const double* values, int vectorIndex = 0)
     {
-      CHECK_EPETRA_CALL(
+      ASSERT_EPETRA_CALL(
           vector_->SumIntoGlobalValues(numIDs, GIDs, numValuesPerID, values, vectorIndex));
     }
 
     void sum_into_global_values(
         int numIDs, const int* GIDs, const double* values, int vectorIndex = 0)
     {
-      CHECK_EPETRA_CALL(vector_->SumIntoGlobalValues(numIDs, GIDs, values, vectorIndex));
+      ASSERT_EPETRA_CALL(vector_->SumIntoGlobalValues(numIDs, GIDs, values, vectorIndex));
     }
 
     void reciprocal_multiply(double ScalarAB, const Epetra_MultiVector& A,
         const Epetra_MultiVector& B, double ScalarThis)
     {
-      CHECK_EPETRA_CALL(vector_->ReciprocalMultiply(ScalarAB, A, B, ScalarThis));
+      ASSERT_EPETRA_CALL(vector_->ReciprocalMultiply(ScalarAB, A, B, ScalarThis));
     }
 
     void sum_into_local_value(int MyRow, int FEVectorIndex, double ScalarValue)
     {
-      CHECK_EPETRA_CALL(vector_->SumIntoMyValue(MyRow, FEVectorIndex, ScalarValue));
+      ASSERT_EPETRA_CALL(vector_->SumIntoMyValue(MyRow, FEVectorIndex, ScalarValue));
     }
 
 

--- a/src/core/linalg/src/sparse/4C_linalg_graph.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_graph.cpp
@@ -7,7 +7,7 @@
 
 #include "4C_linalg_graph.hpp"
 
-#include "4C_utils_epetra_exceptions.hpp"
+#include "4C_linalg_utils_exceptions.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -74,11 +74,11 @@ void Core::LinAlg::Graph::fill_complete()
 {
   if (graphtype_ == CRS_GRAPH)
   {
-    CHECK_EPETRA_CALL(graph_->FillComplete());
+    ASSERT_EPETRA_CALL(graph_->FillComplete());
   }
   else if (graphtype_ == FE_GRAPH)
   {
-    CHECK_EPETRA_CALL(static_cast<Epetra_FECrsGraph*>(graph_.get())->GlobalAssemble());
+    ASSERT_EPETRA_CALL(static_cast<Epetra_FECrsGraph*>(graph_.get())->GlobalAssemble());
   }
 }
 
@@ -86,29 +86,29 @@ void Core::LinAlg::Graph::fill_complete(const Map& domain_map, const Map& range_
 {
   if (graphtype_ == CRS_GRAPH)
   {
-    CHECK_EPETRA_CALL(
+    ASSERT_EPETRA_CALL(
         graph_->FillComplete(domain_map.get_epetra_block_map(), range_map.get_epetra_block_map()));
   }
   else if (graphtype_ == FE_GRAPH)
   {
-    CHECK_EPETRA_CALL(static_cast<Epetra_FECrsGraph*>(graph_.get())
+    ASSERT_EPETRA_CALL(static_cast<Epetra_FECrsGraph*>(graph_.get())
             ->GlobalAssemble(domain_map.get_epetra_map(), range_map.get_epetra_map()));
   }
 }
 
-void Core::LinAlg::Graph::optimize_storage() { CHECK_EPETRA_CALL(graph_->OptimizeStorage()); }
+void Core::LinAlg::Graph::optimize_storage() { ASSERT_EPETRA_CALL(graph_->OptimizeStorage()); }
 
 void Core::LinAlg::Graph::export_to(const Core::LinAlg::Graph& A,
     const Core::LinAlg::Export& Exporter, Epetra_CombineMode CombineMode)
 {
-  CHECK_EPETRA_CALL(
+  ASSERT_EPETRA_CALL(
       graph_->Export(A.get_epetra_crs_graph(), Exporter.get_epetra_export(), CombineMode));
 }
 
 void Core::LinAlg::Graph::import_from(const Core::LinAlg::Graph& A,
     const Core::LinAlg::Import& Importer, Epetra_CombineMode CombineMode)
 {
-  CHECK_EPETRA_CALL(
+  ASSERT_EPETRA_CALL(
       graph_->Import(A.get_epetra_crs_graph(), Importer.get_epetra_import(), CombineMode));
 }
 
@@ -116,11 +116,11 @@ void Core::LinAlg::Graph::insert_global_indices(int GlobalRow, std::span<int>& I
 {
   if (graphtype_ == CRS_GRAPH)
   {
-    CHECK_EPETRA_CALL(graph_->InsertGlobalIndices(GlobalRow, Indices.size(), Indices.data()));
+    ASSERT_EPETRA_CALL(graph_->InsertGlobalIndices(GlobalRow, Indices.size(), Indices.data()));
   }
   else if (graphtype_ == FE_GRAPH)
   {
-    CHECK_EPETRA_CALL(static_cast<Epetra_FECrsGraph*>(graph_.get())
+    ASSERT_EPETRA_CALL(static_cast<Epetra_FECrsGraph*>(graph_.get())
             ->InsertGlobalIndices(1, &GlobalRow, Indices.size(), Indices.data()));
   }
 }
@@ -129,7 +129,7 @@ void Core::LinAlg::Graph::extract_local_row_view(int LocalRow, std::span<int>& I
 {
   int num_indices;
   int* indices;
-  CHECK_EPETRA_CALL(graph_->ExtractMyRowView(LocalRow, num_indices, indices));
+  ASSERT_EPETRA_CALL(graph_->ExtractMyRowView(LocalRow, num_indices, indices));
   Indices = std::span(indices, num_indices);
 }
 
@@ -137,7 +137,7 @@ void Core::LinAlg::Graph::extract_global_row_view(int GlobalRow, std::span<int>&
 {
   int num_indices;
   int* indices;
-  CHECK_EPETRA_CALL(graph_->ExtractGlobalRowView(GlobalRow, num_indices, indices));
+  ASSERT_EPETRA_CALL(graph_->ExtractGlobalRowView(GlobalRow, num_indices, indices));
   Indices = std::span(indices, num_indices);
 }
 

--- a/src/core/linalg/src/sparse/4C_linalg_map.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_map.cpp
@@ -11,7 +11,7 @@
 
 #include "4C_comm_mpi_utils.hpp"
 #include "4C_comm_utils.hpp"
-#include "4C_utils_epetra_exceptions.hpp"
+#include "4C_linalg_utils_exceptions.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -130,7 +130,7 @@ Core::LinAlg::Map::Map(const Epetra_BlockMap& Source)
 
 void Core::LinAlg::Map::my_global_elements(int* MyGlobalElementList) const
 {
-  CHECK_EPETRA_CALL(wrapped().MyGlobalElements(MyGlobalElementList));
+  ASSERT_EPETRA_CALL(wrapped().MyGlobalElements(MyGlobalElementList));
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/linalg/src/sparse/4C_linalg_multi_vector.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_multi_vector.cpp
@@ -8,8 +8,8 @@
 #include "4C_linalg_multi_vector.hpp"
 
 #include "4C_comm_mpi_utils.hpp"
+#include "4C_linalg_utils_exceptions.hpp"
 #include "4C_linalg_vector.hpp"
-#include "4C_utils_exceptions.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -55,70 +55,69 @@ Core::LinAlg::MultiVector<T>& Core::LinAlg::MultiVector<T>::operator=(const Mult
 template <typename T>
 void Core::LinAlg::MultiVector<T>::norm_1(double* Result) const
 {
-  CHECK_EPETRA_CALL(vector_->Norm1(Result));
+  ASSERT_EPETRA_CALL(vector_->Norm1(Result));
 }
 
 template <typename T>
 void Core::LinAlg::MultiVector<T>::norm_2(double* Result) const
 {
-  CHECK_EPETRA_CALL(vector_->Norm2(Result));
+  ASSERT_EPETRA_CALL(vector_->Norm2(Result));
 }
 
 template <typename T>
 void Core::LinAlg::MultiVector<T>::norm_inf(double* Result) const
 {
-  CHECK_EPETRA_CALL(vector_->NormInf(Result));
+  ASSERT_EPETRA_CALL(vector_->NormInf(Result));
 }
-
 
 template <typename T>
 void Core::LinAlg::MultiVector<T>::mean_value(double* Result) const
 {
-  CHECK_EPETRA_CALL(vector_->MeanValue(Result));
+  ASSERT_EPETRA_CALL(vector_->MeanValue(Result));
 }
 
 template <typename T>
 void Core::LinAlg::MultiVector<T>::scale(double ScalarValue)
 {
-  CHECK_EPETRA_CALL(vector_->Scale(ScalarValue));
+  ASSERT_EPETRA_CALL(vector_->Scale(ScalarValue));
 }
 
 template <typename T>
 void Core::LinAlg::MultiVector<T>::dot(const MultiVector& A, double* Result) const
 {
-  CHECK_EPETRA_CALL(vector_->Dot(A.get_epetra_multi_vector(), Result));
+  ASSERT_EPETRA_CALL(vector_->Dot(A.get_epetra_multi_vector(), Result));
 }
 
 template <typename T>
 void Core::LinAlg::MultiVector<T>::abs(const MultiVector& A)
 {
-  CHECK_EPETRA_CALL(vector_->Abs(A.get_epetra_multi_vector()));
+  ASSERT_EPETRA_CALL(vector_->Abs(A.get_epetra_multi_vector()));
 }
 
 template <typename T>
 void Core::LinAlg::MultiVector<T>::scale(double ScalarA, const MultiVector& A)
 {
-  CHECK_EPETRA_CALL(vector_->Scale(ScalarA, A.get_epetra_multi_vector()));
+  ASSERT_EPETRA_CALL(vector_->Scale(ScalarA, A.get_epetra_multi_vector()));
 }
 
 template <typename T>
 void Core::LinAlg::MultiVector<T>::update(double ScalarA, const MultiVector& A, double ScalarThis)
 {
-  CHECK_EPETRA_CALL(vector_->Update(ScalarA, A.get_epetra_multi_vector(), ScalarThis));
+  ASSERT_EPETRA_CALL(vector_->Update(ScalarA, A.get_epetra_multi_vector(), ScalarThis));
 }
 
 template <typename T>
 void Core::LinAlg::MultiVector<T>::update(
     double ScalarA, const MultiVector& A, double ScalarB, const MultiVector& B, double ScalarThis)
 {
-  CHECK_EPETRA_CALL(
+  ASSERT_EPETRA_CALL(
       vector_->Update(ScalarA, A.get_epetra_multi_vector(), ScalarB, *B.vector_, ScalarThis));
 }
 
 template <typename T>
 void Core::LinAlg::MultiVector<T>::put_scalar(double ScalarConstant)
 {
-  CHECK_EPETRA_CALL(vector_->PutScalar(ScalarConstant));
+  ASSERT_EPETRA_CALL(vector_->PutScalar(ScalarConstant));
 }
 
 template <typename T>
@@ -131,35 +130,35 @@ template <typename T>
 void Core::LinAlg::MultiVector<T>::replace_map(const Core::LinAlg::Map& map)
 {
   column_vector_view_.clear();
-  CHECK_EPETRA_CALL(vector_->ReplaceMap(map.get_epetra_block_map()));
+  ASSERT_EPETRA_CALL(vector_->ReplaceMap(map.get_epetra_block_map()));
 }
 
 template <typename T>
 void Core::LinAlg::MultiVector<T>::replace_local_value(
     int MyRow, int VectorIndex, double ScalarValue)
 {
-  CHECK_EPETRA_CALL(vector_->ReplaceMyValue(MyRow, VectorIndex, ScalarValue));
+  ASSERT_EPETRA_CALL(vector_->ReplaceMyValue(MyRow, VectorIndex, ScalarValue));
 }
 
 template <typename T>
 void Core::LinAlg::MultiVector<T>::replace_global_value(
     int GlobalRow, int VectorIndex, double ScalarValue)
 {
-  CHECK_EPETRA_CALL(vector_->ReplaceGlobalValue(GlobalRow, VectorIndex, ScalarValue));
+  ASSERT_EPETRA_CALL(vector_->ReplaceGlobalValue(GlobalRow, VectorIndex, ScalarValue));
 }
 
 template <typename T>
 void Core::LinAlg::MultiVector<T>::replace_global_value(
     long long GlobalRow, int VectorIndex, double ScalarValue)
 {
-  CHECK_EPETRA_CALL(vector_->ReplaceGlobalValue(GlobalRow, VectorIndex, ScalarValue));
+  ASSERT_EPETRA_CALL(vector_->ReplaceGlobalValue(GlobalRow, VectorIndex, ScalarValue));
 }
 
 template <typename T>
 void Core::LinAlg::MultiVector<T>::multiply(
     double ScalarAB, const MultiVector& A, const MultiVector& B, double ScalarThis)
 {
-  CHECK_EPETRA_CALL(vector_->Multiply(
+  ASSERT_EPETRA_CALL(vector_->Multiply(
       ScalarAB, A.get_epetra_multi_vector(), B.get_epetra_multi_vector(), ScalarThis));
 }
 
@@ -167,21 +166,21 @@ template <typename T>
 void Core::LinAlg::MultiVector<T>::multiply(char TransA, char TransB, double ScalarAB,
     const MultiVector& A, const MultiVector& B, double ScalarThis)
 {
-  CHECK_EPETRA_CALL(vector_->Multiply(TransA, TransB, ScalarAB, A.get_epetra_multi_vector(),
+  ASSERT_EPETRA_CALL(vector_->Multiply(TransA, TransB, ScalarAB, A.get_epetra_multi_vector(),
       B.get_epetra_multi_vector(), ScalarThis));
 }
 
 template <typename T>
 void Core::LinAlg::MultiVector<T>::reciprocal(const Epetra_MultiVector& A)
 {
-  CHECK_EPETRA_CALL(vector_->Reciprocal(A));
+  ASSERT_EPETRA_CALL(vector_->Reciprocal(A));
 }
 
 template <typename T>
 void Core::LinAlg::MultiVector<T>::import(
     const MultiVector& A, const Core::LinAlg::Import& Importer, Epetra_CombineMode CombineMode)
 {
-  CHECK_EPETRA_CALL(
+  ASSERT_EPETRA_CALL(
       vector_->Import(A.get_epetra_multi_vector(), Importer.get_epetra_import(), CombineMode));
 }
 
@@ -189,7 +188,7 @@ template <typename T>
 void Core::LinAlg::MultiVector<T>::import(
     const MultiVector& A, const Core::LinAlg::Export& Exporter, Epetra_CombineMode CombineMode)
 {
-  CHECK_EPETRA_CALL(
+  ASSERT_EPETRA_CALL(
       vector_->Import(A.get_epetra_multi_vector(), Exporter.get_epetra_export(), CombineMode));
 }
 
@@ -197,7 +196,7 @@ template <typename T>
 void Core::LinAlg::MultiVector<T>::export_to(
     const MultiVector& A, const Core::LinAlg::Import& Importer, Epetra_CombineMode CombineMode)
 {
-  CHECK_EPETRA_CALL(
+  ASSERT_EPETRA_CALL(
       vector_->Export(A.get_epetra_multi_vector(), Importer.get_epetra_import(), CombineMode));
 }
 
@@ -205,7 +204,7 @@ template <typename T>
 void Core::LinAlg::MultiVector<T>::export_to(
     const MultiVector& A, const Core::LinAlg::Export& Exporter, Epetra_CombineMode CombineMode)
 {
-  CHECK_EPETRA_CALL(
+  ASSERT_EPETRA_CALL(
       vector_->Export(A.get_epetra_multi_vector(), Exporter.get_epetra_export(), CombineMode));
 }
 
@@ -213,34 +212,34 @@ template <typename T>
 void Core::LinAlg::MultiVector<T>::sum_into_global_value(
     int GlobalRow, int VectorIndex, double ScalarValue)
 {
-  CHECK_EPETRA_CALL(vector_->SumIntoGlobalValue(GlobalRow, VectorIndex, ScalarValue));
+  ASSERT_EPETRA_CALL(vector_->SumIntoGlobalValue(GlobalRow, VectorIndex, ScalarValue));
 }
 
 template <typename T>
 void Core::LinAlg::MultiVector<T>::sum_into_global_value(
     long long GlobalRow, int VectorIndex, double ScalarValue)
 {
-  CHECK_EPETRA_CALL(vector_->SumIntoGlobalValue(GlobalRow, VectorIndex, ScalarValue));
+  ASSERT_EPETRA_CALL(vector_->SumIntoGlobalValue(GlobalRow, VectorIndex, ScalarValue));
 }
 
 template <typename T>
 void Core::LinAlg::MultiVector<T>::sum_into_local_value(
     int MyRow, int VectorIndex, double ScalarValue)
 {
-  CHECK_EPETRA_CALL(vector_->SumIntoMyValue(MyRow, VectorIndex, ScalarValue));
+  ASSERT_EPETRA_CALL(vector_->SumIntoMyValue(MyRow, VectorIndex, ScalarValue));
 }
 
 
 template <typename T>
 void Core::LinAlg::MultiVector<T>::extract_view(double*** ArrayOfPointers) const
 {
-  CHECK_EPETRA_CALL(vector_->ExtractView(ArrayOfPointers));
+  ASSERT_EPETRA_CALL(vector_->ExtractView(ArrayOfPointers));
 }
 
 template <typename T>
 void Core::LinAlg::MultiVector<T>::extract_copy(double* A, int MyLDA) const
 {
-  CHECK_EPETRA_CALL(vector_->ExtractCopy(A, MyLDA));
+  ASSERT_EPETRA_CALL(vector_->ExtractCopy(A, MyLDA));
 }
 
 

--- a/src/core/linalg/src/sparse/4C_linalg_multi_vector.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_multi_vector.hpp
@@ -14,7 +14,6 @@
 #include "4C_linalg_map.hpp"
 #include "4C_linalg_transfer.hpp"
 #include "4C_linalg_view.hpp"
-#include "4C_utils_epetra_exceptions.hpp"
 #include "4C_utils_owner_or_view.hpp"
 
 #include <Epetra_FEVector.h>

--- a/src/core/linalg/src/sparse/4C_linalg_sparsematrix.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_sparsematrix.cpp
@@ -1464,13 +1464,12 @@ double Core::LinAlg::SparseMatrix::norm_one() const { return sysmat_->NormOne();
  *----------------------------------------------------------------------*/
 double Core::LinAlg::SparseMatrix::norm_frobenius() const { return sysmat_->NormFrobenius(); }
 
-
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 void Core::LinAlg::SparseMatrix::multiply(
     bool TransA, const Core::LinAlg::Vector<double>& x, Core::LinAlg::Vector<double>& y) const
 {
-  CHECK_EPETRA_CALL(
+  ASSERT_EPETRA_CALL(
       sysmat_->Multiply(TransA, x.get_ref_of_epetra_vector(), y.get_ref_of_epetra_vector()));
 }
 
@@ -1488,7 +1487,7 @@ int Core::LinAlg::SparseMatrix::multiply(bool TransA, const Core::LinAlg::MultiV
  *----------------------------------------------------------------------*/
 void Core::LinAlg::SparseMatrix::left_scale(const Core::LinAlg::Vector<double>& x)
 {
-  CHECK_EPETRA_CALL(sysmat_->LeftScale(x));
+  ASSERT_EPETRA_CALL(sysmat_->LeftScale(x));
 }
 
 
@@ -1496,21 +1495,21 @@ void Core::LinAlg::SparseMatrix::left_scale(const Core::LinAlg::Vector<double>& 
  *----------------------------------------------------------------------*/
 void Core::LinAlg::SparseMatrix::right_scale(const Core::LinAlg::Vector<double>& x)
 {
-  CHECK_EPETRA_CALL(sysmat_->RightScale(x));
+  ASSERT_EPETRA_CALL(sysmat_->RightScale(x));
 }
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 void Core::LinAlg::SparseMatrix::inv_row_sums(Core::LinAlg::Vector<double>& x) const
 {
-  CHECK_EPETRA_CALL(sysmat_->InvRowSums(x));
+  ASSERT_EPETRA_CALL(sysmat_->InvRowSums(x));
 }
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 void Core::LinAlg::SparseMatrix::inv_col_sums(Core::LinAlg::Vector<double>& x) const
 {
-  CHECK_EPETRA_CALL(sysmat_->InvColSums(x));
+  ASSERT_EPETRA_CALL(sysmat_->InvColSums(x));
 }
 
 /*----------------------------------------------------------------------*
@@ -1541,7 +1540,7 @@ int Core::LinAlg::SparseMatrix::replace_diagonal_values(
  *----------------------------------------------------------------------*/
 void Core::LinAlg::SparseMatrix::extract_diagonal_copy(Core::LinAlg::Vector<double>& Diagonal) const
 {
-  CHECK_EPETRA_CALL(sysmat_->ExtractDiagonalCopy(Diagonal.get_ref_of_epetra_vector()));
+  ASSERT_EPETRA_CALL(sysmat_->ExtractDiagonalCopy(Diagonal.get_ref_of_epetra_vector()));
 }
 
 /*----------------------------------------------------------------------*
@@ -1549,7 +1548,7 @@ void Core::LinAlg::SparseMatrix::extract_diagonal_copy(Core::LinAlg::Vector<doub
 void Core::LinAlg::SparseMatrix::extract_my_row_copy(
     int my_row, int length, int& num_entries, double* values, int* indices) const
 {
-  CHECK_EPETRA_CALL(sysmat_->ExtractMyRowCopy(my_row, length, num_entries, values, indices));
+  ASSERT_EPETRA_CALL(sysmat_->ExtractMyRowCopy(my_row, length, num_entries, values, indices));
 }
 
 /*----------------------------------------------------------------------*
@@ -1557,7 +1556,7 @@ void Core::LinAlg::SparseMatrix::extract_my_row_copy(
 void Core::LinAlg::SparseMatrix::extract_global_row_copy(
     int global_row, int length, int& num_entries, double* values, int* indices) const
 {
-  CHECK_EPETRA_CALL(
+  ASSERT_EPETRA_CALL(
       sysmat_->ExtractGlobalRowCopy(global_row, length, num_entries, values, indices));
 }
 
@@ -1566,7 +1565,7 @@ void Core::LinAlg::SparseMatrix::extract_global_row_copy(
 void Core::LinAlg::SparseMatrix::extract_my_row_view(
     int my_row, int& num_entries, double*& values, int*& indices) const
 {
-  CHECK_EPETRA_CALL(sysmat_->ExtractMyRowView(my_row, num_entries, values, indices));
+  ASSERT_EPETRA_CALL(sysmat_->ExtractMyRowView(my_row, num_entries, values, indices));
 }
 
 /*----------------------------------------------------------------------*
@@ -1574,7 +1573,7 @@ void Core::LinAlg::SparseMatrix::extract_my_row_view(
 void Core::LinAlg::SparseMatrix::extract_global_row_view(
     int global_row, int& num_entries, double*& values, int*& indices) const
 {
-  CHECK_EPETRA_CALL(sysmat_->ExtractGlobalRowView(global_row, num_entries, values, indices));
+  ASSERT_EPETRA_CALL(sysmat_->ExtractGlobalRowView(global_row, num_entries, values, indices));
 }
 
 /*----------------------------------------------------------------------*

--- a/src/core/linalg/src/sparse/4C_linalg_sparsematrix.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_sparsematrix.hpp
@@ -14,6 +14,7 @@
 #include "4C_linalg_graph.hpp"
 #include "4C_linalg_mapextractor.hpp"
 #include "4C_linalg_sparseoperator.hpp"
+#include "4C_linalg_utils_exceptions.hpp"
 
 #include <Epetra_CrsMatrix.h>
 #include <Epetra_FECrsMatrix.h>
@@ -603,14 +604,14 @@ namespace Core::LinAlg
     void import(const SparseMatrix& A, const Core::LinAlg::Import& importer,
         Epetra_CombineMode combine_mode)
     {
-      CHECK_EPETRA_CALL(
+      ASSERT_EPETRA_CALL(
           sysmat_->Import(A.epetra_matrix(), importer.get_epetra_import(), combine_mode));
     }
 
     void import(const SparseMatrix& A, const Core::LinAlg::Export& exporter,
         Epetra_CombineMode combine_mode)
     {
-      CHECK_EPETRA_CALL(
+      ASSERT_EPETRA_CALL(
           sysmat_->Import(A.epetra_matrix(), exporter.get_epetra_export(), combine_mode));
     }
 

--- a/src/core/linalg/src/sparse/4C_linalg_utils_exceptions.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_exceptions.hpp
@@ -5,8 +5,8 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
-#ifndef FOUR_C_UTILS_EPETRA_EXCEPTIONS_HPP
-#define FOUR_C_UTILS_EPETRA_EXCEPTIONS_HPP
+#ifndef FOUR_C_LINALG_UTILS_EXCEPTIONS_HPP
+#define FOUR_C_LINALG_UTILS_EXCEPTIONS_HPP
 
 #include "4C_config.hpp"
 
@@ -18,14 +18,14 @@
  * Otherwise, an exception is thrown.
  *
  * @code
- *    CHECK_EPETRA_CALL(graph_->insert_global_value(...));
+ *    ASSERT_EPETRA_CALL(graph_->insert_global_value(...));
  * @endcode
  */
-#define CHECK_EPETRA_CALL(expr)                                     \
-  do                                                                \
-  {                                                                 \
-    int err = (expr);                                               \
-    FOUR_C_ASSERT_ALWAYS(err == 0, "Epetra error (code {}).", err); \
+#define ASSERT_EPETRA_CALL(expr)                             \
+  do                                                         \
+  {                                                          \
+    [[maybe_unused]] int err = (expr);                       \
+    FOUR_C_ASSERT(err == 0, "Epetra error (code {}).", err); \
   } while (0)
 
 #endif

--- a/src/core/linalg/src/sparse/4C_linalg_vector.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_vector.cpp
@@ -9,7 +9,7 @@
 
 #include "4C_comm_mpi_utils.hpp"
 #include "4C_linalg_multi_vector.hpp"
-#include "4C_utils_epetra_exceptions.hpp"
+#include "4C_linalg_utils_exceptions.hpp"
 #include "4C_utils_exceptions.hpp"
 
 #include <Epetra_Vector.h>
@@ -90,114 +90,115 @@ Core::LinAlg::MultiVector<T>& Core::LinAlg::Vector<T>::as_multi_vector()
 template <typename T>
 void Core::LinAlg::Vector<T>::norm_1(double* Result) const
 {
-  CHECK_EPETRA_CALL(vector_->Norm1(Result));
+  ASSERT_EPETRA_CALL(vector_->Norm1(Result));
 }
 
 template <typename T>
 void Core::LinAlg::Vector<T>::norm_2(double* Result) const
 {
-  CHECK_EPETRA_CALL(vector_->Norm2(Result));
+  ASSERT_EPETRA_CALL(vector_->Norm2(Result));
 }
 
 template <typename T>
 void Core::LinAlg::Vector<T>::norm_inf(double* Result) const
 {
-  CHECK_EPETRA_CALL(vector_->NormInf(Result));
+  ASSERT_EPETRA_CALL(vector_->NormInf(Result));
 }
 
 template <typename T>
 void Core::LinAlg::Vector<T>::min_value(double* Result) const
 {
-  CHECK_EPETRA_CALL(vector_->MinValue(Result));
+  ASSERT_EPETRA_CALL(vector_->MinValue(Result));
 }
 
 template <typename T>
 void Core::LinAlg::Vector<T>::max_value(double* Result) const
 {
-  CHECK_EPETRA_CALL(vector_->MaxValue(Result));
+  ASSERT_EPETRA_CALL(vector_->MaxValue(Result));
 }
 
 template <typename T>
 void Core::LinAlg::Vector<T>::mean_value(double* Result) const
 {
-  CHECK_EPETRA_CALL(vector_->MeanValue(Result));
+  ASSERT_EPETRA_CALL(vector_->MeanValue(Result));
 }
 
 template <typename T>
 void Core::LinAlg::Vector<T>::scale(double ScalarValue)
 {
-  CHECK_EPETRA_CALL(vector_->Scale(ScalarValue));
+  ASSERT_EPETRA_CALL(vector_->Scale(ScalarValue));
 }
 
 
 template <typename T>
 void Core::LinAlg::Vector<T>::dot(const Epetra_MultiVector& A, double* Result) const
 {
-  CHECK_EPETRA_CALL(vector_->Dot(A, Result));
+  ASSERT_EPETRA_CALL(vector_->Dot(A, Result));
 }
 
 template <typename T>
 void Core::LinAlg::Vector<T>::abs(const Epetra_MultiVector& A)
 {
-  CHECK_EPETRA_CALL(vector_->Abs(A));
+  ASSERT_EPETRA_CALL(vector_->Abs(A));
 }
 
 template <typename T>
 void Core::LinAlg::Vector<T>::scale(double ScalarA, const Epetra_MultiVector& A)
 {
-  CHECK_EPETRA_CALL(vector_->Scale(ScalarA, A));
+  ASSERT_EPETRA_CALL(vector_->Scale(ScalarA, A));
 }
 
 template <typename T>
 void Core::LinAlg::Vector<T>::update(
     double ScalarA, const Core::LinAlg::MultiVector<double>& A, double ScalarThis)
 {
-  CHECK_EPETRA_CALL(vector_->Update(ScalarA, A.get_epetra_multi_vector(), ScalarThis));
+  ASSERT_EPETRA_CALL(vector_->Update(ScalarA, A.get_epetra_multi_vector(), ScalarThis));
 }
 
 template <typename T>
 void Core::LinAlg::Vector<T>::update(double ScalarA, const Epetra_MultiVector& A, double ScalarB,
     const Epetra_MultiVector& B, double ScalarThis)
 {
-  CHECK_EPETRA_CALL(vector_->Update(ScalarA, A, ScalarB, B, ScalarThis));
+  ASSERT_EPETRA_CALL(vector_->Update(ScalarA, A, ScalarB, B, ScalarThis));
 }
 
 
 template <typename T>
 void Core::LinAlg::Vector<T>::dot(const Vector& A, double* Result) const
 {
-  CHECK_EPETRA_CALL(vector_->Dot(A, Result));
+  ASSERT_EPETRA_CALL(vector_->Dot(A, Result));
 }
 
 template <typename T>
 void Core::LinAlg::Vector<T>::abs(const Vector& A)
 {
-  CHECK_EPETRA_CALL(vector_->Abs(A));
+  ASSERT_EPETRA_CALL(vector_->Abs(A));
 }
 
 template <typename T>
 void Core::LinAlg::Vector<T>::scale(double ScalarA, const Vector& A)
 {
-  CHECK_EPETRA_CALL(vector_->Scale(ScalarA, A));
+  ASSERT_EPETRA_CALL(vector_->Scale(ScalarA, A));
 }
 
 template <typename T>
 void Core::LinAlg::Vector<T>::update(double ScalarA, const Vector& A, double ScalarThis)
 {
-  CHECK_EPETRA_CALL(vector_->Update(ScalarA, A, ScalarThis));
+  ASSERT_EPETRA_CALL(vector_->Update(ScalarA, A, ScalarThis));
 }
 
 template <typename T>
 void Core::LinAlg::Vector<T>::update(
     double ScalarA, const Vector& A, double ScalarB, const Vector& B, double ScalarThis)
 {
-  CHECK_EPETRA_CALL(vector_->Update(ScalarA, A, ScalarB, B.get_ref_of_epetra_vector(), ScalarThis));
+  ASSERT_EPETRA_CALL(
+      vector_->Update(ScalarA, A, ScalarB, B.get_ref_of_epetra_vector(), ScalarThis));
 }
 
 template <typename T>
 void Core::LinAlg::Vector<T>::put_scalar(double ScalarConstant)
 {
-  CHECK_EPETRA_CALL(vector_->PutScalar(ScalarConstant));
+  ASSERT_EPETRA_CALL(vector_->PutScalar(ScalarConstant));
 }
 
 
@@ -207,13 +208,13 @@ void Core::LinAlg::Vector<T>::replace_map(const Map& map)
 {
   multi_vector_view_.invalidate();
   map_.invalidate();
-  CHECK_EPETRA_CALL(vector_->ReplaceMap(map.get_epetra_block_map()));
+  ASSERT_EPETRA_CALL(vector_->ReplaceMap(map.get_epetra_block_map()));
 }
 
 template <typename T>
 void Core::LinAlg::Vector<T>::replace_local_value(int MyRow, double ScalarValue)
 {
-  CHECK_EPETRA_CALL(vector_->ReplaceMyValue(MyRow, 0, ScalarValue));
+  ASSERT_EPETRA_CALL(vector_->ReplaceMyValue(MyRow, 0, ScalarValue));
 }
 
 template <typename T>
@@ -229,7 +230,7 @@ void Core::LinAlg::Vector<T>::replace_local_values(
 template <typename T>
 void Core::LinAlg::Vector<T>::replace_global_value(int GlobalRow, double ScalarValue)
 {
-  CHECK_EPETRA_CALL(vector_->ReplaceGlobalValue(GlobalRow, 0, ScalarValue));
+  ASSERT_EPETRA_CALL(vector_->ReplaceGlobalValue(GlobalRow, 0, ScalarValue));
 }
 
 template <typename T>
@@ -245,13 +246,13 @@ void Core::LinAlg::Vector<T>::replace_global_values(
 template <typename T>
 void Core::LinAlg::Vector<T>::sum_into_local_value(int MyRow, double ScalarValue)
 {
-  CHECK_EPETRA_CALL(vector_->SumIntoMyValue(MyRow, 0, ScalarValue));
+  ASSERT_EPETRA_CALL(vector_->SumIntoMyValue(MyRow, 0, ScalarValue));
 }
 
 template <typename T>
 void Core::LinAlg::Vector<T>::sum_into_global_value(int GlobalRow, double ScalarValue)
 {
-  CHECK_EPETRA_CALL(vector_->SumIntoGlobalValue(GlobalRow, 0, ScalarValue));
+  ASSERT_EPETRA_CALL(vector_->SumIntoGlobalValue(GlobalRow, 0, ScalarValue));
 }
 
 template <typename T>
@@ -269,7 +270,7 @@ void Core::LinAlg::Vector<T>::multiply(char TransA, char TransB, double ScalarAB
     const Core::LinAlg::MultiVector<double>& A, const Core::LinAlg::MultiVector<double>& B,
     double ScalarThis)
 {
-  CHECK_EPETRA_CALL(vector_->Multiply(TransA, TransB, ScalarAB, A.get_epetra_multi_vector(),
+  ASSERT_EPETRA_CALL(vector_->Multiply(TransA, TransB, ScalarAB, A.get_epetra_multi_vector(),
       B.get_epetra_multi_vector(), ScalarThis));
 }
 
@@ -277,49 +278,49 @@ template <typename T>
 void Core::LinAlg::Vector<T>::multiply(double ScalarAB, const Core::LinAlg::MultiVector<double>& A,
     const Core::LinAlg::MultiVector<double>& B, double ScalarThis)
 {
-  CHECK_EPETRA_CALL(vector_->Multiply(
+  ASSERT_EPETRA_CALL(vector_->Multiply(
       ScalarAB, A.get_epetra_multi_vector(), B.get_epetra_multi_vector(), ScalarThis));
 }
 
 template <typename T>
 void Core::LinAlg::Vector<T>::reciprocal(const Epetra_MultiVector& A)
 {
-  CHECK_EPETRA_CALL(vector_->Reciprocal(A));
+  ASSERT_EPETRA_CALL(vector_->Reciprocal(A));
 }
 
 template <typename T>
 void Core::LinAlg::Vector<T>::reciprocal_multiply(
     double ScalarAB, const Epetra_MultiVector& A, const Epetra_MultiVector& B, double ScalarThis)
 {
-  CHECK_EPETRA_CALL(vector_->ReciprocalMultiply(ScalarAB, A, B, ScalarThis));
+  ASSERT_EPETRA_CALL(vector_->ReciprocalMultiply(ScalarAB, A, B, ScalarThis));
 }
 
 template <typename T>
 void Core::LinAlg::Vector<T>::import(const Epetra_SrcDistObject& A,
     const Core::LinAlg::Import& Importer, Epetra_CombineMode CombineMode)
 {
-  CHECK_EPETRA_CALL(vector_->Import(A, Importer.get_epetra_import(), CombineMode));
+  ASSERT_EPETRA_CALL(vector_->Import(A, Importer.get_epetra_import(), CombineMode));
 }
 
 template <typename T>
 void Core::LinAlg::Vector<T>::import(const Epetra_SrcDistObject& A,
     const Core::LinAlg::Export& Exporter, Epetra_CombineMode CombineMode)
 {
-  CHECK_EPETRA_CALL(vector_->Import(A, Exporter.get_epetra_export(), CombineMode));
+  ASSERT_EPETRA_CALL(vector_->Import(A, Exporter.get_epetra_export(), CombineMode));
 }
 
 template <typename T>
 void Core::LinAlg::Vector<T>::export_to(const Epetra_SrcDistObject& A,
     const Core::LinAlg::Import& Importer, Epetra_CombineMode CombineMode)
 {
-  CHECK_EPETRA_CALL(vector_->Export(A, Importer.get_epetra_import(), CombineMode));
+  ASSERT_EPETRA_CALL(vector_->Export(A, Importer.get_epetra_import(), CombineMode));
 }
 
 template <typename T>
 void Core::LinAlg::Vector<T>::export_to(const Epetra_SrcDistObject& A,
     const Core::LinAlg::Export& Exporter, Epetra_CombineMode CombineMode)
 {
-  CHECK_EPETRA_CALL(vector_->Export(A, Exporter.get_epetra_export(), CombineMode));
+  ASSERT_EPETRA_CALL(vector_->Export(A, Exporter.get_epetra_export(), CombineMode));
 }
 
 template <typename T>
@@ -392,7 +393,7 @@ Core::LinAlg::Vector<int>& Core::LinAlg::Vector<int>::operator=(Vector&& other) 
 
 void Core::LinAlg::Vector<int>::put_value(int Value)
 {
-  CHECK_EPETRA_CALL(vector_->PutValue(Value));
+  ASSERT_EPETRA_CALL(vector_->PutValue(Value));
 }
 
 int Core::LinAlg::Vector<int>::max_value() { return vector_->MaxValue(); }
@@ -404,25 +405,25 @@ void Core::LinAlg::Vector<int>::print(std::ostream& os) const { vector_->Print(o
 void Core::LinAlg::Vector<int>::import(
     const Vector& A, const Core::LinAlg::Import& Importer, Epetra_CombineMode CombineMode)
 {
-  CHECK_EPETRA_CALL(vector_->Import(*A.vector_, Importer.get_epetra_import(), CombineMode));
+  ASSERT_EPETRA_CALL(vector_->Import(*A.vector_, Importer.get_epetra_import(), CombineMode));
 }
 
 void Core::LinAlg::Vector<int>::import(
     const Vector& A, const Core::LinAlg::Export& Exporter, Epetra_CombineMode CombineMode)
 {
-  CHECK_EPETRA_CALL(vector_->Import(*A.vector_, Exporter.get_epetra_export(), CombineMode));
+  ASSERT_EPETRA_CALL(vector_->Import(*A.vector_, Exporter.get_epetra_export(), CombineMode));
 }
 
 void Core::LinAlg::Vector<int>::export_to(
     const Vector& A, const Core::LinAlg::Import& Importer, Epetra_CombineMode CombineMode)
 {
-  CHECK_EPETRA_CALL(vector_->Export(*A.vector_, Importer.get_epetra_import(), CombineMode));
+  ASSERT_EPETRA_CALL(vector_->Export(*A.vector_, Importer.get_epetra_import(), CombineMode));
 }
 
 void Core::LinAlg::Vector<int>::export_to(
     const Vector& A, const Core::LinAlg::Export& Exporter, Epetra_CombineMode CombineMode)
 {
-  CHECK_EPETRA_CALL(vector_->Export(*A.vector_, Exporter.get_epetra_export(), CombineMode));
+  ASSERT_EPETRA_CALL(vector_->Export(*A.vector_, Exporter.get_epetra_export(), CombineMode));
 }
 
 MPI_Comm Core::LinAlg::Vector<int>::get_comm() const

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.cpp
@@ -22,7 +22,6 @@
 #include "4C_solver_nonlin_nox_solver_ptc.hpp"
 #include "4C_solver_nonlin_nox_vector.hpp"
 #include "4C_structure_new_nln_linearsystem_scaling.hpp"
-#include "4C_utils_epetra_exceptions.hpp"
 
 #include <Teuchos_LAPACK.hpp>
 #include <Teuchos_ParameterList.hpp>
@@ -574,7 +573,7 @@ void NOX::Nln::LinearSystem::replace_diagonal_of_jacobian(
   const Core::LinAlg::SparseMatrix& diag_block = get_jacobian_block(diag_bid, diag_bid);
   Core::LinAlg::SparseMatrix& mod_diag_block = const_cast<Core::LinAlg::SparseMatrix&>(diag_block);
 
-  CHECK_EPETRA_CALL(mod_diag_block.replace_diagonal_values(new_diag));
+  mod_diag_block.replace_diagonal_values(new_diag);
 }
 
 /*----------------------------------------------------------------------*


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
For some people speed matters, especially when executing a lot of simulations. Therefore, this PR proposes to move all `Epetra` error check calls into `FOUR_C_ENABLE_ASSERTIONS`. In the end the user decides: Do I just want to execute the code and be "fast" or do I want to develop and have assertions at a ton of places.

In addition a lot of method definitions are moved into the respective `.cpp` file.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
Part of #1190