### PR TITLE
[LinAlg] Introduce LinAlg::CombineType

### DIFF
--- a/src/beamcontact/4C_beamcontact_beam3contact_octtree.cpp
+++ b/src/beamcontact/4C_beamcontact_beam3contact_octtree.cpp
@@ -1821,9 +1821,9 @@ void Beam3ContactOctTree::communicate_vector(Core::LinAlg::Vector<double>& InVec
     // zero out all vectors which are not Proc 0. Then, export Proc 0 data to InVec map.
     if (Core::Communication::my_mpi_rank(discret_.get_comm()) != 0 && zerofy)
       OutVec.put_scalar(0.0);
-    InVec.export_to(OutVec, exporter, Add);
+    InVec.export_to(OutVec, exporter, Core::LinAlg::CombineMode::add);
   }
-  if (doimport) OutVec.import(InVec, importer, Insert);
+  if (doimport) OutVec.import(InVec, importer, Core::LinAlg::CombineMode::insert);
   return;
 }
 

--- a/src/cardiovascular0d/4C_cardiovascular0d_manager.cpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_manager.cpp
@@ -290,9 +290,9 @@ Utils::Cardiovascular0DManager::Cardiovascular0DManager(
     cardvasc0d_model_->initialize(p, v_n_red, cv0ddof_n_red);
 
     v_n_->put_scalar(0.0);
-    v_n_->export_to(*v_n_red, *cardvasc0dimpo_, Add);
+    v_n_->export_to(*v_n_red, *cardvasc0dimpo_, Core::LinAlg::CombineMode::add);
 
-    cv0ddof_n_->export_to(*cv0ddof_n_red, *cardvasc0dimpo_, Insert);
+    cv0ddof_n_->export_to(*cv0ddof_n_red, *cardvasc0dimpo_, Core::LinAlg::CombineMode::insert);
 
 
     Core::LinAlg::export_to(*v_n_, *v_n_red2);
@@ -306,12 +306,14 @@ Utils::Cardiovascular0DManager::Cardiovascular0DManager(
         cardvasc0d_f_n_red, nullptr, cv0ddof_n_red, v_n_red2);
 
     // insert compartment volumes into vol vector
-    v_n_->export_to(*v_n_red2, *cardvasc0dimpo_, Insert);
+    v_n_->export_to(*v_n_red2, *cardvasc0dimpo_, Core::LinAlg::CombineMode::insert);
 
     cardvasc0d_df_n_->put_scalar(0.0);
-    cardvasc0d_df_n_->export_to(*cardvasc0d_df_n_red, *cardvasc0dimpo_, Insert);
+    cardvasc0d_df_n_->export_to(
+        *cardvasc0d_df_n_red, *cardvasc0dimpo_, Core::LinAlg::CombineMode::insert);
     cardvasc0d_f_n_->put_scalar(0.0);
-    cardvasc0d_f_n_->export_to(*cardvasc0d_f_n_red, *cardvasc0dimpo_, Insert);
+    cardvasc0d_f_n_->export_to(
+        *cardvasc0d_f_n_red, *cardvasc0dimpo_, Core::LinAlg::CombineMode::insert);
 
     // predict with initial values
     cv0ddof_np_->update(1.0, *cv0ddof_n_, 0.0);
@@ -387,7 +389,7 @@ void Utils::Cardiovascular0DManager::evaluate_force_stiff(const double time,
 
   // import into vol vector at end-point
   v_np_->put_scalar(0.0);
-  v_np_->export_to(*v_np_red, *cardvasc0dimpo_, Add);
+  v_np_->export_to(*v_np_red, *cardvasc0dimpo_, Core::LinAlg::CombineMode::add);
 
   // solution and rate of solution at generalized mid-point t_{n+theta}
   // for post-processing only - residual midpoint evaluation done separately!
@@ -405,15 +407,17 @@ void Utils::Cardiovascular0DManager::evaluate_force_stiff(const double time,
       v_np_red2);
 
   // insert compartment volumes into vol vector
-  v_np_->export_to(*v_np_red2, *cardvasc0dimpo_, Insert);
+  v_np_->export_to(*v_np_red2, *cardvasc0dimpo_, Core::LinAlg::CombineMode::insert);
 
   // volume at generalized mid-point t_{n+theta} - for post-processing only
   v_m_->update(theta_, *v_np_, 1. - theta_, *v_n_, 0.0);
 
   cardvasc0d_df_np_->put_scalar(0.0);
-  cardvasc0d_df_np_->export_to(*cardvasc0d_df_np_red, *cardvasc0dimpo_, Insert);
+  cardvasc0d_df_np_->export_to(
+      *cardvasc0d_df_np_red, *cardvasc0dimpo_, Core::LinAlg::CombineMode::insert);
   cardvasc0d_f_np_->put_scalar(0.0);
-  cardvasc0d_f_np_->export_to(*cardvasc0d_f_np_red, *cardvasc0dimpo_, Insert);
+  cardvasc0d_f_np_->export_to(
+      *cardvasc0d_f_np_red, *cardvasc0dimpo_, Core::LinAlg::CombineMode::insert);
   // df_m = (df_np - df_n) / dt
   cardvasc0d_df_m_->update(1. / ts_size, *cardvasc0d_df_np_, -1. / ts_size, *cardvasc0d_df_n_, 0.0);
   // f_m = theta * f_np + (1-theta) * f_n

--- a/src/cardiovascular0d/4C_cardiovascular0d_mor_pod.cpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_mor_pod.cpp
@@ -151,7 +151,7 @@ Cardiovascular0D::ProperOrthogonalDecomposition::reduce_residual(Core::LinAlg::V
 
   std::shared_ptr<Core::LinAlg::Vector<double>> v_red =
       std::make_shared<Core::LinAlg::Vector<double>>(*structmapr_);
-  v_red->import(v_tmp, *structrimpo_, Insert);
+  v_red->import(v_tmp, *structrimpo_, Core::LinAlg::CombineMode::insert);
 
   return v_red;
 }
@@ -163,7 +163,7 @@ Cardiovascular0D::ProperOrthogonalDecomposition::extend_solution(
     Core::LinAlg::Vector<double>& v_red)
 {
   Core::LinAlg::Vector<double> v_tmp(*redstructmapr_, true);
-  v_tmp.import(v_red, *structrinvimpo_, Insert);
+  v_tmp.import(v_red, *structrinvimpo_, Core::LinAlg::CombineMode::insert);
   std::shared_ptr<Core::LinAlg::Vector<double>> v =
       std::make_shared<Core::LinAlg::Vector<double>>(*full_model_dof_row_map_);
   v->multiply('N', 'N', 1.0, *projmatrix_, v_tmp, 0.0);

--- a/src/constraint/4C_constraint_manager.cpp
+++ b/src/constraint/4C_constraint_manager.cpp
@@ -149,7 +149,7 @@ void Constraints::ConstrManager::setup(
     mpcnormcomp3dpen_->initialize(p);
 
     // Export redundant vector into distributed one
-    refbasevalues_->export_to(*refbaseredundant, *conimpo_, Add);
+    refbasevalues_->export_to(*refbaseredundant, *conimpo_, Core::LinAlg::CombineMode::add);
 
     // Initialize Lagrange Multipliers, reference values and errors
     actdisc_->clear_state();
@@ -201,7 +201,7 @@ void Constraints::ConstrManager::setup(
     areamonitor2d_->evaluate(p1, initialmonredundant);
 
     // Export redundant vector into distributed one
-    initialmonvalues_->export_to(initialmonredundant, *monimpo_, Add);
+    initialmonvalues_->export_to(initialmonredundant, *monimpo_, Core::LinAlg::CombineMode::add);
     monitortypes_ = std::make_shared<Core::LinAlg::Vector<double>>(*redmonmap_);
     build_moni_type();
   }
@@ -274,12 +274,12 @@ void Constraints::ConstrManager::evaluate_force_stiff(const double time,
   mpconline2d_->evaluate(p, stiff, constr_matrix_, fint, refbaseredundant, actredundant);
   // Export redundant vectors into distributed ones
   actvalues_->put_scalar(0.0);
-  actvalues_->export_to(*actredundant, *conimpo_, Add);
+  actvalues_->export_to(*actredundant, *conimpo_, Core::LinAlg::CombineMode::add);
   Core::LinAlg::Vector<double> addrefbase(*constrmap_);
-  addrefbase.export_to(*refbaseredundant, *conimpo_, Add);
+  addrefbase.export_to(*refbaseredundant, *conimpo_, Core::LinAlg::CombineMode::add);
   refbasevalues_->update(1.0, addrefbase, 1.0);
   fact_->put_scalar(0.0);
-  fact_->export_to(*factredundant, *conimpo_, AbsMax);
+  fact_->export_to(*factredundant, *conimpo_, Core::LinAlg::CombineMode::abs_max);
   // ----------------------------------------------------
   // -----------include possible further constraints here
   // ----------------------------------------------------
@@ -326,7 +326,7 @@ void Constraints::ConstrManager::compute_error(
 
   // Export redundant vectors into distributed ones
   actvalues_->put_scalar(0.0);
-  actvalues_->export_to(*actredundant, *conimpo_, Add);
+  actvalues_->export_to(*actredundant, *conimpo_, Core::LinAlg::CombineMode::add);
 
   constrainterr_->update(1.0, *referencevalues_, -1.0, *actvalues_, 0.0);
 }
@@ -415,7 +415,7 @@ void Constraints::ConstrManager::compute_monitor_values(
   areamonitor2d_->evaluate(p, actmonredundant);
 
   Core::LinAlg::Import monimpo(*monitormap_, *redmonmap_);
-  monitorvalues_->export_to(actmonredundant, *monimpo_, Add);
+  monitorvalues_->export_to(actmonredundant, *monimpo_, Core::LinAlg::CombineMode::add);
 }
 
 /*-----------------------------------------------------------------------*
@@ -447,7 +447,7 @@ void Constraints::ConstrManager::compute_monitor_values(const Core::LinAlg::Vect
   areamonitor2d_->evaluate(p, actmonredundant);
 
   Core::LinAlg::Import monimpo(*monitormap_, *redmonmap_);
-  monitorvalues_->export_to(actmonredundant, *monimpo_, Add);
+  monitorvalues_->export_to(actmonredundant, *monimpo_, Core::LinAlg::CombineMode::add);
 }
 
 /*----------------------------------------------------------------------*
@@ -489,7 +489,7 @@ void Constraints::ConstrManager::build_moni_type()
   // do the volumes
   volmonitor3d_->evaluate(p1, dummymonredundant);
   // Export redundant vector into distributed one
-  dummymondist.export_to(dummymonredundant, *monimpo_, Add);
+  dummymondist.export_to(dummymonredundant, *monimpo_, Core::LinAlg::CombineMode::add);
   // Now export back
   Core::LinAlg::export_to(dummymondist, dummymonredundant);
   for (int i = 0; i < dummymonredundant.local_length(); i++)
@@ -503,7 +503,7 @@ void Constraints::ConstrManager::build_moni_type()
   dummymondist.put_scalar(0.0);
   areamonitor3d_->evaluate(p1, dummymonredundant);
   // Export redundant vector into distributed one
-  dummymondist.export_to(dummymonredundant, *monimpo_, Add);
+  dummymondist.export_to(dummymonredundant, *monimpo_, Core::LinAlg::CombineMode::add);
   // Now export back
   Core::LinAlg::export_to(dummymondist, dummymonredundant);
   for (int i = 0; i < dummymonredundant.local_length(); i++)
@@ -517,7 +517,7 @@ void Constraints::ConstrManager::build_moni_type()
   dummymondist.put_scalar(0.0);
   areamonitor2d_->evaluate(p1, dummymonredundant);
   // Export redundant vector into distributed one
-  dummymondist.export_to(dummymonredundant, *monimpo_, Add);
+  dummymondist.export_to(dummymonredundant, *monimpo_, Core::LinAlg::CombineMode::add);
   // Now export back
   Core::LinAlg::export_to(dummymondist, dummymonredundant);
   for (int i = 0; i < dummymonredundant.local_length(); i++)

--- a/src/constraint/4C_constraint_multipointconstraint3penalty.cpp
+++ b/src/constraint/4C_constraint_multipointconstraint3penalty.cpp
@@ -498,8 +498,8 @@ void Constraints::MPConstraint3Penalty::evaluate_error(Core::FE::Discretization&
   }
 
   Core::LinAlg::Vector<double> acterrdist(*errormap_);
-  acterrdist.export_to(systemvector, *errorexport_, Add);
-  systemvector.import(acterrdist, *errorimport_, Insert);
+  acterrdist.export_to(systemvector, *errorexport_, Core::LinAlg::CombineMode::add);
+  systemvector.import(acterrdist, *errorimport_, Core::LinAlg::CombineMode::insert);
   return;
 }  // end of evaluate_error
 

--- a/src/constraint/4C_constraint_penalty.cpp
+++ b/src/constraint/4C_constraint_penalty.cpp
@@ -362,8 +362,8 @@ void Constraints::ConstraintPenalty::evaluate_error(
     }
   }
   Core::LinAlg::Vector<double> acterrdist(*errormap_);
-  acterrdist.export_to(systemvector, *errorexport_, Add);
-  systemvector.import(acterrdist, *errorimport_, Insert);
+  acterrdist.export_to(systemvector, *errorexport_, Core::LinAlg::CombineMode::add);
+  systemvector.import(acterrdist, *errorimport_, Core::LinAlg::CombineMode::insert);
 }  // end of evaluate_error
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/contact/src/4C_contact_interface.cpp
+++ b/src/contact/src/4C_contact_interface.cpp
@@ -1016,7 +1016,7 @@ void CONTACT::Interface::redistribute()
   std::shared_ptr<Core::LinAlg::Graph> outgraph =
       std::make_shared<Core::LinAlg::Graph>(*srownodes, 108);
   Core::LinAlg::Export exporter(graph->row_map(), *srownodes);
-  outgraph->export_to(*graph, exporter, Add);
+  outgraph->export_to(*graph, exporter, Core::LinAlg::CombineMode::add);
 
   // trash old graph
   graph = nullptr;

--- a/src/contact/src/4C_contact_wear_interface.cpp
+++ b/src/contact/src/4C_contact_wear_interface.cpp
@@ -3597,7 +3597,7 @@ void Wear::WearInterface::assemble_inactive_wear_rhs_master(
   }
 
   Core::LinAlg::Export exp(*allredi, *inactivedofs);
-  inactiverhs.export_to(*rhs, exp, Add);
+  inactiverhs.export_to(*rhs, exp, Core::LinAlg::CombineMode::add);
 
 
   return;
@@ -3797,7 +3797,7 @@ void Wear::WearInterface::assemble_wear_cond_rhs_master(Core::LinAlg::FEVector<d
   }
 
   Core::LinAlg::Export exp(*slmastern, *slipmn_);
-  RHS.export_to(*rhs, exp, Add);
+  RHS.export_to(*rhs, exp, Core::LinAlg::CombineMode::add);
 
   return;
 }

--- a/src/core/binstrategy/4C_binstrategy.cpp
+++ b/src/core/binstrategy/4C_binstrategy.cpp
@@ -1433,7 +1433,7 @@ void Core::Binstrategy::BinningStrategy::standard_discretization_ghosting(
 
   newnodegraph = std::make_shared<Core::LinAlg::Graph>(*newnoderowmap, 108);
   Core::LinAlg::Export exporter(initgraph->row_map(), *newnoderowmap);
-  newnodegraph->export_to(*initgraph, exporter, Add);
+  newnodegraph->export_to(*initgraph, exporter, Core::LinAlg::CombineMode::add);
   newnodegraph->fill_complete();
   newnodegraph->optimize_storage();
 

--- a/src/core/fem/src/condition/4C_fem_condition_periodic.cpp
+++ b/src/core/fem/src/condition/4C_fem_condition_periodic.cpp
@@ -1009,7 +1009,7 @@ void Core::Conditions::PeriodicBoundaryConditions::redistribute_and_create_dof_c
 
     {
       Core::LinAlg::Export exporter(*discret_->node_row_map(), *newrownodemap);
-      nodegraph.export_to(*oldnodegraph, exporter, Add);
+      nodegraph.export_to(*oldnodegraph, exporter, Core::LinAlg::CombineMode::add);
     }
     nodegraph.fill_complete();
     nodegraph.optimize_storage();

--- a/src/core/fem/src/condition/4C_fem_condition_point_coupling_redistribution.cpp
+++ b/src/core/fem/src/condition/4C_fem_condition_point_coupling_redistribution.cpp
@@ -226,7 +226,7 @@ void redistribute(const std::vector<int>& rank_to_hold_condition,
   // export nodal graph to new row node layout
   {
     const Core::LinAlg::Export exporter(*discret.node_row_map(), new_row_node_map);
-    node_graph.export_to(*old_node_graph, exporter, Add);
+    node_graph.export_to(*old_node_graph, exporter, Core::LinAlg::CombineMode::add);
   }
   node_graph.fill_complete();
   node_graph.optimize_storage();

--- a/src/core/fem/src/discretization/4C_fem_discretization.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization.cpp
@@ -656,7 +656,7 @@ void Core::FE::Discretization::set_state(
     }
 
     // transfer data
-    tmp->import(state, (*stateimporter_[nds]), Insert);
+    tmp->import(state, (*stateimporter_[nds]), Core::LinAlg::CombineMode::insert);
 
     // save state
     state_[nds][name] = tmp;

--- a/src/core/fem/src/dofset/4C_fem_dofset.cpp
+++ b/src/core/fem/src/dofset/4C_fem_dofset.cpp
@@ -366,8 +366,8 @@ int Core::DOFSets::DofSet::assign_degrees_of_freedom(
 
     // fill ghost node entries
     Core::LinAlg::Import nodeimporter(numdfcolnodes_->get_map(), num_dof_rownodes.get_map());
-    numdfcolnodes_->import(num_dof_rownodes, nodeimporter, Insert);
-    idxcolnodes_->import(idxrownodes, nodeimporter, Insert);
+    numdfcolnodes_->import(num_dof_rownodes, nodeimporter, Core::LinAlg::CombineMode::insert);
+    idxcolnodes_->import(idxrownodes, nodeimporter, Core::LinAlg::CombineMode::insert);
 
     count = maxnodenumdf > 0 ? idxrownodes.max_value() + maxnodenumdf : 0;
 
@@ -424,8 +424,8 @@ int Core::DOFSets::DofSet::assign_degrees_of_freedom(
       }
 
       Core::LinAlg::Import faceimporter(numdfcolfaces_->get_map(), numdfrowfaces.get_map());
-      numdfcolfaces_->import(numdfrowfaces, faceimporter, Insert);
-      idxcolfaces_->import(idxrowfaces, faceimporter, Insert);
+      numdfcolfaces_->import(numdfrowfaces, faceimporter, Core::LinAlg::CombineMode::insert);
+      idxcolfaces_->import(idxrowfaces, faceimporter, Core::LinAlg::CombineMode::insert);
 
       count = idxrowfaces.max_value() + maxfacenumdf;
     }
@@ -464,8 +464,8 @@ int Core::DOFSets::DofSet::assign_degrees_of_freedom(
     }
 
     Core::LinAlg::Import elementimporter(numdfcolelements_->get_map(), numdfrowelements.get_map());
-    numdfcolelements_->import(numdfrowelements, elementimporter, Insert);
-    idxcolelements_->import(idxrowelements, elementimporter, Insert);
+    numdfcolelements_->import(numdfrowelements, elementimporter, Core::LinAlg::CombineMode::insert);
+    idxcolelements_->import(idxrowelements, elementimporter, Core::LinAlg::CombineMode::insert);
   }
 
   // Now finally we have everything in place to build the maps.

--- a/src/core/fem/src/general/utils/4C_fem_general_utils_superconvergent_patch_recovery.cpp
+++ b/src/core/fem/src/general/utils/4C_fem_general_utils_superconvergent_patch_recovery.cpp
@@ -518,7 +518,7 @@ std::shared_ptr<Core::LinAlg::MultiVector<double>> Core::FE::compute_superconver
   }  // end loop over all nodes
 
   // call global assemble
-  nodevec.complete(Insert, false);
+  nodevec.complete(Core::LinAlg::CombineMode::insert, false);
 
   // if no pbc are involved leave here
   if (noderowmap.point_same_as(*fullnoderowmap))

--- a/src/core/linalg/src/sparse/4C_linalg.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg.hpp
@@ -10,6 +10,10 @@
 
 #include "4C_config.hpp"
 
+#include <Epetra_CombineMode.h>
+
+#include <unordered_map>
+
 FOUR_C_NAMESPACE_OPEN
 
 namespace Core::LinAlg
@@ -32,6 +36,47 @@ namespace Core::LinAlg
     Copy,  ///< deep copy
     Share  ///< Shared ownership to original data
   };
+
+  /**
+   * \brief Specifies the strategy used when combining distributed data.
+   *
+   * The CombineMode enum defines how values are combined when assembling or updating
+   * distributed linear algebra objects (such as vectors or matrices) in parallel computations.
+   * It determines how overlapping entries from different processes are merged.
+   */
+  enum class CombineMode
+  {
+    zero,
+    insert,
+    add,
+    max,
+    abs_max
+  };
+
+  /**
+   * \brief Mapping between internal CombineMode values and corresponding Epetra_CombineMode
+   * constants.
+   *
+   * This lookup table allows translation between the internal linear algebra abstraction
+   * and the Epetra library's specific combine mode definitions.
+   */
+  const std::unordered_map<CombineMode, Epetra_CombineMode> linalg_to_epetra_combine_mode = {
+      {CombineMode::zero, Epetra_CombineMode::Zero},
+      {CombineMode::insert, Epetra_CombineMode::Insert},
+      {CombineMode::add, Epetra_CombineMode::Add},
+      {CombineMode::max, Epetra_CombineMode::Epetra_Max},
+      {CombineMode::abs_max, Epetra_CombineMode::AbsMax}};
+
+  /**
+   * \brief Converts a CombineMode enum value to its Epetra_CombineMode equivalent.
+   *
+   * @param combine_mode The CombineMode value to be converted.
+   * @return The corresponding Epetra_CombineMode constant.
+   */
+  inline Epetra_CombineMode to_epetra_combine_mode(CombineMode combine_mode)
+  {
+    return linalg_to_epetra_combine_mode.at(combine_mode);
+  }
 }  // namespace Core::LinAlg
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/linalg/src/sparse/4C_linalg_equilibrate.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_equilibrate.cpp
@@ -360,7 +360,7 @@ void Core::LinAlg::EquilibrationBlock::equilibrate_matrix(
           }
           // combine this block's overlap into the owning DomainMap vector invcolsums
           Core::LinAlg::Import to_dom(invcolsums->get_map(), overlap.get_map());
-          invcolsums->import(overlap, to_dom, Add);
+          invcolsums->import(overlap, to_dom, LinAlg::CombineMode::add);
         }
 
         // invert column sums

--- a/src/core/linalg/src/sparse/4C_linalg_fevector.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_fevector.hpp
@@ -11,6 +11,7 @@
 
 #include "4C_config.hpp"
 
+#include "4C_linalg.hpp"
 #include "4C_linalg_map.hpp"
 #include "4C_linalg_multi_vector.hpp"
 #include "4C_linalg_transfer.hpp"
@@ -210,36 +211,46 @@ namespace Core::LinAlg
 
     //! Imports an Epetra_DistObject using the Core::LinAlg::Import object.
     void import(const Epetra_SrcDistObject& A, const Core::LinAlg::Import& Importer,
-        Epetra_CombineMode CombineMode);
+        Core::LinAlg::CombineMode CombineMode)
+    {
+      ASSERT_EPETRA_CALL(vector_->Import(
+          A, Importer.get_epetra_import(), Core::LinAlg::to_epetra_combine_mode(CombineMode)));
+    }
 
     //! Imports an Epetra_DistObject using the Epetra_Export object.
     void import(const Epetra_SrcDistObject& A, const Epetra_Export& Exporter,
-        Epetra_CombineMode CombineMode)
+        Core::LinAlg::CombineMode CombineMode)
     {
-      ASSERT_EPETRA_CALL(vector_->Import(A, Exporter, CombineMode));
+      ASSERT_EPETRA_CALL(
+          vector_->Import(A, Exporter, Core::LinAlg::to_epetra_combine_mode(CombineMode)));
     }
 
     void export_to(const Epetra_SrcDistObject& A, const Core::LinAlg::Import& Importer,
-        Epetra_CombineMode CombineMode)
+        Core::LinAlg::CombineMode CombineMode)
     {
-      ASSERT_EPETRA_CALL(vector_->Export(A, Importer.get_epetra_import(), CombineMode));
+      ASSERT_EPETRA_CALL(vector_->Export(
+          A, Importer.get_epetra_import(), Core::LinAlg::to_epetra_combine_mode(CombineMode)));
     }
 
     void export_to(const Epetra_SrcDistObject& A, const Core::LinAlg::Export& Exporter,
-        Epetra_CombineMode CombineMode)
+        Core::LinAlg::CombineMode CombineMode)
     {
-      ASSERT_EPETRA_CALL(vector_->Export(A, Exporter.get_epetra_export(), CombineMode));
+      ASSERT_EPETRA_CALL(vector_->Export(
+          A, Exporter.get_epetra_export(), Core::LinAlg::to_epetra_combine_mode(CombineMode)));
     }
 
     void export_to(const Epetra_SrcDistObject& A, const Epetra_Export& Exporter,
-        Epetra_CombineMode CombineMode)
+        Core::LinAlg::CombineMode CombineMode)
     {
-      ASSERT_EPETRA_CALL(vector_->Export(A, Exporter, CombineMode));
+      ASSERT_EPETRA_CALL(
+          vector_->Export(A, Exporter, Core::LinAlg::to_epetra_combine_mode(CombineMode)));
     }
 
