### PR TITLE
Remove MLMC write_mesh function

### DIFF
--- a/src/core/io/src/4C_io.cpp
+++ b/src/core/io/src/4C_io.cpp
@@ -967,51 +967,6 @@ void Core::IO::DiscretizationWriter::write_mesh(const int step, const double tim
 
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-void Core::IO::DiscretizationWriter::write_mesh(
-    const int step, const double time, std::string name_base_file)
-{
-  if (binio_)
-  {
-    // ... write other mesh information
-    if (Core::Communication::my_mpi_rank(get_comm()) == 0)
-    {
-      output_.control_file().try_end_group();
-      output_.control_file()
-          .start_group("field")
-          .write("field", dis_.name())
-          .write("time", time)
-          .write("step", step)
-          .write("num_nd", dis_.num_global_nodes())
-          .write("num_ele", dis_.num_global_elements())
-          .write("num_dof", dis_.dof_row_map(0)->num_global_elements())
-          .write("num_dim", static_cast<int>(dis_.n_dim()));
-
-      // knotvectors for nurbs-discretisation
-      // write_knotvector();
-      // create name for meshfile as in createmeshfile which is not called here
-      std::ostringstream meshname;
-
-      meshname << name_base_file << ".mesh." << dis_.name() << ".s" << step;
-      meshfilename_ = meshname.str();
-
-      if (Core::Communication::num_mpi_ranks(get_comm()) > 1)
-      {
-        output_.control_file().write(
-            "num_output_proc", Core::Communication::num_mpi_ranks(get_comm()));
-      }
-      std::string filename;
-      std::string::size_type pos = meshfilename_.find_last_of('/');
-      if (pos == std::string::npos)
-        filename = meshfilename_;
-      else
-        filename = meshfilename_.substr(pos + 1);
-      output_.control_file().write("mesh_file", filename);
-    }
-  }
-}
-
-/*----------------------------------------------------------------------*/
-/*----------------------------------------------------------------------*/
 void Core::IO::DiscretizationWriter::write_only_nodes_in_new_field_group_to_control_file(
     const int step, const double time, const bool writerestart)
 {

--- a/src/core/io/src/4C_io.hpp
+++ b/src/core/io/src/4C_io.hpp
@@ -301,9 +301,6 @@ namespace Core::IO
     //! write new "field" group to control file including node and element chunks
     void write_mesh(const int step, const double time);
 
-    // for MLMC purposes do not write new meshfile but write name of base mesh file to controlfile
-    void write_mesh(const int step, const double time, std::string name_base_file);
-
     // for particle simulations: write only nodes in new "field" group to control file
     void write_only_nodes_in_new_field_group_to_control_file(
         const int step, const double time, const bool writerestart);


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

While trying to unify `new_step()` and `write_mesh()`, I noticed that there is an unused `write_mesh` version which is apparently not used anymore due to the removal of the MLMC module.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
