### PR TITLE
Fix the pvd file writer for restarts from parent directory

### DIFF
--- a/src/core/io/src/4C_io_vtk_writer_base.hpp
+++ b/src/core/io/src/4C_io_vtk_writer_base.hpp
@@ -312,6 +312,9 @@ class VtkWriterBase
   //! containing [time value and filename] of all yet written master files
   std::stringstream collection_file_midsection_cumulated_content_;
 
+  //! full path of the existing working directory where the vtk subdirectory is created.
+  //! relative or absolute depending on output specification
+  std::string path_existing_working_directory_;
 
   //! full path of the working directory for all vtk files to be written into
   std::string working_directory_full_path_;


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

The current `create_restarted_initial_collection_file_mid_section` had the following problem:
Suppose I have the folder structure:
```
parent_folder
|- folder1
|- folder2
```
`folder1` contains the restart files and the pvd collection. If I navigate to `folder2` and do a restart there with a relative part to `folder1`, i.e. `4C input output_folder2 restartfrom=../folder1/output_folder1` everything worked fine so far (thanks to @knarfnitram), the pvd collection would show entries like
```xml
file="../folder1/output_folder1/output-vtk-files/structure-00000.pvtu"
```

However, doing the same thing in the parent directory via `4C input folder2/output_folder2 restartfrom=folder1/output_folder1`, which leads to exactly the same results, leads to pvd file entries like
```xml
file="folder1/output_folder1/output-vtk-files/structure-00000.pvtu"
```
which gets continuously worse the more often I restart.

This PR fixes that by computing the relative path from the `path_existing_working_directory_` to `p_restart.parent_path()`.


## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->

#1138 