-    void complete(Epetra_CombineMode mode = Add, bool reuse_map_and_exporter = false)
+    void complete(Core::LinAlg::CombineMode mode = Core::LinAlg::CombineMode::add,
+        bool reuse_map_and_exporter = false)
     {
-      ASSERT_EPETRA_CALL(vector_->GlobalAssemble(mode, reuse_map_and_exporter));
+      ASSERT_EPETRA_CALL(vector_->GlobalAssemble(
+          Core::LinAlg::to_epetra_combine_mode(mode), reuse_map_and_exporter));
     }
 
     void sum_into_global_value(int GlobalRow, int FEVectorIndex, double ScalarValue)

--- a/src/core/linalg/src/sparse/4C_linalg_graph.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_graph.cpp
@@ -99,17 +99,17 @@ void Core::LinAlg::Graph::fill_complete(const Map& domain_map, const Map& range_
 void Core::LinAlg::Graph::optimize_storage() { ASSERT_EPETRA_CALL(graph_->OptimizeStorage()); }
 
 void Core::LinAlg::Graph::export_to(const Core::LinAlg::Graph& A,
-    const Core::LinAlg::Export& Exporter, Epetra_CombineMode CombineMode)
+    const Core::LinAlg::Export& Exporter, Core::LinAlg::CombineMode CombineMode)
 {
-  ASSERT_EPETRA_CALL(
-      graph_->Export(A.get_epetra_crs_graph(), Exporter.get_epetra_export(), CombineMode));
+  ASSERT_EPETRA_CALL(graph_->Export(A.get_epetra_crs_graph(), Exporter.get_epetra_export(),
+      Core::LinAlg::to_epetra_combine_mode(CombineMode)));
 }
 
 void Core::LinAlg::Graph::import_from(const Core::LinAlg::Graph& A,
-    const Core::LinAlg::Import& Importer, Epetra_CombineMode CombineMode)
+    const Core::LinAlg::Import& Importer, Core::LinAlg::CombineMode CombineMode)
 {
-  ASSERT_EPETRA_CALL(
-      graph_->Import(A.get_epetra_crs_graph(), Importer.get_epetra_import(), CombineMode));
+  ASSERT_EPETRA_CALL(graph_->Import(A.get_epetra_crs_graph(), Importer.get_epetra_import(),
+      Core::LinAlg::to_epetra_combine_mode(CombineMode)));
 }
 
 void Core::LinAlg::Graph::insert_global_indices(int GlobalRow, std::span<int>& Indices)

