### PR TITLE
Add sym. HA-product

### DIFF
--- a/src/core/linalg/src/dense/4C_linalg_fixedsizematrix_tensor_products.cpp
+++ b/src/core/linalg/src/dense/4C_linalg_fixedsizematrix_tensor_products.cpp
@@ -375,6 +375,19 @@ void Core::LinAlg::FourTensorOperations::add_symmetric_holzapfel_product(
 }
 
 template <typename T>
+Core::LinAlg::SymmetricTensor<T, 3, 3, 3, 3>
+Core::LinAlg::FourTensorOperations::symmetric_holzapfel_product(
+    const Core::LinAlg::Tensor<T, 3, 3>& A, const Core::LinAlg::Tensor<T, 3, 3>& B)
+{
+  auto c1 = einsum_sym<"ca", "db">(A, B);
+  auto c2 = einsum_sym<"da", "cb">(A, B);
+  auto c3 = einsum_sym<"db", "ca">(A, B);
+  auto c4 = einsum_sym<"cb", "da">(A, B);
+
+  return c1 + c2 + c3 + c4;
+}
+
+template <typename T>
 void Core::LinAlg::FourTensorOperations::add_right_non_symmetric_holzapfel_product(
     Core::LinAlg::Matrix<6, 9, T>& out, Core::LinAlg::Matrix<3, 3, T> const& A,
     Core::LinAlg::Matrix<3, 3, T> const& B, T const fac)
@@ -931,6 +944,12 @@ Core::LinAlg::FourTensorOperations::holzapfel_product<double>(
 template Core::LinAlg::SymmetricTensor<FAD, 3, 3, 3, 3>
 Core::LinAlg::FourTensorOperations::holzapfel_product<FAD>(
     const Core::LinAlg::SymmetricTensor<FAD, 3, 3>&);
+template Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>
+Core::LinAlg::FourTensorOperations::symmetric_holzapfel_product<double>(
+    const Core::LinAlg::Tensor<double, 3, 3>&, const Core::LinAlg::Tensor<double, 3, 3>&);
+template Core::LinAlg::SymmetricTensor<FAD, 3, 3, 3, 3>
+Core::LinAlg::FourTensorOperations::symmetric_holzapfel_product<FAD>(
+    const Core::LinAlg::Tensor<FAD, 3, 3>&, const Core::LinAlg::Tensor<FAD, 3, 3>&);
 template void Core::LinAlg::FourTensorOperations::add_right_non_symmetric_holzapfel_product<double>(
     Core::LinAlg::Matrix<6, 9, double>&, Core::LinAlg::Matrix<3, 3, double> const&,
     Core::LinAlg::Matrix<3, 3, double> const&, double const);

--- a/src/core/linalg/src/dense/4C_linalg_fixedsizematrix_tensor_products.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_fixedsizematrix_tensor_products.hpp
@@ -216,6 +216,25 @@ namespace Core::LinAlg::FourTensorOperations
   void add_symmetric_holzapfel_product(Core::LinAlg::Matrix<6, 6>& X,
       const Core::LinAlg::Matrix<3, 3>& A, const Core::LinAlg::Matrix<3, 3>& B, const double fac);
 
+  /*!
+   * @brief Calculates symmetric Holzapfel product
+   *
+   * In tensor index notation this does:
+   * \f[
+   *    X_{abcd} = \text{fac} \cdot \left( A_{ca} \cdot B_{db} + A_{da} \cdot B_{cb} + A_{db}
+   * \cdot B_{ca} + A_{cb} \cdot B_{da} \right)
+   * \f]
+   *
+   * The result is a 4th order tensor with minor symmetries, but no major symmetry, i.e. symmetric
+   * w.r.t. A and B
+   *
+   * @param[out] X 4th order tensor \f[X_{abcd}\f]
+   * @param[in] A     2nd order tensor \f[A_{ef}\f]
+   * @param[in] B     2nd order tensor \f[B_{gh}\f]
+   */
+  template <typename T>
+  Core::LinAlg::SymmetricTensor<T, 3, 3, 3, 3> symmetric_holzapfel_product(
+      const Core::LinAlg::Tensor<T, 3, 3>& A, const Core::LinAlg::Tensor<T, 3, 3>& B);
 
   /*!
    * @brief Add right non-symmetric Holzapfel product to a 4th order tensor in matrix notation

--- a/src/core/linalg/tests/4C_linalg_four_tensor_operations_test.cpp
+++ b/src/core/linalg/tests/4C_linalg_four_tensor_operations_test.cpp
@@ -62,6 +62,29 @@ namespace
     FOUR_C_EXPECT_NEAR(cmat_voigt_old, cmat_voigt_new, 1e-12);
   }
 
+  TEST(FourTensorOperations, SymmetricHolzapfelProductTest)
+  {
+    using T = double;
+
+    // Initialize symmetric tensor
+    Core::LinAlg::Tensor<double, 3, 3> A = {{{-0.7, 1.3, 0.5}, {2.4, 0.2, -1.1}, {3.2, 4.0, 0.8}}};
+
+    Core::LinAlg::Tensor<double, 3, 3> B = {{{2.0, 0.1, 3.0}, {4.0, 1.5, 7.0}, {1.0, 0.2, 1.8}}};
+
+    Core::LinAlg::Matrix<3, 3> A_mat = Core::LinAlg::make_matrix_view(A);
+    Core::LinAlg::Matrix<3, 3> B_mat = Core::LinAlg::make_matrix_view(B);
+
+    Core::LinAlg::Matrix<6, 6, T> X_mat_voigt_old(Core::LinAlg::Initialization::zero);
+    Core::LinAlg::FourTensorOperations::add_symmetric_holzapfel_product(
+        X_mat_voigt_old, A_mat, B_mat, 1.0);
+
+    Core::LinAlg::SymmetricTensor<T, 3, 3, 3, 3> X =
+        Core::LinAlg::FourTensorOperations::symmetric_holzapfel_product(A, B);
+
+    Core::LinAlg::Matrix<6, 6, T> X_mat_voigt_new = Core::LinAlg::make_stress_like_voigt_view(X);
+
+    FOUR_C_EXPECT_NEAR(X_mat_voigt_old, X_mat_voigt_new, 1e-12);
+  }
 }  // namespace
 
 FOUR_C_NAMESPACE_CLOSE


### PR DESCRIPTION
Implemented the symmetric Holzapfel product using tensors and the Einstein Summation Convention.
An exemplary change was made in src/solid_3D_ele/4C_solid_3D_ele_surface_traceestimate.cpp to demonstrate the usage.

Note: The product is also used in plasticity-related code, @dragos-ana, but I did not modify those parts to avoid interfering with your material model.