### PR TITLE
[NOX] Remove `getEpetraVector()`

### DIFF
--- a/src/core/linalg/src/sparse/4C_linalg_map.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_map.hpp
@@ -163,6 +163,9 @@ namespace Core::LinAlg
     //! Puts list of global elements on this processor into the user-provided array.
     void my_global_elements(int* MyGlobalElementList) const;
 
+    //! Number of points across all processors.
+    int num_global_points() const { return wrapped().NumGlobalPoints(); }
+
     //! Number of local points for this map; equals the sum of all element sizes on the calling
     //! processor.
     int num_my_points() const { return wrapped().NumMyPoints(); }

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_group.cpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_group.cpp
@@ -28,8 +28,7 @@ void NOX::FSI::Group::capture_system_state()
 {
   // we know we already have the first linear system calculated
 
-  Core::LinAlg::View rhs_view(RHSVector.getEpetraVector());
-  mfsi_.setup_rhs(rhs_view, true);
+  mfsi_.setup_rhs(RHSVector.get_linalg_vector(), true);
   mfsi_.setup_system_matrix();
 
   isValidJacobian = true;
@@ -63,8 +62,7 @@ void NOX::FSI::Group::capture_system_state()
   {
     if (not isValidRHS)
     {
-      Core::LinAlg::View rhs_view(RHSVector.getEpetraVector());
-      mfsi_.setup_rhs(rhs_view);
+      mfsi_.setup_rhs(RHSVector.get_linalg_vector());
       isValidRHS = true;
     }
   }
@@ -76,13 +74,11 @@ void NOX::FSI::Group::capture_system_state()
  *----------------------------------------------------------------------*/
 ::NOX::Abstract::Group::ReturnType NOX::FSI::Group::computeNewton(Teuchos::ParameterList& p)
 {
-  Core::LinAlg::View rhs_view(RHSVector.getEpetraVector());
-  mfsi_.scale_system(rhs_view);
+  mfsi_.scale_system(RHSVector.get_linalg_vector());
 
   ::NOX::Abstract::Group::ReturnType status = NOX::Nln::GroupBase::computeNewton(p);
-  Core::LinAlg::View newton_vector_view(NewtonVector.getEpetraVector());
 
-  mfsi_.unscale_solution(newton_vector_view, rhs_view);
+  mfsi_.unscale_solution(NewtonVector.get_linalg_vector(), RHSVector.get_linalg_vector());
 
   // check return value of computeNewton call
   if (status == ::NOX::Abstract::Group::NotConverged || status == ::NOX::Abstract::Group::Failed)

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem.cpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem.cpp
@@ -62,7 +62,7 @@ bool NOX::FSI::LinearSystem::apply_jacobian(
     const NOX::Nln::Vector& input, NOX::Nln::Vector& result) const
 {
   jac_ptr_->SetUseTranspose(false);
-  int status = jac_ptr_->Apply(input.getEpetraVector(), result.getEpetraVector());
+  int status = jac_ptr_->Apply(input.get_linalg_vector(), result.get_linalg_vector());
 
   return status == 0;
 }
@@ -74,7 +74,7 @@ bool NOX::FSI::LinearSystem::apply_jacobian_transpose(
     const NOX::Nln::Vector& input, NOX::Nln::Vector& result) const
 {
   jac_ptr_->SetUseTranspose(true);
-  int status = jac_ptr_->Apply(input.getEpetraVector(), result.getEpetraVector());
+  int status = jac_ptr_->Apply(input.get_linalg_vector(), result.get_linalg_vector());
   jac_ptr_->SetUseTranspose(false);
 
   return status == 0;
@@ -130,7 +130,7 @@ bool NOX::FSI::LinearSystem::apply_jacobian_inverse(
  *----------------------------------------------------------------------*/
 bool NOX::FSI::LinearSystem::compute_jacobian(const NOX::Nln::Vector& x)
 {
-  bool success = jac_interface_ptr_->computeJacobian(x.getEpetraVector(), *jac_ptr_);
+  bool success = jac_interface_ptr_->computeJacobian(x.get_linalg_vector(), *jac_ptr_);
   return success;
 }
 

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.cpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.cpp
@@ -67,7 +67,7 @@ bool NOX::FSI::LinearSystemGCR::apply_jacobian(
     const NOX::Nln::Vector& input, NOX::Nln::Vector& result) const
 {
   jacPtr->SetUseTranspose(false);
-  int status = jacPtr->Apply(input.getEpetraVector(), result.getEpetraVector());
+  int status = jacPtr->Apply(input.get_linalg_vector(), result.get_linalg_vector());
   return status == 0;
 }
 
@@ -76,7 +76,7 @@ bool NOX::FSI::LinearSystemGCR::apply_jacobian_transpose(
     const NOX::Nln::Vector& input, NOX::Nln::Vector& result) const
 {
   jacPtr->SetUseTranspose(true);
-  int status = jacPtr->Apply(input.getEpetraVector(), result.getEpetraVector());
+  int status = jacPtr->Apply(input.get_linalg_vector(), result.get_linalg_vector());
   jacPtr->SetUseTranspose(false);
 
   return status == 0;
@@ -97,8 +97,9 @@ bool NOX::FSI::LinearSystemGCR::apply_jacobian_inverse(
   if (zeroInitialGuess) result.init(0.0);
 
   // Create Epetra linear problem object for the linear solve
-  Epetra_LinearProblem Problem(
-      jacPtr.get(), &(result.getEpetraVector()), &(nonConstInput.getEpetraVector()));
+  Epetra_LinearProblem Problem(jacPtr.get(),
+      &(result.get_linalg_vector().get_ref_of_epetra_vector()),
+      &(nonConstInput.get_linalg_vector().get_ref_of_epetra_vector()));
 
   // ************* Begin linear system scaling *******************
   if (scaling)
@@ -385,7 +386,7 @@ void NOX::FSI::LinearSystemGCR::apply_plane_rotation(double& dx, double& dy, dou
 
 bool NOX::FSI::LinearSystemGCR::compute_jacobian(const NOX::Nln::Vector& x)
 {
-  bool success = jacInterfacePtr->computeJacobian(x.getEpetraVector(), *jacPtr);
+  bool success = jacInterfacePtr->computeJacobian(x.get_linalg_vector(), *jacPtr);
   return success;
 }
 

--- a/src/fsi/src/partitioned/model_evaluator/4C_fsi_str_model_evaluator_partitioned.cpp
+++ b/src/fsi/src/partitioned/model_evaluator/4C_fsi_str_model_evaluator_partitioned.cpp
@@ -177,7 +177,7 @@ Solid::ModelEvaluator::PartitionedFSI::solve_relaxation_linear(
   const auto& increment = dynamic_cast<const NOX::Nln::Vector&>(grp_ptr->getNewton());
 
   // return the increment
-  return std::make_shared<Core::LinAlg::Vector<double>>(increment.getEpetraVector());
+  return std::make_shared<Core::LinAlg::Vector<double>>(increment.get_linalg_vector());
 }
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/

--- a/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_aitken.cpp
+++ b/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_aitken.cpp
@@ -127,8 +127,8 @@ bool NOX::FSI::AitkenRelaxation::compute(::NOX::Abstract::Group& grp, double& st
 
   // write omega
   double fnorm = grp.getF().norm();
-  if (Core::Communication::my_mpi_rank(Core::Communication::unpack_epetra_comm(
-          dynamic_cast<const NOX::Nln::Vector&>(F).getEpetraVector().Comm())) == 0)
+  if (Core::Communication::my_mpi_rank(
+          dynamic_cast<const NOX::Nln::Vector&>(F).get_linalg_vector().get_comm()) == 0)
   {
     static int count;
     static std::ofstream* out;

--- a/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_sd.cpp
+++ b/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_sd.cpp
@@ -85,8 +85,8 @@ bool NOX::FSI::SDRelaxation::compute(::NOX::Abstract::Group& newgrp, double& ste
 
   // write omega
   double fnorm = oldgrp.getF().norm();
-  if (Core::Communication::my_mpi_rank(Core::Communication::unpack_epetra_comm(
-          dynamic_cast<const NOX::Nln::Vector&>(oldgrp.getF()).getEpetraVector().Comm())) == 0)
+  if (Core::Communication::my_mpi_rank(
+          dynamic_cast<const NOX::Nln::Vector&>(oldgrp.getF()).get_linalg_vector().get_comm()) == 0)
   {
     static int count;
     static std::ofstream* out;
@@ -118,7 +118,7 @@ bool NOX::FSI::SDRelaxation::compute(::NOX::Abstract::Group& newgrp, double& ste
   // and we want to set our own flag
   // this tells computeF to do a SD relaxation calculation
   interface.computeF(
-      edir.getEpetraVector(), evec.getEpetraVector(), ::NOX::Epetra::Interface::Required::User);
+      edir.get_linalg_vector(), evec.get_linalg_vector(), ::NOX::Epetra::Interface::Required::User);
 
   return *vec_ptr_;
 }

--- a/src/fsi/src/utils/4C_fsi_statustest.cpp
+++ b/src/fsi/src/utils/4C_fsi_statustest.cpp
@@ -169,13 +169,10 @@ double NOX::FSI::PartialNormF::compute_norm(const ::NOX::Abstract::Group& grp)
 
   // extract the block epetra vector
 
-  const ::NOX::Abstract::Vector& abstract_f = grp.getF();
-  const auto& f = Teuchos::dyn_cast<const NOX::Nln::Vector>(abstract_f);
+  const auto& f = dynamic_cast<const NOX::Nln::Vector&>(grp.getF());
 
-  Core::LinAlg::Vector<double> f_copy(f.getEpetraVector());
-  // extract the inner vector elements we are interested in
-
-  std::shared_ptr<Core::LinAlg::Vector<double>> v = extractor_.extract_vector(f_copy, blocknum_);
+  std::shared_ptr<Core::LinAlg::Vector<double>> v =
+      extractor_.extract_vector(f.get_linalg_vector(), blocknum_);
 
   double norm = FSI::GenericNormF::compute_norm(*v);
 

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_group_base.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_group_base.cpp
@@ -144,8 +144,8 @@ void NOX::Nln::GroupBase::computeX(
 {
   if (isF()) return ::NOX::Abstract::Group::Ok;
 
-  isValidRHS = userInterfacePtr->computeF(xVector.getEpetraVector(), RHSVector.getEpetraVector(),
-      ::NOX::Epetra::Interface::Required::Residual);
+  isValidRHS = userInterfacePtr->computeF(xVector.get_linalg_vector(),
+      RHSVector.get_linalg_vector(), ::NOX::Epetra::Interface::Required::Residual);
 
   FOUR_C_ASSERT(isValidRHS, "NOX::Nln::GroupBase::computeF() - failed");
 
@@ -259,6 +259,14 @@ const ::NOX::Abstract::Vector& NOX::Nln::GroupBase::getF() const { return RHSVec
 const ::NOX::Abstract::Vector& NOX::Nln::GroupBase::getGradient() const { return gradVector; }
 
 const ::NOX::Abstract::Vector& NOX::Nln::GroupBase::getNewton() const { return NewtonVector; }
+
+const NOX::Nln::Vector& NOX::Nln::GroupBase::get_x() const { return xVector; }
+
+const NOX::Nln::Vector& NOX::Nln::GroupBase::get_f() const { return RHSVector; }
+
+const NOX::Nln::Vector& NOX::Nln::GroupBase::get_gradient() const { return gradVector; }
+
+const NOX::Nln::Vector& NOX::Nln::GroupBase::get_newton() const { return NewtonVector; }
 
 double NOX::Nln::GroupBase::getNormF() const
 {

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_group_base.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_group_base.hpp
@@ -98,6 +98,14 @@ namespace NOX
 
       const ::NOX::Abstract::Vector& getNewton() const override;
 
+      const NOX::Nln::Vector& get_x() const;
+
+      const NOX::Nln::Vector& get_f() const;
+
+      const NOX::Nln::Vector& get_gradient() const;
+
+      const NOX::Nln::Vector& get_newton() const;
+
       Teuchos::RCP<const ::NOX::Abstract::Vector> getXPtr() const override;
 
       Teuchos::RCP<const ::NOX::Abstract::Vector> getFPtr() const override;

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_singlestep_group.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_singlestep_group.cpp
@@ -57,15 +57,14 @@ void NOX::Nln::SINGLESTEP::Group::computeX(
 void NOX::Nln::SINGLESTEP::Group::computeX(
     const NOX::Nln::SINGLESTEP::Group& grp, const NOX::Nln::Vector& d, double step)
 {
-  Core::LinAlg::View d_view(const_cast<Epetra_Vector&>(d.getEpetraVector()));
-  prePostOperatorPtr_->run_pre_compute_x(grp, d_view, step, *this);
+  prePostOperatorPtr_->run_pre_compute_x(grp, d.get_linalg_vector(), step, *this);
 
   reset_is_valid();
 
   step = 1.0;
   xVector.update(-1.0, d, step, grp.xVector);
 
-  prePostOperatorPtr_->run_post_compute_x(grp, d_view, step, *this);
+  prePostOperatorPtr_->run_post_compute_x(grp, d.get_linalg_vector(), step, *this);
 
   return;
 }

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_solver_ptc.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_solver_ptc.hpp
@@ -437,7 +437,7 @@ namespace NOX
               Core::LinAlg::Vector<double>& F, const NOX::Nln::Group& grp) override;
 
          protected:
-          Teuchos::RCP<NOX::Nln::Vector> eval_pseudo_transient_f_update(const NOX::Nln::Group& grp);
+          NOX::Nln::Vector eval_pseudo_transient_f_update(const NOX::Nln::Group& grp);
 
          private:
           //! read-only access

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_vector.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_vector.cpp
@@ -185,16 +185,6 @@ double NOX::Nln::Vector::innerProduct(const ::NOX::Abstract::Vector& y) const
 
 ::NOX::size_type NOX::Nln::Vector::length() const { return linalg_vec_->global_length(); }
 
-Epetra_Vector& NOX::Nln::Vector::getEpetraVector()
-{
-  return linalg_vec_->get_ref_of_epetra_vector();
-}
-
-const Epetra_Vector& NOX::Nln::Vector::getEpetraVector() const
-{
-  return linalg_vec_->get_ref_of_epetra_vector();
-}
-
 NOX::Nln::Vector::operator ::NOX::Epetra::Vector()
 {
   return ::NOX::Epetra::Vector(Teuchos::rcp(&linalg_vec_->get_ref_of_epetra_vector(), false));

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_vector.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_vector.hpp
@@ -100,12 +100,6 @@ namespace NOX
       //! Return the length of vector.
       ::NOX::size_type length() const override;
 
-      //! Get reference to underlying Epetra vector - temporary and is to be removed
-      Epetra_Vector& getEpetraVector();  // NOLINT(readability-identifier-naming)
-
-      //! Get const reference to underlying Epetra vector - temporary and is to be removed
-      const Epetra_Vector& getEpetraVector() const;  // NOLINT(readability-identifier-naming)
-
       // Create a view-like NOX::Epetra::Vector wrapper - temporary and is to be removed
       operator ::NOX::Epetra::Vector();
 

--- a/src/structure_new/src/4C_structure_new_integrator.cpp
+++ b/src/structure_new/src/4C_structure_new_integrator.cpp
@@ -288,7 +288,7 @@ void Solid::Integrator::compute_mass_matrix_and_init_acc()
   nox_soln.scale(-1.0);
 
   // get the solution vector and add it into the acceleration vector
-  accnp_ptr->update(1.0, nox_soln.getEpetraVector(), 1.0);
+  accnp_ptr->update(1.0, nox_soln.get_linalg_vector(), 1.0);
 
   // re-build the entire initial right-hand-side with correct accelerations
   model_eval().apply_initial_force(*disnp_ptr, rhs_full);

--- a/src/structure_new/src/implicit/4C_structure_new_timint_implicit.cpp
+++ b/src/structure_new/src/implicit/4C_structure_new_timint_implicit.cpp
@@ -173,9 +173,9 @@ void Solid::TimeInt::Implicit::update_state_incrementally(
   grp_ptr->computeX(*grp_ptr, nox_disiterinc_ptr, 1.0);
 
   // Reset the state variables
-  const auto& x_eptra = dynamic_cast<const NOX::Nln::Vector&>(grp_ptr->getX());
+  const auto& x_nox = dynamic_cast<const NOX::Nln::Vector&>(grp_ptr->getX());
   // set the consistent state in the models (e.g. structure and contact models)
-  impl_int().reset_model_states(Core::LinAlg::Vector<double>(x_eptra.getEpetraVector()));
+  impl_int().reset_model_states(Core::LinAlg::Vector<double>(x_nox.get_linalg_vector()));
 }
 
 /*----------------------------------------------------------------------------*

--- a/src/structure_new/src/implicit/4C_structure_new_timint_implicitbase.cpp
+++ b/src/structure_new/src/implicit/4C_structure_new_timint_implicitbase.cpp
@@ -30,8 +30,7 @@ std::shared_ptr<const Core::LinAlg::Vector<double>> Solid::TimeInt::ImplicitBase
 {
   const ::NOX::Abstract::Group& solgrp = get_solution_group();
   const auto& F = dynamic_cast<const NOX::Nln::Vector&>(solgrp.getF());
-  return get_data_global_state().extract_displ_entries(
-      Core::LinAlg::Vector<double>(F.getEpetraVector()));
+  return get_data_global_state().extract_displ_entries(F.get_linalg_vector());
 }
 
 /*----------------------------------------------------------------------------*

--- a/src/structure_new/src/utils/4C_structure_new_dbc.cpp
+++ b/src/structure_new/src/utils/4C_structure_new_dbc.cpp
@@ -495,11 +495,10 @@ void NOX::Nln::LinSystem::PrePostOp::Dbc::run_pre_apply_jacobian_inverse(
     ::NOX::Abstract::Vector& rhs, Core::LinAlg::SparseOperator& jac,
     const NOX::Nln::LinearSystem& linsys)
 {
-  auto& rhs_epetra = dynamic_cast<NOX::Nln::Vector&>(rhs);
-  Core::LinAlg::View rhs_view(rhs_epetra.getEpetraVector());
+  auto& rhs_nox = dynamic_cast<NOX::Nln::Vector&>(rhs);
   std::shared_ptr<Core::LinAlg::SparseOperator> jac_ptr = Core::Utils::shared_ptr_from_ref(jac);
   // apply the dirichlet condition and rotate the system if desired
-  dbc_ptr_->apply_dirichlet_to_local_system(*jac_ptr, rhs_view);
+  dbc_ptr_->apply_dirichlet_to_local_system(*jac_ptr, rhs_nox.get_linalg_vector());
 }
 
 FOUR_C_NAMESPACE_CLOSE


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
The member function `getEpetraVector()` temporary kept in #1445 has been removed. This also allowed to removed instantiation of `Core::LinAlg::View` in multiple locations.

## Related Issues and Pull Requests
#1445