--- a/src/core/linalg/src/sparse/4C_linalg_graph.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_graph.hpp
@@ -12,6 +12,7 @@
 #include "4C_config.hpp"
 
 #include "4C_comm_mpi_utils.hpp"
+#include "4C_linalg.hpp"
 #include "4C_linalg_map.hpp"
 #include "4C_linalg_transfer.hpp"
 
@@ -73,11 +74,11 @@ namespace Core::LinAlg
     void optimize_storage();
 
     void export_to(const Core::LinAlg::Graph& A, const Core::LinAlg::Export& Exporter,
-        Epetra_CombineMode CombineMode);
+        Core::LinAlg::CombineMode CombineMode);
 
     //! Imports a Core::LinAlg::Graph using the Core::LinAlg::Import object.
     void import_from(const Core::LinAlg::Graph& A, const Core::LinAlg::Import& Importer,
-        Epetra_CombineMode CombineMode);
+        Core::LinAlg::CombineMode CombineMode);
 
     //! Enter a list of elements in a specified globally owned row of the graph.
     void insert_global_indices(int GlobalRow, std::span<int>& Indices);

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_manipulation.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_manipulation.cpp
@@ -127,19 +127,19 @@ void Core::LinAlg::export_to(
     else if (sourceunique && targetunique)
     {
       Core::LinAlg::Export exporter(source.get_map(), target.get_map());
-      target.export_to(source, exporter, Insert);
+      target.export_to(source, exporter, Core::LinAlg::CombineMode::insert);
       return;
     }
     else if (sourceunique && !targetunique)
     {
       Core::LinAlg::Import importer(target.get_map(), source.get_map());
-      target.import(source, importer, Insert);
+      target.import(source, importer, Core::LinAlg::CombineMode::insert);
       return;
     }
     else if (!sourceunique && targetunique)
     {
       Core::LinAlg::Export exporter(source.get_map(), target.get_map());
-      target.export_to(source, exporter, Insert);
+      target.export_to(source, exporter, Core::LinAlg::CombineMode::insert);
       return;
     }
     else if (!sourceunique && !targetunique)
@@ -256,7 +256,7 @@ std::shared_ptr<Core::LinAlg::Graph> Core::LinAlg::threshold_matrix_graph(
   Core::LinAlg::Vector<double> ghosted_diagonal(A.col_map(), true);
   const Core::LinAlg::Import importer = Core::LinAlg::Import(A.col_map(), A.row_map());
   ghosted_diagonal.import(
-      diagonal.get_ref_of_epetra_vector(), importer, Epetra_CombineMode::Insert);
+      diagonal.get_ref_of_epetra_vector(), importer, Core::LinAlg::CombineMode::insert);
 
   double* D = ghosted_diagonal.get_values();
 

--- a/src/core/linalg/src/sparse/4C_linalg_vector.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_vector.cpp
@@ -297,30 +297,34 @@ void Core::LinAlg::Vector<T>::reciprocal_multiply(
 
 template <typename T>
 void Core::LinAlg::Vector<T>::import(const Epetra_SrcDistObject& A,
-    const Core::LinAlg::Import& Importer, Epetra_CombineMode CombineMode)
+    const Core::LinAlg::Import& Importer, Core::LinAlg::CombineMode CombineMode)
 {
-  ASSERT_EPETRA_CALL(vector_->Import(A, Importer.get_epetra_import(), CombineMode));
+  ASSERT_EPETRA_CALL(vector_->Import(
+      A, Importer.get_epetra_import(), Core::LinAlg::to_epetra_combine_mode(CombineMode)));
 }
 
 template <typename T>
 void Core::LinAlg::Vector<T>::import(const Epetra_SrcDistObject& A,
-    const Core::LinAlg::Export& Exporter, Epetra_CombineMode CombineMode)
+    const Core::LinAlg::Export& Exporter, Core::LinAlg::CombineMode CombineMode)
 {
-  ASSERT_EPETRA_CALL(vector_->Import(A, Exporter.get_epetra_export(), CombineMode));
+  ASSERT_EPETRA_CALL(vector_->Import(
+      A, Exporter.get_epetra_export(), Core::LinAlg::to_epetra_combine_mode(CombineMode)));
 }
 
 template <typename T>
 void Core::LinAlg::Vector<T>::export_to(const Epetra_SrcDistObject& A,
-    const Core::LinAlg::Import& Importer, Epetra_CombineMode CombineMode)
+    const Core::LinAlg::Import& Importer, Core::LinAlg::CombineMode CombineMode)
 {
-  ASSERT_EPETRA_CALL(vector_->Export(A, Importer.get_epetra_import(), CombineMode));
+  ASSERT_EPETRA_CALL(vector_->Export(
+      A, Importer.get_epetra_import(), Core::LinAlg::to_epetra_combine_mode(CombineMode)));
 }
 
 template <typename T>
 void Core::LinAlg::Vector<T>::export_to(const Epetra_SrcDistObject& A,
-    const Core::LinAlg::Export& Exporter, Epetra_CombineMode CombineMode)
+    const Core::LinAlg::Export& Exporter, Core::LinAlg::CombineMode CombineMode)
 {
-  ASSERT_EPETRA_CALL(vector_->Export(A, Exporter.get_epetra_export(), CombineMode));
+  ASSERT_EPETRA_CALL(vector_->Export(
+      A, Exporter.get_epetra_export(), Core::LinAlg::to_epetra_combine_mode(CombineMode)));
 }
 
 template <typename T>
