### PR TITLE
Preserve commits and formatting of yaml in docs

### DIFF
--- a/utilities/four_c_python/build-requirements.txt
+++ b/utilities/four_c_python/build-requirements.txt
@@ -13,5 +13,6 @@ nbsphinx
 scipy
 sphinx-multibuild
 sphinx-rtd-theme
-pyyaml
+ruamel.yaml
+ruamel.yaml.string
 pyvista[jupyter]


### PR DESCRIPTION
Following @gilrrei comment in https://github.com/4C-multiphysics/4C/pull/1505#discussion_r2540934164

@gilrrei What do you think using ruaml to preserve formatting and comments for the input file?

I replaced pyyaml with our fast `load_yaml` for all other cases.