### PR TITLE
Remove  function that adds restart data to old output

### DIFF
--- a/src/structure_new/src/4C_structure_new_timint_base.cpp
+++ b/src/structure_new/src/4C_structure_new_timint_base.cpp
@@ -501,12 +501,6 @@ void Solid::TimeInt::Base::output_step(bool forced_writerestart)
     if (dataio_->should_write_restart_for_step(dataglobalstate_->get_step_n()) or
         dataglobalstate_->get_step_n() == Global::Problem::instance()->restart())
       return;
-    // if state already exists, add restart information
-    if (dataio_->write_results_for_this_step(dataglobalstate_->get_step_n()))
-    {
-      add_restart_to_output_state();
-      return;
-    }
   }
 
   /* This flag indicates whether some form of output has already been written in the current time
@@ -662,32 +656,6 @@ void Solid::TimeInt::Base::output_restart(bool& datawritten)
   /* Add the restart information of the different time integrators and model
    * evaluators. */
   int_ptr_->write_restart(*output_ptr);
-
-  // info dedicated to user's eyes staring at standard out
-  if ((dataglobalstate_->get_my_rank() == 0) and (dataio_->get_print2_screen_every_n_step() > 0) and
-      (step_old() % dataio_->get_print2_screen_every_n_step() == 0))
-  {
-    Core::IO::cout << "====== Restart for field 'Structure' written in step "
-                   << dataglobalstate_->get_step_n() << Core::IO::endl;
-  }
-}
-
-/*----------------------------------------------------------------------------*
- *----------------------------------------------------------------------------*/
-void Solid::TimeInt::Base::add_restart_to_output_state()
-{
-  std::shared_ptr<Core::IO::DiscretizationWriter> output_ptr = dataio_->get_output_ptr();
-
-  // output of velocity and acceleration
-  output_ptr->write_vector("velocity", dataglobalstate_->get_vel_n());
-  output_ptr->write_vector("acceleration", dataglobalstate_->get_acc_n());
-
-  /* Add the restart information of the different time integrators and model
-   * evaluators. */
-  int_ptr_->write_restart(*output_ptr, true);
-
-  // finally add the missing mesh information, order is important here
-  output_ptr->write_mesh(data_global_state().get_step_n(), data_global_state().get_time_n());
 
   // info dedicated to user's eyes staring at standard out
   if ((dataglobalstate_->get_my_rank() == 0) and (dataio_->get_print2_screen_every_n_step() > 0) and

--- a/src/structure_new/src/4C_structure_new_timint_base.hpp
+++ b/src/structure_new/src/4C_structure_new_timint_base.hpp
@@ -812,8 +812,6 @@ namespace Solid
       /// write restart information
       void output_restart(bool& datawritten);
 
-      /// add restart information to output state
-      void add_restart_to_output_state();
 
       /** \brief set the number of nonlinear iterations of the last time step
        *


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

In the old output mechanism, the output and restart were written using HDF5 output. When writing the output and restart at the same time step, we only had to add the additional data required for the restart to the old output. With the new vtk-based output, the old output is no longer written and only the restart uses HDF5 output. Therefore, we have to write all restart data every time we restart. So, this function (adding restart data to the old output) is no longer useful.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->

part of #211