@@ -403,27 +407,31 @@ int Core::LinAlg::Vector<int>::min_value() { return vector_->MinValue(); }
 void Core::LinAlg::Vector<int>::print(std::ostream& os) const { vector_->Print(os); }
 
 void Core::LinAlg::Vector<int>::import(
-    const Vector& A, const Core::LinAlg::Import& Importer, Epetra_CombineMode CombineMode)
+    const Vector& A, const Core::LinAlg::Import& Importer, Core::LinAlg::CombineMode CombineMode)
 {
-  ASSERT_EPETRA_CALL(vector_->Import(*A.vector_, Importer.get_epetra_import(), CombineMode));
+  ASSERT_EPETRA_CALL(vector_->Import(
+      *A.vector_, Importer.get_epetra_import(), Core::LinAlg::to_epetra_combine_mode(CombineMode)));
 }
 
 void Core::LinAlg::Vector<int>::import(
-    const Vector& A, const Core::LinAlg::Export& Exporter, Epetra_CombineMode CombineMode)
+    const Vector& A, const Core::LinAlg::Export& Exporter, Core::LinAlg::CombineMode CombineMode)
 {
-  ASSERT_EPETRA_CALL(vector_->Import(*A.vector_, Exporter.get_epetra_export(), CombineMode));
+  ASSERT_EPETRA_CALL(vector_->Import(
+      *A.vector_, Exporter.get_epetra_export(), Core::LinAlg::to_epetra_combine_mode(CombineMode)));
 }
 
 void Core::LinAlg::Vector<int>::export_to(
-    const Vector& A, const Core::LinAlg::Import& Importer, Epetra_CombineMode CombineMode)
+    const Vector& A, const Core::LinAlg::Import& Importer, Core::LinAlg::CombineMode CombineMode)
 {
-  ASSERT_EPETRA_CALL(vector_->Export(*A.vector_, Importer.get_epetra_import(), CombineMode));
+  ASSERT_EPETRA_CALL(vector_->Export(
+      *A.vector_, Importer.get_epetra_import(), Core::LinAlg::to_epetra_combine_mode(CombineMode)));
 }
 
 void Core::LinAlg::Vector<int>::export_to(
-    const Vector& A, const Core::LinAlg::Export& Exporter, Epetra_CombineMode CombineMode)
+    const Vector& A, const Core::LinAlg::Export& Exporter, Core::LinAlg::CombineMode CombineMode)
 {
-  ASSERT_EPETRA_CALL(vector_->Export(*A.vector_, Exporter.get_epetra_export(), CombineMode));
+  ASSERT_EPETRA_CALL(vector_->Export(
+      *A.vector_, Exporter.get_epetra_export(), Core::LinAlg::to_epetra_combine_mode(CombineMode)));
 }
 
 MPI_Comm Core::LinAlg::Vector<int>::get_comm() const

--- a/src/core/linalg/src/sparse/4C_linalg_vector.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_vector.hpp
@@ -10,6 +10,7 @@
 
 #include "4C_config.hpp"
 
+#include "4C_linalg.hpp"
 #include "4C_linalg_map.hpp"
 #include "4C_linalg_multi_vector.hpp"
 #include "4C_linalg_transfer.hpp"
