### PR TITLE
Enable vtk in IMCS presets

### DIFF
--- a/presets/imcs/workstation/CMakePresets.json
+++ b/presets/imcs/workstation/CMakePresets.json
@@ -19,6 +19,7 @@
         "FOUR_C_WITH_GOOGLETEST": "ON",
         "FOUR_C_WITH_ARBORX": "ON",
         "FOUR_C_WITH_MIRCO": "ON",
+        "FOUR_C_WITH_VTK": "ON",
         "FOUR_C_BUILD_SHARED_LIBS": "OFF"
       }
     },


### PR DESCRIPTION
## Description and Context
Enable vtk input file capabilities for the IMCS workstation preset.
