### PR TITLE
Remove unused function

### DIFF
--- a/src/beamcontact/4C_beamcontact_str_model_evaluator_beaminteraction_old.cpp
+++ b/src/beamcontact/4C_beamcontact_str_model_evaluator_beaminteraction_old.cpp
@@ -219,14 +219,6 @@ void Solid::ModelEvaluator::BeamInteractionOld::determine_energy()
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void Solid::ModelEvaluator::BeamInteractionOld::determine_optional_quantity()
-{
-  // nothing to do
-  return;
-}
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
 void Solid::ModelEvaluator::BeamInteractionOld::output_step_state(
     Core::IO::DiscretizationWriter& iowriter) const
 {

--- a/src/beamcontact/4C_beamcontact_str_model_evaluator_beaminteraction_old.hpp
+++ b/src/beamcontact/4C_beamcontact_str_model_evaluator_beaminteraction_old.hpp
@@ -108,9 +108,6 @@ namespace Solid
       void determine_energy() override;
 
       //! derived
-      void determine_optional_quantity() override;
-
-      //! derived
       void output_step_state(Core::IO::DiscretizationWriter& iowriter) const override;
 
       //! derived

--- a/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator.cpp
@@ -1106,13 +1106,6 @@ void Solid::ModelEvaluator::BeamInteraction::determine_energy()
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-void Solid::ModelEvaluator::BeamInteraction::determine_optional_quantity()
-{
-  // empty
-}
-
-/*----------------------------------------------------------------------------*
- *----------------------------------------------------------------------------*/
 void Solid::ModelEvaluator::BeamInteraction::output_step_state(
     Core::IO::DiscretizationWriter& iowriter) const
 {

--- a/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator.hpp
+++ b/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator.hpp
@@ -137,9 +137,6 @@ namespace Solid
       void determine_energy() override;
 
       //! derived
-      void determine_optional_quantity() override;
-
-      //! derived
       void output_step_state(Core::IO::DiscretizationWriter& iowriter) const override;
 
       //! derived

--- a/src/browniandyn/4C_browniandyn_str_model_evaluator.cpp
+++ b/src/browniandyn/4C_browniandyn_str_model_evaluator.cpp
@@ -495,14 +495,6 @@ void Solid::ModelEvaluator::BrownianDyn::determine_energy()
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-void Solid::ModelEvaluator::BrownianDyn::determine_optional_quantity()
-{
-  // nothing to do
-  return;
-}
-
-/*----------------------------------------------------------------------------*
- *----------------------------------------------------------------------------*/
 void Solid::ModelEvaluator::BrownianDyn::output_step_state(
     Core::IO::DiscretizationWriter& iowriter) const
 {

--- a/src/browniandyn/4C_browniandyn_str_model_evaluator.hpp
+++ b/src/browniandyn/4C_browniandyn_str_model_evaluator.hpp
@@ -108,9 +108,6 @@ namespace Solid
       void determine_energy() override;
 
       //! derived
-      void determine_optional_quantity() override;
-
-      //! derived
       void output_step_state(Core::IO::DiscretizationWriter& iowriter) const override;
 
       //! derived

--- a/src/cardiovascular0d/4C_cardiovascular0d_structure_new_model_evaluator.cpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_structure_new_model_evaluator.cpp
@@ -291,14 +291,6 @@ void Solid::ModelEvaluator::Cardiovascular0D::determine_energy()
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void Solid::ModelEvaluator::Cardiovascular0D::determine_optional_quantity()
-{
-  // nothing to do
-  return;
-}
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
 void Solid::ModelEvaluator::Cardiovascular0D::output_step_state(
     Core::IO::DiscretizationWriter& iowriter) const
 {

--- a/src/cardiovascular0d/4C_cardiovascular0d_structure_new_model_evaluator.hpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_structure_new_model_evaluator.hpp
@@ -103,9 +103,6 @@ namespace Solid
       void determine_energy() override;
 
       //! derived
-      void determine_optional_quantity() override;
-
-      //! derived
       void output_step_state(Core::IO::DiscretizationWriter& iowriter) const override;
 
       //! derived

--- a/src/constraint_framework/4C_constraint_framework_model_evaluator.cpp
+++ b/src/constraint_framework/4C_constraint_framework_model_evaluator.cpp
@@ -314,9 +314,6 @@ void Solid::ModelEvaluator::Constraint::determine_energy()
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-void Solid::ModelEvaluator::Constraint::determine_optional_quantity() {}
-/*----------------------------------------------------------------------------*
- *----------------------------------------------------------------------------*/
 void Solid::ModelEvaluator::Constraint::reset_step_state()
 {
   FOUR_C_THROW("This function is not implemented");

--- a/src/constraint_framework/4C_constraint_framework_model_evaluator.hpp
+++ b/src/constraint_framework/4C_constraint_framework_model_evaluator.hpp
@@ -105,8 +105,6 @@ namespace Solid
 
       void determine_energy() override;
 
-      void determine_optional_quantity() override;
-
       void reset_step_state() override;
 
       void output_step_state(Core::IO::DiscretizationWriter& iowriter) const override;

--- a/src/fsi/src/partitioned/model_evaluator/4C_fsi_str_model_evaluator_partitioned.hpp
+++ b/src/fsi/src/partitioned/model_evaluator/4C_fsi_str_model_evaluator_partitioned.hpp
@@ -121,9 +121,6 @@ namespace Solid
       void determine_energy() override { return; };
 
       //! [derived]
-      void determine_optional_quantity() override { return; };
-
-      //! [derived]
       void output_step_state(Core::IO::DiscretizationWriter& iowriter) const override { return; };
 
       //! derived

--- a/src/inpar/4C_inpar_io.cpp
+++ b/src/inpar/4C_inpar_io.cpp
@@ -52,7 +52,9 @@ std::vector<Core::IO::InputSpec> Inpar::IO::valid_parameters()
                   {"2PK", Inpar::Solid::stress_2pk},
                   {"2pk", Inpar::Solid::stress_2pk},
               },
-              {.description = "Output of stress", .default_value = Inpar::Solid::stress_none}),
+              {.description = "Output of stress. This is only possible in the new vtk-based "
+                              "output. Make sure to set INTERVAL_STEPS accordingly.",
+                  .default_value = Inpar::Solid::stress_none}),
           deprecated_selection<Inpar::Solid::StrainType>("STRUCT_STRAIN",
               {
                   {"No", Inpar::Solid::strain_none},
@@ -68,7 +70,9 @@ std::vector<Core::IO::InputSpec> Inpar::IO::valid_parameters()
                   {"LOG", Inpar::Solid::strain_log},
                   {"log", Inpar::Solid::strain_log},
               },
-              {.description = "Output of strains", .default_value = Inpar::Solid::strain_none}),
+              {.description = "Output of strains. This is only possible in the new vtk-based "
+                              "output. Make sure to set INTERVAL_STEPS accordingly.",
+                  .default_value = Inpar::Solid::strain_none}),
           deprecated_selection<Inpar::Solid::StrainType>("STRUCT_PLASTIC_STRAIN",
               {
                   {"No", Inpar::Solid::strain_none},

--- a/src/inpar/4C_inpar_structure.cpp
+++ b/src/inpar/4C_inpar_structure.cpp
@@ -120,8 +120,10 @@ namespace Inpar
                       .default_value = 0}),
 
               // Output type
+              // TODO: Modify docu once Contact is migrated to new vtk-based output
               parameter<int>("RESULTSEVERY",
-                  {.description = "save displacements and contact forces every RESULTSEVERY steps",
+                  {.description = "Write old HDF5-based output every RESULTSEVERY steps. Used for "
+                                  "old structure time integration and Contact quantities.",
                       .default_value = 1}),
               parameter<int>(
                   "RESEVERYERGY", {.description = "write system energies every requested step",

--- a/src/pasi/4C_pasi_str_model_evaluator_partitioned.hpp
+++ b/src/pasi/4C_pasi_str_model_evaluator_partitioned.hpp
@@ -126,9 +126,6 @@ namespace Solid
       void determine_energy() override { return; };
 
       //! [derived]
-      void determine_optional_quantity() override { return; };
-
-      //! [derived]
       void output_step_state(Core::IO::DiscretizationWriter& iowriter) const override { return; };
 
       //! [derived]

--- a/src/ssi/4C_ssi_str_model_evaluator_base.hpp
+++ b/src/ssi/4C_ssi_str_model_evaluator_base.hpp
@@ -33,8 +33,6 @@ namespace Solid::ModelEvaluator
 
     void determine_energy() override {}
 
-    void determine_optional_quantity() override {}
-
     void determine_stress_strain() override;
 
     bool evaluate_force() override { return true; }

--- a/src/structure_new/src/4C_structure_new_integrator.cpp
+++ b/src/structure_new/src/4C_structure_new_integrator.cpp
@@ -414,14 +414,6 @@ void Solid::Integrator::update_structural_energy()
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-void Solid::Integrator::determine_optional_quantity()
-{
-  check_init_setup();
-  model_eval().determine_optional_quantity();
-}
-
-/*----------------------------------------------------------------------------*
- *----------------------------------------------------------------------------*/
 void Solid::Integrator::output_step_state(Core::IO::DiscretizationWriter& iowriter) const
 {
   check_init_setup();

--- a/src/structure_new/src/4C_structure_new_integrator.hpp
+++ b/src/structure_new/src/4C_structure_new_integrator.hpp
@@ -257,9 +257,6 @@ namespace Solid
     /// update the structural energy variable in the end of a successful time step
     void update_structural_energy();
 
-    //! calculate an optional quantity in the different model evaluators
-    void determine_optional_quantity();
-
     /*! \brief Output to file
      *
      *  This routine prints always the last converged state, i.e.

--- a/src/structure_new/src/4C_structure_new_timint_base.cpp
+++ b/src/structure_new/src/4C_structure_new_timint_base.cpp
@@ -438,12 +438,7 @@ void Solid::TimeInt::Base::get_restart_data(std::shared_ptr<int> step, std::shar
 void Solid::TimeInt::Base::prepare_output(bool force_prepare_timestep)
 {
   check_init_setup();
-  // --- stress, strain and optional quantity calculation ---------------------
-  if ((dataio_->is_write_results_enabled() && force_prepare_timestep) ||
-      dataio_->write_results_for_this_step(dataglobalstate_->get_step_np()))
-  {
-    int_ptr_->determine_optional_quantity();
-  }
+
   if ((dataio_->is_runtime_output_enabled() && force_prepare_timestep) ||
       dataio_->write_runtime_vtk_results_for_this_step(dataglobalstate_->get_step_np()) ||
       dataio_->write_runtime_vtp_results_for_this_step(dataglobalstate_->get_step_np()))

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_contact.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_contact.cpp
@@ -460,10 +460,6 @@ void Solid::ModelEvaluator::Contact::determine_energy() {}
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void Solid::ModelEvaluator::Contact::determine_optional_quantity() {}
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
 void Solid::ModelEvaluator::Contact::output_step_state(
     Core::IO::DiscretizationWriter& iowriter) const
 {

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_contact.hpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_contact.hpp
@@ -121,9 +121,6 @@ namespace Solid
       void determine_energy() override;
 
       //! [derived]
-      void determine_optional_quantity() override;
-
-      //! [derived]
       void output_step_state(Core::IO::DiscretizationWriter& iowriter) const override;
 
       //! [derived]

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_generic.hpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_generic.hpp
@@ -376,18 +376,6 @@ namespace Solid
        *  */
       virtual void determine_energy() = 0;
 
-      /*! \brief calculate optional quantity contribution of each model evaluator
-       *
-       *  \remark This function is called from Solid::TimeInt::Base::prepare_output() and calculates
-       *  missing quantities, which were not evaluated during the standard evaluate call and are
-       *  only calculated once per load/time step. You can not do the calculations during the
-       *  output_step_state() routine, because of the const status of the named function!
-       *
-       *  \sa output_step_state
-       *
-       *  */
-      virtual void determine_optional_quantity() = 0;
-
       /*! \brief Output routine for model evaluator
        *
        * @param iowriter discretization writer that actually writes binary output to the disk

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_lagpenconstraint.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_lagpenconstraint.cpp
@@ -289,13 +289,6 @@ void Solid::ModelEvaluator::LagPenConstraint::determine_energy()
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void Solid::ModelEvaluator::LagPenConstraint::determine_optional_quantity()
-{
-  // nothing to do
-}
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
 void Solid::ModelEvaluator::LagPenConstraint::output_step_state(
     Core::IO::DiscretizationWriter& iowriter) const
 {

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_lagpenconstraint.hpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_lagpenconstraint.hpp
@@ -111,9 +111,6 @@ namespace Solid
       void determine_energy() override;
 
       //! derived
-      void determine_optional_quantity() override;
-
-      //! derived
       void output_step_state(Core::IO::DiscretizationWriter& iowriter) const override;
 
       //! derived

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_manager.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_manager.cpp
@@ -746,14 +746,6 @@ void Solid::ModelEvaluatorManager::determine_energy()
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-void Solid::ModelEvaluatorManager::determine_optional_quantity()
-{
-  check_init_setup();
-  for (const auto& me_iter : *me_vec_ptr_) me_iter->determine_optional_quantity();
-}
-
-/*----------------------------------------------------------------------------*
- *----------------------------------------------------------------------------*/
 void Solid::ModelEvaluatorManager::output_step_state(Core::IO::DiscretizationWriter& iowriter) const
 {
   check_init_setup();

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_manager.hpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_manager.hpp
@@ -369,9 +369,6 @@ namespace Solid
     //! calculation of energy
     void determine_energy();
 
-    //! calculation of an optional quantity
-    void determine_optional_quantity();
-
     //! Write the current step state
     void output_step_state(Core::IO::DiscretizationWriter& iowriter) const;
 

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_meshtying.hpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_meshtying.hpp
@@ -123,9 +123,6 @@ namespace Solid
       void determine_energy() override {};
 
       //! [derived]
-      void determine_optional_quantity() override {};
-
-      //! [derived]
       void output_step_state(Core::IO::DiscretizationWriter& iowriter) const override {};
 
       //! [derived]

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_multiscale.hpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_multiscale.hpp
@@ -92,8 +92,6 @@ namespace Solid
 
       void determine_energy() override {};
 
-      void determine_optional_quantity() override {};
-
       void runtime_pre_output_step_state() override;
 
       void runtime_output_step_state() const override;

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_springdashpot.hpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_springdashpot.hpp
@@ -89,8 +89,6 @@ namespace Solid
 
       void determine_energy() override {}
 
-      void determine_optional_quantity() override {}
-
       void output_step_state(Core::IO::DiscretizationWriter& iowriter) const override {}
 
       void runtime_output_step_state() const override;

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_structure.hpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_structure.hpp
@@ -142,9 +142,6 @@ namespace Solid
       void determine_strain_energy(const Core::LinAlg::Vector<double>& disnp, const bool global);
 
       //! derived
-      void determine_optional_quantity() override {}
-
-      //! derived
       void reset_step_state() override;
 
       //! derived


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

This pr removes the unused function `determine_optional_quantity()` and improves the documentation of the input parameter `RESULTSEVERY`, `STRUCT_STRESS`, `STRUCT_STRAIN`.



## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
@c-p-schmidt thanks for your help!
