### PR TITLE
Flush control_file correctly for pure structure problems

### DIFF
--- a/src/structure_new/src/4C_structure_new_timint_base.cpp
+++ b/src/structure_new/src/4C_structure_new_timint_base.cpp
@@ -17,6 +17,7 @@
 #include "4C_io_control.hpp"
 #include "4C_io_gmsh.hpp"
 #include "4C_io_pstream.hpp"
+#include "4C_legacy_enum_definitions_problem_type.hpp"
 #include "4C_linalg_map.hpp"
 #include "4C_linalg_vector.hpp"
 #include "4C_structure_new_dbc.hpp"
@@ -662,7 +663,13 @@ void Solid::TimeInt::Base::output_restart(bool& datawritten)
   /* Add the restart information of the different time integrators and model
    * evaluators. */
   int_ptr_->write_restart(*output_ptr);
-
+  // For pure structure problems, all results should be written now,
+  // hence close the control file group to force flushing.
+  // only try closing group, as no group was opened for non-binary output
+  if (Global::Problem::instance()->get_problem_type() == Core::ProblemType::structure)
+  {
+    output_ptr->output().control_file().try_end_group();
+  }
   // info dedicated to user's eyes staring at standard out
   if ((dataglobalstate_->get_my_rank() == 0) and (dataio_->get_print2_screen_every_n_step() > 0) and
       (step_old() % dataio_->get_print2_screen_every_n_step() == 0))


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

For pure structure problems, we can call `control_file().end_group()` at the end of `output_restart()`, since all results should have been written at that point and registered in the control file's result group.

I think it would make sense to call this also in `add_restart_to_output_state()`, but since #1469 tries to remove that anyway, I did not do that. 

For coupled problem types, this is not the case, and hence will not work. In these cases, `end_group()` needs to be called somewhere higher up.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
part of #1476 