@@ -206,19 +207,19 @@ namespace Core::LinAlg
 
     //! Imports an Epetra_DistObject using the Core::LinAlg::Import object.
     void import(const Epetra_SrcDistObject& A, const Core::LinAlg::Import& Importer,
-        Epetra_CombineMode CombineMode);
+        Core::LinAlg::CombineMode CombineMode);
 
     //! Imports an Epetra_DistObject using the Core::LinAlg::Export object.
     void import(const Epetra_SrcDistObject& A, const Core::LinAlg::Export& Exporter,
-        Epetra_CombineMode CombineMode);
+        Core::LinAlg::CombineMode CombineMode);
 
     //! Exports an Epetra_DistObject using the Epetra_Import object.
     void export_to(const Epetra_SrcDistObject& A, const Core::LinAlg::Import& Importer,
-        Epetra_CombineMode CombineMode);
+        Core::LinAlg::CombineMode CombineMode);
 
     //! Exports an Epetra_DistObject using the Epetra_Import object.
     void export_to(const Epetra_SrcDistObject& A, const Core::LinAlg::Export& Exporter,
-        Epetra_CombineMode CombineMode);
+        Core::LinAlg::CombineMode CombineMode);
 
     /**
      * View a given Epetra_Vector object under our own Vector wrapper.
@@ -291,20 +292,20 @@ namespace Core::LinAlg
 
 
     //! Imports an Epetra_DistObject using the Core::LinAlg::Import object.
-    void import(
-        const Vector& A, const Core::LinAlg::Import& Importer, Epetra_CombineMode CombineMode);
+    void import(const Vector& A, const Core::LinAlg::Import& Importer,
+        Core::LinAlg::CombineMode CombineMode);
 
     //! Imports an Epetra_DistObject using the Core::LinAlg::Export object.
-    void import(
-        const Vector& A, const Core::LinAlg::Export& Exporter, Epetra_CombineMode CombineMode);
+    void import(const Vector& A, const Core::LinAlg::Export& Exporter,
+        Core::LinAlg::CombineMode CombineMode);
 
     //! Exports an Epetra_DistObject using the Epetra_Import object.
-    void export_to(
-        const Vector& A, const Core::LinAlg::Import& Importer, Epetra_CombineMode CombineMode);
+    void export_to(const Vector& A, const Core::LinAlg::Import& Importer,
+        Core::LinAlg::CombineMode CombineMode);
 
     //! Exports an Epetra_DistObject using the Epetra_Import object.
-    void export_to(
-        const Vector& A, const Core::LinAlg::Export& Exporter, Epetra_CombineMode CombineMode);
+    void export_to(const Vector& A, const Core::LinAlg::Export& Exporter,
+        Core::LinAlg::CombineMode CombineMode);
 
     [[nodiscard]] MPI_Comm get_comm() const;
 

--- a/src/core/rebalance/src/4C_rebalance_graph_based.cpp
+++ b/src/core/rebalance/src/4C_rebalance_graph_based.cpp
@@ -389,7 +389,8 @@ std::shared_ptr<const Core::LinAlg::Graph> Core::Rebalance::build_monolithic_nod
   Core::LinAlg::Import importer(my_colliding_primitives_map, *dis.element_row_map());
   Core::LinAlg::Graph my_colliding_primitives_connectivity(
       my_colliding_primitives_map, n_nodes_per_element_max);
-  my_colliding_primitives_connectivity.import_from(element_connectivity, importer, Insert);
+  my_colliding_primitives_connectivity.import_from(
+      element_connectivity, importer, Core::LinAlg::CombineMode::insert);
 
   // 4. Build and fill the graph with element internal connectivities
   auto my_graph = std::make_shared<Core::LinAlg::Graph>(

--- a/src/coupling/src/adapter/4C_coupling_adapter.cpp
+++ b/src/coupling/src/adapter/4C_coupling_adapter.cpp
@@ -367,7 +367,7 @@ void Coupling::Adapter::Coupling::finish_coupling(const Core::FE::Discretization
       std::make_shared<Core::LinAlg::Vector<int>>(*slavenodemap);
 
   Core::LinAlg::Export masternodeexport(*permslavenodemap, *slavenodemap);
-  permmasternodevec->export_to(*masternodevec, masternodeexport, Insert);
+  permmasternodevec->export_to(*masternodevec, masternodeexport, Core::LinAlg::CombineMode::insert);
 
   std::shared_ptr<const Core::LinAlg::Map> permmasternodemap =
       std::make_shared<Core::LinAlg::Map>(-1, permmasternodevec->local_length(),
@@ -641,7 +641,7 @@ void Coupling::Adapter::Coupling::master_to_slave(
   Core::LinAlg::Vector<int> perm(*permslavedofmap_);
   std::ranges::copy(mv.get_local_values(), perm.get_local_values().begin());
 
-  sv.export_to(perm, *slaveexport_, Insert);
+  sv.export_to(perm, *slaveexport_, Core::LinAlg::CombineMode::insert);
 }
 
 
@@ -681,7 +681,7 @@ void Coupling::Adapter::Coupling::slave_to_master(
   Core::LinAlg::Vector<int> perm(*permmasterdofmap_);
   std::ranges::copy(sv.get_local_values(), perm.get_local_values().begin());
 
-  mv.export_to(perm, *masterexport_, Insert);
+  mv.export_to(perm, *masterexport_, Core::LinAlg::CombineMode::insert);
 }
 
 

--- a/src/coupling/src/adapter/4C_coupling_adapter_mortar.cpp
+++ b/src/coupling/src/adapter/4C_coupling_adapter_mortar.cpp
@@ -1078,8 +1078,8 @@ void Coupling::Adapter::CouplingMortar::evaluate(
   // Import master and slave displacements into a single vector
   std::shared_ptr<Core::LinAlg::Vector<double>> idisp_master_slave =
       std::make_shared<Core::LinAlg::Vector<double>>(*dofrowmap, true);
-  idisp_master_slave->import(*idispma, master_importer, Add);
-  idisp_master_slave->import(*idispsl, slaveImporter, Add);
+  idisp_master_slave->import(*idispma, master_importer, Core::LinAlg::CombineMode::add);
+  idisp_master_slave->import(*idispsl, slaveImporter, Core::LinAlg::CombineMode::add);
 
   // set new displacement state in mortar interface
   interface_->set_state(Mortar::state_new_displacement, *idisp_master_slave);

--- a/src/deal_ii/src/4C_deal_ii_vector_conversion.cpp
+++ b/src/deal_ii/src/4C_deal_ii_vector_conversion.cpp
@@ -130,7 +130,8 @@ void DealiiWrappers::VectorConverter<VectorType, dim, spacedim>::to_dealii(
   FOUR_C_ASSERT(n_local_elements == dealii_to_four_c_map_.num_my_elements(), "Internal error.");
 
 
-  vector_in_dealii_layout_.export_to(four_c_vector, dealii_to_four_c_importer_, Insert);
+  vector_in_dealii_layout_.export_to(
+      four_c_vector, dealii_to_four_c_importer_, Core::LinAlg::CombineMode::insert);
 
   std::copy(vector_in_dealii_layout_.get_values(),
       vector_in_dealii_layout_.get_values() + n_local_elements, dealii_vector.begin());
@@ -152,7 +153,8 @@ void DealiiWrappers::VectorConverter<VectorType, dim, spacedim>::to_four_c(
   vector_in_dealii_layout_.replace_local_values(
       n_local_elements, dealii_vector.begin(), indices.data());
 
-  four_c_vector.import(vector_in_dealii_layout_, dealii_to_four_c_importer_, Insert);
+  four_c_vector.import(
+      vector_in_dealii_layout_, dealii_to_four_c_importer_, Core::LinAlg::CombineMode::insert);
 }
 
 

--- a/src/ehl/4C_ehl_base.cpp
+++ b/src/ehl/4C_ehl_base.cpp
@@ -528,7 +528,7 @@ void EHL::Base::setup_unprojectable_dbc()
     }
   }
 
-  inf_gap_toggle.complete(Epetra_Max, false);
+  inf_gap_toggle.complete(Core::LinAlg::CombineMode::max, false);
 
   for (int i = 0; i < inf_gap_toggle.get_map().num_my_elements(); ++i)
     if (inf_gap_toggle.get_ref_of_epetra_fevector().operator()(0)->operator[](i) > 0.5)

--- a/src/fluid/4C_fluid_implicit_integration.cpp
+++ b/src/fluid/4C_fluid_implicit_integration.cpp
@@ -1185,7 +1185,7 @@ void FLD::FluidImplicitTimeInt::evaluate_mat_and_rhs(Teuchos::ParameterList& ele
         std::make_shared<Core::LinAlg::Vector<double>>(*discret_->dof_row_map(), true);
 
     Core::LinAlg::Export exporter(residual_col->get_map(), tmp->get_map());
-    tmp->export_to(*residual_col, exporter, Add);
+    tmp->export_to(*residual_col, exporter, Core::LinAlg::CombineMode::add);
     residual_->update(1.0, *tmp, 1.0);
   }
   else
@@ -2007,7 +2007,7 @@ void FLD::FluidImplicitTimeInt::evaluate_fluid_edge_based(
   // need to export residual_col to systemvector1 (residual_)
   Core::LinAlg::Vector<double> res_tmp(systemvector1.get_map(), false);
   Core::LinAlg::Export exporter(residual_col->get_map(), res_tmp.get_map());
-  res_tmp.export_to(*residual_col, exporter, Add);
+  res_tmp.export_to(*residual_col, exporter, Core::LinAlg::CombineMode::add);
   systemvector1.update(1.0, res_tmp, 1.0);
 }
 

--- a/src/fluid/4C_fluid_volumetric_surfaceFlow_condition.cpp
+++ b/src/fluid/4C_fluid_volumetric_surfaceFlow_condition.cpp
@@ -1938,7 +1938,7 @@ void FLD::Utils::FluidVolumetricSurfaceFlowBc::export_and_set_boundary_values(
   // define the exporter
   Core::LinAlg::Export exporter(source.get_map(), target.get_map());
   // Export source vector to target vector
-  target.export_to(source, exporter, Zero);
+  target.export_to(source, exporter, Core::LinAlg::CombineMode::zero);
   // Set state
   discret_->set_state(name, target);
 }
@@ -1952,7 +1952,7 @@ void FLD::Utils::TotalTractionCorrector::export_and_set_boundary_values(
   // define the exporter
   Core::LinAlg::Export exporter(source.get_map(), target.get_map());
   // Export source vector to target vector
-  target.export_to(source, exporter, Zero);
+  target.export_to(source, exporter, Core::LinAlg::CombineMode::zero);
   // Set state
   discret_->set_state(name, target);
 }

--- a/src/fluid_turbulence/4C_fluid_turbulence_turbulent_flow_algorithm.cpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_turbulent_flow_algorithm.cpp
@@ -138,7 +138,7 @@ void FLD::TurbulentFlowAlgorithm::transfer_inflow_velocity()
   // get exporter for transfer of dofs from inflow discretization to complete fluid discretization
   Core::LinAlg::Export exporter(inflowvelnp->get_map(), velnp_->get_map());
   // export inflow velocity
-  velnp_->export_to(*inflowvelnp, exporter, Insert);
+  velnp_->export_to(*inflowvelnp, exporter, Core::LinAlg::CombineMode::insert);
 
   if (Core::Communication::my_mpi_rank(fluiddis_->get_comm()) == 0)
     std::cout << "done\n" << std::endl;
@@ -194,15 +194,15 @@ void FLD::TurbulentFlowAlgorithm::read_restart(const int restart)
 
   // export vectors to inflow discretization
   Core::LinAlg::Export exportvelnp(fluidvelnp->get_map(), velnp->get_map());
-  velnp->export_to(*fluidvelnp, exportvelnp, Insert);
+  velnp->export_to(*fluidvelnp, exportvelnp, Core::LinAlg::CombineMode::insert);
   Core::LinAlg::Export exportveln(fluidveln->get_map(), veln->get_map());
-  veln->export_to(*fluidveln, exportveln, Insert);
+  veln->export_to(*fluidveln, exportveln, Core::LinAlg::CombineMode::insert);
   Core::LinAlg::Export exportvelnm(fluidvelnm->get_map(), velnm->get_map());
-  velnm->export_to(*fluidvelnm, exportvelnm, Insert);
+  velnm->export_to(*fluidvelnm, exportvelnm, Core::LinAlg::CombineMode::insert);
   Core::LinAlg::Export exportaccnp(fluidaccnp->get_map(), accnp->get_map());
-  accnp->export_to(*fluidaccnp, exportaccnp, Insert);
+  accnp->export_to(*fluidaccnp, exportaccnp, Core::LinAlg::CombineMode::insert);
   Core::LinAlg::Export exportaccn(fluidaccn->get_map(), accn->get_map());
-  accn->export_to(*fluidaccn, exportaccn, Insert);
+  accn->export_to(*fluidaccn, exportaccn, Core::LinAlg::CombineMode::insert);
 
 
   // set values in the inflow field

--- a/src/fluid_xfluid/4C_fluid_xfluid.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid.cpp
@@ -29,6 +29,7 @@
 #include "4C_global_data.hpp"
 #include "4C_io.hpp"
 #include "4C_io_control.hpp"
+#include "4C_linalg.hpp"
 #include "4C_linalg_krylov_projector.hpp"
 #include "4C_linalg_sparsematrix.hpp"
 #include "4C_linalg_utils_sparse_algebra_math.hpp"
@@ -803,7 +804,7 @@ void FLD::XFluid::assemble_mat_and_rhs(int itnum)
     // need to export residual_col to state_->residual_ (row)
     Core::LinAlg::Vector<double> res_tmp(state_->residual_->get_map(), true);
     Core::LinAlg::Export exporter(state_->residual_col_->get_map(), res_tmp.get_map());
-    res_tmp.export_to(*state_->residual_col_, exporter, Add);
+    res_tmp.export_to(*state_->residual_col_, exporter, Core::LinAlg::CombineMode::add);
 
     // add Neumann loads and contributions from evaluate of volume and face integrals
     state_->residual_->update(1.0, res_tmp, 1.0, *state_->neumann_loads_, 0.0);
@@ -816,7 +817,8 @@ void FLD::XFluid::assemble_mat_and_rhs(int itnum)
     Core::LinAlg::Vector<double> res_true_tmp(state_->trueresidual_->get_map(), true);
     Core::LinAlg::Export exporter_true_residual(
         state_->trueresidual_->get_map(), res_tmp.get_map());
-    res_true_tmp.export_to(*state_->residual_, exporter_true_residual, Add);
+    res_true_tmp.export_to(
+        *state_->residual_, exporter_true_residual, Core::LinAlg::CombineMode::add);
     state_->trueresidual_->update(-1.0 * residual_scaling(), res_true_tmp, 0.0);
   }
 
@@ -1518,7 +1520,7 @@ void FLD::XFluid::integrate_shape_function(Teuchos::ParameterList& eleparams,
   // need to export residual_col to systemvector1 (residual_)
   Core::LinAlg::Vector<double> vec_tmp(vec.get_map(), false);
   Core::LinAlg::Export exporter(strategy.systemvector1()->get_map(), vec_tmp.get_map());
-  vec_tmp.export_to(*strategy.systemvector1(), exporter, Add);
+  vec_tmp.export_to(*strategy.systemvector1(), exporter, Core::LinAlg::CombineMode::add);
   vec.scale(1.0, vec_tmp);
 }
 
@@ -1604,7 +1606,7 @@ void FLD::XFluid::assemble_mat_and_rhs_gradient_penalty(
   // need to export residual_col to systemvector1 (residual_)
   Core::LinAlg::Vector<double> res_tmp(residual_gp.get_map(), false);
   Core::LinAlg::Export exporter(residual_gp_col->get_map(), res_tmp.get_map());
-  res_tmp.export_to(*residual_gp_col, exporter, Add);
+  res_tmp.export_to(*residual_gp_col, exporter, Core::LinAlg::CombineMode::add);
   residual_gp.update(1.0, res_tmp, 1.0);
 
   //-------------------------------------------------------------------------------

--- a/src/fluid_xfluid/4C_fluid_xfluid_fluid.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid_fluid.cpp
@@ -536,7 +536,7 @@ void FLD::XFluidFluid::add_eos_pres_stab_to_emb_layer()
   {
     Core::LinAlg::Vector<double> res_tmp(embedded_fluid_->residual()->get_map(), true);
     Core::LinAlg::Export exporter(residual_col->get_map(), res_tmp.get_map());
-    res_tmp.export_to(*residual_col, exporter, Add);
+    res_tmp.export_to(*residual_col, exporter, Core::LinAlg::CombineMode::add);
     embedded_fluid_->residual()->update(1.0, res_tmp, 1.0);
   }
 

--- a/src/fluid_xfluid/4C_fluid_xfluid_state.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid_state.cpp
@@ -91,7 +91,7 @@ void FLD::XFluidState::CouplingState::complete_coupling_matrices_and_rhs(
   // export the rhs coupling vector to a row vector
   Core::LinAlg::Vector<double> rhC_s_tmp(rhC_s_->get_map(), true);
   Core::LinAlg::Export exporter_rhC_s_col(rhC_s_col_->get_map(), rhC_s_tmp.get_map());
-  rhC_s_tmp.export_to(*rhC_s_col_, exporter_rhC_s_col, Add);
+  rhC_s_tmp.export_to(*rhC_s_col_, exporter_rhC_s_col, Core::LinAlg::CombineMode::add);
 
   rhC_s_->update(1.0, rhC_s_tmp, 0.0);
 }

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_fluidfluidmonolithic_fluidsplit_nonox.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_fluidfluidmonolithic_fluidsplit_nonox.cpp
@@ -848,7 +848,7 @@ void FSI::FluidFluidMonolithicFluidSplitNoNOX::newton()
   {
     auto dst = std::make_shared<Core::LinAlg::Vector<double>>(target_map, true);
     Core::LinAlg::Import imp(target_map, duiinc_->get_map());
-    dst->import(*duiinc_, imp, Insert);
+    dst->import(*duiinc_, imp, Core::LinAlg::CombineMode::insert);
     duiinc_->update(1.0, *dst, 0.0);
   }
   else

--- a/src/fsi/src/utils/4C_fsi_utils.cpp
+++ b/src/fsi/src/utils/4C_fsi_utils.cpp
@@ -250,8 +250,8 @@ void FSI::Utils::SlideAleUtils::remeshing(Adapter::FSIStructureWrapper& structur
   Core::LinAlg::Import msimpo(*dofrowmap, *structdofrowmap_);
   Core::LinAlg::Import slimpo(*dofrowmap, *fluiddofrowmap_);
 
-  idispms_->import(*idisptotal, msimpo, Add);
-  idispms_->import(iprojdispale, slimpo, Add);
+  idispms_->import(*idisptotal, msimpo, Core::LinAlg::CombineMode::add);
+  idispms_->import(iprojdispale, slimpo, Core::LinAlg::CombineMode::add);
 
   iprojhist_->update(1.0, iprojdispale, 0.0);
 
@@ -271,8 +271,8 @@ void FSI::Utils::SlideAleUtils::evaluate_mortar(Core::LinAlg::Vector<double>& id
   Core::LinAlg::Import master_importer(*dofrowmap, *structdofrowmap_);
   Core::LinAlg::Import slave_importer(*dofrowmap, *fluiddofrowmap_);
 
-  idispms_->import(idispstruct, master_importer, Add);
-  idispms_->import(idispfluid, slave_importer, Add);
+  idispms_->import(idispstruct, master_importer, Core::LinAlg::CombineMode::add);
+  idispms_->import(idispfluid, slave_importer, Core::LinAlg::CombineMode::add);
 
   // new D,M,Dinv out of disp of struct and fluid side
   coupsf.evaluate(idispms_);
@@ -444,7 +444,7 @@ void FSI::Utils::SlideAleUtils::slide_projection(
   Core::LinAlg::Import interimpo(*structfullnodemap_, *structdofrowmap_);
   std::shared_ptr<Core::LinAlg::Vector<double>> reddisp =
       std::make_shared<Core::LinAlg::Vector<double>>(*structfullnodemap_, true);
-  reddisp->import(*idispnp, interimpo, Add);
+  reddisp->import(*idispnp, interimpo, Core::LinAlg::CombineMode::add);
 
   Core::FE::Discretization& interfacedis = coupsf.interface()->discret();
   std::map<int, double> rotrat;

--- a/src/pasi/4C_pasi_partitioned_twowaycoup.cpp
+++ b/src/pasi/4C_pasi_partitioned_twowaycoup.cpp
@@ -313,7 +313,8 @@ void PaSI::PasiPartTwoWayCoup::get_interface_forces()
 
   // assemble interface forces
   Core::LinAlg::Export exporter(walldatastate->get_force_col()->get_map(), intfforcenp_->get_map());
-  intfforcenp_->export_to(*walldatastate->get_force_col(), exporter, Add);
+  intfforcenp_->export_to(
+      *walldatastate->get_force_col(), exporter, Core::LinAlg::CombineMode::add);
 }
 
 bool PaSI::PasiPartTwoWayCoup::convergence_check(int itnum)

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_partitioned.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_partitioned.cpp
@@ -160,7 +160,7 @@ void PoroPressureBased::PorofluidElastScatraPartitionedAlgorithm::iter_update_st
       Core::LinAlg::Import pressure_import(target_pressure_map, source_pressure_map);
       tmp_pressure_vector.import(
           *porofluid_elast_algo()->porofluid_algo()->art_net_tim_int()->pressurenp(),
-          pressure_import, Insert);
+          pressure_import, Core::LinAlg::CombineMode::insert);
       artery_pressure_inc_np_->update(1.0, tmp_pressure_vector, 0.0);
     }
 
@@ -176,7 +176,8 @@ void PoroPressureBased::PorofluidElastScatraPartitionedAlgorithm::iter_update_st
     {
       Core::LinAlg::Vector<double> tmp_phinp(artery_scatra_inc_np_map, /*zeroOut=*/true);
       Core::LinAlg::Import imp(artery_scatra_inc_np_map, phinp_map);
