### PR TITLE
Define order of singleton destruction

### DIFF
--- a/src/core/utils/src/stl_extension/4C_utils_singleton_owner.cpp
+++ b/src/core/utils/src/stl_extension/4C_utils_singleton_owner.cpp
@@ -9,6 +9,8 @@
 
 #include "4C_utils_exceptions.hpp"
 
+#include <algorithm>
+
 FOUR_C_NAMESPACE_OPEN
 
 void Core::Utils::SingletonOwnerRegistry::finalize()
@@ -22,12 +24,14 @@ void Core::Utils::SingletonOwnerRegistry::finalize()
 void Core::Utils::SingletonOwnerRegistry::register_deleter(
     void* owner, std::function<void()> deleter)
 {
-  instance().deleters_.emplace(owner, std::move(deleter));
+  instance().deleters_.emplace_back(owner, std::move(deleter));
 }
 
 void Core::Utils::SingletonOwnerRegistry::unregister(void* owner)
 {
-  instance().deleters_.erase(owner);
+  auto& deleters = instance().deleters_;
+
+  std::erase_if(deleters, [owner](const auto& item) { return item.first == owner; });
 }
 
 void Core::Utils::SingletonOwnerRegistry::initialize() { instance(); }

--- a/src/core/utils/src/stl_extension/4C_utils_singleton_owner.hpp
+++ b/src/core/utils/src/stl_extension/4C_utils_singleton_owner.hpp
@@ -15,6 +15,8 @@
 #include <map>
 #include <memory>
 #include <type_traits>
+#include <utility>
+#include <vector>
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -80,6 +82,8 @@ namespace Core::Utils
      * This function is called at the end of the program to ensure that all singletons are
      * destructed.
      *
+     * @note Singletons are destructed in the order of their registration.
+     *
      * @note Prefer to use the ScopeGuard class which calls this function at the end of scope.
      */
     static void finalize();
@@ -101,7 +105,7 @@ namespace Core::Utils
     /**
      * Store the deleters.
      */
-    std::map<void*, std::function<void()>> deleters_;
+    std::vector<std::pair<void*, std::function<void()>>> deleters_;
 
     template <typename T, typename... CreationArgs>
     friend class SingletonOwner;


### PR DESCRIPTION
This PR defines the order of destruction of singletons that are managed in a singleton owner registry. Until now, the order was (more or less) random and machine dependent. Here, I propose to use the order of construction.

I'm not super happy with this solution. It would be more consistent to destroy the singletons in reverse order of construction. However, our code implicitly relies on such an ordering.

Closes #1553 