### PR TITLE
Remove write_vector call of old output mechanism in Solid::ModelEvaluator::Structure::output_step_state

### DIFF
--- a/src/structure_new/src/4C_structure_new_timint_base.cpp
+++ b/src/structure_new/src/4C_structure_new_timint_base.cpp
@@ -501,6 +501,8 @@ void Solid::TimeInt::Base::output_step(bool forced_writerestart)
     if (dataio_->should_write_restart_for_step(dataglobalstate_->get_step_n()) or
         dataglobalstate_->get_step_n() == Global::Problem::instance()->restart())
       return;
+    // TODO: This if statement can be removed once Solid::ModelEvaluator::Contact::output_step_state
+    // is removed
     // if state already exists, add restart information
     if (dataio_->write_results_for_this_step(dataglobalstate_->get_step_n()))
     {
@@ -524,6 +526,8 @@ void Solid::TimeInt::Base::output_step(bool forced_writerestart)
   }
 
   // output results (not necessary if restart in same step)
+  // TODO: This if statement can be removed once Solid::ModelEvaluator::Contact::output_step_state
+  // is removed
   if (dataio_->is_write_state() and
       dataio_->write_results_for_this_step(dataglobalstate_->get_step_n()) and (not datawritten))
   {
@@ -680,6 +684,7 @@ void Solid::TimeInt::Base::add_restart_to_output_state()
   std::shared_ptr<Core::IO::DiscretizationWriter> output_ptr = dataio_->get_output_ptr();
 
   // output of velocity and acceleration
+  output_ptr->write_vector("displacement", dataglobalstate_->get_dis_n());
   output_ptr->write_vector("velocity", dataglobalstate_->get_vel_n());
   output_ptr->write_vector("acceleration", dataglobalstate_->get_acc_n());
 

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_structure.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_structure.cpp
@@ -1703,16 +1703,6 @@ void Solid::ModelEvaluator::Structure::determine_energy(const Core::LinAlg::Vect
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-void Solid::ModelEvaluator::Structure::output_step_state(
-    Core::IO::DiscretizationWriter& iowriter) const
-{
-  check_init_setup();
-
-  iowriter.write_vector("displacement", global_state().get_dis_n());
-}
-
-/*----------------------------------------------------------------------------*
- *----------------------------------------------------------------------------*/
 void Solid::ModelEvaluator::Structure::runtime_pre_output_step_state()
 {
   check_init_setup();

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_structure.hpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_structure.hpp
@@ -148,7 +148,7 @@ namespace Solid
       void reset_step_state() override;
 
       //! derived
-      void output_step_state(Core::IO::DiscretizationWriter& iowriter) const override;
+      void output_step_state(Core::IO::DiscretizationWriter& iowriter) const override {};
 
       //! derived
       void runtime_pre_output_step_state() override;


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--

-->

This pr removes the old output call in` Solid::ModelEvaluator::Structure`. New vtk-based output is already written here.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->

part of #211
