### PR TITLE
Simplify contact output by removal of irrelevant method.

### DIFF
--- a/src/contact/src/4C_contact_abstract_strategy.hpp
+++ b/src/contact/src/4C_contact_abstract_strategy.hpp
@@ -869,12 +869,6 @@ namespace CONTACT
 
     //! @name Output
     //!@{
-
-    /*! \brief Write strategy specific output
-     *
-     *  \param(in) writer: output writer */
-    virtual void write_output(Core::IO::DiscretizationWriter& writer) const { return; }
-
     //! Print interfaces
     void print(std::ostream& os) const override;
 

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_contact.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_contact.cpp
@@ -563,9 +563,6 @@ void Solid::ModelEvaluator::Contact::output_step_state(
     Core::LinAlg::export_to(*lambdaout, *lambdaoutexp);
     iowriter.write_vector("poronopen_lambda", lambdaoutexp);
   }
-
-  /// general way to write the output corresponding to the active strategy
-  strategy().write_output(iowriter);
 }
 
 /*----------------------------------------------------------------------*


### PR DESCRIPTION
## Description and Context
While working on introducing the vtk-based output for the contact model evaluator, I realised that this method is irrelevant. Thus, removing it.

