### PR TITLE
[LinAlg] Further internal sparse matrix cleanup

### DIFF
--- a/src/core/linalg/src/sparse/4C_linalg_krylov_projector.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_krylov_projector.cpp
@@ -369,7 +369,7 @@ Core::LinAlg::SparseMatrix Core::LinAlg::KrylovProjector::create_projector(
     const int grid = P.global_row_index(rr);
 
     // add identity matrix by adding 1 on diagonal entries
-    P.sum_or_insert_global_values(grid, 1, &one, &grid);
+    P.assemble(one, grid, grid);
   }
 
   // call fill complete

--- a/src/core/linalg/src/sparse/4C_linalg_sparsematrix.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_sparsematrix.hpp
@@ -569,18 +569,6 @@ namespace Core::LinAlg
     void sum_into_global_values(
         int global_row, int num_entries, const double* values, const int* indices);
 
-    /*! \brief Accumulate values into a global row, inserting if summation fails.
-     *
-     * This helper centralizes the logic for handling Epetra's return codes when
-     * adding values to a matrix. Depending on the error code, it will either
-     * sum into an existing row or insert new entries.
-     *
-     * It exists primarily to work around cases where the matrix was not
-     * preallocated with sufficient storage and should be removed in the future.
-     */
-    void sum_or_insert_global_values(
-        int global_row, int num_entries, const double* values, const int* indices);
-
     //@}
 
     /** \name Extraction methods */
@@ -644,6 +632,30 @@ namespace Core::LinAlg
     void print(std::ostream& os) const { sysmat_->Print(os); }
 
    private:
+    /*! \brief Accumulate values into a global row, inserting if summation fails.
+     *
+     * This helper centralizes the logic for handling Epetra's return codes when
+     * adding values to a matrix. Depending on the error code, it will either
+     * sum into an existing row or insert new entries.
+     *
+     * It exists primarily to work around cases where the matrix was not
+     * preallocated with sufficient storage and should be removed in the future.
+     */
+    void sum_or_insert_global_values(
+        int global_row, int num_entries, const double* values, const int* indices);
+
+    /*! \brief Replace values of a global row, inserting if replacement fails.
+     *
+     * This helper centralizes the logic for handling Epetra's return codes when
+     * replacing values of a matrix. Depending on the error code, it will either
+     * replace an existing row or insert new entries.
+     *
+     * It exists primarily to work around cases where the matrix was not
+     * preallocated with sufficient storage and should be removed in the future.
+     */
+    void replace_or_insert_global_values(
+        int global_row, int num_entries, const double* values, const int* indices);
+
     /// internal epetra matrix (Epetra_CrsMatrix or Epetra_FECrsMatrix)
     std::shared_ptr<Epetra_CrsMatrix> sysmat_;
 

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_assemble.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_assemble.cpp
@@ -50,7 +50,7 @@ void Core::LinAlg::assemble(Core::LinAlg::SparseMatrix& A,
 
         // Now that we do not rebuild the sparse mask in each step, we
         // are bound to assemble the whole thing. Zeros included.
-        A.sum_or_insert_global_values(rgid, 1, &val, &cgid);
+        A.assemble(val, rgid, cgid);
       }
     }
   }

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_manipulation.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_manipulation.cpp
@@ -560,7 +560,7 @@ int Core::LinAlg::insert_my_row_diagonal_into_unfilled_matrix(
     if (mat.num_allocated_global_entries(rgid))
     {
       // add all values, including zeros, as we need a proper matrix graph
-      mat.sum_or_insert_global_values(rgid, 1, (diag_values + lid), &rgid);
+      mat.assemble(*(diag_values + lid), rgid, rgid);
     }
     else
     {

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_math.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_math.cpp
@@ -125,7 +125,7 @@ namespace Core::LinAlg
           for (int j = 0; j < NumEntries; ++j) Values[j] *= scalarA;
         for (int j = 0; j < NumEntries; ++j)
         {
-          B.sum_or_insert_global_values(Row, 1, &Values[j], &Indices[j]);
+          B.assemble(Values[j], Row, Indices[j]);
         }
       }
 

--- a/src/coupling/src/adapter/4C_coupling_adapter_converter.cpp
+++ b/src/coupling/src/adapter/4C_coupling_adapter_converter.cpp
@@ -364,7 +364,7 @@ void Coupling::Adapter::MatrixLogicalSplitAndTransform::add_into_unfilled(
       for (int j = 0; j < NumEntries; ++j)
       {
         // add all values, including zeros, as we need a proper matrix graph
-        edst.sum_or_insert_global_values(globalRow, 1, &vals[j], &idx[j]);
+        edst.assemble(vals[j], globalRow, idx[j]);
       }
   }
 }


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
As the title states. This PR acts as follow up to #1546. It moves the temporary `xxx_or_insert` methods to private only to be used inside the sparse matrix implementation. Some other direct matrix calls to `Epetra` are replaced with our internal methods.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
Related to #875