### PR TITLE
Remove unnecessary enum keyword

### DIFF
--- a/src/adapter/4C_adapter_fld_fluid_fluid_fsi.hpp
+++ b/src/adapter/4C_adapter_fld_fluid_fluid_fsi.hpp
@@ -167,7 +167,7 @@ namespace Adapter
 
     /// type of monolithic XFluid-Fluid approach (decides whether ALE-mesh is fixed during
     /// Newton iteration)
-    enum Inpar::XFEM::MonolithicXffsiApproach monolithic_approach_;
+    Inpar::XFEM::MonolithicXffsiApproach monolithic_approach_;
 
     /// flag, that indicates, whether ALE-relaxation is activated
     bool relaxing_ale_;

--- a/src/adapter/4C_adapter_str_fsi_timint_adaptive.hpp
+++ b/src/adapter/4C_adapter_str_fsi_timint_adaptive.hpp
@@ -103,7 +103,7 @@ namespace Adapter
         double& errinfother  ///< L-inf-norm of temporal discretization error based on interior DOFs
     );
 
-    enum Inpar::Solid::VectorNorm errnorm_;  //!< norm for local error vector
+    Inpar::Solid::VectorNorm errnorm_;  //!< norm for local error vector
 
     int numdbcdofs_;       ///< number of DOFs with Dirichlet boundary condition
     int numdbcfsidofs_;    ///< number of interface DOFs with Dirichlet boundary condition

--- a/src/adapter/4C_adapter_str_structure_new.cpp
+++ b/src/adapter/4C_adapter_str_structure_new.cpp
@@ -209,7 +209,7 @@ void Adapter::StructureBaseAlgorithmNew::setup_tim_int()
   // the different conditions
   // ---------------------------------------------------------------------------
   // define and initial with default value
-  std::shared_ptr<std::set<enum Inpar::Solid::ModelType>> modeltypes =
+  std::shared_ptr<std::set<Inpar::Solid::ModelType>> modeltypes =
       std::make_shared<std::set<enum Inpar::Solid::ModelType>>();
   modeltypes->insert(Inpar::Solid::model_structure);
   set_model_types(*modeltypes);
@@ -218,7 +218,7 @@ void Adapter::StructureBaseAlgorithmNew::setup_tim_int()
   // Setup a element technology set by checking
   // the elements of the discretization
   // ---------------------------------------------------------------------------
-  std::shared_ptr<std::set<enum Inpar::Solid::EleTech>> eletechs =
+  std::shared_ptr<std::set<Inpar::Solid::EleTech>> eletechs =
       std::make_shared<std::set<enum Inpar::Solid::EleTech>>();
   detect_element_technologies(*eletechs);
 
@@ -236,7 +236,7 @@ void Adapter::StructureBaseAlgorithmNew::setup_tim_int()
   // ---------------------------------------------------------------------------
   // Setup and create model specific linear solvers
   // ---------------------------------------------------------------------------
-  std::shared_ptr<std::map<enum Inpar::Solid::ModelType, std::shared_ptr<Core::LinAlg::Solver>>>
+  std::shared_ptr<std::map<Inpar::Solid::ModelType, std::shared_ptr<Core::LinAlg::Solver>>>
       linsolvers = Solid::SOLVER::build_lin_solvers(*modeltypes, *sdyn_, *actdis_);
 
   // ---------------------------------------------------------------------------
@@ -330,7 +330,7 @@ void Adapter::StructureBaseAlgorithmNew::setup_tim_int()
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 void Adapter::StructureBaseAlgorithmNew::set_model_types(
-    std::set<enum Inpar::Solid::ModelType>& modeltypes) const
+    std::set<Inpar::Solid::ModelType>& modeltypes) const
 {
   if (not is_init()) FOUR_C_THROW("You have to call init() first!");
   // ---------------------------------------------------------------------------
@@ -592,7 +592,7 @@ void Adapter::StructureBaseAlgorithmNew::set_model_types(
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 void Adapter::StructureBaseAlgorithmNew::detect_element_technologies(
-    std::set<enum Inpar::Solid::EleTech>& eletechs) const
+    std::set<Inpar::Solid::EleTech>& eletechs) const
 {
   int iseas_local = 0;
   int iseas_global = 0;

--- a/src/adapter/4C_adapter_str_structure_new.hpp
+++ b/src/adapter/4C_adapter_str_structure_new.hpp
@@ -634,10 +634,10 @@ namespace Adapter
      *  the Generic::check_init() and Generic::check_init_setup() routines, instead.
      *
      */
-    void set_model_types(std::set<enum Inpar::Solid::ModelType>& modeltypes) const;
+    void set_model_types(std::set<Inpar::Solid::ModelType>& modeltypes) const;
 
     /// Set all found model types.
-    void detect_element_technologies(std::set<enum Inpar::Solid::EleTech>& eletechs) const;
+    void detect_element_technologies(std::set<Inpar::Solid::EleTech>& eletechs) const;
 
     /// Set different time integrator specific parameters in the different parameter lists
     virtual void set_params(Teuchos::ParameterList& ioflags, Teuchos::ParameterList& xparams,

--- a/src/adapter/4C_adapter_str_timeada.cpp
+++ b/src/adapter/4C_adapter_str_timeada.cpp
@@ -215,7 +215,7 @@ int Adapter::StructureTimeAda::integrate()
         accepted = false;
 
         // get the divergence action
-        enum Inpar::Solid::DivContAct div_action = stm_->data_sdyn().get_divergence_action();
+        Inpar::Solid::DivContAct div_action = stm_->data_sdyn().get_divergence_action();
 
         convergencestatus = perform_error_action(div_action, stpsiznew);
       }
@@ -485,8 +485,8 @@ double Adapter::StructureTimeAda::calculate_dt(const double norm)
 
 /*----------------------------------------------------------------------*/
 /* Calculate vector norm */
-double Adapter::StructureTimeAda::calculate_vector_norm(const enum Inpar::Solid::VectorNorm norm,
-    Core::LinAlg::Vector<double>& vect, const int numneglect)
+double Adapter::StructureTimeAda::calculate_vector_norm(
+    const Inpar::Solid::VectorNorm norm, Core::LinAlg::Vector<double>& vect, const int numneglect)
 {
   // L1 norm
   if (norm == Inpar::Solid::norm_l1)

--- a/src/adapter/4C_adapter_str_timeada.hpp
+++ b/src/adapter/4C_adapter_str_timeada.hpp
@@ -93,7 +93,7 @@ namespace Adapter
     void post_output() override {};
 
     //! Provide the name
-    virtual enum Inpar::Solid::TimAdaKind method_name() const = 0;
+    virtual Inpar::Solid::TimAdaKind method_name() const = 0;
 
     //! Provide the name as std::string
     virtual std::string method_title() const = 0;
@@ -113,7 +113,7 @@ namespace Adapter
     virtual double method_lin_err_coeff_vel() const = 0;
 
     //! Provide type of algorithm
-    virtual enum AdaEnum method_adapt_dis() const = 0;
+    virtual AdaEnum method_adapt_dis() const = 0;
 
    protected:
     std::shared_ptr<Solid::TimeInt::Base> stm_;  //!< marching time integrator
@@ -130,19 +130,19 @@ namespace Adapter
 
     //! @name Adaptive time integration constants
     //@{
-    double stepsizemax_;     //!< maximum time step size (upper limit)
-    double stepsizemin_;     //!< minimum time step size (lower limit)
-    double sizeratiomax_;    //!< maximally permitted increase of current step size
-                             //!< relative to last converged one
-    double sizeratiomin_;    //!< minimally permitted increase
-                             //!< (or maximally permitted decrease)
-                             //!< of current step size relative to last converged one
-    double sizeratioscale_;  //!< safety factor, should be lower than 1.0
-    enum CtrlEnum errctrl_;  //!< type of control, see #CtrlEnum
-    enum Inpar::Solid::VectorNorm errnorm_;  //!< norm for local error vector
-    double errtol_;                          //!< target local error tolerance
-    int errorder_;                           //!< order of local error indication
-    int adaptstepmax_;  //!< maximally permitted trials to find tolerable step size
+    double stepsizemax_;                //!< maximum time step size (upper limit)
+    double stepsizemin_;                //!< minimum time step size (lower limit)
+    double sizeratiomax_;               //!< maximally permitted increase of current step size
+                                        //!< relative to last converged one
+    double sizeratiomin_;               //!< minimally permitted increase
+                                        //!< (or maximally permitted decrease)
+                                        //!< of current step size relative to last converged one
+    double sizeratioscale_;             //!< safety factor, should be lower than 1.0
+    CtrlEnum errctrl_;                  //!< type of control, see #CtrlEnum
+    Inpar::Solid::VectorNorm errnorm_;  //!< norm for local error vector
+    double errtol_;                     //!< target local error tolerance
+    int errorder_;                      //!< order of local error indication
+    int adaptstepmax_;                  //!< maximally permitted trials to find tolerable step size
     //@}
 
     //! @name plain time integration variables
@@ -266,8 +266,8 @@ namespace Adapter
     );
 
     /// Determine norm of force residual
-    double calculate_vector_norm(const enum Inpar::Solid::VectorNorm norm,  ///< type of norm to use
-        Core::LinAlg::Vector<double>& vect,  ///< the vector of interest
+    double calculate_vector_norm(const Inpar::Solid::VectorNorm norm,  ///< type of norm to use
+        Core::LinAlg::Vector<double>& vect,                            ///< the vector of interest
         const int numneglect =
             0  ///< number of DOFs that have to be neglected for possible length scaling
     );

--- a/src/adapter/4C_adapter_str_timeada_joint.cpp
+++ b/src/adapter/4C_adapter_str_timeada_joint.cpp
@@ -67,14 +67,14 @@ void Adapter::StructureTimeAdaJoint::setup_auxiliary()
   dataio->setup();
 
   ///// setup datasdyn
-  std::shared_ptr<std::set<enum Inpar::Solid::ModelType>> modeltypes =
+  std::shared_ptr<std::set<Inpar::Solid::ModelType>> modeltypes =
       std::make_shared<std::set<enum Inpar::Solid::ModelType>>();
   modeltypes->insert(Inpar::Solid::model_structure);
   //
-  std::shared_ptr<std::set<enum Inpar::Solid::EleTech>> eletechs =
+  std::shared_ptr<std::set<Inpar::Solid::EleTech>> eletechs =
       std::make_shared<std::set<enum Inpar::Solid::EleTech>>();
   //
-  std::shared_ptr<std::map<enum Inpar::Solid::ModelType, std::shared_ptr<Core::LinAlg::Solver>>>
+  std::shared_ptr<std::map<Inpar::Solid::ModelType, std::shared_ptr<Core::LinAlg::Solver>>>
       linsolvers = Solid::SOLVER::build_lin_solvers(*modeltypes, adyn, *stm_->discretization());
   //
   std::shared_ptr<Solid::TimeInt::BaseDataSDyn> datasdyn = Solid::TimeInt::build_data_sdyn(adyn);
@@ -165,7 +165,7 @@ double Adapter::StructureTimeAdaJoint::method_lin_err_coeff_vel() const
 
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-enum Adapter::StructureTimeAda::AdaEnum Adapter::StructureTimeAdaJoint::method_adapt_dis() const
+Adapter::StructureTimeAda::AdaEnum Adapter::StructureTimeAdaJoint::method_adapt_dis() const
 {
   return ada_;
 }

--- a/src/adapter/4C_adapter_str_timeada_joint.hpp
+++ b/src/adapter/4C_adapter_str_timeada_joint.hpp
@@ -33,7 +33,7 @@ namespace Adapter
     explicit StructureTimeAdaJoint(std::shared_ptr<Structure> structure);
 
     //! Provide the name
-    enum Inpar::Solid::TimAdaKind method_name() const override
+    Inpar::Solid::TimAdaKind method_name() const override
     {
       return Inpar::Solid::timada_kind_joint_explicit;
     }
@@ -53,7 +53,7 @@ namespace Adapter
     double method_lin_err_coeff_vel() const override;
 
     //! Provide type of algorithm
-    enum AdaEnum method_adapt_dis() const override;
+    AdaEnum method_adapt_dis() const override;
 
     //! Override since we need to setup the auxiliary time integrator
     void post_setup() override;
@@ -64,7 +64,7 @@ namespace Adapter
 
    private:
     //! type of adaptivity algorithm
-    enum AdaEnum ada_;
+    AdaEnum ada_;
 
     //! the auxiliary integrator
     std::shared_ptr<Solid::TimeInt::Base> sta_;

--- a/src/adapter/4C_adapter_str_timeada_zienxie.hpp
+++ b/src/adapter/4C_adapter_str_timeada_zienxie.hpp
@@ -41,7 +41,7 @@ namespace Adapter
     }
 
     //! Provide the name
-    enum Inpar::Solid::TimAdaKind method_name() const override
+    Inpar::Solid::TimAdaKind method_name() const override
     {
       return Inpar::Solid::timada_kind_zienxie;
     }
@@ -61,7 +61,7 @@ namespace Adapter
     double method_lin_err_coeff_vel() const override { return -1.0 / 12.0; }
 
     //! Provide type of algorithm
-    enum AdaEnum method_adapt_dis() const override { return ada_upward; }
+    AdaEnum method_adapt_dis() const override { return ada_upward; }
 
    protected:
     /// setup of the auxiliary time integrator

--- a/src/ale/4C_ale.cpp
+++ b/src/ale/4C_ale.cpp
@@ -355,7 +355,7 @@ void ALE::Ale::evaluate_elements()
 
 /*----------------------------------------------------------------------------*/
 /*----------------------------------------------------------------------------*/
-std::string ALE::Ale::element_action_string(const enum ALE::AleDynamic name)
+std::string ALE::Ale::element_action_string(const ALE::AleDynamic name)
 {
   switch (name)
   {

--- a/src/ale/4C_ale.hpp
+++ b/src/ale/4C_ale.hpp
@@ -165,7 +165,7 @@ namespace ALE
     virtual void evaluate_elements();
 
     /// Convert element action enum to std::string
-    virtual std::string element_action_string(const enum ALE::AleDynamic name  ///< enum to convert
+    virtual std::string element_action_string(const ALE::AleDynamic name  ///< enum to convert
     );
 
     //! @name Time step helpers

--- a/src/beaminteraction/src/4C_beaminteraction_beam_to_beam_contact_params.hpp
+++ b/src/beaminteraction/src/4C_beaminteraction_beam_to_beam_contact_params.hpp
@@ -50,9 +50,9 @@ namespace BeamInteraction
       if (!is_init()) FOUR_C_THROW("init() has not been called yet!");
     }
 
-    inline enum BeamContact::Strategy strategy() const { return strategy_; }
+    inline BeamContact::Strategy strategy() const { return strategy_; }
 
-    inline enum BeamContact::PenaltyLaw penalty_law() const { return penalty_law_; }
+    inline BeamContact::PenaltyLaw penalty_law() const { return penalty_law_; }
 
     inline double beam_to_beam_penalty_law_regularization_g0() const
     {
@@ -103,10 +103,10 @@ namespace BeamInteraction
     bool issetup_;
 
     //! strategy
-    enum BeamContact::Strategy strategy_;
+    BeamContact::Strategy strategy_;
 
     //! penalty law
-    enum BeamContact::PenaltyLaw penalty_law_;
+    BeamContact::PenaltyLaw penalty_law_;
 
     //! regularization parameters for penalty law
     double btb_penalty_law_regularization_g0_;

--- a/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator.cpp
@@ -384,7 +384,7 @@ void Solid::ModelEvaluator::BeamInteraction::init_and_setup_sub_model_evaluators
 
   // model map
   me_map_ptr_ = FourC::BeamInteraction::SubmodelEvaluator::build_model_evaluators(*submodeltypes_);
-  std::vector<enum Inpar::BeamInteraction::SubModelType> sorted_submodeltypes;
+  std::vector<Inpar::BeamInteraction::SubModelType> sorted_submodeltypes;
 
   // build and sort submodel vector
   me_vec_ptr_ = transform_to_vector(*me_map_ptr_, sorted_submodeltypes);

--- a/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator.hpp
+++ b/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator.hpp
@@ -242,7 +242,7 @@ namespace Solid
       //!@name data for submodel management
       //! @{
       /// current active model types for the model evaluator
-      std::shared_ptr<std::set<enum Inpar::BeamInteraction::SubModelType>> submodeltypes_;
+      std::shared_ptr<std::set<Inpar::BeamInteraction::SubModelType>> submodeltypes_;
 
       std::shared_ptr<Solid::ModelEvaluator::BeamInteraction::Map> me_map_ptr_;
 

--- a/src/beaminteraction/src/4C_beaminteraction_submodel_evaluator_factory.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_submodel_evaluator_factory.cpp
@@ -28,13 +28,13 @@ BeamInteraction::SubmodelEvaluator::Factory::Factory()
  *----------------------------------------------------------------------------*/
 std::shared_ptr<Solid::ModelEvaluator::BeamInteraction::Map>
 BeamInteraction::SubmodelEvaluator::Factory::build_model_evaluators(
-    const std::set<enum Inpar::BeamInteraction::SubModelType>& submodeltypes) const
+    const std::set<Inpar::BeamInteraction::SubModelType>& submodeltypes) const
 {
   // create a new standard map
   std::shared_ptr<Solid::ModelEvaluator::BeamInteraction::Map> model_map =
       std::make_shared<Solid::ModelEvaluator::BeamInteraction::Map>();
 
-  std::set<enum Inpar::BeamInteraction::SubModelType>::const_iterator mt_iter;
+  std::set<Inpar::BeamInteraction::SubModelType>::const_iterator mt_iter;
   for (mt_iter = submodeltypes.begin(); mt_iter != submodeltypes.end(); ++mt_iter)
   {
     switch (*mt_iter)
@@ -68,7 +68,7 @@ BeamInteraction::SubmodelEvaluator::Factory::build_model_evaluators(
  *----------------------------------------------------------------------------*/
 std::shared_ptr<Solid::ModelEvaluator::BeamInteraction::Map>
 BeamInteraction::SubmodelEvaluator::build_model_evaluators(
-    const std::set<enum Inpar::BeamInteraction::SubModelType>& submodeltypes)
+    const std::set<Inpar::BeamInteraction::SubModelType>& submodeltypes)
 {
   Factory factory;
   return factory.build_model_evaluators(submodeltypes);

--- a/src/beaminteraction/src/4C_beaminteraction_submodel_evaluator_factory.hpp
+++ b/src/beaminteraction/src/4C_beaminteraction_submodel_evaluator_factory.hpp
@@ -36,14 +36,14 @@ namespace BeamInteraction
       virtual ~Factory() = default;
 
       std::shared_ptr<Solid::ModelEvaluator::BeamInteraction::Map> build_model_evaluators(
-          const std::set<enum Inpar::BeamInteraction::SubModelType>& submodeltypes) const;
+          const std::set<Inpar::BeamInteraction::SubModelType>& submodeltypes) const;
 
      private:
     };
 
     //! non-member function, which relates to the Solid::ModelEvaluator::Factory
     std::shared_ptr<Solid::ModelEvaluator::BeamInteraction::Map> build_model_evaluators(
-        const std::set<enum Inpar::BeamInteraction::SubModelType>& submodeltypes);
+        const std::set<Inpar::BeamInteraction::SubModelType>& submodeltypes);
 
   }  // namespace SubmodelEvaluator
 }  // namespace BeamInteraction

--- a/src/constraint_framework/4C_constraint_framework_submodelevaluator_mpc.hpp
+++ b/src/constraint_framework/4C_constraint_framework_submodelevaluator_mpc.hpp
@@ -71,10 +71,10 @@ namespace Constraints::SubmodelEvaluator
     double node_search_toler_ = 0.25;  // #ToDo: Add input parameter
 
     //! Dimension of the rve boundary
-    enum Constraints::MultiPoint::RveDimension rve_dim_;
+    Constraints::MultiPoint::RveDimension rve_dim_;
 
     //! Type of reference vector definition
-    enum Constraints::MultiPoint::RveReferenceDeformationDefinition rve_ref_type_;
+    Constraints::MultiPoint::RveReferenceDeformationDefinition rve_ref_type_;
 
     //@}
 

--- a/src/contact/src/4C_contact_abstract_strategy.cpp
+++ b/src/contact/src/4C_contact_abstract_strategy.cpp
@@ -953,7 +953,7 @@ void CONTACT::AbstractStrategy::apply_force_stiff_cmt(
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 void CONTACT::AbstractStrategy::set_state(
-    const enum Mortar::StateType& statetype, const Core::LinAlg::Vector<double>& vec)
+    const Mortar::StateType& statetype, const Core::LinAlg::Vector<double>& vec)
 {
   switch (statetype)
   {
@@ -2527,7 +2527,7 @@ void CONTACT::AbstractStrategy::evaluate(CONTACT::ParamsInterface& cparams,
 {
   pre_evaluate(cparams);
 
-  const enum Mortar::ActionType& act = cparams.get_action_type();
+  const Mortar::ActionType& act = cparams.get_action_type();
   switch (act)
   {
     // -------------------------------------------------------------------
@@ -2906,7 +2906,7 @@ CONTACT::AbstractStrategy::lagrange_multiplier_n(const bool& redist) const
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 double CONTACT::AbstractStrategy::get_potential_value(
-    const enum NOX::Nln::MeritFunction::MeritFctName mrt_type) const
+    const NOX::Nln::MeritFunction::MeritFctName mrt_type) const
 {
   FOUR_C_THROW("The currently active strategy \"{}\" does not support this method!",
       CONTACT::solving_strategy_to_string(type()));
@@ -2915,10 +2915,9 @@ double CONTACT::AbstractStrategy::get_potential_value(
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 double CONTACT::AbstractStrategy::get_linearized_potential_value_terms(
-    const Core::LinAlg::Vector<double>& dir,
-    const enum NOX::Nln::MeritFunction::MeritFctName mrt_type,
-    const enum NOX::Nln::MeritFunction::LinOrder linorder,
-    const enum NOX::Nln::MeritFunction::LinType lintype) const
+    const Core::LinAlg::Vector<double>& dir, const NOX::Nln::MeritFunction::MeritFctName mrt_type,
+    const NOX::Nln::MeritFunction::LinOrder linorder,
+    const NOX::Nln::MeritFunction::LinType lintype) const
 {
   FOUR_C_THROW("The currently active strategy \"{}\" does not support this method!",
       CONTACT::solving_strategy_to_string(type()));

--- a/src/contact/src/4C_contact_abstract_strategy.hpp
+++ b/src/contact/src/4C_contact_abstract_strategy.hpp
@@ -273,7 +273,7 @@ namespace CONTACT
 
      *  */
     virtual std::shared_ptr<const Core::LinAlg::Vector<double>> get_rhs_block_ptr(
-        const enum CONTACT::VecBlockType& bt) const
+        const CONTACT::VecBlockType& bt) const
     {
       FOUR_C_THROW("Not yet implemented!");
 
@@ -295,7 +295,7 @@ namespace CONTACT
      *
      *  */
     virtual std::shared_ptr<const Core::LinAlg::Vector<double>> get_rhs_block_ptr_for_norm_check(
-        const enum CONTACT::VecBlockType& bt) const
+        const CONTACT::VecBlockType& bt) const
     {
       return get_rhs_block_ptr(bt);
     }
@@ -325,8 +325,7 @@ namespace CONTACT
 
      *  */
     virtual std::shared_ptr<Core::LinAlg::SparseMatrix> get_matrix_block_ptr(
-        const enum CONTACT::MatBlockType& bt,
-        const CONTACT::ParamsInterface* cparams = nullptr) const
+        const CONTACT::MatBlockType& bt, const CONTACT::ParamsInterface* cparams = nullptr) const
     {
       FOUR_C_THROW("Not yet implemented!");
 
@@ -730,7 +729,7 @@ namespace CONTACT
     \param vec (in): current global state of the quantity defined by statename
     */
     void set_state(
-        const enum Mortar::StateType& statetype, const Core::LinAlg::Vector<double>& vec) override;
+        const Mortar::StateType& statetype, const Core::LinAlg::Vector<double>& vec) override;
 
     /*! \brief Evaluate reference state
 
@@ -754,14 +753,13 @@ namespace CONTACT
     //!@{
 
     /// return the potential contributions of the active contact strategy
-    virtual double get_potential_value(
-        const enum NOX::Nln::MeritFunction::MeritFctName mrt_type) const;
+    virtual double get_potential_value(const NOX::Nln::MeritFunction::MeritFctName mrt_type) const;
 
     /// return contributions of the active contact strategy to the linear model
     virtual double get_linearized_potential_value_terms(const Core::LinAlg::Vector<double>& dir,
-        const enum NOX::Nln::MeritFunction::MeritFctName mrt_type,
-        const enum NOX::Nln::MeritFunction::LinOrder linorder,
-        const enum NOX::Nln::MeritFunction::LinType lintype) const;
+        const NOX::Nln::MeritFunction::MeritFctName mrt_type,
+        const NOX::Nln::MeritFunction::LinOrder linorder,
+        const NOX::Nln::MeritFunction::LinType lintype) const;
 
     //!@}
 
@@ -822,7 +820,7 @@ namespace CONTACT
      \param dbcmaps (in): MapExtractor carrying global dbc map */
     void store_dirichlet_status(std::shared_ptr<const Core::LinAlg::MapExtractor> dbcmaps) override;
 
-    virtual void set_parent_state(const enum Mortar::StateType& statetype,
+    virtual void set_parent_state(const Mortar::StateType& statetype,
         const Core::LinAlg::Vector<double>& vec, const Core::FE::Discretization& dis) {
       /* standard contact methods don't need the corresponding bulk element */
     };

--- a/src/contact/src/4C_contact_input.hpp
+++ b/src/contact/src/4C_contact_input.hpp
@@ -50,7 +50,7 @@ namespace CONTACT
     multiscale  ///< method for contact of rough surfaces with a multi scale approach
   };
 
-  inline std::string solving_strategy_to_string(enum SolvingStrategy stype)
+  inline std::string solving_strategy_to_string(SolvingStrategy stype)
   {
     switch (stype)
     {

--- a/src/contact/src/4C_contact_integrator.hpp
+++ b/src/contact/src/4C_contact_integrator.hpp
@@ -68,7 +68,7 @@ namespace CONTACT
     Integrator(const Integrator& old) = delete;
 
     //! get specified integration type
-    inline enum Inpar::Mortar::IntType integration_type() const { return integrationtype_; }
+    inline Inpar::Mortar::IntType integration_type() const { return integrationtype_; }
 
     MPI_Comm get_comm() const { return Comm_; }
 

--- a/src/contact/src/4C_contact_interface.hpp
+++ b/src/contact/src/4C_contact_interface.hpp
@@ -78,9 +78,9 @@ namespace CONTACT
 
     inline bool& is_two_half_pass() { return two_half_pass_; }
 
-    inline enum CONTACT::ConstraintDirection& constraint_direction() { return constr_direction_; }
+    inline CONTACT::ConstraintDirection& constraint_direction() { return constr_direction_; }
 
-    [[nodiscard]] inline enum CONTACT::ConstraintDirection constraint_direction() const
+    [[nodiscard]] inline CONTACT::ConstraintDirection constraint_direction() const
     {
       return constr_direction_;
     }

--- a/src/contact/src/4C_contact_lagrange_strategy.cpp
+++ b/src/contact/src/4C_contact_lagrange_strategy.cpp
@@ -4042,7 +4042,7 @@ void CONTACT::LagrangeStrategy::eval_str_contact_rhs()
  *----------------------------------------------------------------------*/
 void CONTACT::LagrangeStrategy::pre_evaluate(CONTACT::ParamsInterface& cparams)
 {
-  const enum Mortar::ActionType& act = cparams.get_action_type();
+  const Mortar::ActionType& act = cparams.get_action_type();
 
   switch (act)
   {
@@ -4070,7 +4070,7 @@ void CONTACT::LagrangeStrategy::pre_evaluate(CONTACT::ParamsInterface& cparams)
  *----------------------------------------------------------------------*/
 void CONTACT::LagrangeStrategy::post_evaluate(CONTACT::ParamsInterface& cparams)
 {
-  const enum Mortar::ActionType& act = cparams.get_action_type();
+  const Mortar::ActionType& act = cparams.get_action_type();
 
   switch (act)
   {
@@ -4113,7 +4113,7 @@ void CONTACT::LagrangeStrategy::evaluate_force_stiff(CONTACT::ParamsInterface& c
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 std::shared_ptr<Core::LinAlg::SparseMatrix> CONTACT::LagrangeStrategy::get_matrix_block_ptr(
-    const enum CONTACT::MatBlockType& bt, const ParamsInterface* cparams) const
+    const CONTACT::MatBlockType& bt, const ParamsInterface* cparams) const
 {
   // if there are no active LM contact contributions
   if (!is_in_contact() && !was_in_contact() && !was_in_contact_last_time_step())
@@ -4313,7 +4313,7 @@ void CONTACT::LagrangeStrategy::run_post_compute_x(const CONTACT::ParamsInterfac
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 std::shared_ptr<const Core::LinAlg::Vector<double>> CONTACT::LagrangeStrategy::get_rhs_block_ptr(
-    const enum CONTACT::VecBlockType& bt) const
+    const CONTACT::VecBlockType& bt) const
 {
   // if there are no active LM contact contributions
   if (!is_in_contact() && !was_in_contact() && !was_in_contact_last_time_step())

--- a/src/contact/src/4C_contact_lagrange_strategy.hpp
+++ b/src/contact/src/4C_contact_lagrange_strategy.hpp
@@ -78,7 +78,7 @@ namespace CONTACT
      *
      *  \param bt (in): Desired vector block type, e.g. displ, constraint,*/
     std::shared_ptr<const Core::LinAlg::Vector<double>> get_rhs_block_ptr(
-        const enum CONTACT::VecBlockType& bt) const override;
+        const CONTACT::VecBlockType& bt) const override;
 
 
     /*! \brief recover the current state
@@ -111,7 +111,7 @@ namespace CONTACT
      *  \param bt (in): Desired matrix block type, e.g. displ_displ, displ_lm, ...
      *  \param cparams (in): contact parameter interface (read-only) */
     std::shared_ptr<Core::LinAlg::SparseMatrix> get_matrix_block_ptr(
-        const enum CONTACT::MatBlockType& bt,
+        const CONTACT::MatBlockType& bt,
         const CONTACT::ParamsInterface* cparams = nullptr) const override;
 
     /*! \brief Apply modifications (e.g. condensation) directly before linear solve

--- a/src/contact/src/4C_contact_lagrange_strategy_poro.cpp
+++ b/src/contact/src/4C_contact_lagrange_strategy_poro.cpp
@@ -1263,7 +1263,7 @@ void CONTACT::LagrangeStrategyPoro::update_poro_contact()
  | Assign general poro contact state!                          ager 08/14|
  *------------------------------------------------------------------------*/
 void CONTACT::LagrangeStrategyPoro::set_state(
-    const enum Mortar::StateType& statetype, const Core::LinAlg::Vector<double>& vec)
+    const Mortar::StateType& statetype, const Core::LinAlg::Vector<double>& vec)
 {
   switch (statetype)
   {
@@ -1391,7 +1391,7 @@ void CONTACT::LagrangeStrategyPoro::set_state(
 /*------------------------------------------------------------------------*
  | Assign general poro contact state!                          ager 10/14|
  *------------------------------------------------------------------------*/
-void CONTACT::LagrangeStrategyPoro::set_parent_state(const enum Mortar::StateType& statetype,
+void CONTACT::LagrangeStrategyPoro::set_parent_state(const Mortar::StateType& statetype,
     const Core::LinAlg::Vector<double>& vec, const Core::FE::Discretization& dis)
 {
   if (statetype == Mortar::StateType::state_new_displacement)

--- a/src/contact/src/4C_contact_lagrange_strategy_poro.hpp
+++ b/src/contact/src/4C_contact_lagrange_strategy_poro.hpp
@@ -159,9 +159,9 @@ namespace CONTACT
     overview) \param vec (in): current global state of the quantity defined by statetype
     */
     void set_state(
-        const enum Mortar::StateType& statetype, const Core::LinAlg::Vector<double>& vec) override;
+        const Mortar::StateType& statetype, const Core::LinAlg::Vector<double>& vec) override;
 
-    void set_parent_state(const enum Mortar::StateType& statetype,
+    void set_parent_state(const Mortar::StateType& statetype,
         const Core::LinAlg::Vector<double>& vec, const Core::FE::Discretization& dis) override;
 
     // Flag for Poro No Penetration Condition

--- a/src/contact/src/4C_contact_lagrange_strategy_tsi.cpp
+++ b/src/contact/src/4C_contact_lagrange_strategy_tsi.cpp
@@ -45,7 +45,7 @@ CONTACT::LagrangeStrategyTsi::LagrangeStrategyTsi(
  | Assign general thermo contact state                         seitz 08/15|
  *------------------------------------------------------------------------*/
 void CONTACT::LagrangeStrategyTsi::set_state(
-    const enum Mortar::StateType& statetype, const Core::LinAlg::Vector<double>& vec)
+    const Mortar::StateType& statetype, const Core::LinAlg::Vector<double>& vec)
 {
   switch (statetype)
   {

--- a/src/contact/src/4C_contact_lagrange_strategy_tsi.hpp
+++ b/src/contact/src/4C_contact_lagrange_strategy_tsi.hpp
@@ -79,7 +79,7 @@ namespace CONTACT
       an overview) \param vec (in): current global state of the quantity defined by statetype
      */
     void set_state(
-        const enum Mortar::StateType& statetype, const Core::LinAlg::Vector<double>& vec) override;
+        const Mortar::StateType& statetype, const Core::LinAlg::Vector<double>& vec) override;
 
     // Overload CONTACT::AbstractStrategy::apply_force_stiff_cmt as this is called in the structure
     // --> to early for monolithically coupled algorithms!

--- a/src/contact/src/4C_contact_meshtying_abstract_strategy.cpp
+++ b/src/contact/src/4C_contact_meshtying_abstract_strategy.cpp
@@ -278,7 +278,7 @@ void CONTACT::MtAbstractStrategy::apply_force_stiff_cmt(
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 void CONTACT::MtAbstractStrategy::set_state(
-    const enum Mortar::StateType& statetype, const Core::LinAlg::Vector<double>& vec)
+    const Mortar::StateType& statetype, const Core::LinAlg::Vector<double>& vec)
 {
   switch (statetype)
   {

--- a/src/contact/src/4C_contact_meshtying_abstract_strategy.hpp
+++ b/src/contact/src/4C_contact_meshtying_abstract_strategy.hpp
@@ -252,7 +252,7 @@ namespace CONTACT
 
     */
     void set_state(
-        const enum Mortar::StateType& statetype, const Core::LinAlg::Vector<double>& vec) override;
+        const Mortar::StateType& statetype, const Core::LinAlg::Vector<double>& vec) override;
 
     /*!
     \brief Do mortar coupling in reference configuration
@@ -519,7 +519,7 @@ namespace CONTACT
 
      *  */
     virtual std::shared_ptr<const Core::LinAlg::Vector<double>> get_rhs_block_ptr(
-        const enum CONTACT::VecBlockType& bt) const = 0;
+        const CONTACT::VecBlockType& bt) const = 0;
 
     /*! \brief Return the desired matrix block pointer (read-only)
      *
@@ -531,7 +531,7 @@ namespace CONTACT
 
      *  */
     virtual std::shared_ptr<Core::LinAlg::SparseMatrix> get_matrix_block_ptr(
-        const enum CONTACT::MatBlockType& bt) const = 0;
+        const CONTACT::MatBlockType& bt) const = 0;
 
     /*! \brief Return the current (maybe redistributed) Lagrange multiplier dof row map
      *

--- a/src/contact/src/4C_contact_meshtying_lagrange_strategy.cpp
+++ b/src/contact/src/4C_contact_meshtying_lagrange_strategy.cpp
@@ -1085,7 +1085,7 @@ bool CONTACT::MtLagrangeStrategy::evaluate_force_stiff(
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 std::shared_ptr<const Core::LinAlg::Vector<double>> CONTACT::MtLagrangeStrategy::get_rhs_block_ptr(
-    const enum CONTACT::VecBlockType& bt) const
+    const CONTACT::VecBlockType& bt) const
 {
   std::shared_ptr<Core::LinAlg::Vector<double>> vec_ptr = nullptr;
   switch (bt)
@@ -1111,7 +1111,7 @@ std::shared_ptr<const Core::LinAlg::Vector<double>> CONTACT::MtLagrangeStrategy:
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 std::shared_ptr<Core::LinAlg::SparseMatrix> CONTACT::MtLagrangeStrategy::get_matrix_block_ptr(
-    const enum CONTACT::MatBlockType& bt) const
+    const CONTACT::MatBlockType& bt) const
 {
   std::shared_ptr<Core::LinAlg::SparseMatrix> mat_ptr = nullptr;
   switch (bt)

--- a/src/contact/src/4C_contact_meshtying_lagrange_strategy.hpp
+++ b/src/contact/src/4C_contact_meshtying_lagrange_strategy.hpp
@@ -187,11 +187,11 @@ namespace CONTACT
 
     //! Return the desired right-hand-side block pointer (read-only) [derived]
     std::shared_ptr<const Core::LinAlg::Vector<double>> get_rhs_block_ptr(
-        const enum CONTACT::VecBlockType& bt) const override;
+        const CONTACT::VecBlockType& bt) const override;
 
     //! Return the desired matrix block pointer (read-only) [derived]
     std::shared_ptr<Core::LinAlg::SparseMatrix> get_matrix_block_ptr(
-        const enum CONTACT::MatBlockType& bt) const override;
+        const CONTACT::MatBlockType& bt) const override;
 
     /*! \brief Modify system before linear solve
      *

--- a/src/contact/src/4C_contact_meshtying_penalty_strategy.cpp
+++ b/src/contact/src/4C_contact_meshtying_penalty_strategy.cpp
@@ -451,7 +451,7 @@ bool CONTACT::MtPenaltyStrategy::evaluate_force_stiff(
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 std::shared_ptr<const Core::LinAlg::Vector<double>> CONTACT::MtPenaltyStrategy::get_rhs_block_ptr(
-    const enum CONTACT::VecBlockType& bt) const
+    const CONTACT::VecBlockType& bt) const
 {
   std::shared_ptr<Core::LinAlg::Vector<double>> vec_ptr = nullptr;
   switch (bt)
@@ -475,7 +475,7 @@ std::shared_ptr<const Core::LinAlg::Vector<double>> CONTACT::MtPenaltyStrategy::
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 std::shared_ptr<Core::LinAlg::SparseMatrix> CONTACT::MtPenaltyStrategy::get_matrix_block_ptr(
-    const enum CONTACT::MatBlockType& bt) const
+    const CONTACT::MatBlockType& bt) const
 {
   std::shared_ptr<Core::LinAlg::SparseMatrix> mat_ptr = nullptr;
   switch (bt)

--- a/src/contact/src/4C_contact_meshtying_penalty_strategy.hpp
+++ b/src/contact/src/4C_contact_meshtying_penalty_strategy.hpp
@@ -222,11 +222,11 @@ namespace CONTACT
 
     //! Return the desired right-hand-side block pointer (read-only) [derived]
     std::shared_ptr<const Core::LinAlg::Vector<double>> get_rhs_block_ptr(
-        const enum CONTACT::VecBlockType& bt) const override;
+        const CONTACT::VecBlockType& bt) const override;
 
     //! Return the desired matrix block pointer (read-only) [derived]
     std::shared_ptr<Core::LinAlg::SparseMatrix> get_matrix_block_ptr(
-        const enum CONTACT::MatBlockType& bt) const override;
+        const CONTACT::MatBlockType& bt) const override;
 
     //@}
 

--- a/src/contact/src/4C_contact_nitsche_strategy.cpp
+++ b/src/contact/src/4C_contact_nitsche_strategy.cpp
@@ -102,7 +102,7 @@ void CONTACT::NitscheStrategy::do_read_restart(Core::IO::DiscretizationReader& r
 }
 
 void CONTACT::NitscheStrategy::set_state(
-    const enum Mortar::StateType& statename, const Core::LinAlg::Vector<double>& vec)
+    const Mortar::StateType& statename, const Core::LinAlg::Vector<double>& vec)
 {
   if (statename == Mortar::state_new_displacement)
   {
@@ -141,7 +141,7 @@ void CONTACT::NitscheStrategy::set_state(
 /*------------------------------------------------------------------------*
  |                                                             seitz 10/16|
  *------------------------------------------------------------------------*/
-void CONTACT::NitscheStrategy::set_parent_state(const enum Mortar::StateType& statename,
+void CONTACT::NitscheStrategy::set_parent_state(const Mortar::StateType& statename,
     const Core::LinAlg::Vector<double>& vec, const Core::FE::Discretization& dis)
 {
   if (statename == Mortar::state_new_displacement || statename == Mortar::state_svelocity)
@@ -244,7 +244,7 @@ void CONTACT::NitscheStrategy::integrate(const CONTACT::ParamsInterface& cparams
 }
 
 std::shared_ptr<Core::LinAlg::FEVector<double>> CONTACT::NitscheStrategy::setup_rhs_block_vec(
-    const enum CONTACT::VecBlockType& bt) const
+    const CONTACT::VecBlockType& bt) const
 {
   switch (bt)
   {
@@ -259,7 +259,7 @@ std::shared_ptr<Core::LinAlg::FEVector<double>> CONTACT::NitscheStrategy::setup_
 }
 
 std::shared_ptr<Core::LinAlg::FEVector<double>> CONTACT::NitscheStrategy::create_rhs_block_ptr(
-    const enum CONTACT::VecBlockType& bt) const
+    const CONTACT::VecBlockType& bt) const
 {
   if (!curr_state_eval_) FOUR_C_THROW("you didn't evaluate this contact state first");
 
@@ -281,7 +281,7 @@ std::shared_ptr<Core::LinAlg::FEVector<double>> CONTACT::NitscheStrategy::create
 }
 
 std::shared_ptr<const Core::LinAlg::Vector<double>> CONTACT::NitscheStrategy::get_rhs_block_ptr(
-    const enum CONTACT::VecBlockType& bt) const
+    const CONTACT::VecBlockType& bt) const
 {
   if (!curr_state_eval_)
     FOUR_C_THROW(
@@ -302,7 +302,7 @@ std::shared_ptr<const Core::LinAlg::Vector<double>> CONTACT::NitscheStrategy::ge
 }
 
 std::shared_ptr<Core::LinAlg::SparseMatrix> CONTACT::NitscheStrategy::setup_matrix_block_ptr(
-    const enum CONTACT::MatBlockType& bt)
+    const CONTACT::MatBlockType& bt)
 {
   switch (bt)
   {
@@ -318,7 +318,7 @@ std::shared_ptr<Core::LinAlg::SparseMatrix> CONTACT::NitscheStrategy::setup_matr
 }
 
 void CONTACT::NitscheStrategy::complete_matrix_block_ptr(
-    const enum CONTACT::MatBlockType& bt, std::shared_ptr<Core::LinAlg::SparseMatrix> kc)
+    const CONTACT::MatBlockType& bt, std::shared_ptr<Core::LinAlg::SparseMatrix> kc)
 {
   switch (bt)
   {
@@ -332,7 +332,7 @@ void CONTACT::NitscheStrategy::complete_matrix_block_ptr(
 }
 
 std::shared_ptr<Core::LinAlg::SparseMatrix> CONTACT::NitscheStrategy::create_matrix_block_ptr(
-    const enum CONTACT::MatBlockType& bt)
+    const CONTACT::MatBlockType& bt)
 {
   if (!curr_state_eval_) FOUR_C_THROW("you didn't evaluate this contact state first");
 
@@ -354,7 +354,7 @@ std::shared_ptr<Core::LinAlg::SparseMatrix> CONTACT::NitscheStrategy::create_mat
 }
 
 std::shared_ptr<Core::LinAlg::SparseMatrix> CONTACT::NitscheStrategy::get_matrix_block_ptr(
-    const enum CONTACT::MatBlockType& bt, const CONTACT::ParamsInterface* cparams) const
+    const CONTACT::MatBlockType& bt, const CONTACT::ParamsInterface* cparams) const
 {
   if (!curr_state_eval_) FOUR_C_THROW("you didn't evaluate this contact state first");
 

--- a/src/contact/src/4C_contact_nitsche_strategy.hpp
+++ b/src/contact/src/4C_contact_nitsche_strategy.hpp
@@ -81,10 +81,10 @@ namespace CONTACT
     virtual void integrate(const CONTACT::ParamsInterface& cparams);
 
     std::shared_ptr<const Core::LinAlg::Vector<double>> get_rhs_block_ptr(
-        const enum CONTACT::VecBlockType& bt) const override;
+        const CONTACT::VecBlockType& bt) const override;
 
     std::shared_ptr<Core::LinAlg::SparseMatrix> get_matrix_block_ptr(
-        const enum CONTACT::MatBlockType& bt, const ParamsInterface* cparams) const override;
+        const CONTACT::MatBlockType& bt, const ParamsInterface* cparams) const override;
 
     /*! \brief Setup this strategy object (maps, vectors, etc.)
 
@@ -115,7 +115,7 @@ namespace CONTACT
     void compute_contact_stresses() final { /* nothing stress output in nitsche strategy yet */ };
     virtual void reconnect_parent_elements();
     void set_state(
-        const enum Mortar::StateType& statename, const Core::LinAlg::Vector<double>& vec) override;
+        const Mortar::StateType& statename, const Core::LinAlg::Vector<double>& vec) override;
 
     /*!
      * @brief  Set the parent state
@@ -124,7 +124,7 @@ namespace CONTACT
      * @param[in] vec        corresponding state vector
      * @param[in] dis        corresponding discretization
      */
-    void set_parent_state(const enum Mortar::StateType& statename,
+    void set_parent_state(const Mortar::StateType& statename,
         const Core::LinAlg::Vector<double>& vec, const Core::FE::Discretization& dis) override;
 
     std::shared_ptr<const Core::LinAlg::Vector<double>> lagrange_multiplier_n(
@@ -236,7 +236,7 @@ namespace CONTACT
      * @return the filled RHS vector of given vector block type
      */
     virtual std::shared_ptr<Core::LinAlg::FEVector<double>> create_rhs_block_ptr(
-        const enum CONTACT::VecBlockType& bt) const;
+        const CONTACT::VecBlockType& bt) const;
 
     /*!
      * @brief  Create an appropriate vector for the RHS
@@ -245,7 +245,7 @@ namespace CONTACT
      * @return  vector for given vector block type
      */
     virtual std::shared_ptr<Core::LinAlg::FEVector<double>> setup_rhs_block_vec(
-        const enum CONTACT::VecBlockType& bt) const;
+        const CONTACT::VecBlockType& bt) const;
 
     /*!
      * @brief Create appropriate matrix block
@@ -254,7 +254,7 @@ namespace CONTACT
      * @return matrix block for given matrix block type
      */
     virtual std::shared_ptr<Core::LinAlg::SparseMatrix> setup_matrix_block_ptr(
-        const enum MatBlockType& bt);
+        const MatBlockType& bt);
 
     /*!
      * @brief Complete the matrix block with correct maps
@@ -263,7 +263,7 @@ namespace CONTACT
      * @param[in,out] kc  matrix block of given matrix block type that has to be completed
      */
     virtual void complete_matrix_block_ptr(
-        const enum MatBlockType& bt, std::shared_ptr<Core::LinAlg::SparseMatrix> kc);
+        const MatBlockType& bt, std::shared_ptr<Core::LinAlg::SparseMatrix> kc);
 
     /*!
      * @brief Fill block matrix of given matrix block type
@@ -272,7 +272,7 @@ namespace CONTACT
      * @return the filled block matrix of given matrix block type
      */
     virtual std::shared_ptr<Core::LinAlg::SparseMatrix> create_matrix_block_ptr(
-        const enum MatBlockType& bt);
+        const MatBlockType& bt);
 
     std::vector<std::shared_ptr<CONTACT::Interface>> interface_;
 

--- a/src/contact/src/4C_contact_nitsche_strategy_fpi.cpp
+++ b/src/contact/src/4C_contact_nitsche_strategy_fpi.cpp
@@ -14,7 +14,7 @@ FOUR_C_NAMESPACE_OPEN
 
 
 void CONTACT::NitscheStrategyFpi::set_state(
-    const enum Mortar::StateType& statename, const Core::LinAlg::Vector<double>& vec)
+    const Mortar::StateType& statename, const Core::LinAlg::Vector<double>& vec)
 {
   CONTACT::NitscheStrategyPoro::set_state(statename, vec);
   if (statename == Mortar::state_new_displacement)

--- a/src/contact/src/4C_contact_nitsche_strategy_fpi.hpp
+++ b/src/contact/src/4C_contact_nitsche_strategy_fpi.hpp
@@ -63,7 +63,7 @@ namespace CONTACT
     }
     //! Set Contact State and update search tree and normals
     void set_state(
-        const enum Mortar::StateType& statename, const Core::LinAlg::Vector<double>& vec) override;
+        const Mortar::StateType& statename, const Core::LinAlg::Vector<double>& vec) override;
 
     //! The the contact state at local coord of Element cele and compare to the fsi_traction,
     //! return true if contact is evaluated, return false if FSI is evaluated

--- a/src/contact/src/4C_contact_nitsche_strategy_fsi.cpp
+++ b/src/contact/src/4C_contact_nitsche_strategy_fsi.cpp
@@ -27,7 +27,7 @@ void CONTACT::NitscheStrategyFsi::apply_force_stiff_cmt(
 }
 
 void CONTACT::NitscheStrategyFsi::set_state(
-    const enum Mortar::StateType& statename, const Core::LinAlg::Vector<double>& vec)
+    const Mortar::StateType& statename, const Core::LinAlg::Vector<double>& vec)
 {
   CONTACT::NitscheStrategy::set_state(statename, vec);
   if (statename == Mortar::state_new_displacement)

--- a/src/contact/src/4C_contact_nitsche_strategy_fsi.hpp
+++ b/src/contact/src/4C_contact_nitsche_strategy_fsi.hpp
@@ -69,7 +69,7 @@ namespace CONTACT
 
     //! Set Contact State and update search tree and normals
     void set_state(
-        const enum Mortar::StateType& statename, const Core::LinAlg::Vector<double>& vec) override;
+        const Mortar::StateType& statename, const Core::LinAlg::Vector<double>& vec) override;
 
     //! The the contact state at local coord of Element cele and compare to the fsi_traction,
     //! return true if contact is evaluated, return false if FSI is evaluated

--- a/src/contact/src/4C_contact_nitsche_strategy_poro.cpp
+++ b/src/contact/src/4C_contact_nitsche_strategy_poro.cpp
@@ -57,7 +57,7 @@ void CONTACT::NitscheStrategyPoro::integrate(const CONTACT::ParamsInterface& cpa
 }
 
 void CONTACT::NitscheStrategyPoro::set_state(
-    const enum Mortar::StateType& statename, const Core::LinAlg::Vector<double>& vec)
+    const Mortar::StateType& statename, const Core::LinAlg::Vector<double>& vec)
 {
   if (statename == Mortar::state_svelocity)
   {
@@ -70,7 +70,7 @@ void CONTACT::NitscheStrategyPoro::set_state(
     CONTACT::NitscheStrategy::set_state(statename, vec);
 }
 
-void CONTACT::NitscheStrategyPoro::set_parent_state(const enum Mortar::StateType& statename,
+void CONTACT::NitscheStrategyPoro::set_parent_state(const Mortar::StateType& statename,
     const Core::LinAlg::Vector<double>& vec, const Core::FE::Discretization& dis)
 {
   //
@@ -125,7 +125,7 @@ void CONTACT::NitscheStrategyPoro::set_parent_state(const enum Mortar::StateType
 }
 
 std::shared_ptr<Core::LinAlg::FEVector<double>> CONTACT::NitscheStrategyPoro::setup_rhs_block_vec(
-    const enum CONTACT::VecBlockType& bt) const
+    const CONTACT::VecBlockType& bt) const
 {
   switch (bt)
   {
@@ -138,7 +138,7 @@ std::shared_ptr<Core::LinAlg::FEVector<double>> CONTACT::NitscheStrategyPoro::se
 }
 
 std::shared_ptr<const Core::LinAlg::Vector<double>> CONTACT::NitscheStrategyPoro::get_rhs_block_ptr(
-    const enum CONTACT::VecBlockType& bp) const
+    const CONTACT::VecBlockType& bp) const
 {
   if (!curr_state_eval_) FOUR_C_THROW("you didn't evaluate this contact state first");
 
@@ -153,7 +153,7 @@ std::shared_ptr<const Core::LinAlg::Vector<double>> CONTACT::NitscheStrategyPoro
 }
 
 std::shared_ptr<Core::LinAlg::SparseMatrix> CONTACT::NitscheStrategyPoro::setup_matrix_block_ptr(
-    const enum CONTACT::MatBlockType& bt)
+    const CONTACT::MatBlockType& bt)
 {
   switch (bt)
   {
@@ -172,7 +172,7 @@ std::shared_ptr<Core::LinAlg::SparseMatrix> CONTACT::NitscheStrategyPoro::setup_
 }
 
 void CONTACT::NitscheStrategyPoro::complete_matrix_block_ptr(
-    const enum CONTACT::MatBlockType& bt, std::shared_ptr<Core::LinAlg::SparseMatrix> kc)
+    const CONTACT::MatBlockType& bt, std::shared_ptr<Core::LinAlg::SparseMatrix> kc)
 {
   switch (bt)
   {
@@ -194,7 +194,7 @@ void CONTACT::NitscheStrategyPoro::complete_matrix_block_ptr(
 }
 
 std::shared_ptr<Core::LinAlg::SparseMatrix> CONTACT::NitscheStrategyPoro::get_matrix_block_ptr(
-    const enum CONTACT::MatBlockType& bp) const
+    const CONTACT::MatBlockType& bp) const
 {
   if (!curr_state_eval_) FOUR_C_THROW("you didn't evaluate this contact state first");
 

--- a/src/contact/src/4C_contact_nitsche_strategy_poro.hpp
+++ b/src/contact/src/4C_contact_nitsche_strategy_poro.hpp
@@ -58,16 +58,16 @@ namespace CONTACT
     void integrate(const CONTACT::ParamsInterface& cparams) override;
 
     void set_state(
-        const enum Mortar::StateType& statename, const Core::LinAlg::Vector<double>& vec) override;
+        const Mortar::StateType& statename, const Core::LinAlg::Vector<double>& vec) override;
 
-    void set_parent_state(const enum Mortar::StateType& statename,
+    void set_parent_state(const Mortar::StateType& statename,
         const Core::LinAlg::Vector<double>& vec, const Core::FE::Discretization& dis) override;
 
     std::shared_ptr<const Core::LinAlg::Vector<double>> get_rhs_block_ptr(
-        const enum CONTACT::VecBlockType& bp) const override;
+        const CONTACT::VecBlockType& bp) const override;
 
     virtual std::shared_ptr<Core::LinAlg::SparseMatrix> get_matrix_block_ptr(
-        const enum CONTACT::MatBlockType& bp) const;
+        const CONTACT::MatBlockType& bp) const;
 
 
     // Flag for Poro No Penetration Condition
@@ -80,15 +80,15 @@ namespace CONTACT
    protected:
     // create an appropriate vector for the RHS
     std::shared_ptr<Core::LinAlg::FEVector<double>> setup_rhs_block_vec(
-        const enum CONTACT::VecBlockType& bt) const override;
+        const CONTACT::VecBlockType& bt) const override;
 
     // create an appropriate matrix block
     std::shared_ptr<Core::LinAlg::SparseMatrix> setup_matrix_block_ptr(
-        const enum CONTACT::MatBlockType& bt) override;
+        const CONTACT::MatBlockType& bt) override;
 
     // complete matrix block with correct maps
-    void complete_matrix_block_ptr(const enum CONTACT::MatBlockType& bt,
-        std::shared_ptr<Core::LinAlg::SparseMatrix> kc) override;
+    void complete_matrix_block_ptr(
+        const CONTACT::MatBlockType& bt, std::shared_ptr<Core::LinAlg::SparseMatrix> kc) override;
 
     bool no_penetration_;
 

--- a/src/contact/src/4C_contact_nitsche_strategy_ssi.cpp
+++ b/src/contact/src/4C_contact_nitsche_strategy_ssi.cpp
@@ -46,7 +46,7 @@ void CONTACT::NitscheStrategySsi::evaluate_reference_state()
 /*------------------------------------------------------------------------*
 /-------------------------------------------------------------------------*/
 void CONTACT::NitscheStrategySsi::set_state(
-    const enum Mortar::StateType& statename, const Core::LinAlg::Vector<double>& vec)
+    const Mortar::StateType& statename, const Core::LinAlg::Vector<double>& vec)
 {
   switch (statename)
   {
@@ -87,7 +87,7 @@ void CONTACT::NitscheStrategySsi::set_state(
 
 /*------------------------------------------------------------------------*
 /-------------------------------------------------------------------------*/
-void CONTACT::NitscheStrategySsi::set_parent_state(const enum Mortar::StateType& statename,
+void CONTACT::NitscheStrategySsi::set_parent_state(const Mortar::StateType& statename,
     const Core::LinAlg::Vector<double>& vec, const Core::FE::Discretization& dis)
 {
   switch (statename)
@@ -143,7 +143,7 @@ void CONTACT::NitscheStrategySsi::set_parent_state(const enum Mortar::StateType&
 /*------------------------------------------------------------------------*
 /-------------------------------------------------------------------------*/
 std::shared_ptr<Core::LinAlg::FEVector<double>> CONTACT::NitscheStrategySsi::setup_rhs_block_vec(
-    const enum CONTACT::VecBlockType& bt) const
+    const CONTACT::VecBlockType& bt) const
 {
   switch (bt)
   {
@@ -159,7 +159,7 @@ std::shared_ptr<Core::LinAlg::FEVector<double>> CONTACT::NitscheStrategySsi::set
 /*------------------------------------------------------------------------*
 /-------------------------------------------------------------------------*/
 std::shared_ptr<const Core::LinAlg::Vector<double>> CONTACT::NitscheStrategySsi::get_rhs_block_ptr(
-    const enum CONTACT::VecBlockType& bp) const
+    const CONTACT::VecBlockType& bp) const
 {
   if (bp == CONTACT::VecBlockType::constraint) return nullptr;
 
@@ -181,7 +181,7 @@ std::shared_ptr<const Core::LinAlg::Vector<double>> CONTACT::NitscheStrategySsi:
 /*------------------------------------------------------------------------*
 /-------------------------------------------------------------------------*/
 std::shared_ptr<Core::LinAlg::SparseMatrix> CONTACT::NitscheStrategySsi::setup_matrix_block_ptr(
-    const enum CONTACT::MatBlockType& bt)
+    const CONTACT::MatBlockType& bt)
 {
   switch (bt)
   {
@@ -205,7 +205,7 @@ std::shared_ptr<Core::LinAlg::SparseMatrix> CONTACT::NitscheStrategySsi::setup_m
 /*------------------------------------------------------------------------*
 /-------------------------------------------------------------------------*/
 void CONTACT::NitscheStrategySsi::complete_matrix_block_ptr(
-    const enum CONTACT::MatBlockType& bt, std::shared_ptr<Core::LinAlg::SparseMatrix> kc)
+    const CONTACT::MatBlockType& bt, std::shared_ptr<Core::LinAlg::SparseMatrix> kc)
 {
   switch (bt)
   {
@@ -232,7 +232,7 @@ void CONTACT::NitscheStrategySsi::complete_matrix_block_ptr(
 /*------------------------------------------------------------------------*
 /-------------------------------------------------------------------------*/
 std::shared_ptr<Core::LinAlg::SparseMatrix> CONTACT::NitscheStrategySsi::get_matrix_block_ptr(
-    const enum CONTACT::MatBlockType& bp) const
+    const CONTACT::MatBlockType& bp) const
 {
   if (!curr_state_eval_) FOUR_C_THROW("you didn't evaluate this contact state first");
 

--- a/src/contact/src/4C_contact_nitsche_strategy_ssi.hpp
+++ b/src/contact/src/4C_contact_nitsche_strategy_ssi.hpp
@@ -65,13 +65,13 @@ namespace CONTACT
     void integrate(const CONTACT::ParamsInterface& cparams) override;
 
     void set_state(
-        const enum Mortar::StateType& statename, const Core::LinAlg::Vector<double>& vec) override;
+        const Mortar::StateType& statename, const Core::LinAlg::Vector<double>& vec) override;
 
-    void set_parent_state(const enum Mortar::StateType& statename,
+    void set_parent_state(const Mortar::StateType& statename,
         const Core::LinAlg::Vector<double>& vec, const Core::FE::Discretization& dis) override;
 
     std::shared_ptr<const Core::LinAlg::Vector<double>> get_rhs_block_ptr(
-        const enum CONTACT::VecBlockType& bp) const override;
+        const CONTACT::VecBlockType& bp) const override;
 
     /*!
      * @brief get the pointer to the matrix block
@@ -80,7 +80,7 @@ namespace CONTACT
      * @return pointer to matrix block
      */
     std::shared_ptr<Core::LinAlg::SparseMatrix> get_matrix_block_ptr(
-        const enum CONTACT::MatBlockType& bp) const;
+        const CONTACT::MatBlockType& bp) const;
 
     //! don't want = operator
     NitscheStrategySsi operator=(const NitscheStrategySsi& old) = delete;
@@ -89,13 +89,13 @@ namespace CONTACT
 
    protected:
     std::shared_ptr<Core::LinAlg::FEVector<double>> setup_rhs_block_vec(
-        const enum CONTACT::VecBlockType& bt) const override;
+        const CONTACT::VecBlockType& bt) const override;
 
     std::shared_ptr<Core::LinAlg::SparseMatrix> setup_matrix_block_ptr(
-        const enum CONTACT::MatBlockType& bt) override;
+        const CONTACT::MatBlockType& bt) override;
 
-    void complete_matrix_block_ptr(const enum CONTACT::MatBlockType& bt,
-        std::shared_ptr<Core::LinAlg::SparseMatrix> kc) override;
+    void complete_matrix_block_ptr(
+        const CONTACT::MatBlockType& bt, std::shared_ptr<Core::LinAlg::SparseMatrix> kc) override;
 
     //! current scalar state vector
     std::shared_ptr<Core::LinAlg::Vector<double>> curr_state_scalar_;

--- a/src/contact/src/4C_contact_noxinterface.cpp
+++ b/src/contact/src/4C_contact_noxinterface.cpp
@@ -296,7 +296,7 @@ enum ::NOX::StatusTest::StatusType CONTACT::NoxInterface::get_active_set_info(
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 Teuchos::RCP<const Core::LinAlg::Map> CONTACT::NoxInterface::get_current_active_set_map(
-    enum NOX::Nln::StatusTest::QuantityType checkQuantity) const
+    NOX::Nln::StatusTest::QuantityType checkQuantity) const
 {
   switch (checkQuantity)
   {
@@ -323,7 +323,7 @@ Teuchos::RCP<const Core::LinAlg::Map> CONTACT::NoxInterface::get_current_active_
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 Teuchos::RCP<const Core::LinAlg::Map> CONTACT::NoxInterface::get_old_active_set_map(
-    enum NOX::Nln::StatusTest::QuantityType checkQuantity) const
+    NOX::Nln::StatusTest::QuantityType checkQuantity) const
 {
   switch (checkQuantity)
   {
@@ -376,9 +376,9 @@ double CONTACT::NoxInterface::get_model_value(NOX::Nln::MeritFunction::MeritFctN
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 double CONTACT::NoxInterface::get_linearized_model_terms(const Core::LinAlg::Vector<double>& dir,
-    const enum NOX::Nln::MeritFunction::MeritFctName name,
-    const enum NOX::Nln::MeritFunction::LinOrder linorder,
-    const enum NOX::Nln::MeritFunction::LinType lintype) const
+    const NOX::Nln::MeritFunction::MeritFctName name,
+    const NOX::Nln::MeritFunction::LinOrder linorder,
+    const NOX::Nln::MeritFunction::LinType lintype) const
 {
   switch (name)
   {

--- a/src/contact/src/4C_contact_noxinterface.hpp
+++ b/src/contact/src/4C_contact_noxinterface.hpp
@@ -59,15 +59,15 @@ namespace CONTACT
 
     /// Returns the active set info [derived]
     enum ::NOX::StatusTest::StatusType get_active_set_info(
-        enum NOX::Nln::StatusTest::QuantityType checkQuantity, int& activesetsize) const override;
+        NOX::Nln::StatusTest::QuantityType checkQuantity, int& activesetsize) const override;
 
     /// Returns the current active set map
     Teuchos::RCP<const Core::LinAlg::Map> get_current_active_set_map(
-        enum NOX::Nln::StatusTest::QuantityType checkQuantity) const override;
+        NOX::Nln::StatusTest::QuantityType checkQuantity) const override;
 
     /// Returns the old active set map of the previous Newton step
     Teuchos::RCP<const Core::LinAlg::Map> get_old_active_set_map(
-        enum NOX::Nln::StatusTest::QuantityType checkQuantity) const override;
+        NOX::Nln::StatusTest::QuantityType checkQuantity) const override;
     /// @}
 
     /// @name Merit function support functions
@@ -76,9 +76,9 @@ namespace CONTACT
     double get_model_value(NOX::Nln::MeritFunction::MeritFctName name) const override;
 
     double get_linearized_model_terms(const Core::LinAlg::Vector<double>& dir,
-        const enum NOX::Nln::MeritFunction::MeritFctName name,
-        const enum NOX::Nln::MeritFunction::LinOrder linorder,
-        const enum NOX::Nln::MeritFunction::LinType lintype) const override;
+        const NOX::Nln::MeritFunction::MeritFctName name,
+        const NOX::Nln::MeritFunction::LinOrder linorder,
+        const NOX::Nln::MeritFunction::LinType lintype) const override;
 
     /// @}
 

--- a/src/contact/src/4C_contact_paramsinterface.hpp
+++ b/src/contact/src/4C_contact_paramsinterface.hpp
@@ -58,7 +58,7 @@ namespace CONTACT
     //! \brief get the currently active predictor type
     /** \note If the execution of the predictor is finished, this
      *  function will return Inpar::Solid::pred_vague. */
-    virtual enum Inpar::Solid::PredEnum get_predictor_type() const = 0;
+    virtual Inpar::Solid::PredEnum get_predictor_type() const = 0;
 
     //! get the current step length
     virtual double get_step_length() const = 0;
@@ -76,10 +76,10 @@ namespace CONTACT
     virtual std::string get_output_file_path() const = 0;
 
     //! set the coupling approach mode
-    virtual enum CONTACT::CouplingScheme get_coupling_scheme() const = 0;
+    virtual CONTACT::CouplingScheme get_coupling_scheme() const = 0;
 
     //! set the coupling scheme
-    virtual void set_coupling_scheme(const enum CONTACT::CouplingScheme scheme) = 0;
+    virtual void set_coupling_scheme(const CONTACT::CouplingScheme scheme) = 0;
 
     //! Get any additional data that has been set.
     virtual const std::any& get_user_data() const = 0;

--- a/src/contact/src/4C_contact_penalty_strategy.cpp
+++ b/src/contact/src/4C_contact_penalty_strategy.cpp
@@ -930,7 +930,7 @@ void CONTACT::PenaltyStrategy::assemble()
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 std::shared_ptr<const Core::LinAlg::Vector<double>> CONTACT::PenaltyStrategy::get_rhs_block_ptr(
-    const enum CONTACT::VecBlockType& bt) const
+    const CONTACT::VecBlockType& bt) const
 {
   // if there are no active contact contributions
   if (!is_in_contact() && !was_in_contact() && !was_in_contact_last_time_step()) return nullptr;
@@ -973,7 +973,7 @@ void CONTACT::PenaltyStrategy::evaluate_force_stiff(CONTACT::ParamsInterface& cp
  *----------------------------------------------------------------------*/
 void CONTACT::PenaltyStrategy::pre_evaluate(CONTACT::ParamsInterface& cparams)
 {
-  const enum Mortar::ActionType& act = cparams.get_action_type();
+  const Mortar::ActionType& act = cparams.get_action_type();
 
   switch (act)
   {
@@ -1003,7 +1003,7 @@ void CONTACT::PenaltyStrategy::pre_evaluate(CONTACT::ParamsInterface& cparams)
  *----------------------------------------------------------------------*/
 void CONTACT::PenaltyStrategy::post_evaluate(CONTACT::ParamsInterface& cparams)
 {
-  const enum Mortar::ActionType& act = cparams.get_action_type();
+  const Mortar::ActionType& act = cparams.get_action_type();
 
   switch (act)
   {
@@ -1040,7 +1040,7 @@ void CONTACT::PenaltyStrategy::post_evaluate(CONTACT::ParamsInterface& cparams)
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 std::shared_ptr<Core::LinAlg::SparseMatrix> CONTACT::PenaltyStrategy::get_matrix_block_ptr(
-    const enum CONTACT::MatBlockType& bt, const CONTACT::ParamsInterface* cparams) const
+    const CONTACT::MatBlockType& bt, const CONTACT::ParamsInterface* cparams) const
 {
   // if there are no active contact contributions
   if (!is_in_contact() && !was_in_contact() && !was_in_contact_last_time_step()) return nullptr;

--- a/src/contact/src/4C_contact_penalty_strategy.hpp
+++ b/src/contact/src/4C_contact_penalty_strategy.hpp
@@ -239,7 +239,7 @@ namespace CONTACT
      *
      *  \param bt (in): Desired vector block type, e.g. displ, constraint,*/
     std::shared_ptr<const Core::LinAlg::Vector<double>> get_rhs_block_ptr(
-        const enum CONTACT::VecBlockType& bt) const override;
+        const CONTACT::VecBlockType& bt) const override;
 
     /*! \brief Return the desired matrix block pointer (read-only)
      *
@@ -249,7 +249,7 @@ namespace CONTACT
      *  \param bt (in): Desired matrix block type, e.g. displ_displ, displ_lm, ...
      *  \param cparams (in): contact parameter interface (read-only) */
     std::shared_ptr<Core::LinAlg::SparseMatrix> get_matrix_block_ptr(
-        const enum CONTACT::MatBlockType& bt,
+        const CONTACT::MatBlockType& bt,
         const CONTACT::ParamsInterface* cparams = nullptr) const override;
 
     //@}

--- a/src/contact/src/4C_contact_strategy_factory.cpp
+++ b/src/contact/src/4C_contact_strategy_factory.cpp
@@ -662,8 +662,8 @@ void CONTACT::STRATEGY::Factory::build_interfaces(const Teuchos::ParameterList& 
   bool structmaster = false;
   bool structslave = false;
   bool isanyselfcontact = false;
-  enum Mortar::Element::PhysicalType slavetype = Mortar::Element::other;
-  enum Mortar::Element::PhysicalType mastertype = Mortar::Element::other;
+  Mortar::Element::PhysicalType slavetype = Mortar::Element::other;
+  Mortar::Element::PhysicalType mastertype = Mortar::Element::other;
 
   // loop over all contact condition groups
   for (auto& currentgroup : ccond_grps)
@@ -1255,7 +1255,7 @@ std::shared_ptr<CONTACT::Interface> CONTACT::STRATEGY::Factory::create_interface
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 std::shared_ptr<CONTACT::Interface> CONTACT::STRATEGY::Factory::create_interface(
-    const enum CONTACT::SolvingStrategy stype, const int id, MPI_Comm comm, const int dim,
+    const CONTACT::SolvingStrategy stype, const int id, MPI_Comm comm, const int dim,
     Teuchos::ParameterList& icparams, const bool selfcontact,
     std::shared_ptr<CONTACT::InterfaceDataContainer> interface_data_ptr,
     const int contactconstitutivelaw_id)
@@ -1301,10 +1301,9 @@ std::shared_ptr<CONTACT::Interface> CONTACT::STRATEGY::Factory::create_interface
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-void CONTACT::STRATEGY::Factory::set_poro_parent_element(
-    enum Mortar::Element::PhysicalType& slavetype, enum Mortar::Element::PhysicalType& mastertype,
-    CONTACT::Element& cele, std::shared_ptr<Core::Elements::Element>& ele,
-    const Core::FE::Discretization& discret) const
+void CONTACT::STRATEGY::Factory::set_poro_parent_element(Mortar::Element::PhysicalType& slavetype,
+    Mortar::Element::PhysicalType& mastertype, CONTACT::Element& cele,
+    std::shared_ptr<Core::Elements::Element>& ele, const Core::FE::Discretization& discret) const
 {
   // ints to communicate decision over poro bools between processors on every interface
   // safety check - because there may not be mixed interfaces and structural slave elements
@@ -1384,8 +1383,8 @@ void CONTACT::STRATEGY::Factory::set_poro_parent_element(
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 void CONTACT::STRATEGY::Factory::find_poro_interface_types(bool& poromaster, bool& poroslave,
-    bool& structmaster, bool& structslave, enum Mortar::Element::PhysicalType& slavetype,
-    enum Mortar::Element::PhysicalType& mastertype) const
+    bool& structmaster, bool& structslave, Mortar::Element::PhysicalType& slavetype,
+    Mortar::Element::PhysicalType& mastertype) const
 {
   // find poro and structure elements when a poro coupling condition is applied on an element
   // and restrict to pure poroelastic or pure structural interfaces' sides.
@@ -1678,7 +1677,7 @@ void CONTACT::STRATEGY::Factory::print(
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-void CONTACT::STRATEGY::Factory::print_strategy_banner(const enum CONTACT::SolvingStrategy soltype)
+void CONTACT::STRATEGY::Factory::print_strategy_banner(const CONTACT::SolvingStrategy soltype)
 {
   // some parameters
   const Teuchos::ParameterList& smortar = Global::Problem::instance()->mortar_coupling_params();

--- a/src/contact/src/4C_contact_strategy_factory.hpp
+++ b/src/contact/src/4C_contact_strategy_factory.hpp
@@ -74,7 +74,7 @@ namespace CONTACT
        *
        *  */
       static std::shared_ptr<CONTACT::Interface> create_interface(
-          const enum CONTACT::SolvingStrategy stype, const int id, MPI_Comm comm, const int dim,
+          const CONTACT::SolvingStrategy stype, const int id, MPI_Comm comm, const int dim,
           Teuchos::ParameterList& icparams, const bool selfcontact,
           std::shared_ptr<CONTACT::InterfaceDataContainer> interface_data_ptr,
           const int contactconstitutivelaw_id = -1);
@@ -113,7 +113,7 @@ namespace CONTACT
       /*! \brief print strategy banner
        *
        *  \param soltype (in) : contact solving strategy type */
-      static void print_strategy_banner(const enum CONTACT::SolvingStrategy soltype);
+      static void print_strategy_banner(const CONTACT::SolvingStrategy soltype);
 
      protected:
      private:
@@ -126,8 +126,8 @@ namespace CONTACT
       /*! \brief Set Parent Elements for Poro Face Elements
        *
        *  */
-      void set_poro_parent_element(enum Mortar::Element::PhysicalType& slavetype,
-          enum Mortar::Element::PhysicalType& mastertype, CONTACT::Element& cele,
+      void set_poro_parent_element(Mortar::Element::PhysicalType& slavetype,
+          Mortar::Element::PhysicalType& mastertype, CONTACT::Element& cele,
           std::shared_ptr<Core::Elements::Element>& ele,
           const Core::FE::Discretization& discret) const;
 
@@ -135,8 +135,8 @@ namespace CONTACT
        *
        *  */
       void find_poro_interface_types(bool& poromaster, bool& poroslave, bool& structmaster,
-          bool& structslave, enum Mortar::Element::PhysicalType& slavetype,
-          enum Mortar::Element::PhysicalType& mastertype) const;
+          bool& structslave, Mortar::Element::PhysicalType& slavetype,
+          Mortar::Element::PhysicalType& mastertype) const;
 
       //!@}
 

--- a/src/core/fem/src/discretization/4C_fem_discretization_utils.hpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_utils.hpp
@@ -308,7 +308,7 @@ namespace Core::FE
     void read_dirichlet_condition(const Teuchos::ParameterList& params,
         const Core::FE::Discretization& discret, std::span<const Conditions::Condition*> conds,
         double time, DbcInfo& info, const std::shared_ptr<std::set<int>>* dbcgids,
-        const enum Core::Conditions::ConditionType& type) const;
+        const Core::Conditions::ConditionType& type) const;
 
     /** \brief Determine dofs subject to Dirichlet condition from input file
      *
@@ -361,7 +361,7 @@ namespace Core::FE
         std::span<const Core::Conditions::Condition*> conds, double time,
         const std::shared_ptr<Core::LinAlg::Vector<double>>* systemvectors,
         const Core::LinAlg::Vector<int>& toggle, const std::shared_ptr<std::set<int>>* dbcgids,
-        const enum Core::Conditions::ConditionType& type) const;
+        const Core::Conditions::ConditionType& type) const;
 
     /** \brief Apply the Dirichlet values to the system vectors
      *

--- a/src/core/fem/src/discretization/4C_fem_discretization_utils_dbc.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_utils_dbc.cpp
@@ -185,7 +185,7 @@ void Core::FE::Dbc::read_dirichlet_condition(const Teuchos::ParameterList& param
 void Core::FE::Dbc::read_dirichlet_condition(const Teuchos::ParameterList& params,
     const Core::FE::Discretization& discret, std::span<const Conditions::Condition*> conds,
     double time, DbcInfo& info, const std::shared_ptr<std::set<int>>* dbcgids,
-    const enum Core::Conditions::ConditionType& type) const
+    const Core::Conditions::ConditionType& type) const
 {
   int hierarchical_order;
   switch (type)
@@ -439,7 +439,7 @@ void Core::FE::Dbc::do_dirichlet_condition(const Teuchos::ParameterList& params,
     const Core::FE::Discretization& discret, std::span<const Core::Conditions::Condition*> conds,
     double time, const std::shared_ptr<Core::LinAlg::Vector<double>>* systemvectors,
     const Core::LinAlg::Vector<int>& toggle, const std::shared_ptr<std::set<int>>* dbcgids,
-    const enum Core::Conditions::ConditionType& type) const
+    const Core::Conditions::ConditionType& type) const
 {
   for (const auto& cond : conds)
   {

--- a/src/core/fem/src/general/element/4C_fem_general_elements_paramsinterface.hpp
+++ b/src/core/fem/src/general/element/4C_fem_general_elements_paramsinterface.hpp
@@ -46,7 +46,7 @@ namespace Core::Elements
     //! @name Access general control parameters
     //! @{
     //! get the desired action type
-    virtual enum ActionType get_action_type() const = 0;
+    virtual ActionType get_action_type() const = 0;
 
     //! get the current total time for the evaluate call
     virtual double get_total_time() const = 0;

--- a/src/core/fem/src/general/element/4C_fem_general_elements_paramsminimal.hpp
+++ b/src/core/fem/src/general/element/4C_fem_general_elements_paramsminimal.hpp
@@ -27,7 +27,7 @@ namespace Core::Elements
     //! constructor
     ParamsMinimal() : ele_action_(none), total_time_(-1.0), delta_time_(-1.0) {};
 
-    enum ActionType get_action_type() const override { return ele_action_; };
+    ActionType get_action_type() const override { return ele_action_; };
 
     double get_total_time() const override { return total_time_; };
 
@@ -43,7 +43,7 @@ namespace Core::Elements
      *  These functions are not allowed to be called by the elements! */
     //! @{
     //! set the action type
-    inline void set_action_type(const enum Core::Elements::ActionType& actiontype)
+    inline void set_action_type(const Core::Elements::ActionType& actiontype)
     {
       ele_action_ = actiontype;
     }
@@ -66,7 +66,7 @@ namespace Core::Elements
     //! @name General element control parameters
     //! @{
     //! Current action type
-    enum ActionType ele_action_;
+    ActionType ele_action_;
 
     //! total time for the evaluation
     double total_time_;

--- a/src/core/legacy_enum_definitions/4C_legacy_enum_definitions_element_actions.hpp
+++ b/src/core/legacy_enum_definitions/4C_legacy_enum_definitions_element_actions.hpp
@@ -69,7 +69,7 @@ namespace Core::Elements
     struct_calc_analytical_error  //!< compute L2 error in comparison to analytical solution
   };
 
-  static inline enum ActionType string_to_action_type(const std::string& action)
+  static inline ActionType string_to_action_type(const std::string& action)
   {
     if (action == "none")
       return none;
@@ -120,7 +120,7 @@ namespace Core::Elements
   }
 
   //! Map action type enum to std::string
-  static inline std::string action_type_to_string(const enum ActionType& type)
+  static inline std::string action_type_to_string(const ActionType& type)
   {
     switch (type)
     {

--- a/src/core/utils/src/stl_extension/4C_utils_pairedvector.hpp
+++ b/src/core/utils/src/stl_extension/4C_utils_pairedvector.hpp
@@ -100,7 +100,7 @@ namespace Core::Gen
      *  @param[in] type   Apply this copy type.
      *
      *  */
-    Pairedvector(const Pairedvector& source, enum Gen::CopyType type = DeepCopy)
+    Pairedvector(const Pairedvector& source, Gen::CopyType type = DeepCopy)
         : m_(0, pair_type()), entries_(0)
 
     {
@@ -356,7 +356,7 @@ namespace Core::Gen
      *                     only the key but not the values are copied.
      *
      */
-    void clone(const class_type& source, const enum CopyType type)
+    void clone(const class_type& source, const CopyType type)
     {
       clear();
       clone(source);

--- a/src/cut/4C_cut_edge.cpp
+++ b/src/cut/4C_cut_edge.cpp
@@ -777,10 +777,10 @@ bool Cut::ConcreteEdge<prob_dim, edge_type, dim_edge, num_nodes_edge>::compute_c
   if (not edges_parallel)
   {
     // perform the actual edge - edge intersection
-    const enum IntersectionStatus istatus =
+    const IntersectionStatus istatus =
         inter_ptr->compute_edge_side_intersection(tolerance, true, nullptr);
 
-    enum IntersectionStatus retstatus = istatus;
+    IntersectionStatus retstatus = istatus;
 
     switch (istatus)
     {

--- a/src/cut/4C_cut_integrationcellcreator.cpp
+++ b/src/cut/4C_cut_integrationcellcreator.cpp
@@ -189,8 +189,7 @@ bool Cut::IntegrationCellCreator::create_line2_cell(
   std::vector<Point*> line_corner_points;
   line_corner_points.reserve(2);
 
-  const enum Cut::BoundaryCellPosition bcell_pos =
-      mesh.create_options().gen_boundary_cell_position();
+  const Cut::BoundaryCellPosition bcell_pos = mesh.create_options().gen_boundary_cell_position();
 
   for (plain_facet_set::const_iterator cit = facets.begin(); cit != facets.end(); ++cit)
   {
@@ -231,8 +230,7 @@ bool Cut::IntegrationCellCreator::create_2d_cell(
   // check the facet number
   if (facets.size() != numfaces) return false;
 
-  const enum Cut::BoundaryCellPosition bcell_pos =
-      mesh.create_options().gen_boundary_cell_position();
+  const Cut::BoundaryCellPosition bcell_pos = mesh.create_options().gen_boundary_cell_position();
 
   Impl::SimplePointGraph2D pg = Impl::SimplePointGraph2D();
   pg.find_line_facet_cycles(facets, cell->parent_element());

--- a/src/cut/4C_cut_kernel.hpp
+++ b/src/cut/4C_cut_kernel.hpp
@@ -777,7 +777,7 @@ namespace Cut::Kernel
 #endif
 
   /// Convert Newton Status enumerator to string
-  static inline std::string newton_status_to_string(const enum NewtonStatus& status)
+  static inline std::string newton_status_to_string(const NewtonStatus& status)
   {
     switch (status)
     {
@@ -860,7 +860,7 @@ namespace Cut::Kernel
 
     void setup_step(int iter) {}
 
-    enum NewtonStatus test_converged(int iter) { return unconverged; }
+    NewtonStatus test_converged(int iter) { return unconverged; }
 
     bool linear_solve(int iter) { return true; }
 
@@ -902,9 +902,9 @@ namespace Cut::Kernel
       Strategy::setup_step(iter);
     }
 
-    enum NewtonStatus test_converged(int iter)
+    NewtonStatus test_converged(int iter)
     {
-      enum NewtonStatus status = Strategy::test_converged(iter);
+      NewtonStatus status = Strategy::test_converged(iter);
       std::cout << "TestConverged( iter = " << std::setw(2) << iter
                 << " ) = " << newton_status_to_string(status) << "\n"
                 << std::flush;
@@ -1073,7 +1073,7 @@ namespace Cut::Kernel
     }
 
     /// check for convergence
-    enum NewtonStatus test_converged(int iter)
+    NewtonStatus test_converged(int iter)
     {
       FloatType residual = b_.norm2();
 
@@ -1977,7 +1977,7 @@ namespace Cut::Kernel
     }
 
     /// Test the stop / convergence criterion of the Newton scheme
-    enum NewtonStatus test_converged(int iter)
+    NewtonStatus test_converged(int iter)
     {
       if (debug)
       {
@@ -2141,8 +2141,7 @@ namespace Cut::Kernel
       normal_plane_undefined
     };
 
-    enum NormalPlane detect_normal_plane(
-        const Core::LinAlg::Matrix<prob_dim, 1, FloatType>& n) const
+    NormalPlane detect_normal_plane(const Core::LinAlg::Matrix<prob_dim, 1, FloatType>& n) const
     {
       if (prob_dim < 3) FOUR_C_THROW("This function makes only sense for the 3-D case!");
 
@@ -3472,7 +3471,7 @@ namespace Cut::Kernel
     }
 
 
-    enum NewtonStatus test_converged(int iter)
+    NewtonStatus test_converged(int iter)
     {
       residual_ = b_.norm2();
 

--- a/src/cut/4C_cut_options.hpp
+++ b/src/cut/4C_cut_options.hpp
@@ -80,18 +80,18 @@ namespace Cut
     };
 
     /** \brief Float_type for geometric intersection computation */
-    enum Cut::CutFloatType geom_intersect_floattype() const { return geomintersect_floattype_; }
+    Cut::CutFloatType geom_intersect_floattype() const { return geomintersect_floattype_; }
 
     /** \brief Float_type for geometric distance computation */
-    enum Cut::CutFloatType geom_distance_floattype() const { return geomdistance_floattype_; }
+    Cut::CutFloatType geom_distance_floattype() const { return geomdistance_floattype_; }
 
     /** \brief Which Referenceplanes are used in DirectDivergence */
-    enum CutDirectDivergenceRefplane direct_divergence_refplane() const
+    CutDirectDivergenceRefplane direct_divergence_refplane() const
     {
       return direct_divergence_refplane_;
     }
 
-    enum BoundaryCellPosition gen_boundary_cell_position() const { return gen_bcell_position_; }
+    BoundaryCellPosition gen_boundary_cell_position() const { return gen_bcell_position_; }
 
     /** \brief get the quad4 integration cell generation indicator
      *  (TRUE: QUAD4, FALSE: TRI3's are used) */
@@ -192,7 +192,7 @@ namespace Cut
 
 
     /** \brief Where to create boundary cells */
-    enum BoundaryCellPosition gen_bcell_position_;
+    BoundaryCellPosition gen_bcell_position_;
 
     /** \brief Indicator if quad4 cutsides are split into tri3 cutsides */
     bool split_cutsides_;

--- a/src/cut/4C_cut_point.hpp
+++ b/src/cut/4C_cut_point.hpp
@@ -51,7 +51,7 @@ namespace Cut
     };
 
     /// translate PointPosition enumerator to string
-    static inline std::string point_position_to_string(const enum PointPosition& pos)
+    static inline std::string point_position_to_string(const PointPosition& pos)
     {
       switch (pos)
       {

--- a/src/cut/4C_cut_position.hpp
+++ b/src/cut/4C_cut_position.hpp
@@ -47,7 +47,7 @@ namespace Cut
     };
 
     //! Map Status enum to std::string
-    static inline std::string status_to_string(enum Status pstatus)
+    static inline std::string status_to_string(Status pstatus)
     {
       switch (pstatus)
       {
@@ -137,7 +137,7 @@ namespace Cut
 
     virtual unsigned n_prob_dim() const = 0;
 
-    virtual enum Status status() const = 0;
+    virtual Status status() const = 0;
 
     /** \brief Default Compute method
      *
@@ -273,7 +273,7 @@ namespace Cut
     /// return the problem dimension
     unsigned n_prob_dim() const override { return probdim; }
 
-    enum Status status() const override { return pos_status_; }
+    Status status() const override { return pos_status_; }
 
     /*! \brief Return the local coordinates of the given point \c px_
      *
@@ -368,7 +368,7 @@ namespace Cut
     Core::LinAlg::Matrix<dim, 1> xsi_;
 
     /// computation status of the position calculation
-    enum Status pos_status_;
+    Status pos_status_;
 
     /** contains the tolerance used for the internal Newton method
      *  ( see the Compute() routines ) */

--- a/src/cut/4C_cut_side.hpp
+++ b/src/cut/4C_cut_side.hpp
@@ -89,7 +89,7 @@ namespace Cut
     void set_id(int sid) { sid_ = sid; }
 
     /// \brief Set the side ID to the input value
-    void set_marked_side_properties(int markedid, enum MarkedActions markedaction)
+    void set_marked_side_properties(int markedid, MarkedActions markedaction)
     {
       // No combination of cut-sides and marked sides!!
       if (sid_ > -1) FOUR_C_THROW("Currently a marked side and a cut side can not co-exist");
@@ -98,10 +98,10 @@ namespace Cut
         FOUR_C_THROW("Currently more than one mark on a side is NOT possible.");
 
       markedsidemap_.insert(
-          std::pair<enum MarkedActions, int>(Cut::mark_and_create_boundarycells, markedid));
+          std::pair<MarkedActions, int>(Cut::mark_and_create_boundarycells, markedid));
     }
 
-    std::map<enum MarkedActions, int>& get_markedsidemap() { return markedsidemap_; }
+    std::map<MarkedActions, int>& get_markedsidemap() { return markedsidemap_; }
 
     /// \brief Returns true if this is a cut side
     bool is_cut_side() { return (sid_ > -1); }

--- a/src/ehl/4C_ehl_monolithic.cpp
+++ b/src/ehl/4C_ehl_monolithic.cpp
@@ -1375,7 +1375,7 @@ void EHL::Monolithic::unscale_solution(Core::LinAlg::BlockSparseMatrixBase& mat,
  | calculate vector norm                                    wirtz 01/16 |
  *----------------------------------------------------------------------*/
 double EHL::Monolithic::calculate_vector_norm(
-    const enum EHL::VectorNorm norm, Core::LinAlg::Vector<double>& vect)
+    const EHL::VectorNorm norm, Core::LinAlg::Vector<double>& vect)
 {
   // L1 norm
   // norm = sum_0^i vect[i]

--- a/src/ehl/4C_ehl_monolithic.hpp
+++ b/src/ehl/4C_ehl_monolithic.hpp
@@ -182,8 +182,8 @@ namespace EHL
     void print_newton_conv();
 
     //! Determine norm of force residual
-    double calculate_vector_norm(const enum EHL::VectorNorm norm,  //!< norm to use
-        Core::LinAlg::Vector<double>& vect                         //!< the vector of interest
+    double calculate_vector_norm(const EHL::VectorNorm norm,  //!< norm to use
+        Core::LinAlg::Vector<double>& vect                    //!< the vector of interest
     );
 
     //@}
@@ -266,7 +266,7 @@ namespace EHL
     //@}
 
     //! enum for STR time integartion
-    enum Inpar::Solid::DynamicType strmethodname_;
+    Inpar::Solid::DynamicType strmethodname_;
 
    private:
     const Teuchos::ParameterList& ehldyn_;      //!< EHL dynamic parameter list
@@ -292,19 +292,19 @@ namespace EHL
 
     //! @name iterative solution technique
 
-    enum EHL::ConvNorm normtypeinc_;              //!< convergence check for increments
-    enum EHL::ConvNorm normtyperhs_;              //!< convergence check for residual forces
-    enum Inpar::Solid::ConvNorm normtypedisi_;    //!< convergence check for residual displacements
-    enum Inpar::Solid::ConvNorm normtypestrrhs_;  //!< convergence check for residual forces
-    enum Lubrication::ConvNorm normtypeprei_;     //!< convergence check for residual pressures
+    EHL::ConvNorm normtypeinc_;              //!< convergence check for increments
+    EHL::ConvNorm normtyperhs_;              //!< convergence check for residual forces
+    Inpar::Solid::ConvNorm normtypedisi_;    //!< convergence check for residual displacements
+    Inpar::Solid::ConvNorm normtypestrrhs_;  //!< convergence check for residual forces
+    Lubrication::ConvNorm normtypeprei_;     //!< convergence check for residual pressures
     enum Lubrication::ConvNorm
         normtypelubricationrhs_;  //!< convergence check for residual lubrication forces
 
-    enum EHL::BinaryOp combincrhs_;  //!< binary operator to combine increments and forces
+    EHL::BinaryOp combincrhs_;  //!< binary operator to combine increments and forces
 
-    enum EHL::VectorNorm iternorm_;             //!< vector norm to check EHL values with
-    enum EHL::VectorNorm iternormstr_;          //!< vector norm to check structural values with
-    enum EHL::VectorNorm iternormlubrication_;  //!< vector norm to check lubrication values with
+    EHL::VectorNorm iternorm_;             //!< vector norm to check EHL values with
+    EHL::VectorNorm iternormstr_;          //!< vector norm to check structural values with
+    EHL::VectorNorm iternormlubrication_;  //!< vector norm to check lubrication values with
 
     double tolinc_;             //!< tolerance for increment
     double tolrhs_;             //!< tolerance for rhs

--- a/src/fluid/4C_fluid_implicit_integration.hpp
+++ b/src/fluid/4C_fluid_implicit_integration.hpp
@@ -1104,7 +1104,7 @@ namespace FLD
     //! do we move the fluid mesh and calculate the fluid on this moving mesh?
     bool alefluid_;
     //! do we have a turbulence model?
-    enum Inpar::FLUID::TurbModelAction turbmodel_;
+    Inpar::FLUID::TurbModelAction turbmodel_;
 
     //@}
 
@@ -1341,7 +1341,7 @@ namespace FLD
     std::shared_ptr<FLD::XWall> xwall_;
 
     /// flag for mesh-tying
-    enum Inpar::FLUID::MeshTying msht_;
+    Inpar::FLUID::MeshTying msht_;
 
     /// face discretization (only initialized for edge-based stabilization)
     std::shared_ptr<Core::FE::DiscretizationFaces> facediscret_;

--- a/src/fluid/4C_fluid_xwall.hpp
+++ b/src/fluid/4C_fluid_xwall.hpp
@@ -269,13 +269,13 @@ namespace FLD
     double dens_;
 
     //! when and how to update tauw
-    enum Inpar::FLUID::XWallTauwType tauwtype_;
+    Inpar::FLUID::XWallTauwType tauwtype_;
 
     //! how to calculate tauw
-    enum Inpar::FLUID::XWallTauwCalcType tauwcalctype_;
+    Inpar::FLUID::XWallTauwCalcType tauwcalctype_;
 
     //! how to blend
-    enum Inpar::FLUID::XWallBlendingType blendingtype_;
+    Inpar::FLUID::XWallBlendingType blendingtype_;
 
     //! projection
     bool proj_;

--- a/src/fluid_turbulence/4C_fluid_turbulence_statistic_manager.hpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_statistic_manager.hpp
@@ -259,7 +259,7 @@ namespace FLD
     bool withscatra_;
 
     //! toggle additional evaluations for turbulence models
-    enum Inpar::FLUID::TurbModelAction turbmodel_;
+    Inpar::FLUID::TurbModelAction turbmodel_;
 
     //! toggle evaluation of subgrid quantities, dissipation rates etc
     //! this is only possible for the genalpha implementation since

--- a/src/fluid_xfluid/4C_fluid_xfluid.hpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid.hpp
@@ -694,10 +694,10 @@ namespace FLD
     //---------------------------------input parameters------------------
 
     /// type of enforcing interface conditions in XFEM
-    enum Inpar::XFEM::CouplingMethod coupling_method_;
+    Inpar::XFEM::CouplingMethod coupling_method_;
 
     //! @name xfluid time integration
-    enum Inpar::XFEM::XFluidTimeIntScheme xfluid_timintapproach_;
+    Inpar::XFEM::XFluidTimeIntScheme xfluid_timintapproach_;
 
     //! @name check interfacetips in timeintegration
     bool xfluid_timint_check_interfacetips_;
@@ -707,7 +707,7 @@ namespace FLD
     //@}
 
     /// initial flow field
-    enum Inpar::FLUID::InitialField initfield_;
+    Inpar::FLUID::InitialField initfield_;
 
     /// start function number for an initial field
     int startfuncno_;
@@ -737,7 +737,7 @@ namespace FLD
     //--------------------------------------------------------------------
 
     //! do we have a turblence model?
-    enum Inpar::FLUID::TurbModelAction turbmodel_;
+    Inpar::FLUID::TurbModelAction turbmodel_;
     //@}
 
 

--- a/src/fluid_xfluid/4C_fluid_xfluid_fluid.hpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid_fluid.hpp
@@ -285,8 +285,8 @@ namespace FLD
     //! @name Fluid-fluid specific parameters
     //@{
     enum Inpar::XFEM::MonolithicXffsiApproach
-        monolithic_approach_;  ///< type of monolithic XFFSI-approach
-    enum Inpar::XFEM::XFluidFluidTimeInt xfem_timeintapproach_;  ///< XFF time integration approach
+        monolithic_approach_;                               ///< type of monolithic XFFSI-approach
+    Inpar::XFEM::XFluidFluidTimeInt xfem_timeintapproach_;  ///< XFF time integration approach
     //@}
 
     //! name of fluid-fluid condition for access from condition manager

--- a/src/fpsi/4C_fpsi_monolithic.hpp
+++ b/src/fpsi/4C_fpsi_monolithic.hpp
@@ -337,9 +337,9 @@ namespace FPSI
     //! flag for direct solver of linear system
     bool directsolve_;
 
-    enum Inpar::FPSI::ConvergenceNorm normtypeinc_;
-    enum Inpar::FPSI::ConvergenceNorm normtypefres_;
-    enum Inpar::FPSI::BinaryOp combinedconvergence_;
+    Inpar::FPSI::ConvergenceNorm normtypeinc_;
+    Inpar::FPSI::ConvergenceNorm normtypefres_;
+    Inpar::FPSI::BinaryOp combinedconvergence_;
 
     double toleranceiterinc_;
     double toleranceresidualforces_;

--- a/src/fsi/src/monolithic/4C_fsi_monolithic_nonox.hpp
+++ b/src/fsi/src/monolithic/4C_fsi_monolithic_nonox.hpp
@@ -274,9 +274,9 @@ namespace FSI
 
     //! @name Iterative solution technique
     //@{
-    enum Inpar::FSI::ConvNorm normtypeinc_;   //!< convergence check for increment
-    enum Inpar::FSI::ConvNorm normtypefres_;  //!< convergence check for residual forces
-    enum Inpar::FSI::BinaryOp combincfres_;  //!< binary operator to combine temperatures and forces
+    Inpar::FSI::ConvNorm normtypeinc_;   //!< convergence check for increment
+    Inpar::FSI::ConvNorm normtypefres_;  //!< convergence check for residual forces
+    Inpar::FSI::BinaryOp combincfres_;   //!< binary operator to combine temperatures and forces
 
     double tolinc_;   //!< tolerance residual temperatures
     double tolfres_;  //!< tolerance force residual

--- a/src/fsi_xfem/4C_fsi_xfem_monolithic.hpp
+++ b/src/fsi_xfem/4C_fsi_xfem_monolithic.hpp
@@ -459,8 +459,8 @@ namespace FSI
     //--------------------------------------------------------------------------//
     //! @name Convergence criterion and convergence tolerances for Newton scheme
 
-    const enum Inpar::FSI::ConvNorm normtypeinc_;   //!< convergence check for increment
-    const enum Inpar::FSI::ConvNorm normtypefres_;  //!< convergence check for residual forces
+    const Inpar::FSI::ConvNorm normtypeinc_;   //!< convergence check for increment
+    const Inpar::FSI::ConvNorm normtypefres_;  //!< convergence check for residual forces
     const enum Inpar::FSI::BinaryOp
         combincfres_;  //!< binary operator to check for increment plus residual convergence or not
 

--- a/src/inpar/4C_inpar_beaminteraction.hpp
+++ b/src/inpar/4C_inpar_beaminteraction.hpp
@@ -108,7 +108,7 @@ namespace Inpar
     };
 
     //! Map type std::string to enum
-    inline enum JointType string_to_joint_type(const std::string& name)
+    inline JointType string_to_joint_type(const std::string& name)
     {
       JointType type = beam3r_line2_rigid;
       if (name == "beam3rline2rigid")
@@ -124,7 +124,7 @@ namespace Inpar
     };
 
     //! Map type std::string to enum
-    inline enum FilamentType string_to_filament_type(const std::string& name)
+    inline FilamentType string_to_filament_type(const std::string& name)
     {
       FilamentType type = filetype_arbitrary;
       if (name == "arbitrary")
@@ -142,7 +142,7 @@ namespace Inpar
     };
 
     //! Map type std::string to enum
-    inline enum CrosslinkerType string_to_crosslinker_type(const std::string& name)
+    inline CrosslinkerType string_to_crosslinker_type(const std::string& name)
     {
       CrosslinkerType type = linkertype_arbitrary;
       if (name == "arbitrary")
@@ -165,7 +165,7 @@ namespace Inpar
     };
 
     //! Map action type enum to std::string
-    static inline std::string crosslinker_type_to_string(const enum CrosslinkerType type)
+    static inline std::string crosslinker_type_to_string(const CrosslinkerType type)
     {
       switch (type)
       {

--- a/src/mortar/src/4C_mortar_interface.cpp
+++ b/src/mortar/src/4C_mortar_interface.cpp
@@ -2007,7 +2007,7 @@ void Mortar::Interface::initialize()
  |  set current and old deformation state                      popp 12/07|
  *----------------------------------------------------------------------*/
 void Mortar::Interface::set_state(
-    const enum StateType& statetype, const Core::LinAlg::Vector<double>& vec)
+    const StateType& statetype, const Core::LinAlg::Vector<double>& vec)
 {
   switch (statetype)
   {

--- a/src/mortar/src/4C_mortar_interface.hpp
+++ b/src/mortar/src/4C_mortar_interface.hpp
@@ -79,7 +79,7 @@ namespace Mortar
   /*! \brief Map state type enum to std::string
    *
    *  */
-  static inline std::string state_type_to_string(const enum StateType& type)
+  static inline std::string state_type_to_string(const StateType& type)
   {
     switch (type)
     {
@@ -111,7 +111,7 @@ namespace Mortar
   /*! \brief Map std::string to state type enum
    *
    *  */
-  static inline enum Mortar::StateType string_to_state_type(const std::string& name)
+  static inline Mortar::StateType string_to_state_type(const std::string& name)
   {
     Mortar::StateType type = state_vague;
     if (name == "displacement")
@@ -189,20 +189,20 @@ namespace Mortar
 
     inline const Teuchos::ParameterList& i_mortar() const { return imortar_; }
 
-    inline enum Inpar::Mortar::ShapeFcn& shape_fcn() { return shapefcn_; }
+    inline Inpar::Mortar::ShapeFcn& shape_fcn() { return shapefcn_; }
 
-    inline enum Inpar::Mortar::ShapeFcn shape_fcn() const { return shapefcn_; }
+    inline Inpar::Mortar::ShapeFcn shape_fcn() const { return shapefcn_; }
 
     inline bool& is_quad_slave() { return quadslave_; }
 
     inline bool is_quad_slave() const { return quadslave_; }
 
-    inline const enum Inpar::Mortar::ExtendGhosting& get_extend_ghosting() const
+    inline const Inpar::Mortar::ExtendGhosting& get_extend_ghosting() const
     {
       return extendghosting_;
     }
 
-    inline void set_extend_ghosting(const enum Inpar::Mortar::ExtendGhosting& extendghosting)
+    inline void set_extend_ghosting(const Inpar::Mortar::ExtendGhosting& extendghosting)
     {
       extendghosting_ = extendghosting;
     }
@@ -402,7 +402,7 @@ namespace Mortar
 
     inline Inpar::Mortar::SearchAlgorithm& search_algorithm() { return searchalgo_; }
 
-    inline enum Inpar::Mortar::SearchAlgorithm search_algorithm() const { return searchalgo_; }
+    inline Inpar::Mortar::SearchAlgorithm search_algorithm() const { return searchalgo_; }
 
     inline std::shared_ptr<Mortar::BinaryTree>& binary_tree() { return binarytree_; }
 
@@ -1207,7 +1207,7 @@ namespace Mortar
     \param[in] Enum to encode type of state
     \param[in] Vector with state data
     */
-    void set_state(const enum StateType& statetype, const Core::LinAlg::Vector<double>& vec);
+    void set_state(const StateType& statetype, const Core::LinAlg::Vector<double>& vec);
 
     /*!
     \brief Create integration cells for interface

--- a/src/mortar/src/4C_mortar_paramsinterface.hpp
+++ b/src/mortar/src/4C_mortar_paramsinterface.hpp
@@ -53,7 +53,7 @@ namespace Mortar
    * @param[in] act ActionType encoded as enum
    * @return String describing the action type
    */
-  static inline std::string action_type_to_string(const enum ActionType& act)
+  static inline std::string action_type_to_string(const ActionType& act)
   {
     switch (act)
     {
@@ -105,7 +105,7 @@ namespace Mortar
     virtual ~ParamsInterface() = default;
 
     //! Return the mortar/contact action type
-    virtual enum ActionType get_action_type() const = 0;
+    virtual ActionType get_action_type() const = 0;
 
     //! Get the nonlinear iteration number
     virtual int get_nln_iter() const = 0;

--- a/src/mortar/src/4C_mortar_strategy_base.hpp
+++ b/src/mortar/src/4C_mortar_strategy_base.hpp
@@ -333,7 +333,7 @@ namespace Mortar
         std::shared_ptr<const Core::LinAlg::Vector<double>> blocksol) = 0;
     virtual void save_reference_state(std::shared_ptr<const Core::LinAlg::Vector<double>> dis) = 0;
     virtual void set_state(
-        const enum Mortar::StateType& statename, const Core::LinAlg::Vector<double>& vec) = 0;
+        const Mortar::StateType& statename, const Core::LinAlg::Vector<double>& vec) = 0;
     virtual std::shared_ptr<const Core::LinAlg::Map> slip_row_nodes() const = 0;
     virtual void store_dirichlet_status(
         std::shared_ptr<const Core::LinAlg::MapExtractor> dbcmaps) = 0;

--- a/src/particle/src/engine/4C_particle_engine_enums.cpp
+++ b/src/particle/src/engine/4C_particle_engine_enums.cpp
@@ -12,7 +12,7 @@ FOUR_C_NAMESPACE_OPEN
 /*---------------------------------------------------------------------------*
  | definitions                                                               |
  *---------------------------------------------------------------------------*/
-int Particle::enum_to_state_dim(const enum ParticleState& state)
+int Particle::enum_to_state_dim(const ParticleState& state)
 {
   int dim = 0;
 
@@ -73,7 +73,7 @@ int Particle::enum_to_state_dim(const enum ParticleState& state)
   return dim;
 }
 
-std::string Particle::enum_to_state_name(const enum ParticleState& state)
+std::string Particle::enum_to_state_name(const ParticleState& state)
 {
   std::string name;
 
@@ -206,9 +206,9 @@ std::string Particle::enum_to_state_name(const enum ParticleState& state)
   return name;
 }
 
-enum Particle::ParticleState Particle::enum_from_state_name(const std::string& name)
+Particle::ParticleState Particle::enum_from_state_name(const std::string& name)
 {
-  enum ParticleState state;
+  ParticleState state;
 
   if (name == "density")
     state = Density;
@@ -225,23 +225,23 @@ enum Particle::ParticleState Particle::enum_from_state_name(const std::string& n
 static std::vector<std::string> particle_type_names = {
     "phase1", "phase2", "boundaryphase", "rigidphase", "dirichletphase", "neumannphase"};
 
-std::string Particle::enum_to_type_name(const enum ParticleType& type)
+std::string Particle::enum_to_type_name(const ParticleType& type)
 {
   FOUR_C_ASSERT(type >= 0 and type < static_cast<int>(particle_type_names.size()),
       "particle type out of range!");
   return particle_type_names[type];
 }
 
-enum Particle::ParticleType Particle::enum_from_type_name(const std::string& name)
+Particle::ParticleType Particle::enum_from_type_name(const std::string& name)
 {
   auto it = std::ranges::find(particle_type_names, name);
   FOUR_C_ASSERT(it != particle_type_names.end(), "particle type '{}' unknown!", name);
-  return static_cast<enum ParticleType>(std::distance(particle_type_names.begin(), it));
+  return static_cast<ParticleType>(std::distance(particle_type_names.begin(), it));
 }
 
 const std::vector<std::string>& Particle::get_particle_type_names() { return particle_type_names; }
 
-std::string Particle::enum_to_status_name(const enum ParticleStatus& status)
+std::string Particle::enum_to_status_name(const ParticleStatus& status)
 {
   std::string name;
 

--- a/src/particle/src/engine/4C_particle_engine_enums.hpp
+++ b/src/particle/src/engine/4C_particle_engine_enums.hpp
@@ -102,7 +102,7 @@ namespace Particle
    *
    * \return particle state dimension
    */
-  int enum_to_state_dim(const enum ParticleState& state);
+  int enum_to_state_dim(const ParticleState& state);
 
   /*!
    * \brief convert particle state enum to name
@@ -112,7 +112,7 @@ namespace Particle
    *
    * \return particle state name
    */
-  std::string enum_to_state_name(const enum ParticleState& state);
+  std::string enum_to_state_name(const ParticleState& state);
 
   /*!
    * \brief convert particle state name to enum
@@ -128,7 +128,7 @@ namespace Particle
    *
    * \return particle state
    */
-  enum ParticleState enum_from_state_name(const std::string& name);
+  ParticleState enum_from_state_name(const std::string& name);
 
   //! @}
 
@@ -164,7 +164,7 @@ namespace Particle
    *
    * \return particle type name
    */
-  std::string enum_to_type_name(const enum ParticleType& type);
+  std::string enum_to_type_name(const ParticleType& type);
 
   /*!
    * \brief convert particle type name to enum
@@ -177,7 +177,7 @@ namespace Particle
    *
    * \return particle type
    */
-  enum ParticleType enum_from_type_name(const std::string& name);
+  ParticleType enum_from_type_name(const std::string& name);
 
   const std::vector<std::string>& get_particle_type_names();
 
@@ -207,7 +207,7 @@ namespace Particle
    *
    * \return particle status name
    */
-  std::string enum_to_status_name(const enum ParticleStatus& status);
+  std::string enum_to_status_name(const ParticleStatus& status);
 
   //! @}
 

--- a/src/poroelast/4C_poroelast_monolithic.hpp
+++ b/src/poroelast/4C_poroelast_monolithic.hpp
@@ -301,7 +301,7 @@ namespace PoroElast
 
     //!@}
 
-    enum Inpar::Solid::DynamicType strmethodname_;  //!< enum for STR time integration
+    Inpar::Solid::DynamicType strmethodname_;  //!< enum for STR time integration
 
     //! @name Global matrixes
 
@@ -360,11 +360,11 @@ namespace PoroElast
 
     //! @name Iterative solution technique
 
-    enum PoroElast::ConvNorm normtypeinc_;   //!< convergence check for residual temperatures
-    enum PoroElast::ConvNorm normtypefres_;  //!< convergence check for residual forces
-    enum PoroElast::BinaryOp combincfres_;   //!< binary operator to combine temperatures and forces
-    enum PoroElast::VectorNorm vectornormfres_;  //!< type of norm for residual
-    enum PoroElast::VectorNorm vectornorminc_;   //!< type of norm for increments
+    PoroElast::ConvNorm normtypeinc_;       //!< convergence check for residual temperatures
+    PoroElast::ConvNorm normtypefres_;      //!< convergence check for residual forces
+    PoroElast::BinaryOp combincfres_;       //!< binary operator to combine temperatures and forces
+    PoroElast::VectorNorm vectornormfres_;  //!< type of norm for residual
+    PoroElast::VectorNorm vectornorminc_;   //!< type of norm for increments
 
     double tolinc_;   //!< tolerance residual increment
     double tolfres_;  //!< tolerance force residual

--- a/src/poroelast/4C_poroelast_utils.cpp
+++ b/src/poroelast/4C_poroelast_utils.cpp
@@ -324,7 +324,7 @@ void PoroElast::print_logo()
 }
 
 double PoroElast::Utils::calculate_vector_norm(
-    const enum PoroElast::VectorNorm norm, const Core::LinAlg::Vector<double>& vect)
+    const PoroElast::VectorNorm norm, const Core::LinAlg::Vector<double>& vect)
 {
   // L1 norm
   // norm = sum_0^i vect[i]

--- a/src/poroelast/4C_poroelast_utils.hpp
+++ b/src/poroelast/4C_poroelast_utils.hpp
@@ -95,8 +95,8 @@ namespace PoroElast
         Core::FE::Discretization& voldiscret, Core::FE::Discretization* voldiscret2 = nullptr);
 
     //! Determine norm of vector
-    double calculate_vector_norm(const enum PoroElast::VectorNorm norm,  //!< norm to use
-        const Core::LinAlg::Vector<double>& vect                         //!< the vector of interest
+    double calculate_vector_norm(const PoroElast::VectorNorm norm,  //!< norm to use
+        const Core::LinAlg::Vector<double>& vect                    //!< the vector of interest
     );
 
     //! Set the slave and master elements of the face element

--- a/src/poroelast_scatra/4C_poroelast_scatra_monolithic.hpp
+++ b/src/poroelast_scatra/4C_poroelast_scatra_monolithic.hpp
@@ -205,11 +205,11 @@ namespace PoroElastScaTra
 
     //! @name Iterative solution technique
 
-    enum PoroElast::ConvNorm normtypeinc_;   //!< convergence check for increments
-    enum PoroElast::ConvNorm normtypefres_;  //!< convergence check for residual forces
-    enum PoroElast::BinaryOp combincfres_;  //!< binary operator to combine increments and residuals
-    enum PoroElast::VectorNorm vectornormfres_;  //!< type of norm for residual
-    enum PoroElast::VectorNorm vectornorminc_;   //!< type of norm for increments
+    PoroElast::ConvNorm normtypeinc_;       //!< convergence check for increments
+    PoroElast::ConvNorm normtypefres_;      //!< convergence check for residual forces
+    PoroElast::BinaryOp combincfres_;       //!< binary operator to combine increments and residuals
+    PoroElast::VectorNorm vectornormfres_;  //!< type of norm for residual
+    PoroElast::VectorNorm vectornorminc_;   //!< type of norm for increments
 
     double tolinc_;   //!< tolerance residual increment
     double tolfres_;  //!< tolerance force residual

--- a/src/poroelast_scatra/4C_poroelast_scatra_utils.hpp
+++ b/src/poroelast_scatra/4C_poroelast_scatra_utils.hpp
@@ -110,8 +110,8 @@ namespace PoroElastScaTra
         Core::FE::Discretization& voldiscret, Core::FE::Discretization* voldiscret2 = nullptr);
 
     //! Determine norm of vector
-    double calculate_vector_norm(const enum PoroElast::VectorNorm norm,  //!< norm to use
-        const std::shared_ptr<const Core::LinAlg::Vector<double>> vect   //!< the vector of interest
+    double calculate_vector_norm(const PoroElast::VectorNorm norm,      //!< norm to use
+        const std::shared_ptr<const Core::LinAlg::Vector<double>> vect  //!< the vector of interest
     );
 
     //! Set the slave and master elements of the face element

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_algorithm.hpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_algorithm.hpp
@@ -534,7 +534,7 @@ namespace PoroPressureBased
     const int fluxreconsolvernum_;
 
     //! what to do when nonlinear solution fails
-    enum PoroPressureBased::DivergenceAction divcontype_;
+    PoroPressureBased::DivergenceAction divcontype_;
 
     //! flag for finite difference check
     const bool fdcheck_;
@@ -586,9 +586,9 @@ namespace PoroPressureBased
     const int uprestart_;
 
     // vector norm for residuals
-    enum PoroPressureBased::VectorNorm vectornormfres_;
+    PoroPressureBased::VectorNorm vectornormfres_;
     // vector norm for increments
-    enum PoroPressureBased::VectorNorm vectornorminc_;
+    PoroPressureBased::VectorNorm vectornorminc_;
 
     //! convergence tolerance for increments
     double ittolres_;

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_utils.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_utils.cpp
@@ -473,7 +473,7 @@ double PoroPressureBased::get_max_nodal_distance(
  | calculate vector norm                             kremheller 12/17   |
  *----------------------------------------------------------------------*/
 double PoroPressureBased::calculate_vector_norm(
-    const enum PoroPressureBased::VectorNorm norm, const Core::LinAlg::Vector<double>& vect)
+    const PoroPressureBased::VectorNorm norm, const Core::LinAlg::Vector<double>& vect)
 {
   // L1 norm
   // norm = sum_0^i vect[i]

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_utils.hpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_utils.hpp
@@ -107,7 +107,7 @@ namespace PoroPressureBased
       Core::FE::Discretization& dis, const Core::LinAlg::Map* nodemap);
 
   //! Determine norm of vector
-  double calculate_vector_norm(const enum PoroPressureBased::VectorNorm norm,  //!< norm to use
+  double calculate_vector_norm(const PoroPressureBased::VectorNorm norm,  //!< norm to use
       const Core::LinAlg::Vector<double>& vect  //!< the vector of interest
   );
 

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_base.hpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_base.hpp
@@ -139,7 +139,7 @@ namespace PoroPressureBased
 
    protected:
     //! what to do when nonlinear solution fails
-    enum PoroPressureBased::DivergenceAction divergence_action_;
+    PoroPressureBased::DivergenceAction divergence_action_;
     //! do we perform coupling with 1D artery
     const bool artery_coupling_;
 

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_monolithic.hpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_monolithic.hpp
@@ -280,8 +280,8 @@ namespace PoroPressureBased
     double max_inc_;  //!< maximum increment
     double max_res_;  //!< maximum residual
 
-    enum PoroPressureBased::VectorNorm vector_norm_res_;  //!< type of norm for residual
-    enum PoroPressureBased::VectorNorm vector_norm_inc_;  //!< type of norm for increments
+    PoroPressureBased::VectorNorm vector_norm_res_;  //!< type of norm for residual
+    PoroPressureBased::VectorNorm vector_norm_inc_;  //!< type of norm for increments
 
     Teuchos::Time timernewton_;  //!< timer for measurement of solution time of newton iterations
     double dtsolve_;             //!< linear solver time

--- a/src/scatra/4C_scatra_timint_implicit.cpp
+++ b/src/scatra/4C_scatra_timint_implicit.cpp
@@ -3099,7 +3099,7 @@ void ScaTra::ScaTraTimIntImpl::nonlinear_micro_scale_solve()
 /*--------------------------------------------------------------------------*
  *--------------------------------------------------------------------------*/
 std::string ScaTra::ScaTraTimIntImpl::map_tim_int_enum_to_string(
-    const enum Inpar::ScaTra::TimeIntegrationScheme term)
+    const Inpar::ScaTra::TimeIntegrationScheme term)
 {
   // length of return std::string is 14 due to usage in formatted screen output
   switch (term)

--- a/src/scatra/4C_scatra_timint_meshtying_strategy_fluid.hpp
+++ b/src/scatra/4C_scatra_timint_meshtying_strategy_fluid.hpp
@@ -88,7 +88,7 @@ namespace ScaTra
     std::shared_ptr<FLD::Meshtying> meshtying_;
 
     //! type of fluid-fluid meshtying
-    enum Inpar::FLUID::MeshTying type_;
+    Inpar::FLUID::MeshTying type_;
 
    private:
     //! copy constructor

--- a/src/scatra_ele/4C_scatra_ele_boundary_factory.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_factory.cpp
@@ -30,7 +30,7 @@ FOUR_C_NAMESPACE_OPEN
  |                                                 (public) rasthofer 11/13 |
  *--------------------------------------------------------------------------*/
 Discret::Elements::ScaTraBoundaryInterface* Discret::Elements::ScaTraBoundaryFactory::provide_impl(
-    const Core::Elements::Element* ele, const enum Inpar::ScaTra::ImplType impltype,
+    const Core::Elements::Element* ele, const Inpar::ScaTra::ImplType impltype,
     const int numdofpernode, const int numscal, const std::string& disname)
 {
   // number of space dimensions
@@ -125,7 +125,7 @@ Discret::Elements::ScaTraBoundaryInterface* Discret::Elements::ScaTraBoundaryFac
 template <Core::FE::CellType distype, int probdim>
 Discret::Elements::ScaTraBoundaryInterface*
 Discret::Elements::ScaTraBoundaryFactory::define_problem_type(
-    const enum Inpar::ScaTra::ImplType impltype, const int numdofpernode, const int numscal,
+    const Inpar::ScaTra::ImplType impltype, const int numdofpernode, const int numscal,
     const std::string& disname)
 {
   switch (impltype)

--- a/src/scatra_ele/4C_scatra_ele_boundary_factory.hpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_factory.hpp
@@ -32,15 +32,14 @@ namespace Discret
 
       //! ProvideImpl
       static ScaTraBoundaryInterface* provide_impl(const Core::Elements::Element* ele,
-          const enum Inpar::ScaTra::ImplType impltype, const int numdofpernode, const int numscal,
+          const Inpar::ScaTra::ImplType impltype, const int numdofpernode, const int numscal,
           const std::string& disname);
 
      private:
       //! return instance of element evaluation class depending on implementation type
       template <Core::FE::CellType distype, int probdim>
-      static ScaTraBoundaryInterface* define_problem_type(
-          const enum Inpar::ScaTra::ImplType impltype, const int numdofpernode, const int numscal,
-          const std::string& disname);
+      static ScaTraBoundaryInterface* define_problem_type(const Inpar::ScaTra::ImplType impltype,
+          const int numdofpernode, const int numscal, const std::string& disname);
     };  // class ScaTraBoundaryFactory
   }  // namespace Elements
 }  // namespace Discret

--- a/src/scatra_ele/4C_scatra_ele_calc_elch.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_elch.hpp
@@ -236,7 +236,7 @@ namespace Discret
       //! calculate conductivity of electrolyte solution
       void calculate_conductivity(
           const Core::Elements::Element* ele,  //!< the element we are dealing with
-          const enum ElCh::EquPot equpot,      //!< type of closing equation for electric potential
+          const ElCh::EquPot equpot,           //!< type of closing equation for electric potential
           Core::LinAlg::SerialDenseVector&
               sigma,       //!< conductivity of all single ions + overall electrolyte solution
           bool effCond,    //!< flag if effective conductivity should be calculated
@@ -246,8 +246,8 @@ namespace Discret
 
       // Get conductivity from material
       virtual void get_conductivity(
-          const enum ElCh::EquPot equpot,  //!< type of closing equation for electric potential
-          double& sigma_all,               //!< conductivity of electrolyte solution
+          const ElCh::EquPot equpot,  //!< type of closing equation for electric potential
+          double& sigma_all,          //!< conductivity of electrolyte solution
           std::vector<double>&
               sigma,  //!< conductivity of all single ions + overall electrolyte solution
           bool effCond) = 0;

--- a/src/scatra_ele/4C_scatra_ele_calc_elch_NP.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_elch_NP.hpp
@@ -311,8 +311,8 @@ namespace Discret
 
       // Get conductivity from material
       void get_conductivity(
-          const enum ElCh::EquPot equpot,  //!< type of closing equation for electric potential
-          double& sigma_all,               //!< conductivity of electrolyte solution
+          const ElCh::EquPot equpot,  //!< type of closing equation for electric potential
+          double& sigma_all,          //!< conductivity of electrolyte solution
           std::vector<double>&
               sigma,    //!< conductivity of a single ion + overall electrolyte solution
           bool effCond  //!< flag if effective conductivity should be calculated

--- a/src/scatra_ele/4C_scatra_ele_calc_elch_electrode.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_elch_electrode.hpp
@@ -192,8 +192,8 @@ namespace Discret
 
       //! get conductivity
       void get_conductivity(
-          const enum ElCh::EquPot equpot,  //!< type of closing equation for electric potential
-          double& sigma_all,               //!< conductivity of electrolyte solution
+          const ElCh::EquPot equpot,  //!< type of closing equation for electric potential
+          double& sigma_all,          //!< conductivity of electrolyte solution
           std::vector<double>&
               sigma,    //!< conductivity or a single ion + overall electrolyte solution
           bool effCond  //!< flag if effective conductivity should be calculated

--- a/src/scatra_ele/4C_scatra_ele_calc_service_elch.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_service_elch.cpp
@@ -250,7 +250,7 @@ void Discret::Elements::ScaTraEleCalcElch<distype, probdim>::cal_error_compared_
   *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
 void Discret::Elements::ScaTraEleCalcElch<distype, probdim>::calculate_conductivity(
-    const Core::Elements::Element* ele, const enum ElCh::EquPot equpot,
+    const Core::Elements::Element* ele, const ElCh::EquPot equpot,
     Core::LinAlg::SerialDenseVector& sigma_domint, bool effCond, bool specresist)
 {
   // integration points and weights

--- a/src/scatra_ele/4C_scatra_ele_calc_service_elch_NP.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_service_elch_NP.cpp
@@ -161,7 +161,7 @@ void Discret::Elements::ScaTraEleCalcElchNP<distype>::evaluate_elch_boundary_kin
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype>
 void Discret::Elements::ScaTraEleCalcElchNP<distype>::get_conductivity(
-    const enum ElCh::EquPot equpot, double& sigma_all, std::vector<double>& sigma,
+    const ElCh::EquPot equpot, double& sigma_all, std::vector<double>& sigma,
     bool effCond  // the bool effCond is not used for the NP formulation since the volume averaging
                   // is not implemented
 )

--- a/src/scatra_ele/4C_scatra_ele_calc_service_elch_electrode.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_service_elch_electrode.cpp
@@ -77,8 +77,8 @@ void Discret::Elements::ScaTraEleCalcElchElectrode<distype, probdim>::check_elch
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
 void Discret::Elements::ScaTraEleCalcElchElectrode<distype, probdim>::get_conductivity(
-    const enum ElCh::EquPot equpot,  //!< type of closing equation for electric potential
-    double& sigma_all,               //!< conductivity of electrolyte solution
+    const ElCh::EquPot equpot,   //!< type of closing equation for electric potential
+    double& sigma_all,           //!< conductivity of electrolyte solution
     std::vector<double>& sigma,  //!< conductivity or a single ion + overall electrolyte solution
     bool effCond)
 {

--- a/src/scatra_ele/4C_scatra_ele_parameter_elch.hpp
+++ b/src/scatra_ele/4C_scatra_ele_parameter_elch.hpp
@@ -64,7 +64,7 @@ namespace Discret
       bool boundaryfluxcoupling_;
 
       //! equation used for closing of the elch-system
-      enum ElCh::EquPot equpot_;
+      ElCh::EquPot equpot_;
 
       //! Faraday constant
       double faraday_;

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_calc_pressure_velocity_based.cpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_calc_pressure_velocity_based.cpp
@@ -351,8 +351,8 @@ void Discret::Elements::SolidPoroPressureVelocityBasedEleCalc<celltype,
   DiagonalBlockMatrixViews<celltype, porosity_formulation> matrix_views =
       make_optional_block_matrix_view<celltype>(diagonal_block_matrices);
 
-  enum Inpar::Solid::DampKind damping =
-      params.get<enum Inpar::Solid::DampKind>("damping", Inpar::Solid::damp_none);
+  Inpar::Solid::DampKind damping =
+      params.get<Inpar::Solid::DampKind>("damping", Inpar::Solid::damp_none);
 
   auto react_matrix = make_optional_matrix_view<num_dim_ * num_nodes_, num_dim_ * num_nodes_>(
       damping == Inpar::Solid::damp_material ? reactive_matrix : nullptr);

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_aux.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_aux.cpp
@@ -467,10 +467,10 @@ int NOX::Nln::Aux::get_outer_status(const ::NOX::StatusTest::Generic& test)
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-enum NOX::Nln::SolutionType NOX::Nln::Aux::convert_quantity_type_to_solution_type(
-    const enum NOX::Nln::StatusTest::QuantityType& qtype)
+NOX::Nln::SolutionType NOX::Nln::Aux::convert_quantity_type_to_solution_type(
+    const NOX::Nln::StatusTest::QuantityType& qtype)
 {
-  enum NOX::Nln::SolutionType soltype = NOX::Nln::sol_unknown;
+  NOX::Nln::SolutionType soltype = NOX::Nln::sol_unknown;
   switch (qtype)
   {
     case NOX::Nln::StatusTest::quantity_structure:

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_aux.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_aux.hpp
@@ -47,8 +47,7 @@ namespace NOX
 
       /// return linear system type
       NOX::Nln::LinSystem::LinearSystemType get_linear_system_type(
-          const std::map<enum NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>&
-              linsolvers);
+          const std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>& linsolvers);
 
       /*! \brief Calculate the root mean square for the NOX status test
        *  \f[
@@ -121,8 +120,8 @@ namespace NOX
        *
        * \param qtype : Quantity type which has to be converted.
        */
-      enum NOX::Nln::SolutionType convert_quantity_type_to_solution_type(
-          const enum NOX::Nln::StatusTest::QuantityType& qtype);
+      NOX::Nln::SolutionType convert_quantity_type_to_solution_type(
+          const NOX::Nln::StatusTest::QuantityType& qtype);
 
       /*! \brief Map norm type stl_string to norm type enum
        *

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_constraint_group.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_constraint_group.cpp
@@ -121,7 +121,7 @@ Teuchos::RCP<const std::vector<double>> NOX::Nln::CONSTRAINT::Group::get_rhs_nor
     // avoid the execution of this block for NaN and Inf return values
     if (rval < 0.0)
     {
-      enum NOX::Nln::SolutionType soltype =
+      NOX::Nln::SolutionType soltype =
           NOX::Nln::Aux::convert_quantity_type_to_solution_type(chQ[i]);
       Teuchos::RCP<const NOX::Nln::CONSTRAINT::Interface::Required> constrptr =
           get_constraint_interface_ptr(soltype, false);
@@ -178,8 +178,7 @@ Teuchos::RCP<std::vector<double>> NOX::Nln::CONSTRAINT::Group::get_solution_upda
       norms->push_back(rval);
       continue;
     }
-    enum NOX::Nln::SolutionType soltype =
-        NOX::Nln::Aux::convert_quantity_type_to_solution_type(chQ[i]);
+    NOX::Nln::SolutionType soltype = NOX::Nln::Aux::convert_quantity_type_to_solution_type(chQ[i]);
     Teuchos::RCP<const NOX::Nln::CONSTRAINT::Interface::Required> constrptr =
         get_constraint_interface_ptr(soltype);
     rval = constrptr->get_lagrange_multiplier_update_norms(xVector.get_linalg_vector(),
@@ -227,8 +226,7 @@ Teuchos::RCP<std::vector<double>> NOX::Nln::CONSTRAINT::Group::get_previous_solu
       norms->push_back(rval);
       continue;
     }
-    enum NOX::Nln::SolutionType soltype =
-        NOX::Nln::Aux::convert_quantity_type_to_solution_type(chQ[i]);
+    NOX::Nln::SolutionType soltype = NOX::Nln::Aux::convert_quantity_type_to_solution_type(chQ[i]);
     Teuchos::RCP<const NOX::Nln::CONSTRAINT::Interface::Required> constrptr =
         get_constraint_interface_ptr(soltype);
     rval = constrptr->get_previous_lagrange_multiplier_norms(xOldNox.get_linalg_vector(), chQ[i],
@@ -271,8 +269,7 @@ Teuchos::RCP<std::vector<double>> NOX::Nln::CONSTRAINT::Group::get_solution_upda
       continue;
     }
 
-    enum NOX::Nln::SolutionType soltype =
-        NOX::Nln::Aux::convert_quantity_type_to_solution_type(chQ[i]);
+    NOX::Nln::SolutionType soltype = NOX::Nln::Aux::convert_quantity_type_to_solution_type(chQ[i]);
     Teuchos::RCP<const NOX::Nln::CONSTRAINT::Interface::Required> constrptr =
         get_constraint_interface_ptr(soltype);
 
@@ -297,9 +294,9 @@ Teuchos::RCP<std::vector<double>> NOX::Nln::CONSTRAINT::Group::get_solution_upda
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 Teuchos::RCP<const Core::LinAlg::Map> NOX::Nln::CONSTRAINT::Group::get_current_active_set_map(
-    const enum NOX::Nln::StatusTest::QuantityType& qt) const
+    const NOX::Nln::StatusTest::QuantityType& qt) const
 {
-  enum NOX::Nln::SolutionType soltype = NOX::Nln::Aux::convert_quantity_type_to_solution_type(qt);
+  NOX::Nln::SolutionType soltype = NOX::Nln::Aux::convert_quantity_type_to_solution_type(qt);
 
   return get_constraint_interface_ptr(soltype)->get_current_active_set_map(qt);
 }
@@ -307,10 +304,9 @@ Teuchos::RCP<const Core::LinAlg::Map> NOX::Nln::CONSTRAINT::Group::get_current_a
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 Teuchos::RCP<const Core::LinAlg::Map> NOX::Nln::CONSTRAINT::Group::get_old_active_set_map(
-    const enum NOX::Nln::StatusTest::QuantityType& qtype) const
+    const NOX::Nln::StatusTest::QuantityType& qtype) const
 {
-  enum NOX::Nln::SolutionType soltype =
-      NOX::Nln::Aux::convert_quantity_type_to_solution_type(qtype);
+  NOX::Nln::SolutionType soltype = NOX::Nln::Aux::convert_quantity_type_to_solution_type(qtype);
 
   return get_constraint_interface_ptr(soltype)->get_old_active_set_map(qtype);
 }
@@ -318,10 +314,9 @@ Teuchos::RCP<const Core::LinAlg::Map> NOX::Nln::CONSTRAINT::Group::get_old_activ
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 enum ::NOX::StatusTest::StatusType NOX::Nln::CONSTRAINT::Group::get_active_set_info(
-    const enum NOX::Nln::StatusTest::QuantityType& qtype, int& activeset_size) const
+    const NOX::Nln::StatusTest::QuantityType& qtype, int& activeset_size) const
 {
-  enum NOX::Nln::SolutionType soltype =
-      NOX::Nln::Aux::convert_quantity_type_to_solution_type(qtype);
+  NOX::Nln::SolutionType soltype = NOX::Nln::Aux::convert_quantity_type_to_solution_type(qtype);
 
   return get_constraint_interface_ptr(soltype)->get_active_set_info(qtype, activeset_size);
 }

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_constraint_group.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_constraint_group.hpp
@@ -106,16 +106,16 @@ namespace NOX
         //! @{
         //! Returns the current active set map (only needed for inequality constraint problems)
         Teuchos::RCP<const Core::LinAlg::Map> get_current_active_set_map(
-            const enum NOX::Nln::StatusTest::QuantityType& qtype) const;
+            const NOX::Nln::StatusTest::QuantityType& qtype) const;
 
         //! Returns the active set map of the previous Newton step (only needed for inequality
         //! constraint problems)
         Teuchos::RCP<const Core::LinAlg::Map> get_old_active_set_map(
-            const enum NOX::Nln::StatusTest::QuantityType& qtype) const;
+            const NOX::Nln::StatusTest::QuantityType& qtype) const;
 
         //! Returns basic information about the active set status (no Core::LinAlg::Maps needed!)
         enum ::NOX::StatusTest::StatusType get_active_set_info(
-            const enum NOX::Nln::StatusTest::QuantityType& qtype, int& activeset_size) const;
+            const NOX::Nln::StatusTest::QuantityType& qtype, int& activeset_size) const;
 
         //@}
 

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_constraint_interface_required.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_constraint_interface_required.hpp
@@ -63,9 +63,9 @@ namespace NOX
 
           //! Get the desired linearization terms of the objective model
           virtual double get_linearized_model_terms(const Core::LinAlg::Vector<double>& dir,
-              const enum NOX::Nln::MeritFunction::MeritFctName name,
-              const enum NOX::Nln::MeritFunction::LinOrder order,
-              const enum NOX::Nln::MeritFunction::LinType type) const
+              const NOX::Nln::MeritFunction::MeritFctName name,
+              const NOX::Nln::MeritFunction::LinOrder order,
+              const NOX::Nln::MeritFunction::LinType type) const
           {
             FOUR_C_THROW("get_linearized_model_terms() is not implemented!");
           };
@@ -120,20 +120,20 @@ namespace NOX
            *  This is optional and only relevant for inequality constraint problems. */
           //! @{
           virtual enum ::NOX::StatusTest::StatusType get_active_set_info(
-              enum NOX::Nln::StatusTest::QuantityType qt, int& activeset_size) const
+              NOX::Nln::StatusTest::QuantityType qt, int& activeset_size) const
           {
             activeset_size = -1;
             return ::NOX::StatusTest::Unevaluated;
           }
 
           virtual Teuchos::RCP<const Core::LinAlg::Map> get_current_active_set_map(
-              enum NOX::Nln::StatusTest::QuantityType qt) const
+              NOX::Nln::StatusTest::QuantityType qt) const
           {
             return Teuchos::null;
           };
 
           virtual Teuchos::RCP<const Core::LinAlg::Map> get_old_active_set_map(
-              enum NOX::Nln::StatusTest::QuantityType qt) const
+              NOX::Nln::StatusTest::QuantityType qt) const
           {
             return Teuchos::null;
           };

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_enum_lists.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_enum_lists.hpp
@@ -33,7 +33,7 @@ namespace NOX
     };
 
     //! Map quantity enum to std::string
-    inline std::string solution_type_to_string(const enum SolutionType type)
+    inline std::string solution_type_to_string(const SolutionType type)
     {
       switch (type)
       {
@@ -56,7 +56,7 @@ namespace NOX
     };
 
     //! Map quantity std::string to enum
-    inline enum SolutionType string_to_solution_type(const std::string& name)
+    inline SolutionType string_to_solution_type(const std::string& name)
     {
       SolutionType type = sol_unknown;
       if (name == "Structure")
@@ -93,7 +93,7 @@ namespace NOX
     };
 
     //! Map second order correction type enum to std::string
-    inline std::string correction_type_to_string(const enum CorrectionType type)
+    inline std::string correction_type_to_string(const CorrectionType type)
     {
       switch (type)
       {
@@ -119,7 +119,7 @@ namespace NOX
         max_min_ev_ratio  ///< condition number as ration of largest and smallest eigenvalue
       };
 
-      inline std::string condition_number_to_string(const enum ConditionNumber condtype)
+      inline std::string condition_number_to_string(const ConditionNumber condtype)
       {
         switch (condtype)
         {
@@ -156,7 +156,7 @@ namespace NOX
       };
 
       /// Map operator type to std::string
-      inline std::string operator_type_to_string(const enum OperatorType type)
+      inline std::string operator_type_to_string(const OperatorType type)
       {
         switch (type)
         {
@@ -213,7 +213,7 @@ namespace NOX
         mrtfct_vague                          //!< unspecified
       };
 
-      inline std::string merit_func_name_to_string(const enum MeritFctName mrt_func)
+      inline std::string merit_func_name_to_string(const MeritFctName mrt_func)
       {
         switch (mrt_func)
         {
@@ -271,7 +271,7 @@ namespace NOX
       };
 
       /// Map quantity name to std::string
-      inline std::string quantity_type_to_string(const enum QuantityType type)
+      inline std::string quantity_type_to_string(const QuantityType type)
       {
         switch (type)
         {

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_globaldata.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_globaldata.hpp
@@ -48,8 +48,7 @@ namespace NOX
        *  inclusive the pre-conditioner interfaces
        *  inclusive scaling object */
       GlobalData(MPI_Comm comm, Teuchos::ParameterList& noxParams,
-          const std::map<enum NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>&
-              linSolvers,
+          const std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>& linSolvers,
           const Teuchos::RCP<::NOX::Epetra::Interface::Required>& iReq,
           const Teuchos::RCP<::NOX::Epetra::Interface::Jacobian>& iJac,
           const OptimizationProblemType& type, const NOX::Nln::CONSTRAINT::ReqInterfaceMap& iConstr,
@@ -60,8 +59,7 @@ namespace NOX
        * inclusive the constraint interfaces map
        * without any pre-conditioner interfaces */
       GlobalData(MPI_Comm comm, Teuchos::ParameterList& noxParams,
-          const std::map<enum NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>&
-              linSolvers,
+          const std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>& linSolvers,
           const Teuchos::RCP<::NOX::Epetra::Interface::Required>& iReq,
           const Teuchos::RCP<::NOX::Epetra::Interface::Jacobian>& iJac,
           const OptimizationProblemType& type,
@@ -71,8 +69,7 @@ namespace NOX
        *  constructor without the constraint interface map (pure unconstrained optimization)
        *  without a pre-conditioner interface */
       GlobalData(MPI_Comm comm, Teuchos::ParameterList& noxParams,
-          const std::map<enum NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>&
-              linSolvers,
+          const std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>& linSolvers,
           const Teuchos::RCP<::NOX::Epetra::Interface::Required>& iReq,
           const Teuchos::RCP<::NOX::Epetra::Interface::Jacobian>& iJac);
 
@@ -101,7 +98,7 @@ namespace NOX
       bool is_constrained() const;
 
       // return linear solver vector
-      const std::map<enum NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>&
+      const std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>&
       get_linear_solvers();
 
       //! return the user-defined required interface

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_group_prepostoperator.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_group_prepostoperator.hpp
@@ -49,7 +49,7 @@ namespace NOX
       class PrePostOperator
       {
        public:
-        using Map = std::map<enum PrePostOpType, Teuchos::RCP<NOX::Nln::Abstract::PrePostOperator>>;
+        using Map = std::map<PrePostOpType, Teuchos::RCP<NOX::Nln::Abstract::PrePostOperator>>;
 
        private:
         //! Disallow default constructor.

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_inner_statustest_generic.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_inner_statustest_generic.hpp
@@ -45,7 +45,7 @@ namespace NOX
           status_converged = 1
         };
 
-        inline std::string status_type_to_string(enum StatusType status)
+        inline std::string status_type_to_string(StatusType status)
         {
           switch (status)
           {

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_interface_jacobian.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_interface_jacobian.hpp
@@ -46,7 +46,7 @@ namespace NOX
         /*! \brief Compute the correction system of given type.
          *
          *  \return TRUE if computation was successful. */
-        virtual bool compute_correction_system(const enum CorrectionType type,
+        virtual bool compute_correction_system(const CorrectionType type,
             const ::NOX::Abstract::Group& grp, const Epetra_Vector& x, Epetra_Vector& rhs,
             Epetra_Operator& jac)
         {

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_interface_required.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_interface_required.hpp
@@ -67,13 +67,13 @@ namespace NOX
 
         //! compute and return some energy representative
         virtual double get_model_value(const Epetra_Vector& x, const Epetra_Vector& F,
-            const enum MeritFunction::MeritFctName merit_func_type) const = 0;
+            const MeritFunction::MeritFctName merit_func_type) const = 0;
 
         //! return model terms of a linear model (optional)
         virtual double get_linearized_model_terms(const ::NOX::Abstract::Group* group,
-            const Epetra_Vector& dir, const enum NOX::Nln::MeritFunction::MeritFctName mf_type,
-            const enum NOX::Nln::MeritFunction::LinOrder linorder,
-            const enum NOX::Nln::MeritFunction::LinType lintype) const
+            const Epetra_Vector& dir, const NOX::Nln::MeritFunction::MeritFctName mf_type,
+            const NOX::Nln::MeritFunction::LinOrder linorder,
+            const NOX::Nln::MeritFunction::LinType lintype) const
         {
           FOUR_C_THROW("Not implemented!");
         }

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.cpp
@@ -362,7 +362,7 @@ bool NOX::Nln::LinearSystem::compute_f_and_jacobian(
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-bool NOX::Nln::LinearSystem::compute_correction_system(const enum CorrectionType type,
+bool NOX::Nln::LinearSystem::compute_correction_system(const CorrectionType type,
     const ::NOX::Abstract::Group& grp, const NOX::Nln::Vector& x, NOX::Nln::Vector& rhs)
 {
   prePostOperatorPtr_->run_pre_compute_f_and_jacobian(
@@ -491,8 +491,7 @@ Teuchos::RCP<Epetra_Operator> NOX::Nln::LinearSystem::get_jacobian_operator()
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-const enum NOX::Nln::LinSystem::OperatorType& NOX::Nln::LinearSystem::get_jacobian_operator_type()
-    const
+const NOX::Nln::LinSystem::OperatorType& NOX::Nln::LinearSystem::get_jacobian_operator_type() const
 {
   return jacType_;
 }

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.hpp
@@ -97,7 +97,7 @@ namespace NOX
       //! Evaluate the Jacobian and the right hand side based on the solution vector x at once.
       virtual bool compute_f_and_jacobian(const NOX::Nln::Vector& x, NOX::Nln::Vector& rhs);
 
-      bool compute_correction_system(const enum NOX::Nln::CorrectionType type,
+      bool compute_correction_system(const NOX::Nln::CorrectionType type,
           const ::NOX::Abstract::Group& grp, const NOX::Nln::Vector& x, NOX::Nln::Vector& rhs);
 
       bool apply_jacobian_block(const NOX::Nln::Vector& input,
@@ -152,7 +152,7 @@ namespace NOX
       Teuchos::RCP<Epetra_Operator> get_jacobian_operator() override;
 
       //! Returns the operator type of the jacobian
-      const enum NOX::Nln::LinSystem::OperatorType& get_jacobian_operator_type() const;
+      const NOX::Nln::LinSystem::OperatorType& get_jacobian_operator_type() const;
 
       //! destroy the jacobian ptr
       bool destroy_jacobian();

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_prepostoperator.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_prepostoperator.hpp
@@ -52,7 +52,7 @@ namespace NOX
       class PrePostOperator
       {
        public:
-        using Map = std::map<enum PrePostOpType, Teuchos::RCP<NOX::Nln::Abstract::PrePostOperator>>;
+        using Map = std::map<PrePostOpType, Teuchos::RCP<NOX::Nln::Abstract::PrePostOperator>>;
 
        private:
         //! Disallow default constructor.

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linesearch_prepostoperator.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linesearch_prepostoperator.hpp
@@ -31,7 +31,7 @@ namespace NOX
       class PrePostOperator
       {
        public:
-        using map = std::map<enum PrePostOpType, Teuchos::RCP<NOX::Nln::Abstract::PrePostOperator>>;
+        using map = std::map<PrePostOpType, Teuchos::RCP<NOX::Nln::Abstract::PrePostOperator>>;
 
         /// disallow the following
         PrePostOperator() = delete;

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_solver_ptc.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_solver_ptc.cpp
@@ -778,7 +778,7 @@ void NOX::Nln::LinSystem::PrePostOp::PseudoTransient::run_post_compute_jacobian(
   if (not ptcsolver_.is_ptc_solve()) return;
 
   // get the type of the jacobian
-  const enum NOX::Nln::LinSystem::OperatorType& jactype = linsys.get_jacobian_operator_type();
+  const NOX::Nln::LinSystem::OperatorType& jactype = linsys.get_jacobian_operator_type();
 
   switch (jactype)
   {
@@ -823,7 +823,7 @@ void NOX::Nln::LinSystem::PrePostOp::PseudoTransient::modify_jacobian(
 {
   // get the inverse pseudo time step
   const double& deltaInv = ptcsolver_.get_inverse_pseudo_time_step();
-  const enum NOX::Nln::Solver::PseudoTransient::ScaleOpType& scaleoptype =
+  const NOX::Nln::Solver::PseudoTransient::ScaleOpType& scaleoptype =
       ptcsolver_.get_scaling_operator_type();
   const double& scaleFactor = ptcsolver_.get_scaling_factor();
 
@@ -904,7 +904,7 @@ NOX::Nln::Vector NOX::Nln::GROUP::PrePostOp::PseudoTransient::eval_pseudo_transi
    * step size. */
   xUpdate.update(-1.0, xOld, 1.0);
 
-  const enum NOX::Nln::Solver::PseudoTransient::ScaleOpType& scaleoptype =
+  const NOX::Nln::Solver::PseudoTransient::ScaleOpType& scaleoptype =
       ptcsolver_.get_scaling_operator_type();
   switch (scaleoptype)
   {

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_solver_ptc.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_solver_ptc.hpp
@@ -72,7 +72,7 @@ namespace NOX
         };
 
         //! Map pseudo time step control type stl_string to enum
-        inline enum TSCType string_to_tsc_type(const std::string& name)
+        inline TSCType string_to_tsc_type(const std::string& name)
         {
           TSCType type = tsc_set;
           if (name == "SER" || name == "Switched Evolution Relaxation")
@@ -108,7 +108,7 @@ namespace NOX
         };
 
         //! Map build operator type stl_string to enum
-        inline enum BuildOpType string_to_build_op_type(const std::string& name)
+        inline BuildOpType string_to_build_op_type(const std::string& name)
         {
           BuildOpType type = build_op_everyiter;
           if (name == "every iter")
@@ -127,7 +127,7 @@ namespace NOX
         };
 
         //! Map scaling operator type stl_string to enum
-        inline enum ScaleOpType string_to_scale_op_type(const std::string& name)
+        inline ScaleOpType string_to_scale_op_type(const std::string& name)
         {
           ScaleOpType type = scale_op_identity;
           if (name == "Identity")
@@ -179,7 +179,7 @@ namespace NOX
         const double& get_scaling_factor() const;
 
         //! Returns the scaling operator type
-        const enum ScaleOpType& get_scaling_operator_type() const;
+        const ScaleOpType& get_scaling_operator_type() const;
 
         //! Returns the scaling diagonal operator
         const Core::LinAlg::Vector<double>& get_scaling_diag_operator() const;
@@ -350,13 +350,13 @@ namespace NOX
         int maxPseudoTransientIterations_;
 
         //! time step control type
-        enum TSCType tscType_;
+        TSCType tscType_;
 
         //! scaling operator type
-        enum ScaleOpType scaleOpType_;
+        ScaleOpType scaleOpType_;
 
         //! scaling operator type
-        enum BuildOpType build_scaling_op_;
+        BuildOpType build_scaling_op_;
 
         //! vector norm type (necessary for the time step control)
         enum ::NOX::Abstract::Vector::NormType normType_;

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_statustest_activeset.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_statustest_activeset.cpp
@@ -19,7 +19,7 @@ FOUR_C_NAMESPACE_OPEN
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 NOX::Nln::StatusTest::ActiveSet::ActiveSet(
-    const enum NOX::Nln::StatusTest::QuantityType& qtype, const int& max_cycle_size)
+    const NOX::Nln::StatusTest::QuantityType& qtype, const int& max_cycle_size)
     : qtype_(qtype),
       status_(::NOX::StatusTest::Unevaluated),
       max_cycle_size_(max_cycle_size),

--- a/src/stru_multi/4C_stru_multi_microstatic.hpp
+++ b/src/stru_multi/4C_stru_multi_microstatic.hpp
@@ -300,10 +300,10 @@ namespace MultiScale
     double tolfres_;
     double toldisi_;
 
-    enum Inpar::Solid::BinaryOp combdisifres_;  //!< binary operator to
-                                                // combine displacement and forces
-    enum Inpar::Solid::ConvNorm normtypedisi_;  //!< convergence check for residual displacements
-    enum Inpar::Solid::ConvNorm normtypefres_;  //!< convergence check for residual forces
+    Inpar::Solid::BinaryOp combdisifres_;  //!< binary operator to
+                                           // combine displacement and forces
+    Inpar::Solid::ConvNorm normtypedisi_;  //!< convergence check for residual displacements
+    Inpar::Solid::ConvNorm normtypefres_;  //!< convergence check for residual forces
     double normcharforce_;
     double normfres_;
     double normchardis_;

--- a/src/structure/4C_structure_aux.cpp
+++ b/src/structure/4C_structure_aux.cpp
@@ -16,7 +16,7 @@ FOUR_C_NAMESPACE_OPEN
 
 /*----------------------------------------------------------------------*/
 /* Calculate vector norm */
-double Solid::calculate_vector_norm(const enum Inpar::Solid::VectorNorm norm,
+double Solid::calculate_vector_norm(const Inpar::Solid::VectorNorm norm,
     const Core::LinAlg::Vector<double>& vect, const int numneglect)
 {
   // L1 norm

--- a/src/structure/4C_structure_aux.hpp
+++ b/src/structure/4C_structure_aux.hpp
@@ -24,8 +24,8 @@ namespace Core::FE
 namespace Solid
 {
   /// Determine norm of force residual
-  double calculate_vector_norm(const enum Inpar::Solid::VectorNorm norm,  ///< type of norm to use
-      const Core::LinAlg::Vector<double>& vect,  ///< the vector of interest
+  double calculate_vector_norm(const Inpar::Solid::VectorNorm norm,  ///< type of norm to use
+      const Core::LinAlg::Vector<double>& vect,                      ///< the vector of interest
       const int numneglect =
           0  ///< number of DOFs that have to be neglected for possible length scaling
   );

--- a/src/structure/4C_structure_timada.hpp
+++ b/src/structure/4C_structure_timada.hpp
@@ -243,7 +243,7 @@ namespace Solid
     //@{
 
     //! Provide the name
-    virtual enum Inpar::Solid::TimAdaKind method_name() const = 0;
+    virtual Inpar::Solid::TimAdaKind method_name() const = 0;
 
     //! Provide the name as std::string
     std::string method_title() const;
@@ -263,7 +263,7 @@ namespace Solid
     virtual double method_lin_err_coeff_vel() const = 0;
 
     //! Provide type of algorithm
-    virtual enum AdaEnum method_adapt_dis() const = 0;
+    virtual AdaEnum method_adapt_dis() const = 0;
 
     //@}
 
@@ -302,19 +302,19 @@ namespace Solid
 
     //! @name Adaptive time integration constants
     //@{
-    double stepsizemax_;     //!< maximum time step size (upper limit)
-    double stepsizemin_;     //!< minimum time step size (lower limit)
-    double sizeratiomax_;    //!< maximally permitted increase of current step size
-                             //!< relative to last converged one
-    double sizeratiomin_;    //!< minimally permitted increase
-                             //!< (or maximally permitted decrease)
-                             //!< of current step size relative to last converged one
-    double sizeratioscale_;  //!< safety factor, should be lower than 1.0
-    enum CtrlEnum errctrl_;  //!< type of control, see #CtrlEnum
-    enum Inpar::Solid::VectorNorm errnorm_;  //!< norm for local error vector
-    double errtol_;                          //!< target local error tolerance
-    int errorder_;                           //!< order of local error indication
-    int adaptstepmax_;  //!< maximally permitted trials to find tolerable step size
+    double stepsizemax_;                //!< maximum time step size (upper limit)
+    double stepsizemin_;                //!< minimum time step size (lower limit)
+    double sizeratiomax_;               //!< maximally permitted increase of current step size
+                                        //!< relative to last converged one
+    double sizeratiomin_;               //!< minimally permitted increase
+                                        //!< (or maximally permitted decrease)
+                                        //!< of current step size relative to last converged one
+    double sizeratioscale_;             //!< safety factor, should be lower than 1.0
+    CtrlEnum errctrl_;                  //!< type of control, see #CtrlEnum
+    Inpar::Solid::VectorNorm errnorm_;  //!< norm for local error vector
+    double errtol_;                     //!< target local error tolerance
+    int errorder_;                      //!< order of local error indication
+    int adaptstepmax_;                  //!< maximally permitted trials to find tolerable step size
     //@}
 
     //! @name plain time integration variables

--- a/src/structure/4C_structure_timada_joint.hpp
+++ b/src/structure/4C_structure_timada_joint.hpp
@@ -51,8 +51,8 @@ namespace Solid
   {
    public:
     //! Map Solid::TimInt::NameEnum to Solid::TimAda::NameEnum
-    enum Inpar::Solid::TimAdaKind map_name_tim_int_to_tim_ada(
-        const enum Inpar::Solid::DynamicType term  //!< input enum term
+    Inpar::Solid::TimAdaKind map_name_tim_int_to_tim_ada(
+        const Inpar::Solid::DynamicType term  //!< input enum term
     ) const
     {
       switch (term)
@@ -182,7 +182,7 @@ namespace Solid
     //@{
 
     //! Provide the name
-    enum Inpar::Solid::TimAdaKind method_name() const override
+    Inpar::Solid::TimAdaKind method_name() const override
     {
       return map_name_tim_int_to_tim_ada(sti_->method_name());
     }
@@ -206,7 +206,7 @@ namespace Solid
     double method_lin_err_coeff_vel() const override { return sta_->method_lin_err_coeff_vel(); }
 
     //! Provide type of algorithm
-    enum AdaEnum method_adapt_dis() const override { return ada_; }
+    AdaEnum method_adapt_dis() const override { return ada_; }
 
     //@}
 
@@ -218,7 +218,7 @@ namespace Solid
     TimAdaJoint(const TimAdaJoint& old);
 
     //! type of adaptivity algorithm
-    enum AdaEnum ada_;
+    AdaEnum ada_;
 
     //! The auxiliary integrator
     std::shared_ptr<T> sta_;

--- a/src/structure/4C_structure_timada_zienxie.hpp
+++ b/src/structure/4C_structure_timada_zienxie.hpp
@@ -66,7 +66,7 @@ namespace Solid
     //@{
 
     //! Provide the name
-    enum Inpar::Solid::TimAdaKind method_name() const override
+    Inpar::Solid::TimAdaKind method_name() const override
     {
       return Inpar::Solid::timada_kind_zienxie;
     }
@@ -84,7 +84,7 @@ namespace Solid
     double method_lin_err_coeff_vel() const override { return -1.0 / 12.0; }
 
     //! Provide type of algorithm
-    enum AdaEnum method_adapt_dis() const override { return ada_upward; }
+    AdaEnum method_adapt_dis() const override { return ada_upward; }
 
     //@}
 

--- a/src/structure/4C_structure_timint.hpp
+++ b/src/structure/4C_structure_timint.hpp
@@ -543,7 +543,7 @@ namespace Solid
     //@{
 
     //! Provide Name
-    virtual enum Inpar::Solid::DynamicType method_name() const = 0;
+    virtual Inpar::Solid::DynamicType method_name() const = 0;
 
     //! Provide title
     std::string method_title() const;
@@ -1015,7 +1015,7 @@ namespace Solid
                                                            //!< map of global DOFs on Dirichlet
                                                            //!< boundary conditions
 
-    enum Inpar::Solid::DivContAct divcontype_;  //!< what to do when nonlinear solution fails
+    Inpar::Solid::DivContAct divcontype_;  //!< what to do when nonlinear solution fails
     int divconrefinementlevel_;  //!< number of refinement level in case of divercontype_ ==
                                  //!< adapt_step
     int divconnumfinestep_;      //!< number of converged time steps on current refinement level
@@ -1059,9 +1059,9 @@ namespace Solid
     //!
     //! Rayleigh damping means \f${C} = c_\text{K} {K} + c_\text{M} {M}\f$
     //@{
-    enum Inpar::Solid::DampKind damping_;  //!< damping type
-    double dampk_;                         //!< damping factor for stiffness \f$c_\text{K}\f$
-    double dampm_;                         //!< damping factor for mass \f$c_\text{M}\f$
+    Inpar::Solid::DampKind damping_;  //!< damping type
+    double dampk_;                    //!< damping factor for stiffness \f$c_\text{K}\f$
+    double dampm_;                    //!< damping factor for mass \f$c_\text{M}\f$
     //@}
 
     //! @name Managed stuff

--- a/src/structure/4C_structure_timint_ab2.hpp
+++ b/src/structure/4C_structure_timint_ab2.hpp
@@ -122,7 +122,7 @@ namespace Solid
     //@{
 
     //! Return time integrator name
-    enum Inpar::Solid::DynamicType method_name() const override
+    Inpar::Solid::DynamicType method_name() const override
     {
       return Inpar::Solid::DynamicType::AdamsBashforth2;
     }

--- a/src/structure/4C_structure_timint_centrdiff.hpp
+++ b/src/structure/4C_structure_timint_centrdiff.hpp
@@ -131,7 +131,7 @@ namespace Solid
     //@{
 
     //! Return time integrator name
-    enum Inpar::Solid::DynamicType method_name() const override
+    Inpar::Solid::DynamicType method_name() const override
     {
       return Inpar::Solid::DynamicType::CentrDiff;
     }

--- a/src/structure/4C_structure_timint_expl.hpp
+++ b/src/structure/4C_structure_timint_expl.hpp
@@ -155,7 +155,7 @@ namespace Solid
     //@{
 
     //! Return time integrator name
-    enum Inpar::Solid::DynamicType method_name() const override = 0;
+    Inpar::Solid::DynamicType method_name() const override = 0;
 
     //! These time integrators are all explicit (mark their name)
     bool method_implicit() override { return false; }

--- a/src/structure/4C_structure_timint_expleuler.hpp
+++ b/src/structure/4C_structure_timint_expleuler.hpp
@@ -117,7 +117,7 @@ namespace Solid
     //@{
 
     //! Return time integrator name
-    enum Inpar::Solid::DynamicType method_name() const override
+    Inpar::Solid::DynamicType method_name() const override
     {
       return Inpar::Solid::DynamicType::ExplEuler;
     }

--- a/src/structure/4C_structure_timint_genalpha.hpp
+++ b/src/structure/4C_structure_timint_genalpha.hpp
@@ -119,7 +119,7 @@ namespace Solid
     //@{
 
     //! Return name
-    enum Inpar::Solid::DynamicType method_name() const override
+    Inpar::Solid::DynamicType method_name() const override
     {
       return Inpar::Solid::DynamicType::GenAlpha;
     }
@@ -309,7 +309,7 @@ namespace Solid
     //! @name set-up
     //@{
     //! mid-average type more at MidAverageEnum
-    enum Inpar::Solid::MidAverageEnum midavg_;
+    Inpar::Solid::MidAverageEnum midavg_;
     //@}
 
     //! @name Key coefficients

--- a/src/structure/4C_structure_timint_impl.hpp
+++ b/src/structure/4C_structure_timint_impl.hpp
@@ -561,7 +561,7 @@ namespace Solid
     //@{
 
     //! Return time integrator name
-    enum Inpar::Solid::DynamicType method_name() const override = 0;
+    Inpar::Solid::DynamicType method_name() const override = 0;
 
     //! These time integrators are all implicit (mark their name)
     bool method_implicit() override { return true; }
@@ -795,7 +795,7 @@ namespace Solid
 
     //! @name General purpose algorithm parameters
     //@{
-    enum Inpar::Solid::PredEnum pred_;  //!< predictor
+    Inpar::Solid::PredEnum pred_;  //!< predictor
     //@}
 
     //! @name Iterative solution technique
@@ -803,14 +803,14 @@ namespace Solid
     enum Inpar::Solid::NonlinSolTech
         itertype_;  //!< kind of iteration technique or non-linear solution technique
 
-    enum Inpar::Solid::ConvNorm normtypedisi_;   //!< convergence check for residual displacements
-    enum Inpar::Solid::ConvNorm normtypefres_;   //!< convergence check for residual forces
-    enum Inpar::Solid::ConvNorm normtypepres_;   //!< convergence check for residual pressure
-    enum Inpar::Solid::ConvNorm normtypepfres_;  //!< convergence check for residual pressure forces
-    enum Inpar::Solid::ConvNorm normtypecontconstr_;  //!< convergence check for contact constraints
-                                                      //!< (saddlepoint formulation only)
-    enum Inpar::Solid::ConvNorm normtypeplagrincr_;   //!< convergence check for Lagrange multiplier
-                                                      //!< increment (saddlepoint formulation only)
+    Inpar::Solid::ConvNorm normtypedisi_;        //!< convergence check for residual displacements
+    Inpar::Solid::ConvNorm normtypefres_;        //!< convergence check for residual forces
+    Inpar::Solid::ConvNorm normtypepres_;        //!< convergence check for residual pressure
+    Inpar::Solid::ConvNorm normtypepfres_;       //!< convergence check for residual pressure forces
+    Inpar::Solid::ConvNorm normtypecontconstr_;  //!< convergence check for contact constraints
+                                                 //!< (saddlepoint formulation only)
+    Inpar::Solid::ConvNorm normtypeplagrincr_;   //!< convergence check for Lagrange multiplier
+                                                 //!< increment (saddlepoint formulation only)
     enum Inpar::Solid::BinaryOp
         combfresplconstr_;  //!< binary operator to combine field norms (forces and plastic
                             //!< constraints, semi-smooth plasticity only)
@@ -824,8 +824,8 @@ namespace Solid
         combdisiEasIncr_;  //!< binary operator to combine field norms (displacement increments and
                            //!< EAS increments, semi-smooth plasticity only)
 
-    enum Inpar::Solid::BinaryOp combdispre_;     //!< binary operator to combine field norms
-    enum Inpar::Solid::BinaryOp combfrespfres_;  //!< binary operator to combine field norms
+    Inpar::Solid::BinaryOp combdispre_;     //!< binary operator to combine field norms
+    Inpar::Solid::BinaryOp combfrespfres_;  //!< binary operator to combine field norms
     enum Inpar::Solid::BinaryOp
         combdisifres_;  //!< binary operator to combine displacement and forces
     enum Inpar::Solid::BinaryOp
@@ -835,9 +835,9 @@ namespace Solid
         combdisilagr_;  //!< binary operator to combine field norms (displacement increments and LM
                         //!< increments, contact/meshtying in saddlepoint formulation only)
 
-    enum Inpar::Solid::VectorNorm iternorm_;  //!< vector norm to check with
-    int itermax_;                             //!< maximally permitted iterations
-    int itermin_;                             //!< minimally requested iterations
+    Inpar::Solid::VectorNorm iternorm_;  //!< vector norm to check with
+    int itermax_;                        //!< maximally permitted iterations
+    int itermin_;                        //!< minimally requested iterations
 
     double toldisi_;        //!< tolerance residual displacements
     double tolfres_;        //!< tolerance force residual

--- a/src/structure/4C_structure_timint_ost.hpp
+++ b/src/structure/4C_structure_timint_ost.hpp
@@ -203,7 +203,7 @@ namespace Solid
     //@{
 
     //! Return name
-    enum Inpar::Solid::DynamicType method_name() const override
+    Inpar::Solid::DynamicType method_name() const override
     {
       return Inpar::Solid::DynamicType::OneStepTheta;
     }

--- a/src/structure/4C_structure_timint_statics.hpp
+++ b/src/structure/4C_structure_timint_statics.hpp
@@ -108,7 +108,7 @@ namespace Solid
     //@{
 
     //! Return name
-    enum Inpar::Solid::DynamicType method_name() const override
+    Inpar::Solid::DynamicType method_name() const override
     {
       return Inpar::Solid::DynamicType::Statics;
     }

--- a/src/structure_new/src/4C_structure_new_elements_paramsinterface.hpp
+++ b/src/structure_new/src/4C_structure_new_elements_paramsinterface.hpp
@@ -55,7 +55,7 @@ namespace Solid
     };
 
     //! Map evaluation error flag to a std::string
-    static inline std::string eval_error_flag_to_string(const enum EvalErrorFlag& errorflag)
+    static inline std::string eval_error_flag_to_string(const EvalErrorFlag& errorflag)
     {
       switch (errorflag)
       {
@@ -94,10 +94,10 @@ namespace Solid
     {
      public:
       //! return the damping type
-      virtual enum Inpar::Solid::DampKind get_damping_type() const = 0;
+      virtual Inpar::Solid::DampKind get_damping_type() const = 0;
 
       //! return the predictor type
-      virtual enum Inpar::Solid::PredEnum get_predictor_type() const = 0;
+      virtual Inpar::Solid::PredEnum get_predictor_type() const = 0;
 
       /// Shall errors during the element evaluation be tolerated?
       virtual bool is_tolerate_errors() const = 0;
@@ -144,7 +144,7 @@ namespace Solid
       /*! \brief set evaluation error flag
        *
        *  See the EvalErrorFlag enumerators for more information. */
-      virtual void set_ele_eval_error_flag(const enum EvalErrorFlag& error_flag) = 0;
+      virtual void set_ele_eval_error_flag(const EvalErrorFlag& error_flag) = 0;
       //! @}
 
       //! @name output related functions
@@ -158,30 +158,29 @@ namespace Solid
       virtual std::shared_ptr<std::vector<char>> opt_quantity_data_ptr() = 0;
 
       //! get the current stress type
-      virtual enum Inpar::Solid::StressType get_stress_output_type() const = 0;
+      virtual Inpar::Solid::StressType get_stress_output_type() const = 0;
 
       //! get the current strain type
-      virtual enum Inpar::Solid::StrainType get_strain_output_type() const = 0;
+      virtual Inpar::Solid::StrainType get_strain_output_type() const = 0;
 
       //! get the current plastic strain type
-      virtual enum Inpar::Solid::StrainType get_plastic_strain_output_type() const = 0;
+      virtual Inpar::Solid::StrainType get_plastic_strain_output_type() const = 0;
 
       virtual std::shared_ptr<ModelEvaluator::GaussPointDataOutputManager>&
       gauss_point_data_output_manager_ptr() = 0;
 
       //! add contribution to energy of specified type
-      virtual void add_contribution_to_energy_type(double value, enum Solid::EnergyType type) = 0;
+      virtual void add_contribution_to_energy_type(double value, Solid::EnergyType type) = 0;
 
       //! add the current partial update norm of the given quantity
-      virtual void sum_into_my_update_norm(const enum NOX::Nln::StatusTest::QuantityType& qtype,
+      virtual void sum_into_my_update_norm(const NOX::Nln::StatusTest::QuantityType& qtype,
           const int& numentries, const double* my_update_values, const double* my_new_sol_values,
           const double& step_length, const int& owner) = 0;
 
       /*! collects and calculates the solution norm of the previous accepted Newton
        *  step on the current proc */
-      virtual void sum_into_my_previous_sol_norm(
-          const enum NOX::Nln::StatusTest::QuantityType& qtype, const int& numentries,
-          const double* my_old_values, const int& owner) = 0;
+      virtual void sum_into_my_previous_sol_norm(const NOX::Nln::StatusTest::QuantityType& qtype,
+          const int& numentries, const double* my_old_values, const int& owner) = 0;
       //! @}
     };  // class ParamsInterface
 

--- a/src/structure_new/src/4C_structure_new_enum_lists.hpp
+++ b/src/structure_new/src/4C_structure_new_enum_lists.hpp
@@ -34,7 +34,7 @@ namespace Solid
   };
 
   //! Map energy type to std::string
-  inline std::string energy_type_to_string(const enum EnergyType type)
+  inline std::string energy_type_to_string(const EnergyType type)
   {
     switch (type)
     {
@@ -103,7 +103,7 @@ namespace Solid
     lm_lm,        ///< Kzz block (of the corresponding model evaluator)
   };
 
-  inline std::string mat_block_type_to_string(const enum MatBlockType type)
+  inline std::string mat_block_type_to_string(const MatBlockType type)
   {
     switch (type)
     {

--- a/src/structure_new/src/4C_structure_new_factory.cpp
+++ b/src/structure_new/src/4C_structure_new_factory.cpp
@@ -50,8 +50,8 @@ std::shared_ptr<Solid::Integrator> Solid::Factory::build_implicit_integrator(
 {
   std::shared_ptr<Solid::IMPLICIT::Generic> impl_int_ptr = nullptr;
 
-  const enum Inpar::Solid::DynamicType dyntype = datasdyn.get_dynamic_type();
-  const enum Inpar::Solid::PreStress prestresstype = datasdyn.get_pre_stress_type();
+  const Inpar::Solid::DynamicType dyntype = datasdyn.get_dynamic_type();
+  const Inpar::Solid::PreStress prestresstype = datasdyn.get_pre_stress_type();
 
   // check if we have a problem that needs to be prestressed
   const bool is_prestress = prestresstype != Inpar::Solid::PreStress::none;

--- a/src/structure_new/src/4C_structure_new_integrator.cpp
+++ b/src/structure_new/src/4C_structure_new_integrator.cpp
@@ -222,7 +222,7 @@ void Solid::Integrator::compute_mass_matrix_and_init_acc()
   // build a NOX::Nln::Solid::LinearSystem
   // ---------------------------------------------------------------------------
   // get the structural linear solver
-  std::map<enum NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>> str_linsolver;
+  std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>> str_linsolver;
   str_linsolver[NOX::Nln::sol_structure] = Teuchos::rcpFromRef(
       *tim_int().get_data_sdyn().get_lin_solvers().at(Inpar::Solid::model_structure));
 
@@ -470,7 +470,7 @@ void Solid::Integrator::reset_step_state()
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 double Solid::Integrator::get_condensed_update_norm(
-    const enum NOX::Nln::StatusTest::QuantityType& qtype) const
+    const NOX::Nln::StatusTest::QuantityType& qtype) const
 {
   check_init_setup();
 
@@ -484,7 +484,7 @@ double Solid::Integrator::get_condensed_update_norm(
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 double Solid::Integrator::get_condensed_previous_sol_norm(
-    const enum NOX::Nln::StatusTest::QuantityType& qtype) const
+    const NOX::Nln::StatusTest::QuantityType& qtype) const
 {
   check_init_setup();
 
@@ -498,7 +498,7 @@ double Solid::Integrator::get_condensed_previous_sol_norm(
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 double Solid::Integrator::get_condensed_solution_update_rms(
-    const enum NOX::Nln::StatusTest::QuantityType& qtype) const
+    const NOX::Nln::StatusTest::QuantityType& qtype) const
 {
   check_init_setup();
   // global relative mean square norm
@@ -517,7 +517,7 @@ double Solid::Integrator::get_condensed_solution_update_rms(
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 int Solid::Integrator::get_condensed_dof_number(
-    const enum NOX::Nln::StatusTest::QuantityType& qtype) const
+    const NOX::Nln::StatusTest::QuantityType& qtype) const
 {
   check_init_setup();
   // global dof number of the given quantity
@@ -529,8 +529,7 @@ int Solid::Integrator::get_condensed_dof_number(
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-double Solid::Integrator::get_condensed_global_norm(
-    const enum NOX::Nln::StatusTest::QuantityType& qtype,
+double Solid::Integrator::get_condensed_global_norm(const NOX::Nln::StatusTest::QuantityType& qtype,
     const enum ::NOX::Abstract::Vector::NormType& normtype, double& mynorm) const
 {
   double gnorm = 0;

--- a/src/structure_new/src/4C_structure_new_integrator.hpp
+++ b/src/structure_new/src/4C_structure_new_integrator.hpp
@@ -149,7 +149,7 @@ namespace Solid
     /*! \brief Modify the right hand side and Jacobian corresponding to the requested correction
      * action of one (or several) second order constraint (SOC) model(s)
      */
-    virtual bool apply_correction_system(const enum NOX::Nln::CorrectionType type,
+    virtual bool apply_correction_system(const NOX::Nln::CorrectionType type,
         const std::vector<Inpar::Solid::ModelType>& constraint_models,
         const Core::LinAlg::Vector<double>& x, Core::LinAlg::Vector<double>& f,
         Core::LinAlg::SparseOperator& jac) = 0;
@@ -308,15 +308,13 @@ namespace Solid
     //! @name Accessors
     //!@{
 
-    double get_condensed_update_norm(const enum NOX::Nln::StatusTest::QuantityType& qtype) const;
+    double get_condensed_update_norm(const NOX::Nln::StatusTest::QuantityType& qtype) const;
 
-    double get_condensed_previous_sol_norm(
-        const enum NOX::Nln::StatusTest::QuantityType& qtype) const;
+    double get_condensed_previous_sol_norm(const NOX::Nln::StatusTest::QuantityType& qtype) const;
 
-    double get_condensed_solution_update_rms(
-        const enum NOX::Nln::StatusTest::QuantityType& qtype) const;
+    double get_condensed_solution_update_rms(const NOX::Nln::StatusTest::QuantityType& qtype) const;
 
-    int get_condensed_dof_number(const enum NOX::Nln::StatusTest::QuantityType& qtype) const;
+    int get_condensed_dof_number(const NOX::Nln::StatusTest::QuantityType& qtype) const;
 
     //! Return the model evaluator control object (read and write)
     Solid::ModelEvaluatorManager& model_eval();
@@ -389,7 +387,7 @@ namespace Solid
     //! reset the time step dependent parameters for the element evaluation
     virtual void reset_eval_params() {};
 
-    double get_condensed_global_norm(const enum NOX::Nln::StatusTest::QuantityType& qtype,
+    double get_condensed_global_norm(const NOX::Nln::StatusTest::QuantityType& qtype,
         const enum ::NOX::Abstract::Vector::NormType& normtype, double& mynorm) const;
 
    protected:
@@ -450,7 +448,7 @@ namespace Solid
       const Integrator& integrator_;
 
       /// mid-time energy averaging type
-      enum Inpar::Solid::MidAverageEnum avg_type_;
+      Inpar::Solid::MidAverageEnum avg_type_;
 
       /// setup flag
       bool issetup_ = false;

--- a/src/structure_new/src/4C_structure_new_timint_base.cpp
+++ b/src/structure_new/src/4C_structure_new_timint_base.cpp
@@ -316,9 +316,9 @@ void Solid::TimeInt::Base::select_energy_types_to_be_written()
   Solid::ModelEvaluator::Data& evaldata = int_ptr_->eval_data();
 
   // decide which types of energy contributions shall be written separately
-  const std::set<enum Inpar::Solid::ModelType>& mtypes = datasdyn_->get_model_types();
+  const std::set<Inpar::Solid::ModelType>& mtypes = datasdyn_->get_model_types();
 
-  std::set<enum Inpar::Solid::ModelType>::const_iterator model_iter;
+  std::set<Inpar::Solid::ModelType>::const_iterator model_iter;
   for (model_iter = mtypes.begin(); model_iter != mtypes.end(); ++model_iter)
   {
     switch (*model_iter)

--- a/src/structure_new/src/4C_structure_new_timint_base.hpp
+++ b/src/structure_new/src/4C_structure_new_timint_base.hpp
@@ -408,7 +408,7 @@ namespace Solid
       }
 
       //! Get divcont type
-      [[nodiscard]] virtual enum Inpar::Solid::DivContAct get_divergence_action() const
+      [[nodiscard]] virtual Inpar::Solid::DivContAct get_divergence_action() const
       {
         check_init_setup();
         return datasdyn_->get_divergence_action();
@@ -672,7 +672,7 @@ namespace Solid
       //@{
 
       //! Provide Name
-      virtual enum Inpar::Solid::DynamicType method_name() const = 0;
+      virtual Inpar::Solid::DynamicType method_name() const = 0;
 
       //! Provide title
       std::string method_title() const;

--- a/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.cpp
+++ b/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.cpp
@@ -306,7 +306,7 @@ int Solid::TimeInt::BaseDataGlobalState::setup_block_information(
       const Solid::ModelEvaluator::Meshtying& mt_me =
           dynamic_cast<const Solid::ModelEvaluator::Meshtying&>(me);
 
-      enum CONTACT::SystemType systype = mt_me.strategy().system_type();
+      CONTACT::SystemType systype = mt_me.strategy().system_type();
 
       auto soltype = Teuchos::getIntegralValue<CONTACT::SolvingStrategy>(
           mt_me.strategy().params(), "STRATEGY");
@@ -447,7 +447,7 @@ void Solid::TimeInt::BaseDataGlobalState::setup_multi_map_extractor()
   std::map<Inpar::Solid::ModelType, int>::const_iterator ci;
   for (ci = model_block_id_.begin(); ci != model_block_id_.end(); ++ci)
   {
-    enum Inpar::Solid::ModelType mt = ci->first;
+    Inpar::Solid::ModelType mt = ci->first;
     int bid = ci->second;
     maps_vec[bid] = model_maps_.at(mt);
   }
@@ -461,8 +461,8 @@ void Solid::TimeInt::BaseDataGlobalState::setup_element_technology_map_extractor
   check_init();
 
   // loop all active element technologies
-  const std::set<enum Inpar::Solid::EleTech>& ele_techs = datasdyn_->get_element_technologies();
-  for (const enum Inpar::Solid::EleTech et : ele_techs)
+  const std::set<Inpar::Solid::EleTech>& ele_techs = datasdyn_->get_element_technologies();
+  for (const Inpar::Solid::EleTech et : ele_techs)
   {
     // mapextractor for element technology
     Core::LinAlg::MultiMapExtractor mapext;
@@ -494,7 +494,7 @@ void Solid::TimeInt::BaseDataGlobalState::setup_element_technology_map_extractor
  *----------------------------------------------------------------------------*/
 const Core::LinAlg::MultiMapExtractor&
 Solid::TimeInt::BaseDataGlobalState::get_element_technology_map_extractor(
-    const enum Inpar::Solid::EleTech etech) const
+    const Inpar::Solid::EleTech etech) const
 {
   if (mapextractors_.find(etech) == mapextractors_.end())
     FOUR_C_THROW("Could not find element technology \"{}\" in map extractors.", etech);
@@ -603,7 +603,7 @@ const Core::LinAlg::MultiMapExtractor& Solid::TimeInt::BaseDataGlobalState::bloc
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 std::shared_ptr<NOX::Nln::Vector> Solid::TimeInt::BaseDataGlobalState::create_global_vector(
-    const enum VecInitType& vecinittype,
+    const VecInitType& vecinittype,
     const std::shared_ptr<const Solid::ModelEvaluatorManager>& modeleval) const
 {
   check_init();

--- a/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.hpp
+++ b/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.hpp
@@ -222,7 +222,7 @@ namespace Solid
 
       /// Create the global solution vector
       std::shared_ptr<NOX::Nln::Vector> create_global_vector() const;
-      std::shared_ptr<NOX::Nln::Vector> create_global_vector(const enum VecInitType& vecinittype,
+      std::shared_ptr<NOX::Nln::Vector> create_global_vector(const VecInitType& vecinittype,
           const std::shared_ptr<const Solid::ModelEvaluatorManager>& modeleval) const;
 
       /// Create the structural stiffness matrix block
@@ -585,7 +585,7 @@ namespace Solid
       /** \brief Returns the Block id of the given model type.
        *
        *  If the block is not found, -1 is returned. */
-      int block_id(const enum Inpar::Solid::ModelType& mt) const
+      int block_id(const Inpar::Solid::ModelType& mt) const
       {
         if (model_block_id_.find(mt) != model_block_id_.end()) return model_block_id_.at(mt);
 

--- a/src/structure_new/src/4C_structure_new_timint_basedatasdyn.cpp
+++ b/src/structure_new/src/4C_structure_new_timint_basedatasdyn.cpp
@@ -98,10 +98,9 @@ Solid::TimeInt::BaseDataSDyn::BaseDataSDyn()
  *----------------------------------------------------------------------------*/
 void Solid::TimeInt::BaseDataSDyn::init(const std::shared_ptr<Core::FE::Discretization> discret,
     const Teuchos::ParameterList& sdynparams, const Teuchos::ParameterList& xparams,
-    const std::shared_ptr<std::set<enum Inpar::Solid::ModelType>> modeltypes,
-    const std::shared_ptr<std::set<enum Inpar::Solid::EleTech>> eletechs,
-    const std::shared_ptr<
-        std::map<enum Inpar::Solid::ModelType, std::shared_ptr<Core::LinAlg::Solver>>>
+    const std::shared_ptr<std::set<Inpar::Solid::ModelType>> modeltypes,
+    const std::shared_ptr<std::set<Inpar::Solid::EleTech>> eletechs,
+    const std::shared_ptr<std::map<Inpar::Solid::ModelType, std::shared_ptr<Core::LinAlg::Solver>>>
         linsolvers)
 {
   // We have to call setup() after init()
@@ -290,7 +289,7 @@ void Solid::TimeInt::BaseDataSDyn::setup()
 {
   check_init();
 
-  std::set<enum Inpar::Solid::ModelType>::const_iterator it;
+  std::set<Inpar::Solid::ModelType>::const_iterator it;
   // setup model type specific data containers
   for (it = (*modeltypes_).begin(); it != (*modeltypes_).end(); ++it)
   {
@@ -327,7 +326,7 @@ void Solid::TimeInt::BaseDataSDyn::setup()
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 double Solid::TimeInt::BaseDataSDyn::get_res_tolerance(
-    const enum NOX::Nln::StatusTest::QuantityType& qtype) const
+    const NOX::Nln::StatusTest::QuantityType& qtype) const
 {
   check_init_setup();
   switch (qtype)
@@ -367,7 +366,7 @@ double Solid::TimeInt::BaseDataSDyn::get_res_tolerance(
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 double Solid::TimeInt::BaseDataSDyn::get_incr_tolerance(
-    const enum NOX::Nln::StatusTest::QuantityType& qtype) const
+    const NOX::Nln::StatusTest::QuantityType& qtype) const
 {
   check_init_setup();
   switch (qtype)
@@ -406,8 +405,8 @@ double Solid::TimeInt::BaseDataSDyn::get_incr_tolerance(
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-enum Inpar::Solid::ConvNorm Solid::TimeInt::BaseDataSDyn::get_res_tolerance_type(
-    const enum NOX::Nln::StatusTest::QuantityType& qtype) const
+Inpar::Solid::ConvNorm Solid::TimeInt::BaseDataSDyn::get_res_tolerance_type(
+    const NOX::Nln::StatusTest::QuantityType& qtype) const
 {
   check_init_setup();
   switch (qtype)
@@ -446,8 +445,8 @@ enum Inpar::Solid::ConvNorm Solid::TimeInt::BaseDataSDyn::get_res_tolerance_type
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-enum Inpar::Solid::ConvNorm Solid::TimeInt::BaseDataSDyn::get_incr_tolerance_type(
-    const enum NOX::Nln::StatusTest::QuantityType& qtype) const
+Inpar::Solid::ConvNorm Solid::TimeInt::BaseDataSDyn::get_incr_tolerance_type(
+    const NOX::Nln::StatusTest::QuantityType& qtype) const
 {
   check_init_setup();
   switch (qtype)
@@ -486,8 +485,8 @@ enum Inpar::Solid::ConvNorm Solid::TimeInt::BaseDataSDyn::get_incr_tolerance_typ
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-enum Inpar::Solid::BinaryOp Solid::TimeInt::BaseDataSDyn::get_res_combo_type(
-    const enum NOX::Nln::StatusTest::QuantityType& qtype) const
+Inpar::Solid::BinaryOp Solid::TimeInt::BaseDataSDyn::get_res_combo_type(
+    const NOX::Nln::StatusTest::QuantityType& qtype) const
 {
   return get_res_combo_type(NOX::Nln::StatusTest::quantity_structure, qtype);
 }
@@ -495,9 +494,9 @@ enum Inpar::Solid::BinaryOp Solid::TimeInt::BaseDataSDyn::get_res_combo_type(
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-enum Inpar::Solid::BinaryOp Solid::TimeInt::BaseDataSDyn::get_res_combo_type(
-    const enum NOX::Nln::StatusTest::QuantityType& qtype_1,
-    const enum NOX::Nln::StatusTest::QuantityType& qtype_2) const
+Inpar::Solid::BinaryOp Solid::TimeInt::BaseDataSDyn::get_res_combo_type(
+    const NOX::Nln::StatusTest::QuantityType& qtype_1,
+    const NOX::Nln::StatusTest::QuantityType& qtype_2) const
 {
   check_init_setup();
   // combination: STRUCTURE <--> PRESSURE
@@ -556,8 +555,8 @@ enum Inpar::Solid::BinaryOp Solid::TimeInt::BaseDataSDyn::get_res_combo_type(
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-enum Inpar::Solid::BinaryOp Solid::TimeInt::BaseDataSDyn::get_incr_combo_type(
-    const enum NOX::Nln::StatusTest::QuantityType& qtype) const
+Inpar::Solid::BinaryOp Solid::TimeInt::BaseDataSDyn::get_incr_combo_type(
+    const NOX::Nln::StatusTest::QuantityType& qtype) const
 {
   return get_incr_combo_type(NOX::Nln::StatusTest::quantity_structure, qtype);
 }
@@ -565,9 +564,9 @@ enum Inpar::Solid::BinaryOp Solid::TimeInt::BaseDataSDyn::get_incr_combo_type(
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-enum Inpar::Solid::BinaryOp Solid::TimeInt::BaseDataSDyn::get_incr_combo_type(
-    const enum NOX::Nln::StatusTest::QuantityType& qtype_1,
-    const enum NOX::Nln::StatusTest::QuantityType& qtype_2) const
+Inpar::Solid::BinaryOp Solid::TimeInt::BaseDataSDyn::get_incr_combo_type(
+    const NOX::Nln::StatusTest::QuantityType& qtype_1,
+    const NOX::Nln::StatusTest::QuantityType& qtype_2) const
 {
   check_init_setup();
   // combination: STRUCTURE <--> PRESSURE
@@ -626,9 +625,9 @@ enum Inpar::Solid::BinaryOp Solid::TimeInt::BaseDataSDyn::get_incr_combo_type(
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-enum Inpar::Solid::BinaryOp Solid::TimeInt::BaseDataSDyn::get_res_incr_combo_type(
-    const enum NOX::Nln::StatusTest::QuantityType& qtype_res,
-    const enum NOX::Nln::StatusTest::QuantityType& qtype_incr) const
+Inpar::Solid::BinaryOp Solid::TimeInt::BaseDataSDyn::get_res_incr_combo_type(
+    const NOX::Nln::StatusTest::QuantityType& qtype_res,
+    const NOX::Nln::StatusTest::QuantityType& qtype_incr) const
 {
   check_init_setup();
   // combination: STRUCTURE (force/res) <--> STRUCTURE (displ/incr)

--- a/src/structure_new/src/4C_structure_new_timint_basedatasdyn.hpp
+++ b/src/structure_new/src/4C_structure_new_timint_basedatasdyn.hpp
@@ -64,10 +64,10 @@ namespace Solid
       /// initialize class variables (already existing)
       virtual void init(const std::shared_ptr<Core::FE::Discretization> discret,
           const Teuchos::ParameterList& sDynParams, const Teuchos::ParameterList& xparams,
-          const std::shared_ptr<std::set<enum Inpar::Solid::ModelType>> modeltypes,
-          const std::shared_ptr<std::set<enum Inpar::Solid::EleTech>> eletechs,
+          const std::shared_ptr<std::set<Inpar::Solid::ModelType>> modeltypes,
+          const std::shared_ptr<std::set<Inpar::Solid::EleTech>> eletechs,
           const std::shared_ptr<
-              std::map<enum Inpar::Solid::ModelType, std::shared_ptr<Core::LinAlg::Solver>>>
+              std::map<Inpar::Solid::ModelType, std::shared_ptr<Core::LinAlg::Solver>>>
               linsolvers);
 
       /// setup new class variables
@@ -124,14 +124,14 @@ namespace Solid
       };
 
       /// Returns dynamic type
-      enum Inpar::Solid::DynamicType get_dynamic_type() const
+      Inpar::Solid::DynamicType get_dynamic_type() const
       {
         check_init_setup();
         return dyntype_;
       };
 
       /// Get type of shell thickness scaling
-      enum Inpar::Solid::StcScale get_stc_algo_type() const
+      Inpar::Solid::StcScale get_stc_algo_type() const
       {
         check_init_setup();
         return stcscale_;
@@ -187,21 +187,21 @@ namespace Solid
       }
 
       /// Returns prestress type
-      enum Inpar::Solid::PreStress get_pre_stress_type() const
+      Inpar::Solid::PreStress get_pre_stress_type() const
       {
         check_init_setup();
         return prestresstype_;
       };
 
       /// Returns predictor type
-      enum Inpar::Solid::PredEnum get_predictor_type() const
+      Inpar::Solid::PredEnum get_predictor_type() const
       {
         check_init_setup();
         return predtype_;
       };
 
       /// Returns nonlinear solver type
-      enum Inpar::Solid::NonlinSolTech get_nln_solver_type() const
+      Inpar::Solid::NonlinSolTech get_nln_solver_type() const
       {
         check_init_setup();
         return nlnsolvertype_;
@@ -209,14 +209,14 @@ namespace Solid
 
       /// Returns the divergence action
       /// Short: What to do if the non-linear solver fails.
-      enum Inpar::Solid::DivContAct get_divergence_action() const
+      Inpar::Solid::DivContAct get_divergence_action() const
       {
         check_init_setup();
         return divergenceaction_;
       };
 
       /// Returns mid-time energy type
-      enum Inpar::Solid::MidAverageEnum get_mid_time_energy_type() const
+      Inpar::Solid::MidAverageEnum get_mid_time_energy_type() const
       {
         check_init_setup();
         return mid_time_energy_type_;
@@ -245,7 +245,7 @@ namespace Solid
       ///@{
 
       /// Returns linear solvers pointer
-      const std::map<enum Inpar::Solid::ModelType, std::shared_ptr<Core::LinAlg::Solver>>&
+      const std::map<Inpar::Solid::ModelType, std::shared_ptr<Core::LinAlg::Solver>>&
       get_lin_solvers() const
       {
         check_init_setup();
@@ -257,7 +257,7 @@ namespace Solid
       /// @name Get damping control parameters (read only access)
       ///@{
       /// Returns damping type
-      enum Inpar::Solid::DampKind get_damping_type() const
+      Inpar::Solid::DampKind get_damping_type() const
       {
         check_init_setup();
         return damptype_;
@@ -281,7 +281,7 @@ namespace Solid
       /// @name Get mass and inertia control parameters (read only access)
       ///@{
       /// Returns mass linearization type
-      enum Inpar::Solid::MassLin get_mass_lin_type() const
+      Inpar::Solid::MassLin get_mass_lin_type() const
       {
         check_init_setup();
         return masslintype_;
@@ -303,14 +303,14 @@ namespace Solid
       /// @name Get model evaluator control parameters (read only access)
       ///@{
       /// Returns types of the current models
-      const std::set<enum Inpar::Solid::ModelType>& get_model_types() const
+      const std::set<Inpar::Solid::ModelType>& get_model_types() const
       {
         check_init_setup();
         return *modeltypes_;
       };
 
       /// Returns current active element technologies
-      const std::set<enum Inpar::Solid::EleTech>& get_element_technologies() const
+      const std::set<Inpar::Solid::EleTech>& get_element_technologies() const
       {
         check_init_setup();
         return *eletechs_;
@@ -336,7 +336,7 @@ namespace Solid
       /// @name Get the different status test control parameters (read only)
       ///@{
       /// Returns the STR vector norm type
-      enum Inpar::Solid::VectorNorm get_norm_type() const
+      Inpar::Solid::VectorNorm get_norm_type() const
       {
         check_init_setup();
         return normtype_;
@@ -375,49 +375,47 @@ namespace Solid
       /// @name Get residual and increment related parameters
       ///@{
       /// Returns the combination type of the two quantities
-      enum Inpar::Solid::BinaryOp get_res_incr_combo_type(
-          const enum NOX::Nln::StatusTest::QuantityType& qtype_res,
-          const enum NOX::Nln::StatusTest::QuantityType& qtype_incr) const;
+      Inpar::Solid::BinaryOp get_res_incr_combo_type(
+          const NOX::Nln::StatusTest::QuantityType& qtype_res,
+          const NOX::Nln::StatusTest::QuantityType& qtype_incr) const;
       ///@}
 
       /// @name Get residual related parameters
       ///@{
       /// Returns the tolerance values for the different quantities
-      double get_res_tolerance(const enum NOX::Nln::StatusTest::QuantityType& qtype) const;
+      double get_res_tolerance(const NOX::Nln::StatusTest::QuantityType& qtype) const;
 
       /// Returns the tolerance type of the different quantities
-      enum Inpar::Solid::ConvNorm get_res_tolerance_type(
-          const enum NOX::Nln::StatusTest::QuantityType& qtype) const;
+      Inpar::Solid::ConvNorm get_res_tolerance_type(
+          const NOX::Nln::StatusTest::QuantityType& qtype) const;
 
       /// Returns the combination type of the different quantities
-      enum Inpar::Solid::BinaryOp get_res_combo_type(
-          const enum NOX::Nln::StatusTest::QuantityType& qtype) const;
+      Inpar::Solid::BinaryOp get_res_combo_type(
+          const NOX::Nln::StatusTest::QuantityType& qtype) const;
 
-      enum Inpar::Solid::BinaryOp get_res_combo_type(
-          const enum NOX::Nln::StatusTest::QuantityType& qtype_1,
-          const enum NOX::Nln::StatusTest::QuantityType& qtype_2) const;
+      Inpar::Solid::BinaryOp get_res_combo_type(const NOX::Nln::StatusTest::QuantityType& qtype_1,
+          const NOX::Nln::StatusTest::QuantityType& qtype_2) const;
       ///@}
 
       /// @name Get increment related parameters
       ///@{
       /// Returns the tolerance values for the different quantities
-      double get_incr_tolerance(const enum NOX::Nln::StatusTest::QuantityType& qtype) const;
+      double get_incr_tolerance(const NOX::Nln::StatusTest::QuantityType& qtype) const;
 
       /// Returns the tolerance type of the different quantities
-      enum Inpar::Solid::ConvNorm get_incr_tolerance_type(
-          const enum NOX::Nln::StatusTest::QuantityType& qtype) const;
+      Inpar::Solid::ConvNorm get_incr_tolerance_type(
+          const NOX::Nln::StatusTest::QuantityType& qtype) const;
 
-      enum Inpar::Solid::ConvNorm get_incr_tolerance_type(
-          const enum NOX::Nln::StatusTest::QuantityType& qtype_1,
-          const enum NOX::Nln::StatusTest::QuantityType& qtype_2) const;
+      Inpar::Solid::ConvNorm get_incr_tolerance_type(
+          const NOX::Nln::StatusTest::QuantityType& qtype_1,
+          const NOX::Nln::StatusTest::QuantityType& qtype_2) const;
 
       /// Returns the combination type of the different quantities
-      enum Inpar::Solid::BinaryOp get_incr_combo_type(
-          const enum NOX::Nln::StatusTest::QuantityType& qtype) const;
+      Inpar::Solid::BinaryOp get_incr_combo_type(
+          const NOX::Nln::StatusTest::QuantityType& qtype) const;
 
-      enum Inpar::Solid::BinaryOp get_incr_combo_type(
-          const enum NOX::Nln::StatusTest::QuantityType& qtype_1,
-          const enum NOX::Nln::StatusTest::QuantityType& qtype_2) const;
+      Inpar::Solid::BinaryOp get_incr_combo_type(const NOX::Nln::StatusTest::QuantityType& qtype_1,
+          const NOX::Nln::StatusTest::QuantityType& qtype_2) const;
       ///@}
       ///@}
 
@@ -480,7 +478,7 @@ namespace Solid
       /// @name Get mutable linear solver variables (read and write access)
       ///@{
       /// Returns linear solvers pointer
-      std::shared_ptr<std::map<enum Inpar::Solid::ModelType, std::shared_ptr<Core::LinAlg::Solver>>>
+      std::shared_ptr<std::map<Inpar::Solid::ModelType, std::shared_ptr<Core::LinAlg::Solver>>>
       get_lin_solvers_ptr()
       {
         check_init_setup();
@@ -488,8 +486,7 @@ namespace Solid
       }
 
       /// Returns linear solvers pointer
-      std::map<enum Inpar::Solid::ModelType, std::shared_ptr<Core::LinAlg::Solver>>&
-      get_lin_solvers()
+      std::map<Inpar::Solid::ModelType, std::shared_ptr<Core::LinAlg::Solver>>& get_lin_solvers()
       {
         check_init_setup();
         return *linsolvers_;
@@ -508,7 +505,7 @@ namespace Solid
       /// @name Get the initial displacement method
       ///@{
       /// Returns type of initial displacement
-      enum Inpar::Solid::InitialDisp get_initial_disp() const
+      Inpar::Solid::InitialDisp get_initial_disp() const
       {
         check_init_setup();
         return initial_disp_;
@@ -569,7 +566,7 @@ namespace Solid
       /// Rayleigh damping means \f${C} = c_\text{K} {K} + c_\text{M} {M}\f$
       ///@{
       /// damping type
-      enum Inpar::Solid::DampKind damptype_;
+      Inpar::Solid::DampKind damptype_;
 
       /// damping factor for stiffness \f$c_\text{K}\f$
       double dampk_;
@@ -581,7 +578,7 @@ namespace Solid
       /// @name Mass and inertia control parameters
       ///@{
       /// have inertia forces to be linearized?
-      enum Inpar::Solid::MassLin masslintype_;
+      Inpar::Solid::MassLin masslintype_;
 
       /// lump the mass matrix?
       bool lumpmass_;
@@ -594,10 +591,10 @@ namespace Solid
       ///@{
 
       /// current active model types for the model evaluator
-      std::shared_ptr<std::set<enum Inpar::Solid::ModelType>> modeltypes_;
+      std::shared_ptr<std::set<Inpar::Solid::ModelType>> modeltypes_;
 
       /// current active element technologies
-      std::shared_ptr<std::set<enum Inpar::Solid::EleTech>> eletechs_;
+      std::shared_ptr<std::set<Inpar::Solid::EleTech>> eletechs_;
 
       /// pointer to the coupling model evaluator object
       std::shared_ptr<Solid::ModelEvaluator::Generic> coupling_model_ptr_;
@@ -607,10 +604,10 @@ namespace Solid
       /// @name implicit and explicit time integrator parameters
       ///@{
       /// dynamic type
-      enum Inpar::Solid::DynamicType dyntype_;
+      Inpar::Solid::DynamicType dyntype_;
 
       /// scaled thickness conditioning type (necessary for shells)
-      enum Inpar::Solid::StcScale stcscale_;
+      Inpar::Solid::StcScale stcscale_;
 
       /// number of layers for multilayered case
       int stclayer_;
@@ -638,19 +635,19 @@ namespace Solid
       int prestress_min_number_of_load_steps_;
 
       /// type of pre-stressing
-      enum Inpar::Solid::PreStress prestresstype_;
+      Inpar::Solid::PreStress prestresstype_;
 
       /// type of the predictor
-      enum Inpar::Solid::PredEnum predtype_;
+      Inpar::Solid::PredEnum predtype_;
 
       /// type of nonlinear solver
-      enum Inpar::Solid::NonlinSolTech nlnsolvertype_;
+      Inpar::Solid::NonlinSolTech nlnsolvertype_;
 
       /// action to be performed when the non-linear solver diverges
-      enum Inpar::Solid::DivContAct divergenceaction_;
+      Inpar::Solid::DivContAct divergenceaction_;
 
       /// mid-time energy type
-      enum Inpar::Solid::MidAverageEnum mid_time_energy_type_;
+      Inpar::Solid::MidAverageEnum mid_time_energy_type_;
 
       /// how often you want to half your timestep until you give up
       int maxdivconrefinementlevel_;
@@ -666,7 +663,7 @@ namespace Solid
       ///@{
 
       /// pointer to the linear solvers map
-      std::shared_ptr<std::map<enum Inpar::Solid::ModelType, std::shared_ptr<Core::LinAlg::Solver>>>
+      std::shared_ptr<std::map<Inpar::Solid::ModelType, std::shared_ptr<Core::LinAlg::Solver>>>
           linsolvers_;
       ///@}
 
@@ -674,7 +671,7 @@ namespace Solid
       ///@{
 
       /// vector norm type for the status/convergence test
-      enum Inpar::Solid::VectorNorm normtype_;
+      Inpar::Solid::VectorNorm normtype_;
 
       /// vector norm type for the status/convergence test
       enum ::NOX::Abstract::Vector::NormType nox_normtype_;
@@ -685,114 +682,114 @@ namespace Solid
       double tol_disp_incr_;
 
       /// tolerance type for the convergence check of the displacement vector
-      enum Inpar::Solid::ConvNorm toltype_disp_incr_;
+      Inpar::Solid::ConvNorm toltype_disp_incr_;
 
       /// tolerance force residual
       double tol_fres_;
 
       /// tolerance type for the convergence check of the force residual
-      enum Inpar::Solid::ConvNorm toltype_fres_;
+      Inpar::Solid::ConvNorm toltype_fres_;
 
       /// tolerance pressure residual
       double tol_pres_;
 
       /// tolerance type for the convergence check of the pressure residual
-      enum Inpar::Solid::ConvNorm toltype_pres_;
+      Inpar::Solid::ConvNorm toltype_pres_;
 
       /// tolerance incompressible residual/ residual pressure forces
       double tol_inco_;
 
       /// tolerance type for the convergence check if the incompressible residual/ residual
       /// pressure forces
-      enum Inpar::Solid::ConvNorm toltype_inco_;
+      Inpar::Solid::ConvNorm toltype_inco_;
 
       /// tolerance EAS residual
       double tol_eas_res_;
 
       /// tolerance type for the convergence check of the EAS residual
-      enum Inpar::Solid::ConvNorm toltype_eas_res_;
+      Inpar::Solid::ConvNorm toltype_eas_res_;
 
       /// tolerance EAS increment
       double tol_eas_incr_;
 
       /// tolerance type for the convergence check of the EAS increment
-      enum Inpar::Solid::ConvNorm toltype_eas_incr_;
+      Inpar::Solid::ConvNorm toltype_eas_incr_;
 
       /// type of combination of the displacement and the pressure test
-      enum Inpar::Solid::BinaryOp normcombo_disp_pres_;
+      Inpar::Solid::BinaryOp normcombo_disp_pres_;
 
       /// type of combination of the force and the pressure residual test
-      enum Inpar::Solid::BinaryOp normcombo_fres_inco_;
+      Inpar::Solid::BinaryOp normcombo_fres_inco_;
 
       /// type of combination of the force and the EAS residual
-      enum Inpar::Solid::BinaryOp normcombo_fres_eas_res_;
+      Inpar::Solid::BinaryOp normcombo_fres_eas_res_;
 
       /// type of combination of the displacement and the EAS increment
-      enum Inpar::Solid::BinaryOp normcombo_disp_eas_incr_;
+      Inpar::Solid::BinaryOp normcombo_disp_eas_incr_;
 
       /// type of combination of the force and the displacement test
-      enum Inpar::Solid::BinaryOp normcombo_fres_disp_;
+      Inpar::Solid::BinaryOp normcombo_fres_disp_;
       ///@}
 
       /// @name constraint variables
       ///@{
 
       /// tolerance type for the convergence check of the 0D cardiovascular residual
-      enum Inpar::Solid::ConvNorm toltype_cardvasc0d_res_;
+      Inpar::Solid::ConvNorm toltype_cardvasc0d_res_;
 
       /// tolerance 0D cardiovascular residual
       double tol_cardvasc0d_res_;
 
       /// tolerance type for the convergence check of the 0D cardiovascular dof increment
-      enum Inpar::Solid::ConvNorm toltype_cardvasc0d_incr_;
+      Inpar::Solid::ConvNorm toltype_cardvasc0d_incr_;
 
       /// tolerance 0D cardiovascular dof increment
       double tol_cardvasc0d_incr_;
 
       /// tolerance type for the convergence check of the constraint residual
-      enum Inpar::Solid::ConvNorm toltype_constr_res_;
+      Inpar::Solid::ConvNorm toltype_constr_res_;
 
       /// tolerance constraint residual
       double tol_constr_res_;
 
       /// tolerance type for the convergence check of the constraint LM increment
-      enum Inpar::Solid::ConvNorm toltype_constr_incr_;
+      Inpar::Solid::ConvNorm toltype_constr_incr_;
 
       /// tolerance constraint LM increment
       double tol_constr_incr_;
 
       /// tolerance type for the convergence check of the contact residual
-      enum Inpar::Solid::ConvNorm toltype_contact_res_;
+      Inpar::Solid::ConvNorm toltype_contact_res_;
 
       /// tolerance contact constraint residual
       double tol_contact_res_;
 
       /// tolerance type  for the convergence check of the contact lagrange increment
-      enum Inpar::Solid::ConvNorm toltype_contact_lm_incr_;
+      Inpar::Solid::ConvNorm toltype_contact_lm_incr_;
 
       /// tolerance contact lagrange increment
       double tol_contact_lm_incr_;
 
       /// type of combination of the force and the contact residual
-      enum Inpar::Solid::BinaryOp normcombo_fres_contact_res_;
+      Inpar::Solid::BinaryOp normcombo_fres_contact_res_;
 
       /// type of combination of the displacement and the contact lagrange multiplier increment
       /// test
-      enum Inpar::Solid::BinaryOp normcombo_disp_contact_lm_incr_;
+      Inpar::Solid::BinaryOp normcombo_disp_contact_lm_incr_;
 
       /// type of combination of the force and the 0D cardiovascular model residual
-      enum Inpar::Solid::BinaryOp normcombo_fres_cardvasc0d_res_;
+      Inpar::Solid::BinaryOp normcombo_fres_cardvasc0d_res_;
 
       /// type of combination of the displacement and the 0D cardiovascular model dof increment
       /// test
-      enum Inpar::Solid::BinaryOp normcombo_disp_cardvasc0d_incr_;
+      Inpar::Solid::BinaryOp normcombo_disp_cardvasc0d_incr_;
 
       /// type of combination of the force and the constraint residual
-      enum Inpar::Solid::BinaryOp normcombo_fres_constr_res_;
+      Inpar::Solid::BinaryOp normcombo_fres_constr_res_;
 
       /// type of combination of the displacement and the 0D cardiovascular model dof increment
       /// test
-      enum Inpar::Solid::BinaryOp normcombo_disp_constr_incr_;
+      Inpar::Solid::BinaryOp normcombo_disp_constr_incr_;
 
       /// random factor for modifying time-step size in case this way of continuing non-linear
       /// iteration was chosen
@@ -811,7 +808,7 @@ namespace Solid
       ///@{
 
       /// type of initial displacement initialization
-      enum Inpar::Solid::InitialDisp initial_disp_;
+      Inpar::Solid::InitialDisp initial_disp_;
       int start_func_no_;
 
       ///@}
@@ -851,7 +848,7 @@ namespace Solid
       //!@{
 
       //! returns the mid-average type (for more information see MidAverageEnum)
-      const enum Inpar::Solid::MidAverageEnum& get_mid_average_type() const
+      const Inpar::Solid::MidAverageEnum& get_mid_average_type() const
       {
         check_init_setup();
         return midavg_;
@@ -896,7 +893,7 @@ namespace Solid
 
      private:
       //! mid-average type more at MidAverageEnum
-      enum Inpar::Solid::MidAverageEnum midavg_;
+      Inpar::Solid::MidAverageEnum midavg_;
 
       //! Time integration parameter \f$\beta \in (0,1/2]\f$
       double beta_;

--- a/src/structure_new/src/explicit/4C_structure_new_expl_ab2.hpp
+++ b/src/structure_new/src/explicit/4C_structure_new_expl_ab2.hpp
@@ -62,7 +62,7 @@ namespace Solid
       //@{
 
       //! Return time integrator name
-      [[nodiscard]] enum Inpar::Solid::DynamicType method_name() const override
+      [[nodiscard]] Inpar::Solid::DynamicType method_name() const override
       {
         return Inpar::Solid::DynamicType::AdamsBashforth2;
       }

--- a/src/structure_new/src/explicit/4C_structure_new_expl_abx.hpp
+++ b/src/structure_new/src/explicit/4C_structure_new_expl_abx.hpp
@@ -71,7 +71,7 @@ namespace Solid
       //@{
 
       //! Return time integrator name
-      [[nodiscard]] enum Inpar::Solid::DynamicType method_name() const override
+      [[nodiscard]] Inpar::Solid::DynamicType method_name() const override
       {
         return Inpar::Solid::DynamicType::AdamsBashforth4;
       }
@@ -129,7 +129,7 @@ namespace Solid
     struct AdamsBashforthHelper<2>
     {
       static constexpr std::array<double, 2> exc{{1.5, -0.5}};  // extrapolation coefficients
-      static enum Inpar::Solid::DynamicType method_name()
+      static Inpar::Solid::DynamicType method_name()
       {
         return Inpar::Solid::DynamicType::AdamsBashforth2;
       }
@@ -140,7 +140,7 @@ namespace Solid
     {
       static constexpr std::array<double, 4> exc{
           {55.0 / 24.0, -59.0 / 24.0, 37.0 / 24.0, -9.0 / 24.0}};  // extrapolation coefficients
-      static enum Inpar::Solid::DynamicType method_name()
+      static Inpar::Solid::DynamicType method_name()
       {
         return Inpar::Solid::DynamicType::AdamsBashforth4;
       }

--- a/src/structure_new/src/explicit/4C_structure_new_expl_centrdiff.hpp
+++ b/src/structure_new/src/explicit/4C_structure_new_expl_centrdiff.hpp
@@ -62,7 +62,7 @@ namespace Solid
       //@{
 
       //! Return time integrator name
-      [[nodiscard]] enum Inpar::Solid::DynamicType method_name() const override
+      [[nodiscard]] Inpar::Solid::DynamicType method_name() const override
       {
         return Inpar::Solid::DynamicType::CentrDiff;
       }

--- a/src/structure_new/src/explicit/4C_structure_new_expl_forwardeuler.hpp
+++ b/src/structure_new/src/explicit/4C_structure_new_expl_forwardeuler.hpp
@@ -62,7 +62,7 @@ namespace Solid
       //@{
 
       //! Return time integrator name
-      [[nodiscard]] enum Inpar::Solid::DynamicType method_name() const override
+      [[nodiscard]] Inpar::Solid::DynamicType method_name() const override
       {
         return Inpar::Solid::DynamicType::ExplEuler;
       }

--- a/src/structure_new/src/explicit/4C_structure_new_expl_generic.hpp
+++ b/src/structure_new/src/explicit/4C_structure_new_expl_generic.hpp
@@ -47,7 +47,7 @@ namespace Solid
       /*! \brief (derived)
        *
        */
-      bool apply_correction_system(const enum NOX::Nln::CorrectionType type,
+      bool apply_correction_system(const NOX::Nln::CorrectionType type,
           const std::vector<Inpar::Solid::ModelType>& constraint_models,
           const Core::LinAlg::Vector<double>& x, Core::LinAlg::Vector<double>& f,
           Core::LinAlg::SparseOperator& jac) override
@@ -99,7 +99,7 @@ namespace Solid
       //@{
 
       //! Provide Name
-      [[nodiscard]] virtual enum Inpar::Solid::DynamicType method_name() const = 0;
+      [[nodiscard]] virtual Inpar::Solid::DynamicType method_name() const = 0;
 
       //! Provide number of steps, e.g. a single-step method returns 1,
       //! a \f$m\f$-multistep method returns \f$m\f$

--- a/src/structure_new/src/explicit/4C_structure_new_timint_explicit.cpp
+++ b/src/structure_new/src/explicit/4C_structure_new_timint_explicit.cpp
@@ -46,7 +46,7 @@ void Solid::TimeInt::Explicit::setup()
   // ---------------------------------------------------------------------------
   // build non-linear solver
   // ---------------------------------------------------------------------------
-  enum Inpar::Solid::NonlinSolTech nlnSolverType = data_sdyn().get_nln_solver_type();
+  Inpar::Solid::NonlinSolTech nlnSolverType = data_sdyn().get_nln_solver_type();
   if (nlnSolverType != Inpar::Solid::soltech_singlestep)
   {
     std::cout << "WARNING!!!Nonlinear solver for explicit dynamics is given (in the input file) as "
@@ -310,7 +310,7 @@ void Solid::TimeInt::Explicit::use_block_matrix(
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-enum Inpar::Solid::DynamicType Solid::TimeInt::Explicit::method_name() const
+Inpar::Solid::DynamicType Solid::TimeInt::Explicit::method_name() const
 {
   return explint_ptr_->method_name();
 }

--- a/src/structure_new/src/explicit/4C_structure_new_timint_explicit.hpp
+++ b/src/structure_new/src/explicit/4C_structure_new_timint_explicit.hpp
@@ -81,7 +81,7 @@ namespace Solid
       //! @name Attribute access functions
       //@{
 
-      enum Inpar::Solid::DynamicType method_name() const override;
+      Inpar::Solid::DynamicType method_name() const override;
 
       bool is_implicit() const override { return false; }
 

--- a/src/structure_new/src/implicit/4C_structure_new_impl_genalpha.cpp
+++ b/src/structure_new/src/implicit/4C_structure_new_impl_genalpha.cpp
@@ -93,7 +93,7 @@ void Solid::IMPLICIT::GenAlpha::setup()
      * at the end-point t_{n+1} of each time interval, but never explicitly at
      * some generalized midpoint, such as t_{n+1-\alpha_f}. Thus, any cumbersome
      * extrapolation of history variables, etc. becomes obsolete. */
-    const enum Inpar::Solid::MidAverageEnum& midavg = genalpha_sdyn.get_mid_average_type();
+    const Inpar::Solid::MidAverageEnum& midavg = genalpha_sdyn.get_mid_average_type();
     if (midavg != Inpar::Solid::midavg_trlike)
       FOUR_C_THROW("mid-averaging of internal forces only implemented TR-like");
     else

--- a/src/structure_new/src/implicit/4C_structure_new_impl_genalpha.hpp
+++ b/src/structure_new/src/implicit/4C_structure_new_impl_genalpha.hpp
@@ -153,7 +153,7 @@ namespace Solid
       //@{
 
       //! Return name
-      enum Inpar::Solid::DynamicType method_name() const override
+      Inpar::Solid::DynamicType method_name() const override
       {
         return Inpar::Solid::DynamicType::GenAlpha;
       }

--- a/src/structure_new/src/implicit/4C_structure_new_impl_generic.cpp
+++ b/src/structure_new/src/implicit/4C_structure_new_impl_generic.cpp
@@ -122,7 +122,7 @@ void Solid::IMPLICIT::Generic::print_jacobian_in_matlab_format(
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-bool Solid::IMPLICIT::Generic::apply_correction_system(const enum NOX::Nln::CorrectionType type,
+bool Solid::IMPLICIT::Generic::apply_correction_system(const NOX::Nln::CorrectionType type,
     const std::vector<Inpar::Solid::ModelType>& constraint_models,
     const Core::LinAlg::Vector<double>& x, Core::LinAlg::Vector<double>& f,
     Core::LinAlg::SparseOperator& jac)

--- a/src/structure_new/src/implicit/4C_structure_new_impl_generic.hpp
+++ b/src/structure_new/src/implicit/4C_structure_new_impl_generic.hpp
@@ -42,7 +42,7 @@ namespace Solid
       void setup() override;
 
       //! derived
-      bool apply_correction_system(const enum NOX::Nln::CorrectionType type,
+      bool apply_correction_system(const NOX::Nln::CorrectionType type,
           const std::vector<Inpar::Solid::ModelType>& constraint_models,
           const Core::LinAlg::Vector<double>& x, Core::LinAlg::Vector<double>& f,
           Core::LinAlg::SparseOperator& jac) override;
@@ -158,7 +158,7 @@ namespace Solid
       //@{
 
       //! Provide Name
-      virtual enum Inpar::Solid::DynamicType method_name() const = 0;
+      virtual Inpar::Solid::DynamicType method_name() const = 0;
 
       //! Provide number of steps, e.g. a single-step method returns 1,
       //! a \f$m\f$-multistep method returns \f$m\f$

--- a/src/structure_new/src/implicit/4C_structure_new_impl_ost.hpp
+++ b/src/structure_new/src/implicit/4C_structure_new_impl_ost.hpp
@@ -123,7 +123,7 @@ namespace Solid
       //@{
 
       //! Return name
-      enum Inpar::Solid::DynamicType method_name() const override
+      Inpar::Solid::DynamicType method_name() const override
       {
         return Inpar::Solid::DynamicType::OneStepTheta;
       }

--- a/src/structure_new/src/implicit/4C_structure_new_impl_statics.hpp
+++ b/src/structure_new/src/implicit/4C_structure_new_impl_statics.hpp
@@ -101,7 +101,7 @@ namespace Solid
       //@{
 
       //! Return name
-      enum Inpar::Solid::DynamicType method_name() const override
+      Inpar::Solid::DynamicType method_name() const override
       {
         return Inpar::Solid::DynamicType::Statics;
       }

--- a/src/structure_new/src/implicit/4C_structure_new_timint_implicit.cpp
+++ b/src/structure_new/src/implicit/4C_structure_new_timint_implicit.cpp
@@ -54,7 +54,7 @@ void Solid::TimeInt::Implicit::setup()
   // ---------------------------------------------------------------------------
   // build predictor
   // ---------------------------------------------------------------------------
-  const enum Inpar::Solid::PredEnum predtype = data_sdyn().get_predictor_type();
+  const Inpar::Solid::PredEnum predtype = data_sdyn().get_predictor_type();
   predictor_ptr_ = Solid::Predict::build_predictor(predtype);
   predictor_ptr_->init(predtype, implint_ptr_, dbc_ptr(), data_global_state_ptr(), data_io_ptr(),
       data_sdyn().get_nox_params_ptr());
@@ -63,7 +63,7 @@ void Solid::TimeInt::Implicit::setup()
   // ---------------------------------------------------------------------------
   // build non-linear solver
   // ---------------------------------------------------------------------------
-  const enum Inpar::Solid::NonlinSolTech nlnSolverType = data_sdyn().get_nln_solver_type();
+  const Inpar::Solid::NonlinSolTech nlnSolverType = data_sdyn().get_nln_solver_type();
   if (nlnSolverType == Inpar::Solid::soltech_singlestep)
     std::cout << "WARNING!!! You are trying to solve implicitly using the \"singlestep\" nonlinear "
                  "solver. This is not encouraged, since it only works for linear statics analysis. "
@@ -493,8 +493,7 @@ void Solid::TimeInt::Implicit::print_jacobian_in_matlab_format(
   Teuchos::RCP<const NOX::Nln::LinearSystem> nln_lin_system =
       Teuchos::rcp_dynamic_cast<const NOX::Nln::LinearSystem>(linear_system, true);
 
-  const enum NOX::Nln::LinSystem::OperatorType jac_type =
-      nln_lin_system->get_jacobian_operator_type();
+  const NOX::Nln::LinSystem::OperatorType jac_type = nln_lin_system->get_jacobian_operator_type();
 
   Teuchos::RCP<const Epetra_Operator> jac_ptr = nln_lin_system->get_jacobian_operator();
 
@@ -530,7 +529,7 @@ void Solid::TimeInt::Implicit::print_jacobian_in_matlab_format(
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-enum Inpar::Solid::DynamicType Solid::TimeInt::Implicit::method_name() const
+Inpar::Solid::DynamicType Solid::TimeInt::Implicit::method_name() const
 {
   return implint_ptr_->method_name();
 }

--- a/src/structure_new/src/implicit/4C_structure_new_timint_implicit.hpp
+++ b/src/structure_new/src/implicit/4C_structure_new_timint_implicit.hpp
@@ -169,7 +169,7 @@ namespace Solid
       //@{
 
       //! Provide Name
-      enum Inpar::Solid::DynamicType method_name() const override;
+      Inpar::Solid::DynamicType method_name() const override;
 
       //! Provide number of steps, e.g. a single-step method returns 1,
       //! a \f$m\f$-multistep method returns \f$m\f$

--- a/src/structure_new/src/linear_solver/4C_structure_new_solver_factory.cpp
+++ b/src/structure_new/src/linear_solver/4C_structure_new_solver_factory.cpp
@@ -32,13 +32,13 @@ FOUR_C_NAMESPACE_OPEN
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 std::shared_ptr<Solid::SOLVER::Factory::LinSolMap> Solid::SOLVER::Factory::build_lin_solvers(
-    const std::set<enum Inpar::Solid::ModelType>& modeltypes, const Teuchos::ParameterList& sdyn,
+    const std::set<Inpar::Solid::ModelType>& modeltypes, const Teuchos::ParameterList& sdyn,
     Core::FE::Discretization& actdis) const
 {
   // create a new standard map
   std::shared_ptr<LinSolMap> linsolvers = std::make_shared<LinSolMap>();
 
-  std::set<enum Inpar::Solid::ModelType>::const_iterator mt_iter;
+  std::set<Inpar::Solid::ModelType>::const_iterator mt_iter;
   // loop over all model types
   for (mt_iter = modeltypes.begin(); mt_iter != modeltypes.end(); ++mt_iter)
   {
@@ -297,8 +297,8 @@ std::shared_ptr<Core::LinAlg::Solver> Solid::SOLVER::Factory::build_meshtying_co
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 std::shared_ptr<Core::LinAlg::Solver> Solid::SOLVER::Factory::build_meshtying_contact_lin_solver(
-    Core::FE::Discretization& actdis, enum CONTACT::SolvingStrategy sol_type,
-    enum CONTACT::SystemType sys_type, const int lin_solver_id)
+    Core::FE::Discretization& actdis, CONTACT::SolvingStrategy sol_type,
+    CONTACT::SystemType sys_type, const int lin_solver_id)
 {
   std::shared_ptr<Core::LinAlg::Solver> linsolver = nullptr;
 
@@ -552,8 +552,8 @@ std::shared_ptr<Core::LinAlg::Solver> Solid::SOLVER::Factory::build_cardiovascul
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-std::shared_ptr<std::map<enum Inpar::Solid::ModelType, std::shared_ptr<Core::LinAlg::Solver>>>
-Solid::SOLVER::build_lin_solvers(const std::set<enum Inpar::Solid::ModelType>& modeltypes,
+std::shared_ptr<std::map<Inpar::Solid::ModelType, std::shared_ptr<Core::LinAlg::Solver>>>
+Solid::SOLVER::build_lin_solvers(const std::set<Inpar::Solid::ModelType>& modeltypes,
     const Teuchos::ParameterList& sdyn, Core::FE::Discretization& actdis)
 {
   Factory factory;

--- a/src/structure_new/src/linear_solver/4C_structure_new_solver_factory.hpp
+++ b/src/structure_new/src/linear_solver/4C_structure_new_solver_factory.hpp
@@ -50,8 +50,7 @@ namespace Solid
     class Factory
     {
      private:
-      using LinSolMap =
-          std::map<enum Inpar::Solid::ModelType, std::shared_ptr<Core::LinAlg::Solver>>;
+      using LinSolMap = std::map<Inpar::Solid::ModelType, std::shared_ptr<Core::LinAlg::Solver>>;
 
      public:
       //! constructor
@@ -62,13 +61,13 @@ namespace Solid
 
       //! build the desired linear solvers
       std::shared_ptr<LinSolMap> build_lin_solvers(
-          const std::set<enum Inpar::Solid::ModelType>& modeltypes,
-          const Teuchos::ParameterList& sdyn, Core::FE::Discretization& actdis) const;
+          const std::set<Inpar::Solid::ModelType>& modeltypes, const Teuchos::ParameterList& sdyn,
+          Core::FE::Discretization& actdis) const;
 
       //! create the meshtying/contact linear solver
       static std::shared_ptr<Core::LinAlg::Solver> build_meshtying_contact_lin_solver(
-          Core::FE::Discretization& actdis, enum CONTACT::SolvingStrategy sol_type,
-          enum CONTACT::SystemType sys_type, const int lin_solver_id);
+          Core::FE::Discretization& actdis, CONTACT::SolvingStrategy sol_type,
+          CONTACT::SystemType sys_type, const int lin_solver_id);
 
      private:
       //! create the structural linear solver (should be called by default)
@@ -91,8 +90,8 @@ namespace Solid
 
     /*! Non-member function, which relates to the Solid::SOLVER::Factory class
      *  Please call this method from outside! */
-    std::shared_ptr<std::map<enum Inpar::Solid::ModelType, std::shared_ptr<Core::LinAlg::Solver>>>
-    build_lin_solvers(const std::set<enum Inpar::Solid::ModelType>& modeltypes,
+    std::shared_ptr<std::map<Inpar::Solid::ModelType, std::shared_ptr<Core::LinAlg::Solver>>>
+    build_lin_solvers(const std::set<Inpar::Solid::ModelType>& modeltypes,
         const Teuchos::ParameterList& sdyn, Core::FE::Discretization& actdis);
   }  // namespace SOLVER
 }  // namespace Solid

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_data.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_data.cpp
@@ -212,8 +212,8 @@ void Solid::ModelEvaluator::Data::setup()
 {
   check_init();
 
-  const std::set<enum Inpar::Solid::ModelType>& mt = sdyn_ptr_->get_model_types();
-  std::set<enum Inpar::Solid::ModelType>::const_iterator it;
+  const std::set<Inpar::Solid::ModelType>& mt = sdyn_ptr_->get_model_types();
+  std::set<Inpar::Solid::ModelType>::const_iterator it;
   // setup model type specific data containers
   for (it = mt.begin(); it != mt.end(); ++it)
   {
@@ -260,7 +260,7 @@ void Solid::ModelEvaluator::Data::fill_norm_type_maps()
   // we have to do all this only once...
   if (isntmaps_filled_) return;
 
-  std::set<enum NOX::Nln::StatusTest::QuantityType> qtypes;
+  std::set<NOX::Nln::StatusTest::QuantityType> qtypes;
   Solid::Nln::SOLVER::create_quantity_types(qtypes, *sdyn_ptr_);
 
   // --- check if the nox nln solver is active ---------------------------------
@@ -276,7 +276,7 @@ void Solid::ModelEvaluator::Data::fill_norm_type_maps()
   }
 
   // --- get the normtypes for the different quantities -------------------------
-  std::set<enum NOX::Nln::StatusTest::QuantityType>::const_iterator qiter;
+  std::set<NOX::Nln::StatusTest::QuantityType>::const_iterator qiter;
   if (isnox)
   {
     const ::NOX::StatusTest::Generic& ostatus = nox_nln_ptr->get_outer_status_test();
@@ -339,7 +339,7 @@ void Solid::ModelEvaluator::Data::collect_norm_types_over_all_procs(
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 bool Solid::ModelEvaluator::Data::get_update_norm_type(
-    const enum NOX::Nln::StatusTest::QuantityType& qtype,
+    const NOX::Nln::StatusTest::QuantityType& qtype,
     enum ::NOX::Abstract::Vector::NormType& normtype)
 {
   fill_norm_type_maps();
@@ -359,12 +359,12 @@ bool Solid::ModelEvaluator::Data::get_update_norm_type(
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 bool Solid::ModelEvaluator::Data::get_wrms_tolerances(
-    const enum NOX::Nln::StatusTest::QuantityType& qtype, double& atol, double& rtol)
+    const NOX::Nln::StatusTest::QuantityType& qtype, double& atol, double& rtol)
 {
   fill_norm_type_maps();
 
   // check if there is a wrms test for the corresponding quantity type
-  std::map<enum NOX::Nln::StatusTest::QuantityType, double>::const_iterator iter;
+  std::map<NOX::Nln::StatusTest::QuantityType, double>::const_iterator iter;
   iter = atol_wrms_.find(qtype);
   if (iter == atol_wrms_.end()) return false;
 
@@ -378,7 +378,7 @@ bool Solid::ModelEvaluator::Data::get_wrms_tolerances(
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 void Solid::ModelEvaluator::Data::sum_into_my_update_norm(
-    const enum NOX::Nln::StatusTest::QuantityType& qtype, const int& numentries,
+    const NOX::Nln::StatusTest::QuantityType& qtype, const int& numentries,
     const double* my_update_values, const double* my_new_sol_values, const double& step_length,
     const int& owner)
 {
@@ -401,7 +401,7 @@ void Solid::ModelEvaluator::Data::sum_into_my_update_norm(
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 void Solid::ModelEvaluator::Data::sum_into_my_previous_sol_norm(
-    const enum NOX::Nln::StatusTest::QuantityType& qtype, const int& numentries,
+    const NOX::Nln::StatusTest::QuantityType& qtype, const int& numentries,
     const double* my_old_sol_values, const int& owner)
 {
   if (owner != Core::Communication::my_mpi_rank(comm_)) return;
@@ -465,7 +465,7 @@ void Solid::ModelEvaluator::Data::sum_into_my_norm(const int& numentries, const 
 void Solid::ModelEvaluator::Data::reset_my_norms(const bool& isdefaultstep)
 {
   check_init_setup();
-  std::map<enum NOX::Nln::StatusTest::QuantityType, double>::iterator it;
+  std::map<NOX::Nln::StatusTest::QuantityType, double>::iterator it;
   for (it = my_update_norm_.begin(); it != my_update_norm_.end(); ++it) it->second = 0.0;
   for (it = my_rms_norm_.begin(); it != my_rms_norm_.end(); ++it) it->second = 0.0;
 
@@ -475,7 +475,7 @@ void Solid::ModelEvaluator::Data::reset_my_norms(const bool& isdefaultstep)
     // Newton step
     for (it = my_prev_sol_norm_.begin(); it != my_prev_sol_norm_.end(); ++it) it->second = 0.0;
     // reset the dof number
-    std::map<enum NOX::Nln::StatusTest::QuantityType, std::size_t>::iterator dit;
+    std::map<NOX::Nln::StatusTest::QuantityType, std::size_t>::iterator dit;
     for (dit = my_dof_number_.begin(); dit != my_dof_number_.end(); ++dit) dit->second = 0;
   }
 }
@@ -503,7 +503,7 @@ bool Solid::ModelEvaluator::Data::is_predictor_state() const
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-enum Inpar::Solid::DampKind Solid::ModelEvaluator::Data::get_damping_type() const
+Inpar::Solid::DampKind Solid::ModelEvaluator::Data::get_damping_type() const
 {
   check_init_setup();
   return sdyn_ptr_->get_damping_type();
@@ -575,7 +575,7 @@ const std::vector<char>& Solid::ModelEvaluator::Data::opt_quantity_data() const
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-enum Inpar::Solid::StressType Solid::ModelEvaluator::Data::get_stress_output_type() const
+Inpar::Solid::StressType Solid::ModelEvaluator::Data::get_stress_output_type() const
 {
   check_init_setup();
   return io_ptr_->get_stress_output_type();
@@ -583,7 +583,7 @@ enum Inpar::Solid::StressType Solid::ModelEvaluator::Data::get_stress_output_typ
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-enum Inpar::Solid::StrainType Solid::ModelEvaluator::Data::get_strain_output_type() const
+Inpar::Solid::StrainType Solid::ModelEvaluator::Data::get_strain_output_type() const
 {
   check_init_setup();
   return io_ptr_->get_strain_output_type();
@@ -591,7 +591,7 @@ enum Inpar::Solid::StrainType Solid::ModelEvaluator::Data::get_strain_output_typ
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-enum Inpar::Solid::StrainType Solid::ModelEvaluator::Data::get_plastic_strain_output_type() const
+Inpar::Solid::StrainType Solid::ModelEvaluator::Data::get_plastic_strain_output_type() const
 {
   check_init_setup();
   return io_ptr_->get_plastic_strain_output_type();
@@ -599,7 +599,7 @@ enum Inpar::Solid::StrainType Solid::ModelEvaluator::Data::get_plastic_strain_ou
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-enum Inpar::Solid::OptQuantityType Solid::ModelEvaluator::Data::get_opt_quantity_output_type() const
+Inpar::Solid::OptQuantityType Solid::ModelEvaluator::Data::get_opt_quantity_output_type() const
 {
   check_init_setup();
 
@@ -615,14 +615,14 @@ Solid::ModelEvaluator::Data::gauss_point_data_output_manager_ptr()
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-std::map<enum Solid::EnergyType, double> const& Solid::ModelEvaluator::Data::get_energy_data() const
+std::map<Solid::EnergyType, double> const& Solid::ModelEvaluator::Data::get_energy_data() const
 {
   return energy_data_;
 }
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-double Solid::ModelEvaluator::Data::get_energy_data(enum Solid::EnergyType type) const
+double Solid::ModelEvaluator::Data::get_energy_data(Solid::EnergyType type) const
 {
   auto check = get_energy_data().find(type);
   if (check == get_energy_data().cend())
@@ -648,15 +648,14 @@ double Solid::ModelEvaluator::Data::get_energy_data(const std::string type) cons
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-void Solid::ModelEvaluator::Data::insert_energy_type_to_be_considered(enum Solid::EnergyType type)
+void Solid::ModelEvaluator::Data::insert_energy_type_to_be_considered(Solid::EnergyType type)
 {
   energy_data_[type] = 0.0;
 }
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-void Solid::ModelEvaluator::Data::set_value_for_energy_type(
-    double value, enum Solid::EnergyType type)
+void Solid::ModelEvaluator::Data::set_value_for_energy_type(double value, Solid::EnergyType type)
 {
   energy_data_[type] = value;
 }
@@ -674,7 +673,7 @@ void Solid::ModelEvaluator::Data::clear_values_for_all_energy_types()
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 void Solid::ModelEvaluator::Data::add_contribution_to_energy_type(
-    const double value, const enum Solid::EnergyType type)
+    const double value, const Solid::EnergyType type)
 {
   energy_data_[type] += value;
 }

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_data.hpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_data.hpp
@@ -78,7 +78,7 @@ namespace Solid
     class Data : public Solid::Elements::ParamsInterface
     {
       using quantity_norm_type_map =
-          std::map<enum NOX::Nln::StatusTest::QuantityType, enum ::NOX::Abstract::Vector::NormType>;
+          std::map<NOX::Nln::StatusTest::QuantityType, enum ::NOX::Abstract::Vector::NormType>;
 
      public:
       //! constructor
@@ -95,7 +95,7 @@ namespace Solid
       //!@{
 
       //! get the desired action type [derived]
-      [[nodiscard]] inline enum Core::Elements::ActionType get_action_type() const override
+      [[nodiscard]] inline Core::Elements::ActionType get_action_type() const override
       {
         check_init_setup();
         return ele_action_;
@@ -136,7 +136,7 @@ namespace Solid
       }
 
       //! get the current damping type [derived]
-      [[nodiscard]] enum Inpar::Solid::DampKind get_damping_type() const override;
+      [[nodiscard]] Inpar::Solid::DampKind get_damping_type() const override;
 
       //! get the tolerate errors indicator [derived]
       [[nodiscard]] inline bool is_tolerate_errors() const override
@@ -160,7 +160,7 @@ namespace Solid
       }
 
       //! get the predictor type of the structural time integration
-      [[nodiscard]] enum Inpar::Solid::PredEnum get_predictor_type() const override
+      [[nodiscard]] Inpar::Solid::PredEnum get_predictor_type() const override
       {
         check_init_setup();
         return predict_type_;
@@ -184,34 +184,34 @@ namespace Solid
       std::shared_ptr<std::vector<char>> opt_quantity_data_ptr() override;
 
       //! get the current stress type [derived]
-      [[nodiscard]] enum Inpar::Solid::StressType get_stress_output_type() const override;
+      [[nodiscard]] Inpar::Solid::StressType get_stress_output_type() const override;
 
       //! get the current strain type [derived]
-      [[nodiscard]] enum Inpar::Solid::StrainType get_strain_output_type() const override;
+      [[nodiscard]] Inpar::Solid::StrainType get_strain_output_type() const override;
 
       //! get the current plastic strain type [derived]
-      [[nodiscard]] enum Inpar::Solid::StrainType get_plastic_strain_output_type() const override;
+      [[nodiscard]] Inpar::Solid::StrainType get_plastic_strain_output_type() const override;
 
       //! get the current strain type [derived]
-      virtual enum Inpar::Solid::OptQuantityType get_opt_quantity_output_type() const;
+      virtual Inpar::Solid::OptQuantityType get_opt_quantity_output_type() const;
 
       //< get the manager of Gauss point data output
       std::shared_ptr<GaussPointDataOutputManager>& gauss_point_data_output_manager_ptr() override;
 
       //! register energy type to be computed and written to file
-      void insert_energy_type_to_be_considered(enum Solid::EnergyType type);
+      void insert_energy_type_to_be_considered(Solid::EnergyType type);
 
       //! read-only access to energy data
-      std::map<enum Solid::EnergyType, double> const& get_energy_data() const;
+      std::map<Solid::EnergyType, double> const& get_energy_data() const;
 
       //! read-only access to energy data
-      double get_energy_data(enum Solid::EnergyType type) const;
+      double get_energy_data(Solid::EnergyType type) const;
 
       //! read-only access to energy data
       double get_energy_data(const std::string type) const;
 
       //! set value for a specific energy type
-      void set_value_for_energy_type(double value, enum Solid::EnergyType type);
+      void set_value_for_energy_type(double value, Solid::EnergyType type);
 
       //! set function manager
       void set_function_manager(const Core::Utils::FunctionManager& function_manager)
@@ -228,7 +228,7 @@ namespace Solid
        * @param type Type of energy to be added to
        */
       void add_contribution_to_energy_type(
-          const double value, const enum Solid::EnergyType type) override;
+          const double value, const Solid::EnergyType type) override;
 
       //! get Interface to brownian dyn data [derived]
       [[nodiscard]] inline std::shared_ptr<BrownianDynamics::ParamsInterface>
@@ -289,7 +289,7 @@ namespace Solid
        *
        * \sa sum_into_my_previous_sol_norm
        */
-      void sum_into_my_update_norm(const enum NOX::Nln::StatusTest::QuantityType& qtype,
+      void sum_into_my_update_norm(const NOX::Nln::StatusTest::QuantityType& qtype,
           const int& numentries, const double* my_update_values, const double* my_new_sol_values,
           const double& step_length, const int& owner) override;
 
@@ -304,7 +304,7 @@ namespace Solid
        *
        * \sa sum_into_my_update_norm
        */
-      void sum_into_my_previous_sol_norm(const enum NOX::Nln::StatusTest::QuantityType& qtype,
+      void sum_into_my_previous_sol_norm(const NOX::Nln::StatusTest::QuantityType& qtype,
           const int& numentries, const double* my_old_sol_values, const int& owner) override;
 
       //!@}
@@ -316,10 +316,10 @@ namespace Solid
        * @param[in] qtype Quantity type which is tested
        * @return
        */
-      inline double get_my_update_norm(const enum NOX::Nln::StatusTest::QuantityType& qtype) const
+      inline double get_my_update_norm(const NOX::Nln::StatusTest::QuantityType& qtype) const
       {
         check_init_setup();
-        std::map<enum NOX::Nln::StatusTest::QuantityType, double>::const_iterator c_it;
+        std::map<NOX::Nln::StatusTest::QuantityType, double>::const_iterator c_it;
         c_it = my_update_norm_.find(qtype);
         // not on this proc
         if (c_it == my_update_norm_.end()) return 0.0;
@@ -333,10 +333,10 @@ namespace Solid
        * @param[in] qtype Quantity type which is tested
        * @return
        */
-      inline double get_my_rms_norm(const enum NOX::Nln::StatusTest::QuantityType& qtype) const
+      inline double get_my_rms_norm(const NOX::Nln::StatusTest::QuantityType& qtype) const
       {
         check_init_setup();
-        std::map<enum NOX::Nln::StatusTest::QuantityType, double>::const_iterator c_it;
+        std::map<NOX::Nln::StatusTest::QuantityType, double>::const_iterator c_it;
         c_it = my_rms_norm_.find(qtype);
         // not on this proc
         if (c_it == my_rms_norm_.end()) return 0.0;
@@ -351,11 +351,10 @@ namespace Solid
        * @param[in] qtype Quantity type which is tested
        * @return
        */
-      inline double get_my_previous_sol_norm(
-          const enum NOX::Nln::StatusTest::QuantityType& qtype) const
+      inline double get_my_previous_sol_norm(const NOX::Nln::StatusTest::QuantityType& qtype) const
       {
         check_init_setup();
-        std::map<enum NOX::Nln::StatusTest::QuantityType, double>::const_iterator c_it;
+        std::map<NOX::Nln::StatusTest::QuantityType, double>::const_iterator c_it;
         c_it = my_prev_sol_norm_.find(qtype);
         // not on this proc
         if (c_it == my_prev_sol_norm_.end()) return 0.0;
@@ -370,7 +369,7 @@ namespace Solid
        * @return
        */
       inline enum ::NOX::Abstract::Vector::NormType get_update_norm_type(
-          const enum NOX::Nln::StatusTest::QuantityType& qtype) const
+          const NOX::Nln::StatusTest::QuantityType& qtype) const
       {
         check_init_setup();
         // collect the norm types only once
@@ -397,10 +396,10 @@ namespace Solid
        * @param[in] qtype Quantity type which is tested
        * @return
        */
-      inline int get_my_dof_number(const enum NOX::Nln::StatusTest::QuantityType& qtype) const
+      inline int get_my_dof_number(const NOX::Nln::StatusTest::QuantityType& qtype) const
       {
         check_init_setup();
-        std::map<enum NOX::Nln::StatusTest::QuantityType, std::size_t>::const_iterator c_it;
+        std::map<NOX::Nln::StatusTest::QuantityType, std::size_t>::const_iterator c_it;
         c_it = my_dof_number_.find(qtype);
         // not on this proc
         if (c_it == my_dof_number_.end()) return 0;
@@ -432,7 +431,7 @@ namespace Solid
        *
        * @param[in] actiontype Action type
        */
-      inline void set_action_type(const enum Core::Elements::ActionType& actiontype)
+      inline void set_action_type(const Core::Elements::ActionType& actiontype)
       {
         ele_action_ = actiontype;
       }
@@ -753,7 +752,7 @@ namespace Solid
        *
        *  If the norm type can be found, the function returns true,
        *  otherwise false. */
-      bool get_update_norm_type(const enum NOX::Nln::StatusTest::QuantityType& qtype,
+      bool get_update_norm_type(const NOX::Nln::StatusTest::QuantityType& qtype,
           enum ::NOX::Abstract::Vector::NormType& normtype);
 
       /*! \brief Get the WRMS absolute and relative tolerances of the desired quantity.
@@ -761,7 +760,7 @@ namespace Solid
        *  If the tolerances can be found, the function returns true,
        *  otherwise false. */
       bool get_wrms_tolerances(
-          const enum NOX::Nln::StatusTest::QuantityType& qtype, double& atol, double& rtol);
+          const NOX::Nln::StatusTest::QuantityType& qtype, double& atol, double& rtol);
 
       /*! \brief Sum locally values into a norm of the desired type
        *
@@ -817,13 +816,13 @@ namespace Solid
       //!@{
 
       //! Current action type
-      enum Core::Elements::ActionType ele_action_;
+      Core::Elements::ActionType ele_action_;
 
       //! Current predictor type
-      enum Inpar::Solid::PredEnum predict_type_;
+      Inpar::Solid::PredEnum predict_type_;
 
       //! element evaluation error flag
-      enum Solid::Elements::EvalErrorFlag ele_eval_error_flag_;
+      Solid::Elements::EvalErrorFlag ele_eval_error_flag_;
 
       //! tolerate errors flag
       bool is_tolerate_errors_;
@@ -892,7 +891,7 @@ namespace Solid
       std::shared_ptr<Core::LinAlg::MultiVector<double>> opt_quantity_data_postprocessed_nodal_ptr_;
 
       //! system energy, stored separately by type
-      std::map<enum Solid::EnergyType, double> energy_data_;
+      std::map<Solid::EnergyType, double> energy_data_;
 
       //! Manager of gauss point data output
       std::shared_ptr<GaussPointDataOutputManager> gauss_point_data_manager_ptr_;
@@ -906,24 +905,24 @@ namespace Solid
       quantity_norm_type_map normtype_update_;
 
       //! map holding the dof number of the the active quantities on the current processor
-      std::map<enum NOX::Nln::StatusTest::QuantityType, std::size_t> my_dof_number_;
+      std::map<NOX::Nln::StatusTest::QuantityType, std::size_t> my_dof_number_;
 
       /*! map holding the absolute tolerance for the wrms status test of the active
        *  quantities on the current processor */
-      std::map<enum NOX::Nln::StatusTest::QuantityType, double> atol_wrms_;
+      std::map<NOX::Nln::StatusTest::QuantityType, double> atol_wrms_;
 
       /*! map holding the relative tolerance for the wrms status test of the active
        *  quantities on the current processor */
-      std::map<enum NOX::Nln::StatusTest::QuantityType, double> rtol_wrms_;
+      std::map<NOX::Nln::StatusTest::QuantityType, double> rtol_wrms_;
 
       //! partial update norm of the current processor
-      std::map<enum NOX::Nln::StatusTest::QuantityType, double> my_update_norm_;
+      std::map<NOX::Nln::StatusTest::QuantityType, double> my_update_norm_;
 
       //! partial relative mean square norm of the current processor
-      std::map<enum NOX::Nln::StatusTest::QuantityType, double> my_rms_norm_;
+      std::map<NOX::Nln::StatusTest::QuantityType, double> my_rms_norm_;
 
       //! global partial solution norm of the previous step
-      std::map<enum NOX::Nln::StatusTest::QuantityType, double> my_prev_sol_norm_;
+      std::map<NOX::Nln::StatusTest::QuantityType, double> my_prev_sol_norm_;
 
       //! read-only access to the structural dynamic parameters
       std::shared_ptr<const Solid::TimeInt::BaseDataSDyn> sdyn_ptr_;
@@ -1075,7 +1074,7 @@ namespace Solid
       void setup();
 
       //! returns the mortar/contact action type
-      [[nodiscard]] inline enum Mortar::ActionType get_action_type() const override
+      [[nodiscard]] inline Mortar::ActionType get_action_type() const override
       {
         check_init_setup();
         return mortar_action_;
@@ -1108,7 +1107,7 @@ namespace Solid
        * @return Type of predictor
        *
        * */
-      [[nodiscard]] enum Inpar::Solid::PredEnum get_predictor_type() const override
+      [[nodiscard]] Inpar::Solid::PredEnum get_predictor_type() const override
       {
         check_init();
         return str_data_ptr_->get_predictor_type();
@@ -1153,13 +1152,13 @@ namespace Solid
       [[nodiscard]] std::string get_output_file_path() const override;
 
       //! set coupling mode enumerator
-      [[nodiscard]] enum CONTACT::CouplingScheme get_coupling_scheme() const override
+      [[nodiscard]] CONTACT::CouplingScheme get_coupling_scheme() const override
       {
         return coupling_scheme_;
       }
 
       //! set coupling mode enumerator
-      void set_coupling_scheme(const enum CONTACT::CouplingScheme scheme) override
+      void set_coupling_scheme(const CONTACT::CouplingScheme scheme) override
       {
         coupling_scheme_ = scheme;
       }
@@ -1180,7 +1179,7 @@ namespace Solid
       //! @{
 
       //! set the action type
-      inline void set_action_type(const enum Mortar::ActionType& actiontype)
+      inline void set_action_type(const Mortar::ActionType& actiontype)
       {
         mortar_action_ = actiontype;
       }
@@ -1259,9 +1258,9 @@ namespace Solid
 
       bool issetup_;
 
-      enum Mortar::ActionType mortar_action_;
+      Mortar::ActionType mortar_action_;
 
-      enum CONTACT::CouplingScheme coupling_scheme_;
+      CONTACT::CouplingScheme coupling_scheme_;
 
       std::shared_ptr<const Solid::ModelEvaluator::Data> str_data_ptr_;
 

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_factory.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_factory.cpp
@@ -35,14 +35,14 @@ Solid::ModelEvaluator::Factory::Factory()
  *----------------------------------------------------------------------------*/
 std::shared_ptr<Solid::ModelEvaluatorManager::Map>
 Solid::ModelEvaluator::Factory::build_model_evaluators(
-    const std::set<enum Inpar::Solid::ModelType>& modeltypes,
+    const std::set<Inpar::Solid::ModelType>& modeltypes,
     const std::shared_ptr<Solid::ModelEvaluator::Generic>& coupling_model_ptr) const
 {
   // create a new standard map
   std::shared_ptr<Solid::ModelEvaluatorManager::Map> model_map =
       std::make_shared<Solid::ModelEvaluatorManager::Map>();
 
-  std::set<enum Inpar::Solid::ModelType>::const_iterator mt_iter;
+  std::set<Inpar::Solid::ModelType>::const_iterator mt_iter;
   for (mt_iter = modeltypes.begin(); mt_iter != modeltypes.end(); ++mt_iter)
   {
     switch (*mt_iter)
@@ -131,7 +131,7 @@ Solid::ModelEvaluator::Factory::build_structure_model_evaluator() const
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 std::shared_ptr<Solid::ModelEvaluatorManager::Map> Solid::ModelEvaluator::build_model_evaluators(
-    const std::set<enum Inpar::Solid::ModelType>& modeltypes,
+    const std::set<Inpar::Solid::ModelType>& modeltypes,
     const std::shared_ptr<Solid::ModelEvaluator::Generic>& coupling_model_ptr)
 {
   Factory factory;

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_factory.hpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_factory.hpp
@@ -38,7 +38,7 @@ namespace Solid
 
 
       std::shared_ptr<Solid::ModelEvaluatorManager::Map> build_model_evaluators(
-          const std::set<enum Inpar::Solid::ModelType>& modeltypes,
+          const std::set<Inpar::Solid::ModelType>& modeltypes,
           const std::shared_ptr<Solid::ModelEvaluator::Generic>& coupling_model_ptr) const;
 
      private:
@@ -52,7 +52,7 @@ namespace Solid
 
     //! non-member function, which relates to the Solid::ModelEvaluator::Factory
     std::shared_ptr<Solid::ModelEvaluatorManager::Map> build_model_evaluators(
-        const std::set<enum Inpar::Solid::ModelType>& modeltypes,
+        const std::set<Inpar::Solid::ModelType>& modeltypes,
         const std::shared_ptr<Solid::ModelEvaluator::Generic>& coupling_model_ptr);
 
   }  // namespace ModelEvaluator

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_manager.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_manager.cpp
@@ -439,7 +439,7 @@ bool Solid::ModelEvaluatorManager::apply_force_stiff(const Core::LinAlg::Vector<
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-bool Solid::ModelEvaluatorManager::apply_cheap_soc_rhs(const enum NOX::Nln::CorrectionType type,
+bool Solid::ModelEvaluatorManager::apply_cheap_soc_rhs(const NOX::Nln::CorrectionType type,
     const std::vector<Inpar::Solid::ModelType>& constraint_models,
     const Core::LinAlg::Vector<double>& x, Core::LinAlg::Vector<double>& f,
     const double& timefac_np) const
@@ -499,8 +499,7 @@ void Solid::ModelEvaluatorManager::assemble_cheap_soc_rhs(
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-bool Solid::ModelEvaluatorManager::correct_parameters(
-    const enum NOX::Nln::CorrectionType type) const
+bool Solid::ModelEvaluatorManager::correct_parameters(const NOX::Nln::CorrectionType type) const
 {
   bool ok = true;
   for (auto& cit : *me_vec_ptr_)
@@ -653,7 +652,7 @@ const std::shared_ptr<const Solid::TimeInt::Base>& Solid::ModelEvaluatorManager:
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 Solid::ModelEvaluator::Generic& Solid::ModelEvaluatorManager::evaluator(
-    const enum Inpar::Solid::ModelType& mt)
+    const Inpar::Solid::ModelType& mt)
 {
   check_init_setup();
   // sanity check, if there is a model evaluator for the given model type
@@ -667,7 +666,7 @@ Solid::ModelEvaluator::Generic& Solid::ModelEvaluatorManager::evaluator(
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 const Solid::ModelEvaluator::Generic& Solid::ModelEvaluatorManager::evaluator(
-    const enum Inpar::Solid::ModelType& mt) const
+    const Inpar::Solid::ModelType& mt) const
 {
   check_init_setup();
   // sanity check, if there is a model evaluator for the given model type

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_manager.hpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_manager.hpp
@@ -77,8 +77,7 @@ namespace Solid
   class ModelEvaluatorManager
   {
    public:
-    using Map =
-        std::map<enum Inpar::Solid::ModelType, std::shared_ptr<Solid::ModelEvaluator::Generic>>;
+    using Map = std::map<Inpar::Solid::ModelType, std::shared_ptr<Solid::ModelEvaluator::Generic>>;
     using Vector = std::vector<std::shared_ptr<Solid::ModelEvaluator::Generic>>;
 
     //! constructor
@@ -177,12 +176,12 @@ namespace Solid
      *
      * @return Boolean flag to indicate success (true) or failure (false)
      */
-    bool apply_cheap_soc_rhs(const enum NOX::Nln::CorrectionType type,
+    bool apply_cheap_soc_rhs(const NOX::Nln::CorrectionType type,
         const std::vector<Inpar::Solid::ModelType>& constraint_models,
         const Core::LinAlg::Vector<double>& x, Core::LinAlg::Vector<double>& f,
         const double& timefac_np) const;
 
-    bool correct_parameters(const enum NOX::Nln::CorrectionType type) const;
+    bool correct_parameters(const NOX::Nln::CorrectionType type) const;
 
     /*! \brief Remove any condensed contributions from the structural right-hand side
      *
@@ -347,8 +346,8 @@ namespace Solid
      *
      * \param[in] mt Type of model evaluator to be accessed
      */
-    Solid::ModelEvaluator::Generic& evaluator(const enum Inpar::Solid::ModelType& mt);
-    const Solid::ModelEvaluator::Generic& evaluator(const enum Inpar::Solid::ModelType& mt) const;
+    Solid::ModelEvaluator::Generic& evaluator(const Inpar::Solid::ModelType& mt);
+    const Solid::ModelEvaluator::Generic& evaluator(const Inpar::Solid::ModelType& mt) const;
 
     //!@}
 

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_multiphysics.hpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_multiphysics.hpp
@@ -86,7 +86,7 @@ namespace Solid
       //! set the active model type wrapped in this class.
       //! only active model type is evaluated.
       //! e.g. mt_fsi in case fluid-structure interaction is to be evaluated
-      void set_active_model_type(enum Solid::ModelEvaluator::MultiphysicType mtype)
+      void set_active_model_type(Solid::ModelEvaluator::MultiphysicType mtype)
       {
         active_mt_ = mtype;
       };
@@ -221,7 +221,7 @@ namespace Solid
      public:
       //! return RCP to model evaluator of specific MultiphysicType
       std::shared_ptr<Solid::ModelEvaluator::Generic> get_model_evaluator_from_map(
-          enum Solid::ModelEvaluator::MultiphysicType mtype) const
+          Solid::ModelEvaluator::MultiphysicType mtype) const
       {
         return me_map_.at(mtype);
       }

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_structure.hpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_structure.hpp
@@ -518,7 +518,7 @@ namespace Solid
       double* dt_ele_ptr_;
 
       //! mass linearization type
-      enum Inpar::Solid::MassLin masslin_type_;
+      Inpar::Solid::MassLin masslin_type_;
 
       //! @name class only variables
       //! @{

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_linearsystem_scaling.hpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_linearsystem_scaling.hpp
@@ -63,7 +63,7 @@ namespace Solid
         std::shared_ptr<Core::LinAlg::SparseMatrix> stiff_scaled_;
 
         //! scale thickness of shells
-        const enum Inpar::Solid::StcScale stcscale_;
+        const Inpar::Solid::StcScale stcscale_;
 
         //! number of layers for multilayered case
         const int stclayer_;

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_factory.cpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_factory.cpp
@@ -17,7 +17,7 @@
 FOUR_C_NAMESPACE_OPEN
 
 std::shared_ptr<Solid::Nln::SOLVER::Generic> Solid::Nln::SOLVER::build_nln_solver(
-    const enum Inpar::Solid::NonlinSolTech& nlnSolType,
+    const Inpar::Solid::NonlinSolTech& nlnSolType,
     const std::shared_ptr<Solid::TimeInt::BaseDataGlobalState>& gstate,
     const std::shared_ptr<Solid::TimeInt::BaseDataSDyn>& sdyn,
     const std::shared_ptr<Solid::TimeInt::NoxInterface>& noxinterface,
@@ -137,7 +137,7 @@ std::shared_ptr<Solid::Nln::SOLVER::Generic> Solid::Nln::SOLVER::build_nln_solve
    */
   if (not is_xml_status_test_file(sdyn->get_nox_params().sublist("Status Test")))
   {
-    std::set<enum NOX::Nln::StatusTest::QuantityType> qtypes;
+    std::set<NOX::Nln::StatusTest::QuantityType> qtypes;
     Solid::Nln::SOLVER::create_quantity_types(qtypes, *sdyn);
 
     // remove the unsupported quantity of status test:

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_factory.hpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_factory.hpp
@@ -34,7 +34,7 @@ namespace Solid
     /*! Non-member function, which relates to the Solid::Nln::SOLVER::Factory class
      *  Please call this method from outside! */
     std::shared_ptr<Solid::Nln::SOLVER::Generic> build_nln_solver(
-        const enum Inpar::Solid::NonlinSolTech& nlnSolType,
+        const Inpar::Solid::NonlinSolTech& nlnSolType,
         const std::shared_ptr<Solid::TimeInt::BaseDataGlobalState>& gstate,
         const std::shared_ptr<Solid::TimeInt::BaseDataSDyn>& sdyn,
         const std::shared_ptr<Solid::TimeInt::NoxInterface>& noxinterface,

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_nox.cpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_nox.cpp
@@ -54,7 +54,7 @@ Solid::Nln::SOLVER::Nox::Nox(const Teuchos::ParameterList& default_params,
       Teuchos::rcpFromRef(*nox_interface_ptr());
 
   // vector of currently present solution types
-  std::vector<enum NOX::Nln::SolutionType> soltypes;
+  std::vector<NOX::Nln::SolutionType> soltypes;
   // map of linear solvers, the key is the solution type
   NOX::Nln::LinearSystem::SolverMap linsolvers;
   /* convert the Inpar::Solid::ModelType to a NOX::Nln::SolType
@@ -178,7 +178,7 @@ void Solid::Nln::SOLVER::Nox::reset_params()
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-enum Inpar::Solid::ConvergenceStatus Solid::Nln::SOLVER::Nox::solve()
+Inpar::Solid::ConvergenceStatus Solid::Nln::SOLVER::Nox::solve()
 {
 #if !(FOUR_C_TRILINOS_INTERNAL_VERSION_GE(2025, 4))
   const auto solver_type =
@@ -208,7 +208,7 @@ enum Inpar::Solid::ConvergenceStatus Solid::Nln::SOLVER::Nox::solve()
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-enum Inpar::Solid::ConvergenceStatus Solid::Nln::SOLVER::Nox::convert_final_status(
+Inpar::Solid::ConvergenceStatus Solid::Nln::SOLVER::Nox::convert_final_status(
     const ::NOX::StatusTest::StatusType& finalstatus) const
 {
   Inpar::Solid::ConvergenceStatus convstatus = Inpar::Solid::conv_success;

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_nox.hpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_nox.hpp
@@ -93,7 +93,7 @@ namespace Solid
         virtual void reset_params();
 
         //! Convert the final nox status into a structural status
-        enum Inpar::Solid::ConvergenceStatus convert_final_status(
+        Inpar::Solid::ConvergenceStatus convert_final_status(
             const ::NOX::StatusTest::StatusType& finalstatus) const;
 
        protected:

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_utils.cpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_utils.cpp
@@ -46,17 +46,16 @@ bool Solid::Nln::SOLVER::is_xml_status_test_file(const Teuchos::ParameterList& p
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-void Solid::Nln::SOLVER::create_quantity_types(
-    std::set<enum NOX::Nln::StatusTest::QuantityType>& qtypes,
+void Solid::Nln::SOLVER::create_quantity_types(std::set<NOX::Nln::StatusTest::QuantityType>& qtypes,
     const Solid::TimeInt::BaseDataSDyn& datasdyn)
 {
   // ---------------------------------------------------------------------------
   // get the model types
   // ---------------------------------------------------------------------------
-  const std::set<enum Inpar::Solid::ModelType>& mtypes = datasdyn.get_model_types();
-  std::vector<enum NOX::Nln::StatusTest::QuantityType> qt_vec;
+  const std::set<Inpar::Solid::ModelType>& mtypes = datasdyn.get_model_types();
+  std::vector<NOX::Nln::StatusTest::QuantityType> qt_vec;
 
-  std::set<enum Inpar::Solid::ModelType>::const_iterator miter;
+  std::set<Inpar::Solid::ModelType>::const_iterator miter;
   for (miter = mtypes.begin(); miter != mtypes.end(); ++miter)
   {
     convert_model_type_to_quantity_type(*miter, qt_vec);
@@ -72,9 +71,9 @@ void Solid::Nln::SOLVER::create_quantity_types(
   // ---------------------------------------------------------------------------
   // get the element technologies
   // ---------------------------------------------------------------------------
-  const std::set<enum Inpar::Solid::EleTech>& eletechs = datasdyn.get_element_technologies();
+  const std::set<Inpar::Solid::EleTech>& eletechs = datasdyn.get_element_technologies();
 
-  std::set<enum Inpar::Solid::EleTech>::const_iterator etiter;
+  std::set<Inpar::Solid::EleTech>::const_iterator etiter;
   for (etiter = eletechs.begin(); etiter != eletechs.end(); ++etiter)
   {
     convert_ele_tech_to_quantity_type(*etiter, qt_vec);
@@ -91,8 +90,8 @@ void Solid::Nln::SOLVER::create_quantity_types(
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-void Solid::Nln::SOLVER::convert_model_type_to_quantity_type(const enum Inpar::Solid::ModelType& mt,
-    std::vector<enum NOX::Nln::StatusTest::QuantityType>& qt)
+void Solid::Nln::SOLVER::convert_model_type_to_quantity_type(
+    const Inpar::Solid::ModelType& mt, std::vector<NOX::Nln::StatusTest::QuantityType>& qt)
 {
   // clear quantity type vector
   qt.clear();
@@ -162,7 +161,7 @@ void Solid::Nln::SOLVER::convert_model_type_to_quantity_type(const enum Inpar::S
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 void Solid::Nln::SOLVER::convert_ele_tech_to_quantity_type(
-    const enum Inpar::Solid::EleTech& et, std::vector<enum NOX::Nln::StatusTest::QuantityType>& qt)
+    const Inpar::Solid::EleTech& et, std::vector<NOX::Nln::StatusTest::QuantityType>& qt)
 {
   // clear quantity type vector
   qt.clear();
@@ -187,7 +186,7 @@ void Solid::Nln::SOLVER::convert_ele_tech_to_quantity_type(
  *----------------------------------------------------------------------------*/
 void Solid::Nln::SOLVER::set_status_test_params(Teuchos::ParameterList& pstatus,
     const Solid::TimeInt::BaseDataSDyn& datasdyn,
-    const std::set<enum NOX::Nln::StatusTest::QuantityType>& qt)
+    const std::set<NOX::Nln::StatusTest::QuantityType>& qt)
 {
   // ------ outer status test ------
   // Combo test: OR-combination:
@@ -329,16 +328,16 @@ void Solid::Nln::SOLVER::set_status_test_params(Teuchos::ParameterList& pstatus,
  *----------------------------------------------------------------------------*/
 void Solid::Nln::SOLVER::set_combo_quantity_test_params(Teuchos::ParameterList& p,
     const Solid::TimeInt::BaseDataSDyn& datasdyn, const std::size_t& count,
-    const std::string& testname, const std::set<enum NOX::Nln::StatusTest::QuantityType>& qtypes)
+    const std::string& testname, const std::set<NOX::Nln::StatusTest::QuantityType>& qtypes)
 {
-  std::vector<enum NOX::Nln::StatusTest::QuantityType> combo_or;
-  std::vector<enum NOX::Nln::StatusTest::QuantityType> combo_and;
+  std::vector<NOX::Nln::StatusTest::QuantityType> combo_or;
+  std::vector<NOX::Nln::StatusTest::QuantityType> combo_and;
   split_and_or_combo(combo_or, combo_and, datasdyn, testname, qtypes);
   std::ostringstream test_string;
   test_string << "Test " << count;
   Teuchos::ParameterList& ptest = p.sublist(test_string.str());
 
-  std::vector<enum NOX::Nln::StatusTest::QuantityType>::const_iterator qtiter;
+  std::vector<NOX::Nln::StatusTest::QuantityType>::const_iterator qtiter;
   // if there are any OR combinations
   std::size_t count_or = 0;
   std::size_t count_and = 0;
@@ -387,9 +386,8 @@ void Solid::Nln::SOLVER::set_combo_quantity_test_params(Teuchos::ParameterList& 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 void Solid::Nln::SOLVER::set_quantity_test_params(Teuchos::ParameterList& p,
-    const Solid::TimeInt::BaseDataSDyn& datasdyn,
-    const enum NOX::Nln::StatusTest::QuantityType& qtype, const std::size_t& count,
-    const std::string& testname)
+    const Solid::TimeInt::BaseDataSDyn& datasdyn, const NOX::Nln::StatusTest::QuantityType& qtype,
+    const std::size_t& count, const std::string& testname)
 {
   std::ostringstream test_string;
   test_string << "Test " << count;
@@ -401,8 +399,8 @@ void Solid::Nln::SOLVER::set_quantity_test_params(Teuchos::ParameterList& p,
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 void Solid::Nln::SOLVER::set_quantity_test_params(Teuchos::ParameterList& p,
-    const Solid::TimeInt::BaseDataSDyn& datasdyn,
-    const enum NOX::Nln::StatusTest::QuantityType& qtype, const std::string& testname)
+    const Solid::TimeInt::BaseDataSDyn& datasdyn, const NOX::Nln::StatusTest::QuantityType& qtype,
+    const std::string& testname)
 {
   if (testname == "NormUpdate")
     set_norm_update_params(p, qtype, datasdyn.get_incr_tolerance_type(qtype),
@@ -420,18 +418,18 @@ void Solid::Nln::SOLVER::set_quantity_test_params(Teuchos::ParameterList& p,
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 void Solid::Nln::SOLVER::split_and_or_combo(
-    std::vector<enum NOX::Nln::StatusTest::QuantityType>& combo_or,
-    std::vector<enum NOX::Nln::StatusTest::QuantityType>& combo_and,
+    std::vector<NOX::Nln::StatusTest::QuantityType>& combo_or,
+    std::vector<NOX::Nln::StatusTest::QuantityType>& combo_and,
     const Solid::TimeInt::BaseDataSDyn& datasdyn, const std::string& testname,
-    const std::set<enum NOX::Nln::StatusTest::QuantityType>& qtypes)
+    const std::set<NOX::Nln::StatusTest::QuantityType>& qtypes)
 {
-  std::set<enum NOX::Nln::StatusTest::QuantityType>::const_iterator qtiter;
+  std::set<NOX::Nln::StatusTest::QuantityType>::const_iterator qtiter;
 
   for (qtiter = qtypes.begin(); qtiter != qtypes.end(); ++qtiter)
   {
     if (*qtiter == NOX::Nln::StatusTest::quantity_structure) continue;
 
-    enum Inpar::Solid::BinaryOp combotype = datasdyn.get_incr_combo_type(*qtiter);
+    Inpar::Solid::BinaryOp combotype = datasdyn.get_incr_combo_type(*qtiter);
     if (testname == "NormF")
       combotype = datasdyn.get_res_combo_type(*qtiter);
     else if (testname != "NormUpdate")
@@ -458,9 +456,8 @@ void Solid::Nln::SOLVER::split_and_or_combo(
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 void Solid::Nln::SOLVER::set_norm_update_params(Teuchos::ParameterList& qlist,
-    const enum NOX::Nln::StatusTest::QuantityType& qtype,
-    const enum Inpar::Solid::ConvNorm& toltype, const double& tol,
-    const enum Inpar::Solid::VectorNorm& normtype)
+    const NOX::Nln::StatusTest::QuantityType& qtype, const Inpar::Solid::ConvNorm& toltype,
+    const double& tol, const Inpar::Solid::VectorNorm& normtype)
 {
   set_norm_update_params(qlist, qtype, 1.0, 0.5, toltype, tol, normtype, false);
 }
@@ -469,9 +466,9 @@ void Solid::Nln::SOLVER::set_norm_update_params(Teuchos::ParameterList& qlist,
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 void Solid::Nln::SOLVER::set_norm_update_params(Teuchos::ParameterList& qlist,
-    const enum NOX::Nln::StatusTest::QuantityType& qtype, const double& alpha, const double& beta,
-    const enum Inpar::Solid::ConvNorm& toltype, const double& tol,
-    const enum Inpar::Solid::VectorNorm& normtype, const bool& isscaled)
+    const NOX::Nln::StatusTest::QuantityType& qtype, const double& alpha, const double& beta,
+    const Inpar::Solid::ConvNorm& toltype, const double& tol,
+    const Inpar::Solid::VectorNorm& normtype, const bool& isscaled)
 {
   /* Set the tolerance type
    * Be careful: This has to be done in first place because of the special
@@ -558,9 +555,8 @@ void Solid::Nln::SOLVER::set_norm_update_params(Teuchos::ParameterList& qlist,
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 void Solid::Nln::SOLVER::set_norm_f_params(Teuchos::ParameterList& qlist,
-    const enum NOX::Nln::StatusTest::QuantityType& qtype,
-    const enum Inpar::Solid::ConvNorm& toltype, const double& tol,
-    const enum Inpar::Solid::VectorNorm& normtype)
+    const NOX::Nln::StatusTest::QuantityType& qtype, const Inpar::Solid::ConvNorm& toltype,
+    const double& tol, const Inpar::Solid::VectorNorm& normtype)
 {
   set_norm_f_params(qlist, qtype, toltype, tol, normtype, false);
 }
@@ -569,9 +565,8 @@ void Solid::Nln::SOLVER::set_norm_f_params(Teuchos::ParameterList& qlist,
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 void Solid::Nln::SOLVER::set_norm_f_params(Teuchos::ParameterList& qlist,
-    const enum NOX::Nln::StatusTest::QuantityType& qtype,
-    const enum Inpar::Solid::ConvNorm& toltype, const double& tol,
-    const enum Inpar::Solid::VectorNorm& normtype, const bool& isscaled)
+    const NOX::Nln::StatusTest::QuantityType& qtype, const Inpar::Solid::ConvNorm& toltype,
+    const double& tol, const Inpar::Solid::VectorNorm& normtype, const bool& isscaled)
 {
   /* Set the tolerance type
    * Be careful: This has to be done in first place because of the special
@@ -651,7 +646,7 @@ void Solid::Nln::SOLVER::set_norm_f_params(Teuchos::ParameterList& qlist,
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 void Solid::Nln::SOLVER::set_active_set_params(
-    Teuchos::ParameterList& qlist, const enum NOX::Nln::StatusTest::QuantityType& qtype)
+    Teuchos::ParameterList& qlist, const NOX::Nln::StatusTest::QuantityType& qtype)
 {
   qlist.set("Test Type", "ActiveSet");
   // set the quantity type

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_utils.hpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_utils.hpp
@@ -43,14 +43,14 @@ namespace Solid
        *  into quantity types.
        *
        */
-      void create_quantity_types(std::set<enum NOX::Nln::StatusTest::QuantityType>& qtypes,
+      void create_quantity_types(std::set<NOX::Nln::StatusTest::QuantityType>& qtypes,
           const Solid::TimeInt::BaseDataSDyn& datasdyn);
 
-      void convert_model_type_to_quantity_type(const enum Inpar::Solid::ModelType& mt,
-          std::vector<enum NOX::Nln::StatusTest::QuantityType>& qt);
+      void convert_model_type_to_quantity_type(
+          const Inpar::Solid::ModelType& mt, std::vector<NOX::Nln::StatusTest::QuantityType>& qt);
 
-      void convert_ele_tech_to_quantity_type(const enum Inpar::Solid::EleTech& et,
-          std::vector<enum NOX::Nln::StatusTest::QuantityType>& qt);
+      void convert_ele_tech_to_quantity_type(
+          const Inpar::Solid::EleTech& et, std::vector<NOX::Nln::StatusTest::QuantityType>& qt);
 
       /*! \brief Create a status test parameter list
        *
@@ -66,13 +66,13 @@ namespace Solid
        */
       void set_status_test_params(Teuchos::ParameterList& pstatus,
           const Solid::TimeInt::BaseDataSDyn& datasdyn,
-          const std::set<enum NOX::Nln::StatusTest::QuantityType>& qt);
+          const std::set<NOX::Nln::StatusTest::QuantityType>& qt);
 
       //! Split the given tests into and/or combinations
-      void split_and_or_combo(std::vector<enum NOX::Nln::StatusTest::QuantityType>& combo_or,
-          std::vector<enum NOX::Nln::StatusTest::QuantityType>& combo_and,
+      void split_and_or_combo(std::vector<NOX::Nln::StatusTest::QuantityType>& combo_or,
+          std::vector<NOX::Nln::StatusTest::QuantityType>& combo_and,
           const Solid::TimeInt::BaseDataSDyn& datasdyn, const std::string& testname,
-          const std::set<enum NOX::Nln::StatusTest::QuantityType>& qtypes);
+          const std::set<NOX::Nln::StatusTest::QuantityType>& qtypes);
 
       /*! \brief Set the combination of different NormF or NormUpdate tests in the status test
        * parameter list
@@ -110,8 +110,7 @@ namespace Solid
        */
       void set_combo_quantity_test_params(Teuchos::ParameterList& p,
           const Solid::TimeInt::BaseDataSDyn& datasdyn, const std::size_t& count,
-          const std::string& testname,
-          const std::set<enum NOX::Nln::StatusTest::QuantityType>& qtypes);
+          const std::string& testname, const std::set<NOX::Nln::StatusTest::QuantityType>& qtypes);
 
       /*! \brief Set the status test corresponding to the given quantity
        *
@@ -121,37 +120,34 @@ namespace Solid
        */
       void set_quantity_test_params(Teuchos::ParameterList& p,
           const Solid::TimeInt::BaseDataSDyn& datasdyn,
-          const enum NOX::Nln::StatusTest::QuantityType& qtype, const std::size_t& count,
+          const NOX::Nln::StatusTest::QuantityType& qtype, const std::size_t& count,
           const std::string& testname);
 
       //! Set the status test parameters corresponding to the given quantity
       void set_quantity_test_params(Teuchos::ParameterList& p,
           const Solid::TimeInt::BaseDataSDyn& datasdyn,
-          const enum NOX::Nln::StatusTest::QuantityType& qtype, const std::string& testname);
+          const NOX::Nln::StatusTest::QuantityType& qtype, const std::string& testname);
 
       //! Set the NormUpdate status test parameters
       void set_norm_update_params(Teuchos::ParameterList& qlist,
-          const enum NOX::Nln::StatusTest::QuantityType& qtype,
-          const enum Inpar::Solid::ConvNorm& toltype, const double& tol,
-          const enum Inpar::Solid::VectorNorm& normtype);
+          const NOX::Nln::StatusTest::QuantityType& qtype, const Inpar::Solid::ConvNorm& toltype,
+          const double& tol, const Inpar::Solid::VectorNorm& normtype);
       void set_norm_update_params(Teuchos::ParameterList& qlist,
-          const enum NOX::Nln::StatusTest::QuantityType& qtype, const double& alpha,
-          const double& beta, const enum Inpar::Solid::ConvNorm& toltype, const double& tol,
-          const enum Inpar::Solid::VectorNorm& normtype, const bool& isscaled);
+          const NOX::Nln::StatusTest::QuantityType& qtype, const double& alpha, const double& beta,
+          const Inpar::Solid::ConvNorm& toltype, const double& tol,
+          const Inpar::Solid::VectorNorm& normtype, const bool& isscaled);
 
       //! Set the NormF status test parameters
       void set_norm_f_params(Teuchos::ParameterList& qlist,
-          const enum NOX::Nln::StatusTest::QuantityType& qtype,
-          const enum Inpar::Solid::ConvNorm& toltype, const double& tol,
-          const enum Inpar::Solid::VectorNorm& normtype);
+          const NOX::Nln::StatusTest::QuantityType& qtype, const Inpar::Solid::ConvNorm& toltype,
+          const double& tol, const Inpar::Solid::VectorNorm& normtype);
       void set_norm_f_params(Teuchos::ParameterList& qlist,
-          const enum NOX::Nln::StatusTest::QuantityType& qtype,
-          const enum Inpar::Solid::ConvNorm& toltype, const double& tol,
-          const enum Inpar::Solid::VectorNorm& normtype, const bool& isscaled);
+          const NOX::Nln::StatusTest::QuantityType& qtype, const Inpar::Solid::ConvNorm& toltype,
+          const double& tol, const Inpar::Solid::VectorNorm& normtype, const bool& isscaled);
 
       //! Set the ActiveSet status test parameters
       void set_active_set_params(
-          Teuchos::ParameterList& qlist, const enum NOX::Nln::StatusTest::QuantityType& qtype);
+          Teuchos::ParameterList& qlist, const NOX::Nln::StatusTest::QuantityType& qtype);
 
     }  // namespace SOLVER
   }  // namespace Nln

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_timint_noxinterface.cpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_timint_noxinterface.cpp
@@ -144,9 +144,9 @@ bool Solid::TimeInt::NoxInterface::compute_f_and_jacobian(
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-bool Solid::TimeInt::NoxInterface::compute_correction_system(
-    const enum NOX::Nln::CorrectionType type, const ::NOX::Abstract::Group& grp,
-    const Epetra_Vector& x, Epetra_Vector& rhs, Epetra_Operator& jac)
+bool Solid::TimeInt::NoxInterface::compute_correction_system(const NOX::Nln::CorrectionType type,
+    const ::NOX::Abstract::Group& grp, const Epetra_Vector& x, Epetra_Vector& rhs,
+    Epetra_Operator& jac)
 {
   check_init_setup();
 
@@ -434,9 +434,9 @@ double Solid::TimeInt::NoxInterface::get_model_value(const Epetra_Vector& x, con
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 double Solid::TimeInt::NoxInterface::get_linearized_model_terms(const ::NOX::Abstract::Group* group,
-    const Epetra_Vector& dir, const enum NOX::Nln::MeritFunction::MeritFctName mf_type,
-    const enum NOX::Nln::MeritFunction::LinOrder linorder,
-    const enum NOX::Nln::MeritFunction::LinType lintype) const
+    const Epetra_Vector& dir, const NOX::Nln::MeritFunction::MeritFctName mf_type,
+    const NOX::Nln::MeritFunction::LinOrder linorder,
+    const NOX::Nln::MeritFunction::LinType lintype) const
 {
   switch (mf_type)
   {
@@ -455,8 +455,8 @@ double Solid::TimeInt::NoxInterface::get_linearized_model_terms(const ::NOX::Abs
  *----------------------------------------------------------------------------*/
 double Solid::TimeInt::NoxInterface::get_linearized_energy_model_terms(
     const ::NOX::Abstract::Group* group, const Epetra_Vector& dir,
-    const enum NOX::Nln::MeritFunction::LinOrder linorder,
-    const enum NOX::Nln::MeritFunction::LinType lintype) const
+    const NOX::Nln::MeritFunction::LinOrder linorder,
+    const NOX::Nln::MeritFunction::LinType lintype) const
 {
   double lin_val = 0.0;
 
@@ -520,8 +520,8 @@ void Solid::TimeInt::NoxInterface::find_constraint_models(const ::NOX::Abstract:
 
   for (auto cit = imap.begin(); cit != imap.end(); ++cit)
   {
-    const enum NOX::Nln::SolutionType soltype = cit->first;
-    const enum Inpar::Solid::ModelType mtype = Solid::Nln::convert_sol_type2_model_type(soltype);
+    const NOX::Nln::SolutionType soltype = cit->first;
+    const Inpar::Solid::ModelType mtype = Solid::Nln::convert_sol_type2_model_type(soltype);
 
     constraint_models.push_back(mtype);
   }

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_timint_noxinterface.hpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_timint_noxinterface.hpp
@@ -73,7 +73,7 @@ namespace Solid
       bool compute_f_and_jacobian(
           const Epetra_Vector& x, Epetra_Vector& rhs, Epetra_Operator& jac) override;
 
-      bool compute_correction_system(const enum NOX::Nln::CorrectionType type,
+      bool compute_correction_system(const NOX::Nln::CorrectionType type,
           const ::NOX::Abstract::Group& grp, const Epetra_Vector& x, Epetra_Vector& rhs,
           Epetra_Operator& jac) override;
 
@@ -112,9 +112,9 @@ namespace Solid
           const NOX::Nln::MeritFunction::MeritFctName merit_func_type) const override;
 
       double get_linearized_model_terms(const ::NOX::Abstract::Group* group,
-          const Epetra_Vector& dir, const enum NOX::Nln::MeritFunction::MeritFctName mf_type,
-          const enum NOX::Nln::MeritFunction::LinOrder linorder,
-          const enum NOX::Nln::MeritFunction::LinType lintype) const override;
+          const Epetra_Vector& dir, const NOX::Nln::MeritFunction::MeritFctName mf_type,
+          const NOX::Nln::MeritFunction::LinOrder linorder,
+          const NOX::Nln::MeritFunction::LinType lintype) const override;
 
       /*! \brief calculate characteristic/reference norms for forces
        *
@@ -155,8 +155,8 @@ namespace Solid
       void check_init_setup() const;
 
       double get_linearized_energy_model_terms(const ::NOX::Abstract::Group* group,
-          const Epetra_Vector& dir, const enum NOX::Nln::MeritFunction::LinOrder linorder,
-          const enum NOX::Nln::MeritFunction::LinType lintype) const;
+          const Epetra_Vector& dir, const NOX::Nln::MeritFunction::LinOrder linorder,
+          const NOX::Nln::MeritFunction::LinType lintype) const;
 
       void find_constraint_models(const ::NOX::Abstract::Group* grp,
           std::vector<Inpar::Solid::ModelType>& constraint_models) const;

--- a/src/structure_new/src/predict/4C_structure_new_predict_factory.cpp
+++ b/src/structure_new/src/predict/4C_structure_new_predict_factory.cpp
@@ -23,7 +23,7 @@ Solid::Predict::Factory::Factory()
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 std::shared_ptr<Solid::Predict::Generic> Solid::Predict::Factory::build_predictor(
-    const enum Inpar::Solid::PredEnum& predType) const
+    const Inpar::Solid::PredEnum& predType) const
 {
   std::shared_ptr<Solid::Predict::Generic> predictor = nullptr;
 
@@ -53,7 +53,7 @@ std::shared_ptr<Solid::Predict::Generic> Solid::Predict::Factory::build_predicto
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 std::shared_ptr<Solid::Predict::Generic> Solid::Predict::build_predictor(
-    const enum Inpar::Solid::PredEnum& predType)
+    const Inpar::Solid::PredEnum& predType)
 {
   Factory factory;
   return factory.build_predictor(predType);

--- a/src/structure_new/src/predict/4C_structure_new_predict_factory.hpp
+++ b/src/structure_new/src/predict/4C_structure_new_predict_factory.hpp
@@ -35,7 +35,7 @@ namespace Solid
 
       //! build the desired predictor
       std::shared_ptr<Solid::Predict::Generic> build_predictor(
-          const enum Inpar::Solid::PredEnum& predType) const;
+          const Inpar::Solid::PredEnum& predType) const;
     };
 
     /*! \brief Non-member function, which relates to the Solid::Predict::Factory class
@@ -43,7 +43,7 @@ namespace Solid
      * \note Call this method from outside!
      */
     std::shared_ptr<Solid::Predict::Generic> build_predictor(
-        const enum Inpar::Solid::PredEnum& predType);
+        const Inpar::Solid::PredEnum& predType);
 
   }  // namespace Predict
 }  // namespace Solid

--- a/src/structure_new/src/predict/4C_structure_new_predict_generic.cpp
+++ b/src/structure_new/src/predict/4C_structure_new_predict_generic.cpp
@@ -31,7 +31,7 @@ Solid::Predict::Generic::Generic()
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-void Solid::Predict::Generic::init(const enum Inpar::Solid::PredEnum& type,
+void Solid::Predict::Generic::init(const Inpar::Solid::PredEnum& type,
     const std::shared_ptr<Solid::IMPLICIT::Generic>& implint_ptr,
     const std::shared_ptr<Solid::Dbc>& dbc_ptr,
     const std::shared_ptr<Solid::TimeInt::BaseDataGlobalState>& gstate_ptr,

--- a/src/structure_new/src/predict/4C_structure_new_predict_generic.hpp
+++ b/src/structure_new/src/predict/4C_structure_new_predict_generic.hpp
@@ -56,7 +56,7 @@ namespace Solid
       virtual ~Generic() = default;
 
       //! initialize the base class variables
-      virtual void init(const enum Inpar::Solid::PredEnum& type,
+      virtual void init(const Inpar::Solid::PredEnum& type,
           const std::shared_ptr<Solid::IMPLICIT::Generic>& implint_ptr,
           const std::shared_ptr<Solid::Dbc>& dbc_ptr,
           const std::shared_ptr<Solid::TimeInt::BaseDataGlobalState>& gstate_ptr,
@@ -128,7 +128,7 @@ namespace Solid
 
      private:
       //! predictor type
-      enum Inpar::Solid::PredEnum type_;
+      Inpar::Solid::PredEnum type_;
 
       //! pointer to the implicit integrator
       std::shared_ptr<Solid::IMPLICIT::Generic> implint_ptr_;

--- a/src/structure_new/src/utils/4C_structure_new_utils.cpp
+++ b/src/structure_new/src/utils/4C_structure_new_utils.cpp
@@ -54,7 +54,7 @@ NOX::Nln::LinSystem::ConditionNumber Solid::Nln::convert2_nox_condition_number_t
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 enum ::NOX::Abstract::Vector::NormType Solid::Nln::convert2_nox_norm_type(
-    const enum Inpar::Solid::VectorNorm& normtype)
+    const Inpar::Solid::VectorNorm& normtype)
 {
   enum ::NOX::Abstract::Vector::NormType nox_normtype = ::NOX::Abstract::Vector::TwoNorm;
 
@@ -81,11 +81,10 @@ enum ::NOX::Abstract::Vector::NormType Solid::Nln::convert2_nox_norm_type(
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-void Solid::Nln::convert_model_type2_sol_type(std::vector<enum NOX::Nln::SolutionType>& soltypes,
-    std::map<enum NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>& slinsolvers,
-    const std::set<enum Inpar::Solid::ModelType>& modeltypes,
-    const std::map<enum Inpar::Solid::ModelType, std::shared_ptr<Core::LinAlg::Solver>>&
-        mlinsolvers)
+void Solid::Nln::convert_model_type2_sol_type(std::vector<NOX::Nln::SolutionType>& soltypes,
+    std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>& slinsolvers,
+    const std::set<Inpar::Solid::ModelType>& modeltypes,
+    const std::map<Inpar::Solid::ModelType, std::shared_ptr<Core::LinAlg::Solver>>& mlinsolvers)
 {
   // initialize the vector and/or force the length to zero
   if (soltypes.size() > 0)
@@ -98,10 +97,10 @@ void Solid::Nln::convert_model_type2_sol_type(std::vector<enum NOX::Nln::Solutio
   soltypes.reserve(modeltypes.size());
 
   // The strings of the different enums have to fit!
-  std::set<enum Inpar::Solid::ModelType>::const_iterator mt_iter;
+  std::set<Inpar::Solid::ModelType>::const_iterator mt_iter;
   for (mt_iter = modeltypes.begin(); mt_iter != modeltypes.end(); ++mt_iter)
   {
-    const enum NOX::Nln::SolutionType soltype = convert_model_type2_sol_type(*mt_iter);
+    const NOX::Nln::SolutionType soltype = convert_model_type2_sol_type(*mt_iter);
 
     soltypes.push_back(soltype);
     // copy the linsolver pointers into the new map
@@ -112,10 +111,10 @@ void Solid::Nln::convert_model_type2_sol_type(std::vector<enum NOX::Nln::Solutio
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-enum NOX::Nln::SolutionType Solid::Nln::convert_model_type2_sol_type(
-    const enum Inpar::Solid::ModelType& modeltype, const bool& do_check)
+NOX::Nln::SolutionType Solid::Nln::convert_model_type2_sol_type(
+    const Inpar::Solid::ModelType& modeltype, const bool& do_check)
 {
-  enum NOX::Nln::SolutionType soltype = NOX::Nln::sol_unknown;
+  NOX::Nln::SolutionType soltype = NOX::Nln::sol_unknown;
   switch (modeltype)
   {
     case Inpar::Solid::model_structure:
@@ -157,10 +156,10 @@ enum NOX::Nln::SolutionType Solid::Nln::convert_model_type2_sol_type(
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-enum Inpar::Solid::ModelType Solid::Nln::convert_sol_type2_model_type(
-    const enum NOX::Nln::SolutionType& soltype, const bool& do_check)
+Inpar::Solid::ModelType Solid::Nln::convert_sol_type2_model_type(
+    const NOX::Nln::SolutionType& soltype, const bool& do_check)
 {
-  enum Inpar::Solid::ModelType modeltype = Inpar::Solid::model_vague;
+  Inpar::Solid::ModelType modeltype = Inpar::Solid::model_vague;
   switch (soltype)
   {
     case NOX::Nln::sol_structure:
@@ -193,8 +192,8 @@ enum Inpar::Solid::ModelType Solid::Nln::convert_sol_type2_model_type(
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-enum Inpar::Solid::ModelType Solid::Nln::convert_quantity_type2_model_type(
-    const enum NOX::Nln::StatusTest::QuantityType& qtype, const bool& do_check)
+Inpar::Solid::ModelType Solid::Nln::convert_quantity_type2_model_type(
+    const NOX::Nln::StatusTest::QuantityType& qtype, const bool& do_check)
 {
   const NOX::Nln::SolutionType st = NOX::Nln::Aux::convert_quantity_type_to_solution_type(qtype);
   return convert_sol_type2_model_type(st, do_check);
@@ -202,10 +201,10 @@ enum Inpar::Solid::ModelType Solid::Nln::convert_quantity_type2_model_type(
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-enum Inpar::Solid::EleTech Solid::Nln::convert_quantity_type2_ele_tech(
-    const enum NOX::Nln::StatusTest::QuantityType& qtype)
+Inpar::Solid::EleTech Solid::Nln::convert_quantity_type2_ele_tech(
+    const NOX::Nln::StatusTest::QuantityType& qtype)
 {
-  enum Inpar::Solid::EleTech eletech;
+  Inpar::Solid::EleTech eletech;
   switch (qtype)
   {
     case NOX::Nln::StatusTest::quantity_eas:
@@ -222,11 +221,11 @@ enum Inpar::Solid::EleTech Solid::Nln::convert_quantity_type2_ele_tech(
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-enum NOX::Nln::OptimizationProblemType Solid::Nln::optimization_type(
-    const std::vector<enum NOX::Nln::SolutionType>& soltypes)
+NOX::Nln::OptimizationProblemType Solid::Nln::optimization_type(
+    const std::vector<NOX::Nln::SolutionType>& soltypes)
 {
-  enum NOX::Nln::OptimizationProblemType opttype = NOX::Nln::opt_unconstrained;
-  std::vector<enum NOX::Nln::SolutionType>::const_iterator st_iter;
+  NOX::Nln::OptimizationProblemType opttype = NOX::Nln::opt_unconstrained;
+  std::vector<NOX::Nln::SolutionType>::const_iterator st_iter;
 
   for (st_iter = soltypes.begin(); st_iter != soltypes.end(); ++st_iter)
   {
@@ -267,11 +266,11 @@ enum NOX::Nln::OptimizationProblemType Solid::Nln::optimization_type(
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 void Solid::Nln::create_constraint_interfaces(NOX::Nln::CONSTRAINT::ReqInterfaceMap& iconstr,
-    Solid::Integrator& integrator, const std::vector<enum NOX::Nln::SolutionType>& soltypes)
+    Solid::Integrator& integrator, const std::vector<NOX::Nln::SolutionType>& soltypes)
 {
   if (iconstr.size() > 0) iconstr.clear();
 
-  std::vector<enum NOX::Nln::SolutionType>::const_iterator st_iter;
+  std::vector<NOX::Nln::SolutionType>::const_iterator st_iter;
   for (st_iter = soltypes.begin(); st_iter != soltypes.end(); ++st_iter)
   {
     switch (*st_iter)
@@ -314,11 +313,11 @@ void Solid::Nln::create_constraint_interfaces(NOX::Nln::CONSTRAINT::ReqInterface
  *----------------------------------------------------------------------------*/
 void Solid::Nln::create_constraint_preconditioner(
     NOX::Nln::CONSTRAINT::PrecInterfaceMap& iconstr_prec, Solid::Integrator& integrator,
-    const std::vector<enum NOX::Nln::SolutionType>& soltypes)
+    const std::vector<NOX::Nln::SolutionType>& soltypes)
 {
   if (iconstr_prec.size() > 0) iconstr_prec.clear();
 
-  std::vector<enum NOX::Nln::SolutionType>::const_iterator st_iter;
+  std::vector<NOX::Nln::SolutionType>::const_iterator st_iter;
   for (st_iter = soltypes.begin(); st_iter != soltypes.end(); ++st_iter)
   {
     switch (*st_iter)

--- a/src/structure_new/src/utils/4C_structure_new_utils.hpp
+++ b/src/structure_new/src/utils/4C_structure_new_utils.hpp
@@ -55,7 +55,7 @@ namespace Solid
   {
     //! Convert the structural vector types to a corresponding nox norm type
     enum ::NOX::Abstract::Vector::NormType convert2_nox_norm_type(
-        const enum Inpar::Solid::VectorNorm& normtype);
+        const Inpar::Solid::VectorNorm& normtype);
 
     /*! Convert the structural model type enums to nox nln solution
      *  type enums
@@ -64,10 +64,10 @@ namespace Solid
      *  enums. This is necessary, because the nox framework is not
      *  supposed to be restricted to structural problems only.
      */
-    void convert_model_type2_sol_type(std::vector<enum NOX::Nln::SolutionType>& soltypes,
-        std::map<enum NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>& slinsolvers,
-        const std::set<enum Inpar::Solid::ModelType>& modeltypes,
-        const std::map<enum Inpar::Solid::ModelType, std::shared_ptr<Core::LinAlg::Solver>>&
+    void convert_model_type2_sol_type(std::vector<NOX::Nln::SolutionType>& soltypes,
+        std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>& slinsolvers,
+        const std::set<Inpar::Solid::ModelType>& modeltypes,
+        const std::map<Inpar::Solid::ModelType, std::shared_ptr<Core::LinAlg::Solver>>&
             mlinsolvers);
 
     /*! \brief Convert the structural model type enumerator to a nox nln solution
@@ -75,15 +75,15 @@ namespace Solid
      *
      *  \param modeltype (in) : Model type enumerator which has to be converted
      *  \param do_check  (in) : Check if a corresponding solution type exists */
-    enum NOX::Nln::SolutionType convert_model_type2_sol_type(
-        const enum Inpar::Solid::ModelType& modeltype, const bool& do_check);
+    NOX::Nln::SolutionType convert_model_type2_sol_type(
+        const Inpar::Solid::ModelType& modeltype, const bool& do_check);
 
     /*! \brief Convert the structural model type enumerator to a nox nln solution
      *  type enumerator and check if the conversion was successful
      *
      *  \param modeltype (in) : Model type enumerator which has to be converted. */
-    inline enum NOX::Nln::SolutionType convert_model_type2_sol_type(
-        const enum Inpar::Solid::ModelType& modeltype)
+    inline NOX::Nln::SolutionType convert_model_type2_sol_type(
+        const Inpar::Solid::ModelType& modeltype)
     {
       return convert_model_type2_sol_type(modeltype, true);
     }
@@ -93,15 +93,15 @@ namespace Solid
      *
      *  \param soltype (in)   : Solution type enumerator which has to be converted.
      *  \param do_check  (in) : Check if a corresponding model type exists. */
-    enum Inpar::Solid::ModelType convert_sol_type2_model_type(
-        const enum NOX::Nln::SolutionType& soltype, const bool& do_check);
+    Inpar::Solid::ModelType convert_sol_type2_model_type(
+        const NOX::Nln::SolutionType& soltype, const bool& do_check);
 
     /*! \brief Convert the structural model type enumerator to a nox nln solution
      *  type enumerator and check if the conversion was successful
      *
      *  \param soltype (in) : Solution type enumerator which has to be converted. */
-    inline enum Inpar::Solid::ModelType convert_sol_type2_model_type(
-        const enum NOX::Nln::SolutionType& soltype)
+    inline Inpar::Solid::ModelType convert_sol_type2_model_type(
+        const NOX::Nln::SolutionType& soltype)
     {
       return convert_sol_type2_model_type(soltype, true);
     }
@@ -111,15 +111,15 @@ namespace Solid
      *
      *  \param qtype (in)    : Quantity type enumerator which has to be converted.
      *  \param do_check (in) : Check if a corresponding model type exists. */
-    enum Inpar::Solid::ModelType convert_quantity_type2_model_type(
-        const enum NOX::Nln::StatusTest::QuantityType& qtype, const bool& do_check);
+    Inpar::Solid::ModelType convert_quantity_type2_model_type(
+        const NOX::Nln::StatusTest::QuantityType& qtype, const bool& do_check);
 
     /*! \brief Convert the nox nln statustest quantity type enumerator to a structural model
      *  type enumerator and check if the conversion was successful
      *
      *  \param qtype (in) : Quantity type enumerator which has to be converted. */
-    inline enum Inpar::Solid::ModelType convert_quantity_type2_model_type(
-        const enum NOX::Nln::StatusTest::QuantityType& qtype)
+    inline Inpar::Solid::ModelType convert_quantity_type2_model_type(
+        const NOX::Nln::StatusTest::QuantityType& qtype)
     {
       return convert_quantity_type2_model_type(qtype, true);
     }
@@ -128,12 +128,12 @@ namespace Solid
      *  type enumerator
      *
      *  \param qtype (in)    : Quantity type enumerator which has to be converted. */
-    enum Inpar::Solid::EleTech convert_quantity_type2_ele_tech(
-        const enum NOX::Nln::StatusTest::QuantityType& qtype);
+    Inpar::Solid::EleTech convert_quantity_type2_ele_tech(
+        const NOX::Nln::StatusTest::QuantityType& qtype);
 
     //! Returns the optimization type of the underlying structural problem
-    enum NOX::Nln::OptimizationProblemType optimization_type(
-        const std::vector<enum NOX::Nln::SolutionType>& soltypes);
+    NOX::Nln::OptimizationProblemType optimization_type(
+        const std::vector<NOX::Nln::SolutionType>& soltypes);
 
     /// convert structure condition number type to a nox condition number type
     NOX::Nln::LinSystem::ConditionNumber convert2_nox_condition_number_type(
@@ -143,13 +143,13 @@ namespace Solid
     void create_constraint_interfaces(
         std::map<enum NOX::Nln::SolutionType,
             Teuchos::RCP<NOX::Nln::CONSTRAINT::Interface::Required>>& iconstr,
-        Solid::Integrator& integrator, const std::vector<enum NOX::Nln::SolutionType>& soltypes);
+        Solid::Integrator& integrator, const std::vector<NOX::Nln::SolutionType>& soltypes);
 
     //! Set the constraint preconditioner interfaces
     void create_constraint_preconditioner(
         std::map<NOX::Nln::SolutionType,
             Teuchos::RCP<NOX::Nln::CONSTRAINT::Interface::Preconditioner>>& iconstr_prec,
-        Solid::Integrator& integrator, const std::vector<enum NOX::Nln::SolutionType>& soltypes);
+        Solid::Integrator& integrator, const std::vector<NOX::Nln::SolutionType>& soltypes);
 
     //! Create object to scale linear system
     void create_scaling(std::shared_ptr<NOX::Nln::Scaling>& iscale,

--- a/src/thermo/src/implicit/4C_thermo_timint.hpp
+++ b/src/thermo/src/implicit/4C_thermo_timint.hpp
@@ -248,7 +248,7 @@ namespace Thermo
     //@{
 
     //! Provide Name
-    virtual enum Thermo::DynamicType method_name() const = 0;
+    virtual Thermo::DynamicType method_name() const = 0;
 
     //@}
 

--- a/src/thermo/src/implicit/4C_thermo_timint_genalpha.hpp
+++ b/src/thermo/src/implicit/4C_thermo_timint_genalpha.hpp
@@ -70,7 +70,7 @@ namespace Thermo
     //@{
 
     //! Return name
-    enum Thermo::DynamicType method_name() const override { return Thermo::DynamicType::GenAlpha; }
+    Thermo::DynamicType method_name() const override { return Thermo::DynamicType::GenAlpha; }
 
     //! Consistent predictor with constant temperatures
     //! and consistent temperature rates and temperatures
@@ -171,7 +171,7 @@ namespace Thermo
     //! @name set-up
     //@{
     //! mid-average type more at #MidAverageEnum
-    enum Thermo::MidAverageEnum midavg_;
+    Thermo::MidAverageEnum midavg_;
     //@}
 
     //! @name Key coefficients

--- a/src/thermo/src/implicit/4C_thermo_timint_impl.hpp
+++ b/src/thermo/src/implicit/4C_thermo_timint_impl.hpp
@@ -244,7 +244,7 @@ namespace Thermo
     //@{
 
     //! Return time integrator name
-    enum Thermo::DynamicType method_name() const override = 0;
+    Thermo::DynamicType method_name() const override = 0;
 
     //@}
 
@@ -307,23 +307,23 @@ namespace Thermo
 
     //! @name General purpose algorithm parameters
     //@{
-    enum Thermo::PredEnum pred_;  //!< predictor
+    Thermo::PredEnum pred_;  //!< predictor
     //@}
 
     //! @name Iterative solution technique
     //@{
-    enum Thermo::NonlinSolTech itertype_;  //!< kind of iteration technique
-                                           //!< or non-linear solution technique
-    enum Thermo::ConvNorm normtypetempi_;  //!< convergence check for residual temperatures
-    enum Thermo::ConvNorm normtypefres_;   //!< convergence check for residual forces
+    Thermo::NonlinSolTech itertype_;  //!< kind of iteration technique
+                                      //!< or non-linear solution technique
+    Thermo::ConvNorm normtypetempi_;  //!< convergence check for residual temperatures
+    Thermo::ConvNorm normtypefres_;   //!< convergence check for residual forces
 
-    enum Thermo::BinaryOp combtempifres_;  //!< binary operator to combine temperatures and forces
+    Thermo::BinaryOp combtempifres_;  //!< binary operator to combine temperatures and forces
 
-    enum Thermo::VectorNorm iternorm_;    //!< vector norm to check with
-    int itermax_;                         //!< maximally permitted iterations
-    int itermin_;                         //!< minimally requested iterations
-    enum Thermo::DivContAct divcontype_;  // what to do when nonlinear solution fails
-    int divcontrefinelevel_;              //!< refinement level of adaptive time stepping
+    Thermo::VectorNorm iternorm_;    //!< vector norm to check with
+    int itermax_;                    //!< maximally permitted iterations
+    int itermin_;                    //!< minimally requested iterations
+    Thermo::DivContAct divcontype_;  // what to do when nonlinear solution fails
+    int divcontrefinelevel_;         //!< refinement level of adaptive time stepping
     int divcontfinesteps_;  //!< number of time steps already performed at current refinement level
     double toltempi_;       //!< tolerance residual temperatures
     double tolfres_;        //!< tolerance force residual

--- a/src/thermo/src/implicit/4C_thermo_timint_ost.hpp
+++ b/src/thermo/src/implicit/4C_thermo_timint_ost.hpp
@@ -143,10 +143,7 @@ namespace Thermo
     //@{
 
     //! Return name
-    enum Thermo::DynamicType method_name() const override
-    {
-      return Thermo::DynamicType::OneStepTheta;
-    }
+    Thermo::DynamicType method_name() const override { return Thermo::DynamicType::OneStepTheta; }
 
     //! Consistent predictor with constant temperatures
     //! and consistent temperature rates and temperatures

--- a/src/thermo/src/implicit/4C_thermo_timint_statics.hpp
+++ b/src/thermo/src/implicit/4C_thermo_timint_statics.hpp
@@ -58,7 +58,7 @@ namespace Thermo
     //@{
 
     //! Return name
-    enum Thermo::DynamicType method_name() const override { return Thermo::DynamicType::Statics; }
+    Thermo::DynamicType method_name() const override { return Thermo::DynamicType::Statics; }
 
     //! Consistent predictor with constant temperatures
     //! and consistent temperature rates and temperatures

--- a/src/thermo/src/utils/4C_thermo_aux.cpp
+++ b/src/thermo/src/utils/4C_thermo_aux.cpp
@@ -14,7 +14,7 @@ FOUR_C_NAMESPACE_OPEN
  | Calculate vector norm                                    bborn 08/09 |
  *----------------------------------------------------------------------*/
 double Thermo::Aux::calculate_vector_norm(
-    const enum Thermo::VectorNorm norm, Core::LinAlg::Vector<double>& vect)
+    const Thermo::VectorNorm norm, Core::LinAlg::Vector<double>& vect)
 {
   // L1 norm
   if (norm == Thermo::norm_l1)

--- a/src/thermo/src/utils/4C_thermo_aux.hpp
+++ b/src/thermo/src/utils/4C_thermo_aux.hpp
@@ -31,8 +31,8 @@ namespace Thermo
   namespace Aux
   {
     //! Determine norm of force residual
-    double calculate_vector_norm(const enum Thermo::VectorNorm norm,  //!< norm to use
-        Core::LinAlg::Vector<double>& vect                            //!< the vector of interest
+    double calculate_vector_norm(const Thermo::VectorNorm norm,  //!< norm to use
+        Core::LinAlg::Vector<double>& vect                       //!< the vector of interest
     );
 
   }  // namespace Aux

--- a/src/tsi/4C_tsi_monolithic.cpp
+++ b/src/tsi/4C_tsi_monolithic.cpp
@@ -2093,7 +2093,7 @@ void TSI::Monolithic::unscale_solution(Core::LinAlg::BlockSparseMatrixBase& mat,
  | calculate vector norm                                     dano 04/13 |
  *----------------------------------------------------------------------*/
 double TSI::Monolithic::calculate_vector_norm(
-    const enum TSI::VectorNorm norm, const Core::LinAlg::Vector<double>& vect)
+    const TSI::VectorNorm norm, const Core::LinAlg::Vector<double>& vect)
 {
   // L1 norm
   // norm = sum_0^i vect[i]
@@ -2162,12 +2162,11 @@ void TSI::Monolithic::set_default_parameters()
   // what kind of norm do we wanna test for the single fields
   normtypedisi_ = Teuchos::getIntegralValue<Inpar::Solid::ConvNorm>(sdyn_, "NORM_DISP");
   normtypestrrhs_ = Teuchos::getIntegralValue<Inpar::Solid::ConvNorm>(sdyn_, "NORM_RESF");
-  enum Inpar::Solid::VectorNorm striternorm =
+  Inpar::Solid::VectorNorm striternorm =
       Teuchos::getIntegralValue<Inpar::Solid::VectorNorm>(sdyn_, "ITERNORM");
   normtypetempi_ = Teuchos::getIntegralValue<Thermo::ConvNorm>(tdyn, "NORM_TEMP");
   normtypethrrhs_ = Teuchos::getIntegralValue<Thermo::ConvNorm>(tdyn, "NORM_RESF");
-  enum Thermo::VectorNorm thriternorm =
-      Teuchos::getIntegralValue<Thermo::VectorNorm>(tdyn, "ITERNORM");
+  Thermo::VectorNorm thriternorm = Teuchos::getIntegralValue<Thermo::VectorNorm>(tdyn, "ITERNORM");
   // in total when do we reach a converged state for complete problem
   combincrhs_ = Teuchos::getIntegralValue<TSI::BinaryOp>(tsidynmono_, "NORMCOMBI_RESFINC");
 

--- a/src/tsi/4C_tsi_monolithic.hpp
+++ b/src/tsi/4C_tsi_monolithic.hpp
@@ -185,8 +185,8 @@ namespace TSI
     void print_newton_conv();
 
     //! Determine norm of force residual
-    double calculate_vector_norm(const enum TSI::VectorNorm norm,  //!< norm to use
-        const Core::LinAlg::Vector<double>& vect                   //!< the vector of interest
+    double calculate_vector_norm(const TSI::VectorNorm norm,  //!< norm to use
+        const Core::LinAlg::Vector<double>& vect              //!< the vector of interest
     );
 
     //@}
@@ -280,7 +280,7 @@ namespace TSI
     //@}
 
     //! enum for STR time integartion
-    enum Inpar::Solid::DynamicType strmethodname_;
+    Inpar::Solid::DynamicType strmethodname_;
 
     //! apply structural displacements and velocities on thermo discretization
     void apply_struct_coupling_state(std::shared_ptr<const Core::LinAlg::Vector<double>> disp,
@@ -319,21 +319,21 @@ namespace TSI
 
     //! @name iterative solution technique
 
-    enum TSI::NlnSolTech soltech_;  //!< kind of iteration technique or
-                                    //!< nonlinear solution technique
+    TSI::NlnSolTech soltech_;  //!< kind of iteration technique or
+                               //!< nonlinear solution technique
 
-    enum TSI::ConvNorm normtypeinc_;              //!< convergence check for increments
-    enum TSI::ConvNorm normtyperhs_;              //!< convergence check for residual forces
-    enum Inpar::Solid::ConvNorm normtypedisi_;    //!< convergence check for residual displacements
-    enum Inpar::Solid::ConvNorm normtypestrrhs_;  //!< convergence check for residual forces
-    enum Thermo::ConvNorm normtypetempi_;         //!< convergence check for residual temperatures
-    enum Thermo::ConvNorm normtypethrrhs_;        //!< convergence check for residual thermal forces
+    TSI::ConvNorm normtypeinc_;              //!< convergence check for increments
+    TSI::ConvNorm normtyperhs_;              //!< convergence check for residual forces
+    Inpar::Solid::ConvNorm normtypedisi_;    //!< convergence check for residual displacements
+    Inpar::Solid::ConvNorm normtypestrrhs_;  //!< convergence check for residual forces
+    Thermo::ConvNorm normtypetempi_;         //!< convergence check for residual temperatures
+    Thermo::ConvNorm normtypethrrhs_;        //!< convergence check for residual thermal forces
 
-    enum TSI::BinaryOp combincrhs_;  //!< binary operator to combine increments and forces
+    TSI::BinaryOp combincrhs_;  //!< binary operator to combine increments and forces
 
-    enum TSI::VectorNorm iternorm_;     //!< vector norm to check TSI values with
-    enum TSI::VectorNorm iternormstr_;  //!< vector norm to check structural values with
-    enum TSI::VectorNorm iternormthr_;  //!< vector norm to check thermal values with
+    TSI::VectorNorm iternorm_;     //!< vector norm to check TSI values with
+    TSI::VectorNorm iternormstr_;  //!< vector norm to check structural values with
+    TSI::VectorNorm iternormthr_;  //!< vector norm to check thermal values with
 
     double tolinc_;     //!< tolerance for increment
     double tolrhs_;     //!< tolerance for rhs

--- a/src/tsi/4C_tsi_partitioned.hpp
+++ b/src/tsi/4C_tsi_partitioned.hpp
@@ -103,7 +103,7 @@ namespace TSI
         double ittol                   //!< iteration tolerance
     );
 
-    enum ConvNorm normtypeinc_;  //!< convergence check for residual temperatures
+    ConvNorm normtypeinc_;  //!< convergence check for residual temperatures
 
     //! maximum iteration steps
     int itmax_;

--- a/src/w1/4C_w1.hpp
+++ b/src/w1/4C_w1.hpp
@@ -357,7 +357,7 @@ namespace Discret
       /// eas or not
       bool iseas_;
       /// EAS type
-      enum EasType eastype_;
+      EasType eastype_;
 
       /** \brief interface ptr
        *

--- a/src/w1/4C_w1_poro_evaluate.cpp
+++ b/src/w1/4C_w1_poro_evaluate.cpp
@@ -222,8 +222,8 @@ int Discret::Elements::Wall1Poro<distype>::my_evaluate(Teuchos::ParameterList& p
       Core::LinAlg::Matrix<numdof_, numdof_>* matptr = nullptr;
       if (elemat_1.is_initialized()) matptr = &elemat_1;
 
-      enum Inpar::Solid::DampKind damping =
-          params.get<enum Inpar::Solid::DampKind>("damping", Inpar::Solid::damp_none);
+      Inpar::Solid::DampKind damping =
+          params.get<Inpar::Solid::DampKind>("damping", Inpar::Solid::damp_none);
       Core::LinAlg::Matrix<numdof_, numdof_>* matptr2 = nullptr;
       if (elemat_2.is_initialized() and (damping == Inpar::Solid::damp_material))
         matptr2 = &elemat_2;

--- a/src/w1/4C_w1_poro_p1_evaluate.cpp
+++ b/src/w1/4C_w1_poro_p1_evaluate.cpp
@@ -243,8 +243,8 @@ int Discret::Elements::Wall1PoroP1<distype>::my_evaluate(Teuchos::ParameterList&
         Core::LinAlg::Matrix<numdof_, numdof_>* matptr = nullptr;
         if (elemat_1.is_initialized()) matptr = &elemat_1;
 
-        enum Inpar::Solid::DampKind damping =
-            params.get<enum Inpar::Solid::DampKind>("damping", Inpar::Solid::damp_none);
+        Inpar::Solid::DampKind damping =
+            params.get<Inpar::Solid::DampKind>("damping", Inpar::Solid::damp_none);
         Core::LinAlg::Matrix<numdof_, numdof_>* matptr2 = nullptr;
         if (elemat_2.is_initialized() and (damping == Inpar::Solid::damp_material))
           matptr2 = &elemat_2;

--- a/src/xfem/4C_xfem_multi_field_mapextractor.cpp
+++ b/src/xfem/4C_xfem_multi_field_mapextractor.cpp
@@ -741,7 +741,7 @@ void XFEM::MultiFieldMapExtractor::build_element_map_extractor()
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 std::shared_ptr<Core::LinAlg::Vector<double>> XFEM::MultiFieldMapExtractor::extract_vector(
-    const Core::LinAlg::Vector<double>& full, enum FieldName field, enum MapType map_type) const
+    const Core::LinAlg::Vector<double>& full, FieldName field, MapType map_type) const
 {
   const int dis_id = slave_id(field);
 
@@ -765,8 +765,7 @@ std::shared_ptr<Core::LinAlg::Vector<double>> XFEM::MultiFieldMapExtractor::extr
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 std::shared_ptr<Core::LinAlg::MultiVector<double>> XFEM::MultiFieldMapExtractor::extract_vector(
-    const Core::LinAlg::MultiVector<double>& full, enum FieldName field,
-    enum MapType map_type) const
+    const Core::LinAlg::MultiVector<double>& full, FieldName field, MapType map_type) const
 {
   const int dis_id = slave_id(field);
 
@@ -790,7 +789,7 @@ std::shared_ptr<Core::LinAlg::MultiVector<double>> XFEM::MultiFieldMapExtractor:
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 void XFEM::MultiFieldMapExtractor::extract_vector(const Core::LinAlg::MultiVector<double>& full,
-    int block, Core::LinAlg::MultiVector<double>& partial, enum MapType map_type) const
+    int block, Core::LinAlg::MultiVector<double>& partial, MapType map_type) const
 {
   // --------------------------------------------------------------------------
   // extract the non-interface part
@@ -841,7 +840,7 @@ void XFEM::MultiFieldMapExtractor::add_element_vector(
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 std::shared_ptr<Core::LinAlg::Vector<double>> XFEM::MultiFieldMapExtractor::insert_vector(
-    const Core::LinAlg::Vector<double>& partial, enum FieldName field, enum MapType map_type) const
+    const Core::LinAlg::Vector<double>& partial, FieldName field, MapType map_type) const
 {
   const int dis_id = slave_id(field);
   std::shared_ptr<Core::LinAlg::Vector<double>> full =
@@ -853,8 +852,7 @@ std::shared_ptr<Core::LinAlg::Vector<double>> XFEM::MultiFieldMapExtractor::inse
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 std::shared_ptr<Core::LinAlg::MultiVector<double>> XFEM::MultiFieldMapExtractor::insert_vector(
-    const Core::LinAlg::MultiVector<double>& partial, enum FieldName field,
-    enum MapType map_type) const
+    const Core::LinAlg::MultiVector<double>& partial, FieldName field, MapType map_type) const
 {
   const int dis_id = slave_id(field);
 
@@ -869,7 +867,7 @@ std::shared_ptr<Core::LinAlg::MultiVector<double>> XFEM::MultiFieldMapExtractor:
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 void XFEM::MultiFieldMapExtractor::insert_vector(const Core::LinAlg::MultiVector<double>& partial,
-    int block, Core::LinAlg::MultiVector<double>& full, enum MapType map_type) const
+    int block, Core::LinAlg::MultiVector<double>& full, MapType map_type) const
 {
   // --------------------------------------------------------------------------
   // insert the non_interface part
@@ -894,7 +892,7 @@ void XFEM::MultiFieldMapExtractor::insert_vector(const Core::LinAlg::MultiVector
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 void XFEM::MultiFieldMapExtractor::add_vector(const Core::LinAlg::MultiVector<double>& partial,
-    int block, Core::LinAlg::MultiVector<double>& full, double scale, enum MapType map_type) const
+    int block, Core::LinAlg::MultiVector<double>& full, double scale, MapType map_type) const
 {
   // --------------------------------------------------------------------------
   // insert the non_interface part
@@ -952,9 +950,9 @@ bool XFEM::MultiFieldMapExtractor::is_x_fem_dis(int dis_id) const
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-int XFEM::MultiFieldMapExtractor::slave_id(enum FieldName field) const
+int XFEM::MultiFieldMapExtractor::slave_id(FieldName field) const
 {
-  std::map<enum FieldName, int>::const_iterator cit = slave_discret_id_map_.find(field);
+  std::map<FieldName, int>::const_iterator cit = slave_discret_id_map_.find(field);
   if (cit == slave_discret_id_map_.end())
     FOUR_C_THROW("The slave field \"{}\" could not be found!", field);
 
@@ -1063,7 +1061,7 @@ void XFEM::MultiFieldMapExtractor::build_master_interface_node_maps(
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 std::shared_ptr<const Core::LinAlg::Map> XFEM::MultiFieldMapExtractor::node_row_map(
-    enum FieldName field, enum MultiField::BlockType block) const
+    FieldName field, MultiField::BlockType block) const
 {
   switch (block)
   {
@@ -1147,7 +1145,7 @@ void XFEM::MultiFieldMapExtractor::add_matrix(
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 const std::shared_ptr<const Core::LinAlg::Map>& XFEM::MultiFieldMapExtractor::full_map(
-    enum MapType map_type) const
+    MapType map_type) const
 {
   return ma_map_extractor(map_type).full_map();
 }
@@ -1206,7 +1204,7 @@ void XFEM::MultiFieldMapExtractor::i_dof(std::vector<int>& dof, Core::Nodes::Nod
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 const Core::LinAlg::Map& XFEM::MultiFieldMapExtractor::slave_node_row_map(
-    unsigned dis_id, enum MultiField::BlockType btype) const
+    unsigned dis_id, MultiField::BlockType btype) const
 {
   check_init();
   return *(sl_map_extractor(dis_id, map_nodes).map(btype));

--- a/src/xfem/4C_xfem_multi_field_mapextractor.hpp
+++ b/src/xfem/4C_xfem_multi_field_mapextractor.hpp
@@ -201,13 +201,13 @@ namespace XFEM
 
     /// @}
 
-    const Core::LinAlg::MultiMapExtractor& sl_dof_map_extractor(enum FieldName field) const
+    const Core::LinAlg::MultiMapExtractor& sl_dof_map_extractor(FieldName field) const
     {
       return sl_map_extractor(slave_id(field), map_dofs);
     }
 
     std::shared_ptr<const Core::LinAlg::Map> node_row_map(
-        enum FieldName field, enum MultiField::BlockType block) const;
+        FieldName field, MultiField::BlockType block) const;
 
     /** \brief return TRUE if the given global node id corresponds to an
      *  interface node
@@ -216,30 +216,29 @@ namespace XFEM
     bool is_interface_node(const int& ngid) const;
 
     /// Access the full maps
-    const std::shared_ptr<const Core::LinAlg::Map>& full_map(
-        enum MapType map_type = map_dofs) const;
+    const std::shared_ptr<const Core::LinAlg::Map>& full_map(MapType map_type = map_dofs) const;
 
     /// @name Extract vector routines
     /// @{
     std::shared_ptr<Core::LinAlg::Vector<double>> extract_vector(
-        const Core::LinAlg::Vector<double>& full, enum FieldName field,
-        enum MapType map_type = map_dofs) const;
+        const Core::LinAlg::Vector<double>& full, FieldName field,
+        MapType map_type = map_dofs) const;
 
     std::shared_ptr<Core::LinAlg::MultiVector<double>> extract_vector(
-        const Core::LinAlg::MultiVector<double>& full, enum FieldName field,
-        enum MapType map_type = map_dofs) const;
+        const Core::LinAlg::MultiVector<double>& full, FieldName field,
+        MapType map_type = map_dofs) const;
 
-    inline void extract_vector(const Core::LinAlg::MultiVector<double>& full, enum FieldName field,
-        Core::LinAlg::MultiVector<double>& partial, enum MapType map_type = map_dofs) const
+    inline void extract_vector(const Core::LinAlg::MultiVector<double>& full, FieldName field,
+        Core::LinAlg::MultiVector<double>& partial, MapType map_type = map_dofs) const
     {
       extract_vector(full, slave_id(field), partial, map_type);
     }
 
     void extract_vector(const Core::LinAlg::MultiVector<double>& full, int block,
-        Core::LinAlg::MultiVector<double>& partial, enum MapType map_type = map_dofs) const;
+        Core::LinAlg::MultiVector<double>& partial, MapType map_type = map_dofs) const;
 
     inline void extract_element_vector(const Core::LinAlg::MultiVector<double>& full,
-        enum FieldName field, Core::LinAlg::MultiVector<double>& partial) const
+        FieldName field, Core::LinAlg::MultiVector<double>& partial) const
     {
       extract_element_vector(full, slave_id(field), partial);
     }
@@ -258,8 +257,8 @@ namespace XFEM
      *
      *  */
     std::shared_ptr<Core::LinAlg::Vector<double>> insert_vector(
-        const Core::LinAlg::Vector<double>& partial, enum FieldName field,
-        enum MapType map_type = map_dofs) const;
+        const Core::LinAlg::Vector<double>& partial, FieldName field,
+        MapType map_type = map_dofs) const;
 
     /** \brief Put a partial vector into a full vector (Core::LinAlg::MultiVector<double>)
      *
@@ -268,8 +267,8 @@ namespace XFEM
      *
      *  */
     std::shared_ptr<Core::LinAlg::MultiVector<double>> insert_vector(
-        const Core::LinAlg::MultiVector<double>& partial, enum FieldName field,
-        enum MapType map_type = map_dofs) const;
+        const Core::LinAlg::MultiVector<double>& partial, FieldName field,
+        MapType map_type = map_dofs) const;
 
     /** \brief Put a partial vector into a full vector (Core::LinAlg::MultiVector<double>)
      *
@@ -278,8 +277,8 @@ namespace XFEM
      *  \param full   (out): vector to copy into
      *
      *  */
-    void insert_vector(const Core::LinAlg::MultiVector<double>& partial, enum FieldName field,
-        Core::LinAlg::MultiVector<double>& full, enum MapType map_type = map_dofs) const
+    void insert_vector(const Core::LinAlg::MultiVector<double>& partial, FieldName field,
+        Core::LinAlg::MultiVector<double>& full, MapType map_type = map_dofs) const
     {
       return insert_vector(partial, slave_id(field), full, map_type);
     }
@@ -288,10 +287,10 @@ namespace XFEM
      *
      *  */
     void insert_vector(const Core::LinAlg::MultiVector<double>& partial, int block,
-        Core::LinAlg::MultiVector<double>& full, enum MapType map_type = map_dofs) const;
+        Core::LinAlg::MultiVector<double>& full, MapType map_type = map_dofs) const;
 
     inline void insert_element_vector(const Core::LinAlg::MultiVector<double>& partial,
-        enum FieldName field, Core::LinAlg::MultiVector<double>& full) const
+        FieldName field, Core::LinAlg::MultiVector<double>& full) const
     {
       insert_element_vector(partial, slave_id(field), full);
     }
@@ -310,8 +309,8 @@ namespace XFEM
      *  \param scale   (in): scaling factor for partial vector
      *
      *  */
-    inline void add_vector(const Core::LinAlg::Vector<double>& partial, enum FieldName field,
-        Core::LinAlg::Vector<double>& full, double scale, enum MapType map_type = map_dofs) const
+    inline void add_vector(const Core::LinAlg::Vector<double>& partial, FieldName field,
+        Core::LinAlg::Vector<double>& full, double scale, MapType map_type = map_dofs) const
     {
       add_vector(partial, slave_id(field), full, scale, map_type);
     }
@@ -324,9 +323,8 @@ namespace XFEM
      *  \param scale   (in): scaling factor for partial vector
      *
      *  */
-    inline void add_vector(const Core::LinAlg::MultiVector<double>& partial, enum FieldName field,
-        Core::LinAlg::MultiVector<double>& full, double scale,
-        enum MapType map_type = map_dofs) const
+    inline void add_vector(const Core::LinAlg::MultiVector<double>& partial, FieldName field,
+        Core::LinAlg::MultiVector<double>& full, double scale, MapType map_type = map_dofs) const
     {
       return add_vector(partial, slave_id(field), full, scale, map_type);
     }
@@ -335,11 +333,10 @@ namespace XFEM
      *
      *  */
     void add_vector(const Core::LinAlg::MultiVector<double>& partial, int block,
-        Core::LinAlg::MultiVector<double>& full, double scale,
-        enum MapType map_type = map_dofs) const;
+        Core::LinAlg::MultiVector<double>& full, double scale, MapType map_type = map_dofs) const;
 
     inline void add_element_vector(const Core::LinAlg::MultiVector<double>& partial,
-        enum FieldName field, Core::LinAlg::MultiVector<double>& full, double scale) const
+        FieldName field, Core::LinAlg::MultiVector<double>& full, double scale) const
     {
       add_element_vector(partial, slave_id(field), full, scale);
     }
@@ -350,7 +347,7 @@ namespace XFEM
 
     /// @name Add a partial system-matrix to the full matrix
     /// @{
-    inline void add_matrix(const Core::LinAlg::SparseOperator& partial_mat, enum FieldName field,
+    inline void add_matrix(const Core::LinAlg::SparseOperator& partial_mat, FieldName field,
         Core::LinAlg::SparseOperator& full_mat, double scale)
     {
       add_matrix(partial_mat, slave_id(field), full_mat, scale);
@@ -369,7 +366,7 @@ namespace XFEM
      *  \param dis_id (in): entry of the slave discretization vector
      *
      */
-    bool is_x_fem_dis(enum FieldName field) const { return is_x_fem_dis(slave_id(field)); }
+    bool is_x_fem_dis(FieldName field) const { return is_x_fem_dis(slave_id(field)); }
 
    protected:
     /// check if init() has been called yet
@@ -399,7 +396,7 @@ namespace XFEM
      *  \param dis_id (in): entry of the slave discretization vector
      *
      */
-    inline const Core::LinAlg::Map& master_interface_node_row_map(enum FieldName field) const
+    inline const Core::LinAlg::Map& master_interface_node_row_map(FieldName field) const
     {
       return master_interface_node_row_map(slave_id(field));
     }
@@ -425,7 +422,7 @@ namespace XFEM
     /** \brief Access the master map extractor
      *
      */
-    const Core::LinAlg::MultiMapExtractor& ma_map_extractor(enum MapType map_type) const
+    const Core::LinAlg::MultiMapExtractor& ma_map_extractor(MapType map_type) const
     {
       if (master_map_extractor_.at(map_type) == nullptr)
         FOUR_C_THROW("The master dof/node map extractor was not initialized!");
@@ -440,15 +437,13 @@ namespace XFEM
      *
      */
     inline const Core::LinAlg::Map& slave_node_row_map(
-        enum XFEM::FieldName field, enum MultiField::BlockType btype) const
+        XFEM::FieldName field, MultiField::BlockType btype) const
     {
       return slave_node_row_map(slave_id(field), btype);
     }
-    const Core::LinAlg::Map& slave_node_row_map(
-        unsigned dis_id, enum MultiField::BlockType btype) const;
+    const Core::LinAlg::Map& slave_node_row_map(unsigned dis_id, MultiField::BlockType btype) const;
 
-    const Core::LinAlg::MultiMapExtractor& sl_map_extractor(
-        unsigned dis_id, enum MapType map_type) const
+    const Core::LinAlg::MultiMapExtractor& sl_map_extractor(unsigned dis_id, MapType map_type) const
     {
       check_init();
 
@@ -470,7 +465,7 @@ namespace XFEM
     /** \brief Access the interface matrix row transformer for the given field
      *
      *  */
-    Coupling::Adapter::MatrixRowTransform& i_mat_row_transform(enum FieldName field)
+    Coupling::Adapter::MatrixRowTransform& i_mat_row_transform(FieldName field)
     {
       return i_mat_row_transform(slave_id(field));
     }
@@ -496,7 +491,7 @@ namespace XFEM
     /** \brief Access the interface matrix column transformer for the given field
      *
      *  */
-    Coupling::Adapter::MatrixColTransform& i_mat_col_transform(enum FieldName field)
+    Coupling::Adapter::MatrixColTransform& i_mat_col_transform(FieldName field)
     {
       return i_mat_col_transform(slave_id(field));
     }
@@ -522,7 +517,7 @@ namespace XFEM
     /** \brief Access the interface matrix row and column transformer for the given field
      *
      *  */
-    Coupling::Adapter::MatrixRowColTransform& i_mat_row_col_transform(enum FieldName field)
+    Coupling::Adapter::MatrixRowColTransform& i_mat_row_col_transform(FieldName field)
     {
       return i_mat_row_col_transform(slave_id(field));
     }
@@ -554,7 +549,7 @@ namespace XFEM
       return *idiscret_;
     }
 
-    inline const Core::FE::Discretization& sl_discret(enum FieldName field) const
+    inline const Core::FE::Discretization& sl_discret(FieldName field) const
     {
       return sl_discret(slave_id(field));
     }
@@ -622,7 +617,7 @@ namespace XFEM
 
     void build_slave_discret_id_map();
 
-    int slave_id(enum FieldName field) const;
+    int slave_id(FieldName field) const;
 
     const std::vector<std::shared_ptr<const Core::FE::Discretization>>& sl_dis_vec() const
     {
@@ -664,7 +659,7 @@ namespace XFEM
     std::vector<std::shared_ptr<const Core::FE::Discretization>> slave_discret_vec_;
 
     /// mapping between the FieldName enumerator and the slave vector entry number
-    std::map<enum FieldName, int> slave_discret_id_map_;
+    std::map<FieldName, int> slave_discret_id_map_;
 
     /** \brief global interface node GID set
      *

--- a/src/xfem/4C_xfem_xfield_field_coupling.cpp
+++ b/src/xfem/4C_xfem_xfield_field_coupling.cpp
@@ -25,7 +25,7 @@ XFEM::XFieldField::Coupling::Coupling()
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-void XFEM::XFieldField::Coupling::init(const enum MinDofDiscretization& min_dof_dis)
+void XFEM::XFieldField::Coupling::init(const MinDofDiscretization& min_dof_dis)
 {
   min_dof_dis_ = min_dof_dis;
 
@@ -35,7 +35,7 @@ void XFEM::XFieldField::Coupling::init(const enum MinDofDiscretization& min_dof_
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 std::shared_ptr<Core::LinAlg::Vector<double>> XFEM::XFieldField::Coupling::master_to_slave(
-    const Core::LinAlg::Vector<double>& mv, const enum XFEM::MapType& map_type) const
+    const Core::LinAlg::Vector<double>& mv, const XFEM::MapType& map_type) const
 {
   std::shared_ptr<Core::LinAlg::Vector<double>> sv = nullptr;
   switch (map_type)
@@ -55,7 +55,7 @@ std::shared_ptr<Core::LinAlg::Vector<double>> XFEM::XFieldField::Coupling::maste
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 std::shared_ptr<Core::LinAlg::Vector<double>> XFEM::XFieldField::Coupling::slave_to_master(
-    const Core::LinAlg::Vector<double>& sv, const enum XFEM::MapType& map_type) const
+    const Core::LinAlg::Vector<double>& sv, const XFEM::MapType& map_type) const
 {
   std::shared_ptr<Core::LinAlg::Vector<double>> mv = nullptr;
   switch (map_type)
@@ -75,7 +75,7 @@ std::shared_ptr<Core::LinAlg::Vector<double>> XFEM::XFieldField::Coupling::slave
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 std::shared_ptr<Core::LinAlg::MultiVector<double>> XFEM::XFieldField::Coupling::master_to_slave(
-    const Core::LinAlg::MultiVector<double>& mv, const enum XFEM::MapType& map_type) const
+    const Core::LinAlg::MultiVector<double>& mv, const XFEM::MapType& map_type) const
 {
   std::shared_ptr<Core::LinAlg::MultiVector<double>> sv = nullptr;
   switch (map_type)
@@ -95,7 +95,7 @@ std::shared_ptr<Core::LinAlg::MultiVector<double>> XFEM::XFieldField::Coupling::
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 std::shared_ptr<Core::LinAlg::MultiVector<double>> XFEM::XFieldField::Coupling::slave_to_master(
-    const Core::LinAlg::MultiVector<double>& sv, const enum XFEM::MapType& map_type) const
+    const Core::LinAlg::MultiVector<double>& sv, const XFEM::MapType& map_type) const
 {
   std::shared_ptr<Core::LinAlg::MultiVector<double>> mv = nullptr;
   switch (map_type)
@@ -115,7 +115,7 @@ std::shared_ptr<Core::LinAlg::MultiVector<double>> XFEM::XFieldField::Coupling::
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 void XFEM::XFieldField::Coupling::master_to_slave(const Core::LinAlg::MultiVector<double>& mv,
-    const enum XFEM::MapType& map_type, Core::LinAlg::MultiVector<double>& sv) const
+    const XFEM::MapType& map_type, Core::LinAlg::MultiVector<double>& sv) const
 {
   switch (map_type)
   {
@@ -147,7 +147,7 @@ void XFEM::XFieldField::Coupling::master_to_slave(const Core::LinAlg::MultiVecto
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 void XFEM::XFieldField::Coupling::slave_to_master(const Core::LinAlg::MultiVector<double>& sv,
-    const enum XFEM::MapType& map_type, Core::LinAlg::MultiVector<double>& mv) const
+    const XFEM::MapType& map_type, Core::LinAlg::MultiVector<double>& mv) const
 {
   switch (map_type)
   {

--- a/src/xfem/4C_xfem_xfield_field_coupling.hpp
+++ b/src/xfem/4C_xfem_xfield_field_coupling.hpp
@@ -52,7 +52,7 @@ namespace XFEM
       Coupling();
 
       /// initialize class member variables
-      void init(const enum MinDofDiscretization& min_dof_dis);
+      void init(const MinDofDiscretization& min_dof_dis);
 
       /** \name Conversion between master and slave
        *
@@ -68,7 +68,7 @@ namespace XFEM
        *  \param map_type (in) : map type of the master vector */
       inline std::shared_ptr<Core::LinAlg::Vector<double>> master_to_slave(
           const std::shared_ptr<Core::LinAlg::Vector<double>>& mv,
-          const enum XFEM::MapType& map_type) const
+          const XFEM::MapType& map_type) const
       {
         return master_to_slave(
             *std::const_pointer_cast<const Core::LinAlg::Vector<double>>(mv), map_type);
@@ -79,8 +79,7 @@ namespace XFEM
        *  \param sv       (in) : slave vector (to be transferred)
        *  \param map_type (in) : map type of the slave vector */
       inline std::shared_ptr<Core::LinAlg::Vector<double>> slave_to_master(
-          std::shared_ptr<Core::LinAlg::Vector<double>> sv,
-          const enum XFEM::MapType& map_type) const
+          std::shared_ptr<Core::LinAlg::Vector<double>> sv, const XFEM::MapType& map_type) const
       {
         return slave_to_master(
             *std::const_pointer_cast<const Core::LinAlg::Vector<double>>(sv), map_type);
@@ -92,7 +91,7 @@ namespace XFEM
        *  \param map_type (in) : map type of the master vector */
       inline std::shared_ptr<Core::LinAlg::MultiVector<double>> master_to_slave(
           std::shared_ptr<Core::LinAlg::MultiVector<double>> mv,
-          const enum XFEM::MapType& map_type) const
+          const XFEM::MapType& map_type) const
       {
         return master_to_slave(
             *std::const_pointer_cast<const Core::LinAlg::MultiVector<double>>(mv), map_type);
@@ -104,7 +103,7 @@ namespace XFEM
        *  \param map_type (in) : map type of the slave vector */
       inline std::shared_ptr<Core::LinAlg::MultiVector<double>> slave_to_master(
           std::shared_ptr<Core::LinAlg::MultiVector<double>> sv,
-          const enum XFEM::MapType& map_type) const
+          const XFEM::MapType& map_type) const
       {
         return slave_to_master(
             *std::const_pointer_cast<const Core::LinAlg::MultiVector<double>>(sv), map_type);
@@ -115,28 +114,28 @@ namespace XFEM
        *  \param mv       (in) : master vector (to be transferred)
        *  \param map_type (in) : map type of the master vector */
       std::shared_ptr<Core::LinAlg::Vector<double>> master_to_slave(
-          const Core::LinAlg::Vector<double>& mv, const enum XFEM::MapType& map_type) const;
+          const Core::LinAlg::Vector<double>& mv, const XFEM::MapType& map_type) const;
 
       /** \brief transfer a nodal/dof vector from slave to master
        *
        *  \param sv       (in) : slave vector (to be transferred)
        *  \param map_type (in) : map type of the slave vector */
       std::shared_ptr<Core::LinAlg::Vector<double>> slave_to_master(
-          const Core::LinAlg::Vector<double>& sv, const enum XFEM::MapType& map_type) const;
+          const Core::LinAlg::Vector<double>& sv, const XFEM::MapType& map_type) const;
 
       /** \brief transfer a nodel/dof vector from master to slave
        *
        *  \param mv       (in) : master vector (to be transferred)
        *  \param map_type (in) : map type of the master vector */
       std::shared_ptr<Core::LinAlg::MultiVector<double>> master_to_slave(
-          const Core::LinAlg::MultiVector<double>& mv, const enum XFEM::MapType& map_type) const;
+          const Core::LinAlg::MultiVector<double>& mv, const XFEM::MapType& map_type) const;
 
       /** \brief transfer a nodal/dof multi vector from slave to master
        *
        *  \param sv       (in) : slave multi vector (to be transferred)
        *  \param map_type (in) : map type of the slave vector */
       std::shared_ptr<Core::LinAlg::MultiVector<double>> slave_to_master(
-          const Core::LinAlg::MultiVector<double>& sv, const enum XFEM::MapType& map_type) const;
+          const Core::LinAlg::MultiVector<double>& sv, const XFEM::MapType& map_type) const;
 
       /** \brief transfer a nodel/dof multi vector from master to slave
        *
@@ -144,7 +143,7 @@ namespace XFEM
        *  \param map_type (in) : map type of the master vector
        *  \param sv       (out): slave multi vector (target)*/
       void master_to_slave(const Core::LinAlg::MultiVector<double>& mv,
-          const enum XFEM::MapType& map_type, Core::LinAlg::MultiVector<double>& sv) const;
+          const XFEM::MapType& map_type, Core::LinAlg::MultiVector<double>& sv) const;
 
       /** \brief transfer a nodal/dof multi vector from slave to master
        *
@@ -152,7 +151,7 @@ namespace XFEM
        *  \param map_type (in) : map type of the slave vector
        *  \param mv       (out): master multi vector (target)*/
       void slave_to_master(const Core::LinAlg::MultiVector<double>& sv,
-          const enum XFEM::MapType& map_type, Core::LinAlg::MultiVector<double>& mv) const;
+          const XFEM::MapType& map_type, Core::LinAlg::MultiVector<double>& mv) const;
 
       //@}
 
@@ -214,12 +213,12 @@ namespace XFEM
           std::shared_ptr<Core::LinAlg::Export>& max_exporter,
           const std::map<int, unsigned>& my_mindofpernode) const;
 
-      inline const enum MinDofDiscretization& min_dof_dis() const { return min_dof_dis_; }
+      inline const MinDofDiscretization& min_dof_dis() const { return min_dof_dis_; }
 
      private:
       bool isinit_;
 
-      enum MinDofDiscretization min_dof_dis_;
+      MinDofDiscretization min_dof_dis_;
 
       std::shared_ptr<const Core::LinAlg::Map> masternodemap_;
 

--- a/src/xfem/4C_xfem_xfluid_timeInt.cpp
+++ b/src/xfem/4C_xfem_xfluid_timeInt.cpp
@@ -148,8 +148,7 @@ void XFEM::XFluidTimeInt::set_and_print_status(const bool screenout)
 /*----------------------------------------------------------------------*
 | returns matching std::string for each reconstruction method   schott 07/12 |
 *----------------------------------------------------------------------*/
-std::string XFEM::XFluidTimeInt::map_method_enum_to_string(
-    const enum Inpar::XFEM::XFluidTimeInt term)
+std::string XFEM::XFluidTimeInt::map_method_enum_to_string(const Inpar::XFEM::XFluidTimeInt term)
 {
   // length of return std::string is 14 due to usage in formatted screen output
   switch (term)

--- a/src/xfem/4C_xfem_xfluid_timeInt.hpp
+++ b/src/xfem/4C_xfem_xfluid_timeInt.hpp
@@ -139,7 +139,7 @@ namespace XFEM
     );
 
     /// returns matching std::string for each reconstruction method
-    std::string map_method_enum_to_string(const enum Inpar::XFEM::XFluidTimeInt term);
+    std::string map_method_enum_to_string(const Inpar::XFEM::XFluidTimeInt term);
 
     /// all surrounding elements non-intersected?
     bool non_intersected_elements(Core::Nodes::Node* n, Cut::CutWizard& wizard);


### PR DESCRIPTION
A relic from C and not something you typically write  in C++. Removing this makes it easier to grep for enum definitions.