### PR TITLE
[LinAlg] Remove usage of multiple setters

### DIFF
--- a/src/core/linalg/src/sparse/4C_linalg_vector.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_vector.cpp
@@ -219,7 +219,10 @@ template <typename T>
 void Core::LinAlg::Vector<T>::replace_local_values(
     int NumEntries, const double* Values, const int* Indices)
 {
-  CHECK_EPETRA_CALL(vector_->ReplaceMyValues(NumEntries, Values, Indices));
+  for (int i = 0; i < NumEntries; i++)
+  {
+    replace_local_value(Indices[i], Values[i]);
+  }
 }
 
 template <typename T>
@@ -232,7 +235,10 @@ template <typename T>
 void Core::LinAlg::Vector<T>::replace_global_values(
     int NumEntries, const double* Values, const int* Indices)
 {
-  CHECK_EPETRA_CALL(vector_->ReplaceGlobalValues(NumEntries, Values, Indices));
+  for (int i = 0; i < NumEntries; i++)
+  {
+    replace_global_value(Indices[i], Values[i]);
+  }
 }
 
 template <typename T>
@@ -251,7 +257,10 @@ template <typename T>
 void Core::LinAlg::Vector<T>::sum_into_global_values(
     int NumEntries, const double* Values, const int* Indices)
 {
-  CHECK_EPETRA_CALL(vector_->SumIntoGlobalValues(NumEntries, Values, Indices));
+  for (int i = 0; i < NumEntries; i++)
+  {
+    sum_into_global_value(Indices[i], Values[i]);
+  }
 }
 
 template <typename T>


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
Since within Tpetra the bulk setters are not available anymore, we switch to the single version with a loop at the vector interface:
- `ReplaceGlobalValues` -> `replace_global_value`
- `ReplaceMyValues` -> `replace_local_value`
- `SumIntoGlobalValues` -> `sum_into_global_value`

For the vector interface we currently decided to keep the still allow to set multiple values(e.g. `replace_global_values`) and do not pollute the for loops to the remaining code base. 

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
Part of https://github.com/4C-multiphysics/4C/issues/1121