-      tmp_phinp.import(*scatra_meshtying_strategy_->art_scatra_field()->phinp(), imp, Insert);
+      tmp_phinp.import(*scatra_meshtying_strategy_->art_scatra_field()->phinp(), imp,
+          Core::LinAlg::CombineMode::insert);
       artery_scatra_inc_np_->update(1.0, tmp_phinp, 0.0);
     }
   }
@@ -229,7 +230,7 @@ bool PoroPressureBased::PorofluidElastScatraPartitionedAlgorithm::convergence_ch
       Core::LinAlg::Import pressure_import(target_pressure_map, source_pressure_map);
       tmp_pressure_vector.import(
           *porofluid_elast_algo()->porofluid_algo()->art_net_tim_int()->pressurenp(),
-          pressure_import, Insert);
+          pressure_import, Core::LinAlg::CombineMode::insert);
       artery_pressure_inc_np_->update(1.0, tmp_pressure_vector, -1.0);
     }
 
@@ -245,7 +246,8 @@ bool PoroPressureBased::PorofluidElastScatraPartitionedAlgorithm::convergence_ch
     {
       Core::LinAlg::Vector<double> tmp(artery_scatra_inc_np_map, true);
       Core::LinAlg::Import imp(artery_scatra_inc_np_map, phinp_map);
-      tmp.import(*scatra_meshtying_strategy_->art_scatra_field()->phinp(), imp, Insert);
+      tmp.import(*scatra_meshtying_strategy_->art_scatra_field()->phinp(), imp,
+          Core::LinAlg::CombineMode::insert);
       artery_scatra_inc_np_->update(1.0, tmp, -1.0);
     }
   }

