### PR TITLE
Simplify handling of Lagrange multiplier flag

### DIFF
--- a/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator.cpp
@@ -741,9 +741,7 @@ bool Solid::ModelEvaluator::BeamInteraction::have_lagrange_dofs() const
             (*me_vec_ptr_)[i]);
     if (!beam_contact_model) continue;
 
-    auto params = beam_contact_model->beam_contact_params().beam_to_solid_volume_meshtying_params();
-    if (params && params->get_constraint_enforcement() ==
-                      Inpar::BeamToSolid::BeamToSolidConstraintEnforcement::lagrange)
+    if (beam_contact_model->have_lagrange_dofs())
     {
       lagrange_flag = true;
       if (me_vec_ptr_->size() > 1)

--- a/src/beaminteraction/src/4C_beaminteraction_submodel_evaluator_beamcontact.hpp
+++ b/src/beaminteraction/src/4C_beaminteraction_submodel_evaluator_beamcontact.hpp
@@ -149,6 +149,11 @@ namespace BeamInteraction
       }
 
       /**
+       * \brief Return flag if this submodel evaluator carries Lagrange multipliers.
+       */
+      [[nodiscard]] bool have_lagrange_dofs() const;
+
+      /**
        * \brief Lagrange Multiplier specific function returning the first assembly manager.
        */
       std::shared_ptr<const BeamInteraction::SubmodelEvaluator::BeamContactAssemblyManagerInDirect>


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

Improve handling of Lagrange multipliers in beaminteraction by not relying on the beam-to-solid volume meshtying parameters but taking this value out of the mortar manager directly.