### PR TITLE
Make tutorial directories self-contained

### DIFF
--- a/tests/list_of_tests.cmake
+++ b/tests/list_of_tests.cmake
@@ -2710,9 +2710,9 @@ four_c_test_tutorial(TEST_FILE poisson/tutorial_poisson_thermo.4C.yaml NP 2 COPY
 four_c_test_tutorial(TEST_FILE contact/tutorial_contact_3d.4C.yaml NP 2 COPY_FILES ${PROJECT_SOURCE_DIR}/tests/tutorials/contact/tutorial_contact_3d.e)
 four_c_test_tutorial(TEST_FILE fluid/tutorial_fluid.4C.yaml NP 2 COPY_FILES ${PROJECT_SOURCE_DIR}/tests/tutorials/fluid/tutorial_fluid.e)
 four_c_test_tutorial(TEST_FILE fsi/tutorial_fsi_2d.4C.yaml NP 2 COPY_FILES ${PROJECT_SOURCE_DIR}/tests/tutorials/fsi/tutorial_fsi_2d.e)
-four_c_test_tutorial(TEST_FILE fsi/tutorial_fsi_3d.4C.yaml NP 2 COPY_FILES ${PROJECT_SOURCE_DIR}/tests/input_files/fsi_part_struct_solver.xml ${PROJECT_SOURCE_DIR}/tests/tutorials/fsi/tutorial_fsi_3d.e)
-four_c_test_tutorial(TEST_FILE fsi/tutorial_fsi_monolithic.4C.yaml NP 2 COPY_FILES ${PROJECT_SOURCE_DIR}/tests/tutorials/fsi/tutorial_fsi_monolithic_pw_m1.exo ${PROJECT_SOURCE_DIR}/tests/input_files/xml/linear_solver/iterative_gmres_template.xml ${PROJECT_SOURCE_DIR}/tests/input_files/xml/multigrid/fluid_solid_ale.xml)
-four_c_test_tutorial(TEST_FILE solid/tutorial_solid.4C.yaml NP 2 COPY_FILES ${PROJECT_SOURCE_DIR}/tests/input_files/xml/multigrid/elasticity_template.xml ${PROJECT_SOURCE_DIR}/tests/input_files/xml/linear_solver/iterative_gmres_template.xml ${PROJECT_SOURCE_DIR}/tests/tutorials/solid/tutorial_solid_geo_coarse.e)
+four_c_test_tutorial(TEST_FILE fsi/tutorial_fsi_3d.4C.yaml NP 2 COPY_FILES ${PROJECT_SOURCE_DIR}/tests/tutorials/fsi/fsi_part_struct_solver.xml ${PROJECT_SOURCE_DIR}/tests/tutorials/fsi/tutorial_fsi_3d.e)
+four_c_test_tutorial(TEST_FILE fsi/tutorial_fsi_monolithic.4C.yaml NP 2 COPY_FILES ${PROJECT_SOURCE_DIR}/tests/tutorials/fsi/tutorial_fsi_monolithic_pw_m1.exo ${PROJECT_SOURCE_DIR}/tests/tutorials/fsi/iterative_gmres_template.xml ${PROJECT_SOURCE_DIR}/tests/tutorials/fsi/fluid_solid_ale.xml)
+four_c_test_tutorial(TEST_FILE solid/tutorial_solid.4C.yaml NP 2 COPY_FILES ${PROJECT_SOURCE_DIR}/tests/tutorials/solid/elasticity_template.xml ${PROJECT_SOURCE_DIR}/tests/tutorials/solid/iterative_gmres_template.xml ${PROJECT_SOURCE_DIR}/tests/tutorials/solid/tutorial_solid_geo_coarse.e)
 # Test use case solid with Jacobi preconditioner on mesh 2 with 2 MPI ranks
 four_c_test_tutorial(TEST_FILE preconditioner/tutorial_prec_solid_jacobi.4C.yaml NP 2 COPY_FILES
         ${PROJECT_SOURCE_DIR}/tests/tutorials/preconditioner/tutorial_prec_solid_2.exo

--- a/tests/tutorials/fsi/fluid_solid_ale.xml
+++ b/tests/tutorials/fsi/fluid_solid_ale.xml
@@ -1,0 +1,1 @@
+../../input_files/xml/multigrid/fluid_solid_ale.xml

--- a/tests/tutorials/fsi/fsi_part_struct_solver.xml
+++ b/tests/tutorials/fsi/fsi_part_struct_solver.xml
@@ -1,0 +1,1 @@
+../../input_files/fsi_part_struct_solver.xml

--- a/tests/tutorials/fsi/iterative_gmres_template.xml
+++ b/tests/tutorials/fsi/iterative_gmres_template.xml
@@ -1,0 +1,1 @@
+../../input_files/xml/linear_solver/iterative_gmres_template.xml

--- a/tests/tutorials/solid/elasticity_template.xml
+++ b/tests/tutorials/solid/elasticity_template.xml
@@ -1,0 +1,1 @@
+../../input_files/xml/multigrid/elasticity_template.xml

--- a/tests/tutorials/solid/iterative_gmres_template.xml
+++ b/tests/tutorials/solid/iterative_gmres_template.xml
@@ -1,0 +1,1 @@
+../../input_files/xml/linear_solver/iterative_gmres_template.xml


### PR DESCRIPTION
## Description and Context
Today, @lkoeglmeier, while preparing introductory material to 4C for a student, brought up the issue that our tutorial input files in the tutorial folders are not runnable out of the box. The tests are only runnable in the pipeline, as the testing functionality copies relevant files to the respective testing directories.

However, this is challenging for newcomers to 4C (e.g., students or individuals who get in touch with 4C for the first time and explore the tutorials) who are unfamiliar with the intricate testing infrastructure.

Since we also do not want to double up the files, which are often default solver settings files, introducing a symbolic link is an elegant solution to achieve this, IMO. This way, the respective files are in the repository only once, but the tests are still directly executable without needing to determine where to copy them from.

That the symbolic links are working is even tested, since the paths where to copy the files from during the ctest run are adapted accordingly.