--- a/src/post/4C_post_ensight_writer.cpp
+++ b/src/post/4C_post_ensight_writer.cpp
@@ -1556,7 +1556,7 @@ void EnsightWriter::write_dof_result_step(std::ofstream& file, PostResult& resul
     // contract result values on proc0 (proc0 gets everything, other procs empty)
     Core::LinAlg::Import proc0dataimporter(*proc0datamap, datamap);
     Core::LinAlg::Vector<double> proc0data(*proc0datamap);
-    proc0data.import(*data, proc0dataimporter, Insert);
+    proc0data.import(*data, proc0dataimporter, Core::LinAlg::CombineMode::insert);
 
     const Core::LinAlg::Map& finaldatamap = proc0data.get_map();
 
@@ -1818,7 +1818,7 @@ void EnsightWriter::write_element_dof_result_step(std::ofstream& file, PostResul
   // contract result values on proc0 (proc0 gets everything, other procs empty)
   Core::LinAlg::Import proc0dataimporter(*proc0datamap, datamap);
   Core::LinAlg::Vector<double> proc0data(*proc0datamap);
-  proc0data.import(*data, proc0dataimporter, Insert);
+  proc0data.import(*data, proc0dataimporter, Core::LinAlg::CombineMode::insert);
 
   const Core::LinAlg::Map& finaldatamap = proc0data.get_map();
 

--- a/src/post/4C_post_ensight_writer_nurbs.cpp
+++ b/src/post/4C_post_ensight_writer_nurbs.cpp
@@ -1908,7 +1908,7 @@ void EnsightWriter::write_dof_result_step_for_nurbs(std::ofstream& file, const i
 
   // create an importer and import the data
   Core::LinAlg::Import importer((coldata).get_map(), (data).get_map());
-  (coldata).import((data), importer, Insert);
+  (coldata).import((data), importer, Core::LinAlg::CombineMode::insert);
 
 
   // loop all available elements

--- a/src/red_airways/4C_red_airways_implicitintegration.cpp
+++ b/src/red_airways/4C_red_airways_implicitintegration.cpp
@@ -1430,27 +1430,27 @@ void Airway::RedAirwayImplicitTimeInt::output(
 
     {
       Core::LinAlg::Export exporter(acini_e_volumenm_->get_map(), qexp_->get_map());
-      qexp_->export_to(*acini_e_volumenm_, exporter, Zero);
+      qexp_->export_to(*acini_e_volumenm_, exporter, Core::LinAlg::CombineMode::zero);
       output_.write_vector("acini_vnm", qexp_);
     }
     {
       Core::LinAlg::Export exporter(acini_e_volumen_->get_map(), qexp_->get_map());
-      qexp_->export_to(*acini_e_volumen_, exporter, Zero);
+      qexp_->export_to(*acini_e_volumen_, exporter, Core::LinAlg::CombineMode::zero);
       output_.write_vector("acini_vn", qexp_);
     }
     {
       Core::LinAlg::Export exporter(acini_e_volumenp_->get_map(), qexp_->get_map());
-      qexp_->export_to(*acini_e_volumenp_, exporter, Zero);
+      qexp_->export_to(*acini_e_volumenp_, exporter, Core::LinAlg::CombineMode::zero);
       output_.write_vector("acini_vnp", qexp_);
     }
     {
       Core::LinAlg::Export exporter(acini_e_volume_strain_->get_map(), qexp_->get_map());
-      qexp_->export_to(*acini_e_volume_strain_, exporter, Zero);
+      qexp_->export_to(*acini_e_volume_strain_, exporter, Core::LinAlg::CombineMode::zero);
       output_.write_vector("acini_volumetric_strain", qexp_);
     }
     {
       Core::LinAlg::Export exporter(acini_e_volume0_->get_map(), qexp_->get_map());
-      qexp_->export_to(*acini_e_volume0_, exporter, Zero);
+      qexp_->export_to(*acini_e_volume0_, exporter, Core::LinAlg::CombineMode::zero);
       output_.write_vector("acini_v0", qexp_);
     }
 
@@ -1821,11 +1821,11 @@ bool Airway::RedAirwayImplicitTimeInt::sum_all_col_elem_val(
     // define epetra exporter
     Core::LinAlg::Export exporter(vec.get_map(), qexp_->get_map());
     // export from ColMap to RowMap
-    qexp_->export_to(vec, exporter, Zero);
+    qexp_->export_to(vec, exporter, Core::LinAlg::CombineMode::zero);
 
     Core::LinAlg::Export exporter2(sumCond.get_map(), qexp2_->get_map());
     // export from ColMap to RowMap
-    qexp2_->export_to(sumCond, exporter2, Zero);
+    qexp2_->export_to(sumCond, exporter2, Core::LinAlg::CombineMode::zero);
   }
 
   // Get the mean acinar volume on the current processor

--- a/src/scatra/4C_scatra_timint_genalpha.cpp
+++ b/src/scatra/4C_scatra_timint_genalpha.cpp
@@ -331,14 +331,14 @@ void ScaTra::TimIntGenAlpha::compute_time_derivative()
   {
     phinp_owned->put_scalar(0.0);
     auto importer_phinp = std::make_unique<Core::LinAlg::Import>(tgtMap, phinp_->get_map());
-    phinp_owned->import(*phinp_, *importer_phinp, Insert);
+    phinp_owned->import(*phinp_, *importer_phinp, Core::LinAlg::CombineMode::insert);
     phinp_ref = phinp_owned.get();
   }
   if (!phin_->get_map().same_as(tgtMap))
   {
     auto importer_phin = std::make_unique<Core::LinAlg::Import>(tgtMap, phin_->get_map());
     phin_owned->put_scalar(0.0);
-    phin_owned->import(*phin_, *importer_phin, Insert);
+    phin_owned->import(*phin_, *importer_phin, Core::LinAlg::CombineMode::insert);
     phin_ref = phin_owned.get();
   }
 

--- a/src/scatra/4C_scatra_timint_hdg.cpp
+++ b/src/scatra/4C_scatra_timint_hdg.cpp
@@ -256,7 +256,7 @@ void ScaTra::TimIntHDG::gen_alpha_intermediate_values()
 
     dst = std::make_unique<Core::LinAlg::Vector<double>>(target_map, true);
     auto importer = std::make_unique<Core::LinAlg::Import>(target_map, src.get_map());
-    dst->import(src, *importer, Insert);
+    dst->import(src, *importer, Core::LinAlg::CombineMode::insert);
     return *dst;
   };
 
@@ -679,8 +679,8 @@ void ScaTra::TimIntHDG::gen_alpha_compute_time_derivative()
   Core::LinAlg::Import importer_phin(phidtnp_->get_map(), phin_->get_map());
 
   // Bring data over
-  phinp_owned.import(*phinp_, importer_phinp, Insert);
-  phin_owned.import(*phin_, importer_phin, Insert);
+  phinp_owned.import(*phinp_, importer_phinp, Core::LinAlg::CombineMode::insert);
+  phin_owned.import(*phin_, importer_phin, Core::LinAlg::CombineMode::insert);
 
   // Now maps match and any update is safe
   phidtnp_->update(fact2, *phidtn_, 0.0);

--- a/src/scatra/4C_scatra_timint_implicit.cpp
+++ b/src/scatra/4C_scatra_timint_implicit.cpp
@@ -2570,7 +2570,7 @@ void ScaTra::ScaTraTimIntImpl::scaling_and_neumann()
           std::make_unique<Core::LinAlg::Import>(res_map, res_src.get_map());
 
       residual_owned->put_scalar(0.0);
-      residual_owned->import(res_src, *import_residual, Insert);
+      residual_owned->import(res_src, *import_residual, Core::LinAlg::CombineMode::insert);
       trueresidual_->update(residual_scaling(), *residual_owned, 0.0);
     }
     else

--- a/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
+++ b/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
@@ -652,7 +652,7 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
           lmside_ == Inpar::S2I::side_master or couplingtype_ == Inpar::S2I::coupling_nts_standard)
       {
         imastermatrix_->complete(*interfacemaps_->full_map(), *interfacemaps_->map(2));
-        imasterresidual_->complete(Add, true);
+        imasterresidual_->complete(Core::LinAlg::CombineMode::add, true);
       }
 
       // assemble global system of equations depending on matrix type

--- a/src/stru_multi/4C_stru_multi_microstatic.cpp
+++ b/src/stru_multi/4C_stru_multi_microstatic.cpp
@@ -346,7 +346,7 @@ void MultiScale::MicroStatic::predict_const_dis(const Core::LinAlg::Matrix<3, 3>
   fresn_->update(-1.0, *fintn_, 0.0);
 
   // extract reaction forces
-  freactn_->import(*fresn_, *importp_, Insert);
+  freactn_->import(*fresn_, *importp_, Core::LinAlg::CombineMode::insert);
 
   // blank residual at DOFs on Dirichlet BC
   Core::LinAlg::Vector<double> fresncopy(*fresn_);
@@ -497,7 +497,7 @@ void MultiScale::MicroStatic::predict_tang_dis(const Core::LinAlg::Matrix<3, 3>*
   fresn_->update(-1.0, *fintn_, 0.0);
 
   // extract reaction forces
-  freactn_->import(*fresn_, *importp_, Insert);
+  freactn_->import(*fresn_, *importp_, Core::LinAlg::CombineMode::insert);
 
   // blank residual at DOFs on Dirichlet BC
   Core::LinAlg::Vector<double> fresncopy(*fresn_);
@@ -588,7 +588,7 @@ void MultiScale::MicroStatic::full_newton()
     fresn_->update(-1.0, *fintn_, 0.0);
 
     // extract reaction forces
-    freactn_->import(*fresn_, *importp_, Insert);
+    freactn_->import(*fresn_, *importp_, Core::LinAlg::CombineMode::insert);
 
     // blank residual DOFs which are on Dirichlet BC
     Core::LinAlg::Vector<double> fresncopy(*fresn_);

--- a/src/stru_multi/4C_stru_multi_microstatic_service.cpp
+++ b/src/stru_multi/4C_stru_multi_microstatic_service.cpp
@@ -193,7 +193,7 @@ void MultiScale::MicroStatic::set_up_homogenization()
 
   for (int i = 0; i < 9; ++i)
   {
-    ((*rhs_)(i)).export_to((d_matrix_transposed(i)), *importp_, Insert);
+    ((*rhs_)(i)).export_to((d_matrix_transposed(i)), *importp_, Core::LinAlg::CombineMode::insert);
   }
 }
 

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_meshtying.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_meshtying.cpp
@@ -132,7 +132,7 @@ void Solid::ModelEvaluator::Meshtying::setup()
           Core::LinAlg::Export exporter(
               Xslavemod->get_map(), *strategy_ptr_->non_redist_slave_row_dofs());
 
-          original_vec->export_to(*Xslavemod, exporter, Insert);
+          original_vec->export_to(*Xslavemod, exporter, Core::LinAlg::CombineMode::insert);
 
           Xslavemod_noredist = original_vec;
         }

--- a/src/xfem/4C_xfem_coupling_fpi_mesh.cpp
+++ b/src/xfem/4C_xfem_coupling_fpi_mesh.cpp
@@ -130,7 +130,7 @@ void XFEM::MeshCouplingFPI::complete_state_vectors()
   // need to export the interface forces
   Core::LinAlg::Vector<double> iforce_tmp(itrueresidual_->get_map(), true);
   Core::LinAlg::Export exporter_iforce(iforcecol_->get_map(), iforce_tmp.get_map());
-  iforce_tmp.export_to(*iforcecol_, exporter_iforce, Add);
+  iforce_tmp.export_to(*iforcecol_, exporter_iforce, Core::LinAlg::CombineMode::add);
 
   // scale the interface trueresidual with -1.0 to get the forces acting on structural side (no
   // residual-scaling!)

--- a/src/xfem/4C_xfem_coupling_mesh.cpp
+++ b/src/xfem/4C_xfem_coupling_mesh.cpp
@@ -1637,7 +1637,7 @@ void XFEM::MeshCouplingFSI::complete_state_vectors()
   // need to export the interface forces
   Core::LinAlg::Vector<double> iforce_tmp(itrueresidual_->get_map(), true);
   Core::LinAlg::Export exporter_iforce(iforcecol_->get_map(), iforce_tmp.get_map());
-  iforce_tmp.export_to(*iforcecol_, exporter_iforce, Add);
+  iforce_tmp.export_to(*iforcecol_, exporter_iforce, Core::LinAlg::CombineMode::add);
 
   // scale the interface trueresidual with -1.0 to get the forces acting on structural side (no
   // residual-scaling!)

--- a/src/xfem/4C_xfem_discretization.cpp
+++ b/src/xfem/4C_xfem_discretization.cpp
@@ -136,7 +136,7 @@ void XFEM::DiscretizationXFEM::export_initialto_active_vector(
     else
     {
       Core::LinAlg::Import importer(fullvec.get_map(), initialvec.get_map());
-      fullvec.import(initialvec, importer, Insert);
+      fullvec.import(initialvec, importer, Core::LinAlg::CombineMode::insert);
     }
   }
   fullvec.replace_map(*initialfulldofrowmap_);  /// replace |1 2 3 4|1 2 3 4| -> |1 2 3 4|5 6 7 8|


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
This PR aims to provide the functionality to map between `Epetra_CombineType` and our own `LinAlg::CombineType`. Several enum classes are combined into one file and `LinAlg::CombineType` is introduced.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
Part of #875