### PR TITLE
Fix nodal result check of additional quantities in porofluid_pressure_based_* framework

### DIFF
--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_algorithm.hpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_algorithm.hpp
@@ -293,7 +293,10 @@ namespace PoroPressureBased
     std::shared_ptr<Core::LinAlg::Vector<double>> det_def_grad() const { return det_def_grad_; }
 
     //! return number of dof set associated with solid pressure
-    int get_dof_set_number_of_solid_pressure() const override { return nds_solidpressure_; };
+    [[nodiscard]] int get_dof_set_number_of_solid_pressure() const override
+    {
+      return nds_solidpressure_;
+    };
 
     //! return valid volume fraction species
     std::shared_ptr<const Core::LinAlg::Vector<double>> valid_vol_frac_spec_dofs() const override

--- a/tests/input_files/porofluid_pressure_based_elast_scatra_2D_quad4_nodetopoint_artery_airway_coupling_volfrac_closingrelation_lung_mono.4C.yaml
+++ b/tests/input_files/porofluid_pressure_based_elast_scatra_2D_quad4_nodetopoint_artery_airway_coupling_volfrac_closingrelation_lung_mono.4C.yaml
@@ -288,25 +288,25 @@ RESULT DESCRIPTION:
       DIS: "porofluid"
       NODE: 8
       QUANTITY: "det_def_grad"
-      VALUE: 1.02954297733447486e+00
+      VALUE: 1.02848653476776875e+00
       TOLERANCE: 1e-08
   - POROFLUIDMULTIPHASE:
       DIS: "porofluid"
       NODE: 3
       QUANTITY: "det_def_grad"
-      VALUE: 1.02733986975627234e+00
+      VALUE: 1.02580845308239832e+00
       TOLERANCE: 1e-08
   - POROFLUIDMULTIPHASE:
       DIS: "porofluid"
       NODE: 8
       QUANTITY: "volfrac_blood_lung"
-      VALUE: 9.91303541813164935e-02
+      VALUE: 9.91608910783433189e-02
       TOLERANCE: 1e-08
   - POROFLUIDMULTIPHASE:
       DIS: "porofluid"
       NODE: 3
       QUANTITY: "volfrac_blood_lung"
-      VALUE: 9.91940858042239804e-02
+      VALUE: 9.92385076677815975e-02
       TOLERANCE: 1e-08
   - SCATRA:
       DIS: "scatra"

--- a/tests/input_files/porofluid_pressure_based_elast_scatra_3D_hex8_volfrac_closingrelation_lung_mono.4C.yaml
+++ b/tests/input_files/porofluid_pressure_based_elast_scatra_3D_hex8_volfrac_closingrelation_lung_mono.4C.yaml
@@ -34,6 +34,10 @@ STRUCTURAL DYNAMIC/ONESTEPTHETA:
 porofluid_dynamic:
   initial_condition:
     type: by_condition
+  output:
+    volfrac_blood_lung: true
+    determinant_of_deformation_gradient: true
+    solid_pressure: true
 porofluid_elasticity_dynamic:
   solve_structure: true
   coupling_scheme: twoway_monolithic
@@ -263,6 +267,24 @@ RESULT DESCRIPTION:
       NODE: 11
       QUANTITY: "dispz"
       VALUE: -4.01656532514576350e-02
+      TOLERANCE: 1e-08
+  - POROFLUIDMULTIPHASE:
+      DIS: "porofluid"
+      NODE: 8
+      QUANTITY: "solid_pressure"
+      VALUE: 4.04777865720795993e-01
+      TOLERANCE: 1e-08
+  - POROFLUIDMULTIPHASE:
+      DIS: "porofluid"
+      NODE: 19
+      QUANTITY: "det_def_grad"
+      VALUE: 1.19249957115334926e+00
+      TOLERANCE: 1e-08
+  - POROFLUIDMULTIPHASE:
+      DIS: "porofluid"
+      NODE: 8
+      QUANTITY: "volfrac_blood_lung"
+      VALUE: 9.82572713935260245e-02
       TOLERANCE: 1e-08
 DESIGN SURF PORO NEUMANN CONDITIONS:
   - E: 1


### PR DESCRIPTION
This pr fixes the access to optional output quantities at nodes for the result check.

