### PR TITLE
[solver] Rework `setup` and `solve` input arguments

### DIFF
--- a/src/core/linear_solver/src/amgnxn/4C_linear_solver_amgnxn_preconditioner.cpp
+++ b/src/core/linear_solver/src/amgnxn/4C_linear_solver_amgnxn_preconditioner.cpp
@@ -43,8 +43,8 @@ std::shared_ptr<Epetra_Operator> Core::LinearSolver::AmGnxnPreconditioner::prec_
 /*------------------------------------------------------------------------------*/
 /*------------------------------------------------------------------------------*/
 
-void Core::LinearSolver::AmGnxnPreconditioner::setup(Core::LinAlg::SparseOperator& matrix,
-    const Core::LinAlg::MultiVector<double>& x, Core::LinAlg::MultiVector<double>& b)
+void Core::LinearSolver::AmGnxnPreconditioner::setup(
+    Core::LinAlg::SparseOperator& matrix, Core::LinAlg::MultiVector<double>& b)
 {
   // Check whether this is a block sparse matrix
   auto* A_bl = dynamic_cast<Core::LinAlg::BlockSparseMatrixBase*>(&matrix);

--- a/src/core/linear_solver/src/amgnxn/4C_linear_solver_amgnxn_preconditioner.hpp
+++ b/src/core/linear_solver/src/amgnxn/4C_linear_solver_amgnxn_preconditioner.hpp
@@ -34,8 +34,7 @@ namespace Core::LinearSolver
    public:
     AmGnxnPreconditioner(Teuchos::ParameterList& params);
 
-    void setup(Core::LinAlg::SparseOperator& matrix, const Core::LinAlg::MultiVector<double>& x,
-        Core::LinAlg::MultiVector<double>& b) override;
+    void setup(Core::LinAlg::SparseOperator& matrix, Core::LinAlg::MultiVector<double>& b) override;
 
     virtual void setup(std::shared_ptr<Core::LinAlg::BlockSparseMatrixBase> A);
 

--- a/src/core/linear_solver/src/method/4C_linear_solver_method.hpp
+++ b/src/core/linear_solver/src/method/4C_linear_solver_method.hpp
@@ -84,11 +84,10 @@ namespace Core::LinearSolver
      * @param projector Krylov projector
      */
     virtual void setup(std::shared_ptr<Core::LinAlg::SparseOperator> A,
-        std::shared_ptr<Core::LinAlg::MultiVector<double>> x,
         std::shared_ptr<Core::LinAlg::MultiVector<double>> b, const bool refactor, const bool reset,
         std::shared_ptr<Core::LinAlg::LinearSystemProjector> projector) = 0;
 
-    virtual int solve() = 0;
+    virtual int solve(Core::LinAlg::MultiVector<double>& x) = 0;
 
     /// return number of iterations performed by solver
     virtual int get_num_iters() const

--- a/src/core/linear_solver/src/method/4C_linear_solver_method_direct.hpp
+++ b/src/core/linear_solver/src/method/4C_linear_solver_method_direct.hpp
@@ -36,11 +36,10 @@ namespace Core::LinearSolver
      * @param projector Krylov projector
      */
     void setup(std::shared_ptr<Core::LinAlg::SparseOperator> matrix,
-        std::shared_ptr<Core::LinAlg::MultiVector<double>> x,
         std::shared_ptr<Core::LinAlg::MultiVector<double>> b, const bool refactor, const bool reset,
         std::shared_ptr<Core::LinAlg::LinearSystemProjector> projector = nullptr) override;
 
-    int solve() override;
+    int solve(Core::LinAlg::MultiVector<double>& x) override;
 
     bool is_factored() { return factored_; }
 
@@ -50,9 +49,6 @@ namespace Core::LinearSolver
 
     //! flag indicating whether a valid factorization is stored
     bool factored_;
-
-    //! initial guess and solution
-    std::shared_ptr<Core::LinAlg::MultiVector<double>> x_;
 
     //! right hand side vector
     std::shared_ptr<Core::LinAlg::MultiVector<double>> b_;

--- a/src/core/linear_solver/src/method/4C_linear_solver_method_iterative.cpp
+++ b/src/core/linear_solver/src/method/4C_linear_solver_method_iterative.cpp
@@ -43,7 +43,6 @@ Core::LinearSolver::IterativeSolver::IterativeSolver(MPI_Comm comm, Teuchos::Par
 //----------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------
 void Core::LinearSolver::IterativeSolver::setup(std::shared_ptr<Core::LinAlg::SparseOperator> A,
-    std::shared_ptr<Core::LinAlg::MultiVector<double>> x,
     std::shared_ptr<Core::LinAlg::MultiVector<double>> b, const bool refactor, const bool reset,
     std::shared_ptr<Core::LinAlg::LinearSystemProjector> projector)
 {
@@ -62,7 +61,6 @@ void Core::LinearSolver::IterativeSolver::setup(std::shared_ptr<Core::LinAlg::Sp
   }
 
   a_ = A;
-  x_ = x;
   b_ = b;
 
   if (create)
@@ -73,7 +71,7 @@ void Core::LinearSolver::IterativeSolver::setup(std::shared_ptr<Core::LinAlg::Sp
       std::cout << "*******************************************************" << std::endl;
     }
 
-    preconditioner_->setup(*a_, *x_, *b_);
+    preconditioner_->setup(*a_, *b_);
   }
   else
   {
@@ -87,13 +85,12 @@ void Core::LinearSolver::IterativeSolver::setup(std::shared_ptr<Core::LinAlg::Sp
 
 //----------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------
-int Core::LinearSolver::IterativeSolver::solve()
+int Core::LinearSolver::IterativeSolver::solve(Core::LinAlg::MultiVector<double>& x)
 {
   Teuchos::ParameterList& belist = params().sublist("Belos Parameters");
 
   auto problem = Teuchos::make_rcp<Belos::LinearProblem<double, BelosVectorType, BelosMatrixType>>(
-      Teuchos::rcpFromRef(a_->epetra_operator()),
-      Teuchos::rcpFromRef(x_->get_epetra_multi_vector()),
+      Teuchos::rcpFromRef(a_->epetra_operator()), Teuchos::rcpFromRef(x.get_epetra_multi_vector()),
       Teuchos::rcpFromRef(b_->get_epetra_multi_vector()));
 
   if (preconditioner_ != nullptr)

--- a/src/core/linear_solver/src/method/4C_linear_solver_method_iterative.hpp
+++ b/src/core/linear_solver/src/method/4C_linear_solver_method_iterative.hpp
@@ -40,12 +40,11 @@ namespace Core::LinearSolver
      * @param projector Krylov projector
      */
     void setup(std::shared_ptr<Core::LinAlg::SparseOperator> A,
-        std::shared_ptr<Core::LinAlg::MultiVector<double>> x,
         std::shared_ptr<Core::LinAlg::MultiVector<double>> b, const bool refactor, const bool reset,
         std::shared_ptr<Core::LinAlg::LinearSystemProjector> projector) override;
 
     //! Actual call to the underlying Belos solver
-    int solve() override;
+    int solve(Core::LinAlg::MultiVector<double>& x) override;
 
     int ncall() { return ncall_; }
 
@@ -85,9 +84,6 @@ namespace Core::LinearSolver
 
     //! (internal) parameter lists
     Teuchos::ParameterList& params_;
-
-    //! initial guess and solution
-    std::shared_ptr<Core::LinAlg::MultiVector<double>> x_;
 
     //! right hand side vector
     std::shared_ptr<Core::LinAlg::MultiVector<double>> b_;

--- a/src/core/linear_solver/src/method/4C_linear_solver_method_linalg.cpp
+++ b/src/core/linear_solver/src/method/4C_linear_solver_method_linalg.cpp
@@ -192,7 +192,7 @@ void Core::LinAlg::Solver::setup(std::shared_ptr<Core::LinAlg::SparseOperator> m
       FOUR_C_THROW("Unknown type of solver");
   }
 
-  solver_->setup(matrix, x, b, refactor, params.reset, params.projector);
+  solver_->setup(matrix, b, refactor, params.reset, params.projector);
 }
 
 /*----------------------------------------------------------------------*
@@ -208,7 +208,7 @@ int Core::LinAlg::Solver::solve_with_multi_vector(
   int error_value = 0;
   {
     TEUCHOS_FUNC_TIME_MONITOR("Core::LinAlg::Solver:  2)   Solve");
-    error_value = solver_->solve();
+    error_value = solver_->solve(*x);
   }
 
   return error_value;
@@ -224,7 +224,7 @@ int Core::LinAlg::Solver::solve(std::shared_ptr<Core::LinAlg::SparseOperator> ma
   int error_value = 0;
   {
     TEUCHOS_FUNC_TIME_MONITOR("Core::LinAlg::Solver:  2)   Solve");
-    error_value = solver_->solve();
+    error_value = solver_->solve(*x);
   }
 
   return error_value;

--- a/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_ifpack.cpp
+++ b/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_ifpack.cpp
@@ -25,8 +25,8 @@ Core::LinearSolver::IFPACKPreconditioner::IFPACKPreconditioner(
 
 //------------------------------------------------------------------------------
 //------------------------------------------------------------------------------
-void Core::LinearSolver::IFPACKPreconditioner::setup(Core::LinAlg::SparseOperator& matrix,
-    const Core::LinAlg::MultiVector<double>& x, Core::LinAlg::MultiVector<double>& b)
+void Core::LinearSolver::IFPACKPreconditioner::setup(
+    Core::LinAlg::SparseOperator& matrix, Core::LinAlg::MultiVector<double>& b)
 {
   auto A_crs = std::dynamic_pointer_cast<Core::LinAlg::SparseMatrix>(
       Core::Utils::shared_ptr_from_ref(matrix));

--- a/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_ifpack.hpp
+++ b/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_ifpack.hpp
@@ -29,8 +29,7 @@ namespace Core::LinearSolver
     IFPACKPreconditioner(Teuchos::ParameterList& ifpacklist, Teuchos::ParameterList& solverlist);
 
     //! Setup
-    void setup(Core::LinAlg::SparseOperator& matrix, const Core::LinAlg::MultiVector<double>& x,
-        Core::LinAlg::MultiVector<double>& b) override;
+    void setup(Core::LinAlg::SparseOperator& matrix, Core::LinAlg::MultiVector<double>& b) override;
 
     /// linear operator used for preconditioning
     std::shared_ptr<Epetra_Operator> prec_operator() const override { return prec_; }

--- a/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_muelu.cpp
+++ b/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_muelu.cpp
@@ -49,8 +49,8 @@ Core::LinearSolver::MueLuPreconditioner::MueLuPreconditioner(Teuchos::ParameterL
 
 //----------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------
-void Core::LinearSolver::MueLuPreconditioner::setup(Core::LinAlg::SparseOperator& matrix,
-    const Core::LinAlg::MultiVector<double>& x, Core::LinAlg::MultiVector<double>& b)
+void Core::LinearSolver::MueLuPreconditioner::setup(
+    Core::LinAlg::SparseOperator& matrix, Core::LinAlg::MultiVector<double>& b)
 {
   using EpetraCrsMatrix = Xpetra::EpetraCrsMatrixT<GO, NO>;
   using EpetraMap = Xpetra::EpetraMapT<GO, NO>;

--- a/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_muelu.hpp
+++ b/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_muelu.hpp
@@ -56,8 +56,7 @@ namespace Core::LinearSolver
      * @param x Solution of the linear system
      * @param b Right-hand side of the linear system
      */
-    void setup(Core::LinAlg::SparseOperator& matrix, const Core::LinAlg::MultiVector<double>& x,
-        Core::LinAlg::MultiVector<double>& b) override;
+    void setup(Core::LinAlg::SparseOperator& matrix, Core::LinAlg::MultiVector<double>& b) override;
 
     //! linear operator used for preconditioning
     std::shared_ptr<Epetra_Operator> prec_operator() const final

--- a/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_projection.cpp
+++ b/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_projection.cpp
@@ -24,15 +24,15 @@ Core::LinearSolver::ProjectionPreconditioner::ProjectionPreconditioner(
 
 //----------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------
-void Core::LinearSolver::ProjectionPreconditioner::setup(Core::LinAlg::SparseOperator& matrix,
-    const Core::LinAlg::MultiVector<double>& x, Core::LinAlg::MultiVector<double>& b)
+void Core::LinearSolver::ProjectionPreconditioner::setup(
+    Core::LinAlg::SparseOperator& matrix, Core::LinAlg::MultiVector<double>& b)
 {
   FOUR_C_ASSERT_ALWAYS(b.num_vectors() == 1,
       "Expecting only one solution vector during projector call! Got {} vectors.", b.num_vectors());
   b(0) = projector_->to_reduced(b(0));
 
   // setup wrapped preconditioner
-  preconditioner_->setup(matrix, x, b);
+  preconditioner_->setup(matrix, b);
 
   // Wrap the linear operator of the contained preconditioner. This way the
   // actual preconditioner is called first and the projection is done

--- a/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_projection.hpp
+++ b/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_projection.hpp
@@ -29,8 +29,7 @@ namespace Core::LinearSolver
     ProjectionPreconditioner(std::shared_ptr<PreconditionerTypeBase> preconditioner,
         std::shared_ptr<Core::LinAlg::LinearSystemProjector> projector);
 
-    void setup(Core::LinAlg::SparseOperator& matrix, const Core::LinAlg::MultiVector<double>& x,
-        Core::LinAlg::MultiVector<double>& b) override;
+    void setup(Core::LinAlg::SparseOperator& matrix, Core::LinAlg::MultiVector<double>& b) override;
 
     /// linear operator used for preconditioning
     std::shared_ptr<Epetra_Operator> prec_operator() const override { return p_; }

--- a/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_teko.cpp
+++ b/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_teko.cpp
@@ -38,8 +38,8 @@ Core::LinearSolver::TekoPreconditioner::TekoPreconditioner(Teuchos::ParameterLis
 
 //----------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------
-void Core::LinearSolver::TekoPreconditioner::setup(Core::LinAlg::SparseOperator& matrix,
-    const Core::LinAlg::MultiVector<double>& x, Core::LinAlg::MultiVector<double>& b)
+void Core::LinearSolver::TekoPreconditioner::setup(
+    Core::LinAlg::SparseOperator& matrix, Core::LinAlg::MultiVector<double>& b)
 {
   using EpetraMultiVector = Xpetra::EpetraMultiVectorT<GlobalOrdinal, Node>;
   using XpetraMultiVector = Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>;

--- a/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_teko.hpp
+++ b/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_teko.hpp
@@ -33,8 +33,7 @@ namespace Core::LinearSolver
    public:
     TekoPreconditioner(Teuchos::ParameterList& tekolist);
 
-    void setup(Core::LinAlg::SparseOperator& matrix, const Core::LinAlg::MultiVector<double>& x,
-        Core::LinAlg::MultiVector<double>& b) override;
+    void setup(Core::LinAlg::SparseOperator& matrix, Core::LinAlg::MultiVector<double>& b) override;
 
     /// linear operator used for preconditioning
     std::shared_ptr<Epetra_Operator> prec_operator() const override { return p_; }

--- a/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_type.hpp
+++ b/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_type.hpp
@@ -40,8 +40,8 @@ namespace Core::LinearSolver
     virtual ~PreconditionerTypeBase() = default;
 
     /// Setup preconditioner with a given linear system.
-    virtual void setup(Core::LinAlg::SparseOperator& matrix,
-        const Core::LinAlg::MultiVector<double>& x, Core::LinAlg::MultiVector<double>& b) = 0;
+    virtual void setup(
+        Core::LinAlg::SparseOperator& matrix, Core::LinAlg::MultiVector<double>& b) = 0;
 
     /// linear operator used for preconditioning
     virtual std::shared_ptr<Epetra_Operator> prec_operator() const = 0;


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
This PR moves the solution vector directly to the solve method as input argument. This allows to directly modify the solution vector on spot and therefore the respective member variable is removed. This also makes modifications to the solution vector easier and more explicit instead of holding a pointer to a pointer to a pointer that enters some function at some point somewhere before.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
Related to  #1400