### PR TITLE
[NOX] Inherit matrix-free operators from `SparseOperator`

### DIFF
--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.cpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.cpp
@@ -14,7 +14,6 @@
 #include "4C_utils_shared_ptr_from_ref.hpp"
 
 #include <Epetra_LinearProblem.h>
-#include <Epetra_Operator.h>
 #include <Teuchos_ParameterList.hpp>
 
 #include <vector>
@@ -26,8 +25,8 @@ NOX::FSI::LinearSystemGCR::LinearSystemGCR(Teuchos::ParameterList& printParams,
     Teuchos::ParameterList& linearSolverParams,
     const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
     const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
-    const std::shared_ptr<Epetra_Operator>& jacobian, const NOX::Nln::Vector& cloneVector,
-    const Teuchos::RCP<::NOX::Epetra::Scaling> s)
+    const std::shared_ptr<Core::LinAlg::SparseOperator>& jacobian,
+    const NOX::Nln::Vector& cloneVector, const Teuchos::RCP<::NOX::Epetra::Scaling> s)
     : utils(printParams),
       jacInterfacePtr(iJac),
       jacType(EpetraOperator),
@@ -63,8 +62,7 @@ void NOX::FSI::LinearSystemGCR::reset(Teuchos::ParameterList& linearSolverParams
 bool NOX::FSI::LinearSystemGCR::apply_jacobian(
     const NOX::Nln::Vector& input, NOX::Nln::Vector& result) const
 {
-  jacPtr->SetUseTranspose(false);
-  int status = jacPtr->Apply(input.get_linalg_vector(), result.get_linalg_vector());
+  int status = jacPtr->multiply(false, input.get_linalg_vector(), result.get_linalg_vector());
   return status == 0;
 }
 
@@ -72,10 +70,7 @@ bool NOX::FSI::LinearSystemGCR::apply_jacobian(
 bool NOX::FSI::LinearSystemGCR::apply_jacobian_transpose(
     const NOX::Nln::Vector& input, NOX::Nln::Vector& result) const
 {
-  jacPtr->SetUseTranspose(true);
-  int status = jacPtr->Apply(input.get_linalg_vector(), result.get_linalg_vector());
-  jacPtr->SetUseTranspose(false);
-
+  int status = jacPtr->multiply(true, input.get_linalg_vector(), result.get_linalg_vector());
   return status == 0;
 }
 

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.hpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.hpp
@@ -10,6 +10,7 @@
 
 #include "4C_config.hpp"
 
+#include "4C_linalg_sparseoperator.hpp"
 #include "4C_solver_nonlin_nox_interface_jacobian_base.hpp"
 #include "4C_solver_nonlin_nox_interface_required_base.hpp"
 #include "4C_solver_nonlin_nox_linearsystem_base.hpp"
@@ -57,7 +58,8 @@ namespace NOX
           Teuchos::ParameterList& linearSolverParams,
           const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
           const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
-          const std::shared_ptr<Epetra_Operator>& J, const NOX::Nln::Vector& cloneVector,
+          const std::shared_ptr<Core::LinAlg::SparseOperator>& J,
+          const NOX::Nln::Vector& cloneVector,
           const Teuchos::RCP<::NOX::Epetra::Scaling> scalingObject = Teuchos::null);
 
       //! Reset the linear solver parameters.
@@ -152,7 +154,7 @@ namespace NOX
       OperatorType jacType;
 
       //! Pointer to the Jacobian operator.
-      mutable std::shared_ptr<Epetra_Operator> jacPtr;
+      std::shared_ptr<Core::LinAlg::SparseOperator> jacPtr;
 
       //! Scaling object supplied by the user
       Teuchos::RCP<::NOX::Epetra::Scaling> scaling;

--- a/src/fsi/src/partitioned/4C_fsi_partitioned.cpp
+++ b/src/fsi/src/partitioned/4C_fsi_partitioned.cpp
@@ -503,7 +503,7 @@ Teuchos::RCP<NOX::Nln::LinearSystemBase> FSI::Partitioned::create_linear_system(
 
   std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac;
 
-  std::shared_ptr<Epetra_Operator> J;
+  std::shared_ptr<Core::LinAlg::SparseOperator> J;
 
   Teuchos::RCP<NOX::Nln::LinearSystemBase> linSys;
 
@@ -549,7 +549,7 @@ Teuchos::RCP<NOX::Nln::LinearSystemBase> FSI::Partitioned::create_linear_system(
     auto MF = std::make_shared<NOX::Nln::MatrixFree>(
         printParams, epetra_rcp_interface, noxSoln, lambda, kelleyPerturbation);
     iJac = MF;
-    J = Core::Utils::shared_ptr_from_ref(MF->get_matrix_free());
+    J = Core::Utils::shared_ptr_from_ref(MF->get_operator());
   }
 
   // No Jacobian at all. Do a fix point iteration.

--- a/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_jacobian.cpp
+++ b/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_jacobian.cpp
@@ -52,23 +52,93 @@ NOX::FSI::FSIMatrixFree::FSIMatrixFree(Teuchos::ParameterList& printParams,
   }
 }
 
+Epetra_Operator& NOX::FSI::FSIMatrixFree::epetra_operator() { return *this; }
 
+void NOX::FSI::FSIMatrixFree::zero() { FOUR_C_THROW("Not implemented"); }
 
-int NOX::FSI::FSIMatrixFree::SetUseTranspose(bool UseTranspose)
+void NOX::FSI::FSIMatrixFree::reset() { FOUR_C_THROW("Not implemented"); }
+
+void NOX::FSI::FSIMatrixFree::assemble(int eid, const std::vector<int>& lmstride,
+    const Core::LinAlg::SerialDenseMatrix& Aele, const std::vector<int>& lmrow,
+    const std::vector<int>& lmrowowner, const std::vector<int>& lmcol)
 {
-  if (UseTranspose == true)
-  {
-    utils.out()
-        << "ERROR: FSIMatrixFree::SetUseTranspose() - Transpose is unavailable in Matrix-Free mode!"
-        << std::endl;
-    throw "NOX Error";
-  }
-  return (-1);
+  FOUR_C_THROW("Not implemented");
 }
 
-
-int NOX::FSI::FSIMatrixFree::Apply(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const
+void NOX::FSI::FSIMatrixFree::assemble(double val, int rgid, int cgid)
 {
+  FOUR_C_THROW("Not implemented");
+}
+
+bool NOX::FSI::FSIMatrixFree::filled() const { FOUR_C_THROW("Not implemented"); }
+
+void NOX::FSI::FSIMatrixFree::complete(Core::LinAlg::OptionsMatrixComplete options_matrix_complete)
+{
+  FOUR_C_THROW("Not implemented");
+}
+
+void NOX::FSI::FSIMatrixFree::complete(const Core::LinAlg::Map& domainmap,
+    const Core::LinAlg::Map& rangemap, Core::LinAlg::OptionsMatrixComplete options_matrix_complete)
+{
+  FOUR_C_THROW("Not implemented");
+}
+
+void NOX::FSI::FSIMatrixFree::un_complete() { FOUR_C_THROW("Not implemented"); }
+
+void NOX::FSI::FSIMatrixFree::apply_dirichlet(
+    const Core::LinAlg::Vector<double>& dbctoggle, bool diagonalblock)
+{
+  FOUR_C_THROW("Not implemented");
+}
+
+void NOX::FSI::FSIMatrixFree::apply_dirichlet(const Core::LinAlg::Map& dbcmap, bool diagonalblock)
+{
+  FOUR_C_THROW("Not implemented");
+}
+
+bool NOX::FSI::FSIMatrixFree::is_dbc_applied(const Core::LinAlg::Map& dbcmap, bool diagonalblock,
+    const Core::LinAlg::SparseMatrix* trafo) const
+{
+  FOUR_C_THROW("Not implemented");
+}
+
+const Core::LinAlg::Map& NOX::FSI::FSIMatrixFree::domain_map() const
+{
+  FOUR_C_THROW("Not implemented");
+}
+
+void NOX::FSI::FSIMatrixFree::add(const Core::LinAlg::SparseOperator& A, const bool transposeA,
+    const double scalarA, const double scalarB)
+{
+  FOUR_C_THROW("Not implemented");
+}
+
+void NOX::FSI::FSIMatrixFree::add_other(Core::LinAlg::SparseMatrix& A, const bool transposeA,
+    const double scalarA, const double scalarB) const
+{
+  FOUR_C_THROW("Not implemented");
+}
+
+void NOX::FSI::FSIMatrixFree::add_other(Core::LinAlg::BlockSparseMatrixBase& A,
+    const bool transposeA, const double scalarA, const double scalarB) const
+{
+  FOUR_C_THROW("Not implemented");
+}
+
+int NOX::FSI::FSIMatrixFree::scale(double ScalarConstant) { FOUR_C_THROW("Not implemented"); }
+
+int NOX::FSI::FSIMatrixFree::multiply(bool TransA, const Core::LinAlg::MultiVector<double>& X,
+    Core::LinAlg::MultiVector<double>& Y) const
+{
+  if (TransA == true)
+  {
+    utils.out()
+        << "ERROR: FSIMatrixFree::multiply() - Transpose is unavailable in Matrix-Free mode!"
+        << std::endl;
+    throw "NOX Error";
+    return -1;
+  }
+
   // Calculate the matrix-vector product:
   //
   // y = R' x = S'(F(d)) F'(d) x - x
@@ -82,15 +152,12 @@ int NOX::FSI::FSIMatrixFree::Apply(const Epetra_MultiVector& X, Epetra_MultiVect
   // Convert X and Y from an Epetra_MultiVector to a Core::LinAlg::Vectors
   // and NOX::Nln::Vectors.  This is done so we use a consistent
   // vector space for norms and inner products.
-  Core::LinAlg::View wrappedX(X);
-  Core::LinAlg::View wrappedY(Y);
 
   // There is a const_cast introduced - should be removed
-  NOX::Nln::Vector nevX(Core::Utils::shared_ptr_from_ref(
-                            const_cast<Core::LinAlg::Vector<double>&>(wrappedX.underlying()(0))),
+  NOX::Nln::Vector nevX(
+      Core::Utils::shared_ptr_from_ref(const_cast<Core::LinAlg::Vector<double>&>(X(0))),
       NOX::Nln::Vector::MemoryType::View);
-  NOX::Nln::Vector nevY(Core::Utils::shared_ptr_from_ref(wrappedY.underlying()(0)),
-      NOX::Nln::Vector::MemoryType::View);
+  NOX::Nln::Vector nevY(Core::Utils::shared_ptr_from_ref(Y(0)), NOX::Nln::Vector::MemoryType::View);
 
   // The trial vector x is not guaranteed to be a suitable interface
   // displacement. It might be much too large to fit the ALE
@@ -132,43 +199,74 @@ int NOX::FSI::FSIMatrixFree::Apply(const Epetra_MultiVector& X, Epetra_MultiVect
   return 0;
 }
 
+int NOX::FSI::FSIMatrixFree::SetUseTranspose(bool UseTranspose)
+{
+  FOUR_C_THROW("Not implemented");
+  return -1;
+}
+
+
+int NOX::FSI::FSIMatrixFree::Apply(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const
+{
+  FOUR_C_THROW("Not implemented");
+  return -1;
+}
+
 
 int NOX::FSI::FSIMatrixFree::ApplyInverse(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const
 {
-  utils.out() << "ERROR: FSIMatrixFree::ApplyInverse - Not available for Matrix Free!" << std::endl;
-  throw "NOX Error";
-  return (-1);
+  FOUR_C_THROW("Not implemented");
+  return -1;
 }
 
 
 double NOX::FSI::FSIMatrixFree::NormInf() const
 {
-  utils.out() << "ERROR: FSIMatrixFree::NormInf() - Not Available for Matrix-Free mode!"
-              << std::endl;
-  throw "NOX Error";
+  FOUR_C_THROW("Not implemented");
   return 1.0;
 }
 
 
-const char* NOX::FSI::FSIMatrixFree::Label() const { return label.c_str(); }
+const char* NOX::FSI::FSIMatrixFree::Label() const
+{
+  FOUR_C_THROW("Not implemented");
+  return label.c_str();
+}
 
 
-bool NOX::FSI::FSIMatrixFree::UseTranspose() const { return false; }
+bool NOX::FSI::FSIMatrixFree::UseTranspose() const
+{
+  FOUR_C_THROW("Not implemented");
+  return false;
+}
 
 
-bool NOX::FSI::FSIMatrixFree::HasNormInf() const { return false; }
+bool NOX::FSI::FSIMatrixFree::HasNormInf() const
+{
+  FOUR_C_THROW("Not implemented");
+  return false;
+}
 
 
 const Epetra_Comm& NOX::FSI::FSIMatrixFree::Comm() const
 {
+  FOUR_C_THROW("Not implemented");
   return Core::Communication::as_epetra_comm(currentX.get_linalg_vector().get_map().get_comm());
 }
 
 
-const Epetra_Map& NOX::FSI::FSIMatrixFree::OperatorDomainMap() const { return *epetraMap; }
+const Epetra_Map& NOX::FSI::FSIMatrixFree::OperatorDomainMap() const
+{
+  FOUR_C_THROW("Not implemented");
+  return *epetraMap;
+}
 
 
-const Epetra_Map& NOX::FSI::FSIMatrixFree::OperatorRangeMap() const { return *epetraMap; }
+const Epetra_Map& NOX::FSI::FSIMatrixFree::OperatorRangeMap() const
+{
+  FOUR_C_THROW("Not implemented");
+  return *epetraMap;
+}
 
 
 bool NOX::FSI::FSIMatrixFree::computeJacobian(const Epetra_Vector& x, Epetra_Operator& Jac)

--- a/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_jacobian.hpp
+++ b/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_jacobian.hpp
@@ -10,6 +10,7 @@
 
 #include "4C_config.hpp"
 
+#include "4C_linalg_sparseoperator.hpp"
 #include "4C_solver_nonlin_nox_interface_jacobian_base.hpp"
 #include "4C_solver_nonlin_nox_interface_required_base.hpp"
 #include "4C_solver_nonlin_nox_vector.hpp"
@@ -35,7 +36,8 @@ namespace NOX
   namespace FSI
   {
     /// Matrix Free Newton Krylov based on an approximation of the residuum derivatives
-    class FSIMatrixFree : public Epetra_Operator, public virtual NOX::Nln::Interface::JacobianBase
+    class FSIMatrixFree : public Core::LinAlg::SparseOperator,
+                          public virtual NOX::Nln::Interface::JacobianBase
     {
      public:
       /*! \brief Constructor
@@ -45,7 +47,54 @@ namespace NOX
       FSIMatrixFree(Teuchos::ParameterList& printParams,
           const std::shared_ptr<NOX::Nln::Interface::RequiredBase> i, const NOX::Nln::Vector& x);
 
+      // Methods of Core::LinAlg::SparseOperator interface
+      Epetra_Operator& epetra_operator() override;
 
+      void zero() override;
+
+      void reset() override;
+
+      void assemble(int eid, const std::vector<int>& lmstride,
+          const Core::LinAlg::SerialDenseMatrix& Aele, const std::vector<int>& lmrow,
+          const std::vector<int>& lmrowowner, const std::vector<int>& lmcol) override;
+
+      void assemble(double val, int rgid, int cgid) override;
+
+      bool filled() const override;
+
+      void complete(Core::LinAlg::OptionsMatrixComplete options_matrix_complete = {}) override;
+
+      void complete(const Core::LinAlg::Map& domainmap, const Core::LinAlg::Map& rangemap,
+          Core::LinAlg::OptionsMatrixComplete options_matrix_complete = {}) override;
+
+      void un_complete() override;
+
+      void apply_dirichlet(
+          const Core::LinAlg::Vector<double>& dbctoggle, bool diagonalblock = true) override;
+
+      void apply_dirichlet(const Core::LinAlg::Map& dbcmap, bool diagonalblock = true) override;
+
+      bool is_dbc_applied(const Core::LinAlg::Map& dbcmap, bool diagonalblock = true,
+          const Core::LinAlg::SparseMatrix* trafo = nullptr) const override;
+
+      const Core::LinAlg::Map& domain_map() const override;
+
+      void add(const Core::LinAlg::SparseOperator& A, const bool transposeA, const double scalarA,
+          const double scalarB) override;
+
+      void add_other(Core::LinAlg::SparseMatrix& A, const bool transposeA, const double scalarA,
+          const double scalarB) const override;
+
+      void add_other(Core::LinAlg::BlockSparseMatrixBase& A, const bool transposeA,
+          const double scalarA, const double scalarB) const override;
+
+      int scale(double ScalarConstant) override;
+
+      int multiply(bool TransA, const Core::LinAlg::MultiVector<double>& X,
+          Core::LinAlg::MultiVector<double>& Y) const override;
+
+
+      // Methods of Epetra_Operator interface
       //! If set true, transpose of this operator will be applied.
       /*! This flag allows the transpose of the given operator to be used implicitly.  Setting this
         flag affects only the Apply() and ApplyInverse() methods.  If the implementation of this

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_matrixfree.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_matrixfree.cpp
@@ -9,17 +9,183 @@
 
 FOUR_C_NAMESPACE_OPEN
 
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
+NOX::Nln::MatrixFree::SparseOperatorWrapper::SparseOperatorWrapper(Epetra_Operator& op)
+    : operator_(op)
+{
+}
+
+Epetra_Operator& NOX::Nln::MatrixFree::SparseOperatorWrapper::epetra_operator()
+{
+  return operator_;
+}
+
+void NOX::Nln::MatrixFree::SparseOperatorWrapper::zero() { FOUR_C_THROW("Not implemented"); }
+
+void NOX::Nln::MatrixFree::SparseOperatorWrapper::reset() { FOUR_C_THROW("Not implemented"); }
+
+void NOX::Nln::MatrixFree::SparseOperatorWrapper::assemble(int eid,
+    const std::vector<int>& lmstride, const Core::LinAlg::SerialDenseMatrix& Aele,
+    const std::vector<int>& lmrow, const std::vector<int>& lmrowowner,
+    const std::vector<int>& lmcol)
+{
+  FOUR_C_THROW("Not implemented");
+}
+
+void NOX::Nln::MatrixFree::SparseOperatorWrapper::assemble(double val, int rgid, int cgid)
+{
+  FOUR_C_THROW("Not implemented");
+}
+
+bool NOX::Nln::MatrixFree::SparseOperatorWrapper::filled() const
+{
+  FOUR_C_THROW("Not implemented");
+}
+
+void NOX::Nln::MatrixFree::SparseOperatorWrapper::complete(
+    Core::LinAlg::OptionsMatrixComplete options_matrix_complete)
+{
+  FOUR_C_THROW("Not implemented");
+}
+
+void NOX::Nln::MatrixFree::SparseOperatorWrapper::complete(const Core::LinAlg::Map& domainmap,
+    const Core::LinAlg::Map& rangemap, Core::LinAlg::OptionsMatrixComplete options_matrix_complete)
+{
+  FOUR_C_THROW("Not implemented");
+}
+
+void NOX::Nln::MatrixFree::SparseOperatorWrapper::un_complete() { FOUR_C_THROW("Not implemented"); }
+
+void NOX::Nln::MatrixFree::SparseOperatorWrapper::apply_dirichlet(
+    const Core::LinAlg::Vector<double>& dbctoggle, bool diagonalblock)
+{
+  FOUR_C_THROW("Not implemented");
+}
+
+void NOX::Nln::MatrixFree::SparseOperatorWrapper::apply_dirichlet(
+    const Core::LinAlg::Map& dbcmap, bool diagonalblock)
+{
+  FOUR_C_THROW("Not implemented");
+}
+
+bool NOX::Nln::MatrixFree::SparseOperatorWrapper::is_dbc_applied(const Core::LinAlg::Map& dbcmap,
+    bool diagonalblock, const Core::LinAlg::SparseMatrix* trafor) const
+{
+  FOUR_C_THROW("Not implemented");
+}
+
+const Core::LinAlg::Map& NOX::Nln::MatrixFree::SparseOperatorWrapper::domain_map() const
+{
+  FOUR_C_THROW("Not implemented");
+}
+
+void NOX::Nln::MatrixFree::SparseOperatorWrapper::add(const Core::LinAlg::SparseOperator& A,
+    const bool transposeA, const double scalarA, const double scalarB)
+{
+  FOUR_C_THROW("Not implemented");
+}
+
+void NOX::Nln::MatrixFree::SparseOperatorWrapper::add_other(Core::LinAlg::SparseMatrix& A,
+    const bool transposeA, const double scalarA, const double scalarB) const
+{
+  FOUR_C_THROW("Not implemented");
+}
+
+void NOX::Nln::MatrixFree::SparseOperatorWrapper::add_other(Core::LinAlg::BlockSparseMatrixBase& A,
+    const bool transposeA, const double scalarA, const double scalarB) const
+{
+  FOUR_C_THROW("Not implemented");
+}
+
+int NOX::Nln::MatrixFree::SparseOperatorWrapper::scale(double ScalarConstant)
+{
+  FOUR_C_THROW("Not implemented");
+}
+
+int NOX::Nln::MatrixFree::SparseOperatorWrapper::multiply(bool TransA,
+    const Core::LinAlg::MultiVector<double>& X, Core::LinAlg::MultiVector<double>& Y) const
+{
+  FOUR_C_ASSERT(!TransA, "Transposed multiplication is not supported");
+  return operator_.Apply(X.get_epetra_multi_vector(), Y.get_epetra_multi_vector());
+}
+
+
+int NOX::Nln::MatrixFree::SparseOperatorWrapper::SetUseTranspose(bool UseTranspose)
+{
+  FOUR_C_THROW("Not implemented");
+  return -1;
+}
+
+
+int NOX::Nln::MatrixFree::SparseOperatorWrapper::Apply(
+    const Epetra_MultiVector& X, Epetra_MultiVector& Y) const
+{
+  FOUR_C_THROW("Not implemented");
+  return -1;
+}
+
+
+int NOX::Nln::MatrixFree::SparseOperatorWrapper::ApplyInverse(
+    const Epetra_MultiVector& X, Epetra_MultiVector& Y) const
+{
+  FOUR_C_THROW("Not implemented");
+  return -1;
+}
+
+
+double NOX::Nln::MatrixFree::SparseOperatorWrapper::NormInf() const
+{
+  FOUR_C_THROW("Not implemented");
+  return -1;
+}
+
+
+const char* NOX::Nln::MatrixFree::SparseOperatorWrapper::Label() const
+{
+  FOUR_C_THROW("Not implemented");
+  return nullptr;
+}
+
+
+bool NOX::Nln::MatrixFree::SparseOperatorWrapper::UseTranspose() const
+{
+  FOUR_C_THROW("Not implemented");
+  return false;
+}
+
+
+bool NOX::Nln::MatrixFree::SparseOperatorWrapper::HasNormInf() const
+{
+  FOUR_C_THROW("Not implemented");
+  return false;
+}
+
+
+const Epetra_Comm& NOX::Nln::MatrixFree::SparseOperatorWrapper::Comm() const
+{
+  FOUR_C_THROW("Not implemented");
+}
+
+
+const Epetra_Map& NOX::Nln::MatrixFree::SparseOperatorWrapper::OperatorDomainMap() const
+{
+  FOUR_C_THROW("Not implemented");
+}
+
+
+const Epetra_Map& NOX::Nln::MatrixFree::SparseOperatorWrapper::OperatorRangeMap() const
+{
+  FOUR_C_THROW("Not implemented");
+}
+
 NOX::Nln::MatrixFree::MatrixFree(Teuchos::ParameterList& printParams,
     const Teuchos::RCP<NOX::Nln::Interface::RequiredBase>& required,
     const NOX::Nln::Vector& cloneVector, double lambda, bool useNewPerturbation)
-    : matrix_free_(printParams, required, cloneVector, useNewPerturbation)
+    : matrix_free_(printParams, required, cloneVector, useNewPerturbation), wrapper_(matrix_free_)
 {
   matrix_free_.setLambda(lambda);
 }
 
-::NOX::Epetra::MatrixFree& NOX::Nln::MatrixFree::get_matrix_free() { return matrix_free_; }
+Core::LinAlg::SparseOperator& NOX::Nln::MatrixFree::get_operator() { return wrapper_; }
 
 bool NOX::Nln::MatrixFree::computeJacobian(const Epetra_Vector& x, Epetra_Operator& Jac)
 {

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_matrixfree.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_matrixfree.hpp
@@ -10,6 +10,7 @@
 
 #include "4C_config.hpp"
 
+#include "4C_linalg_sparseoperator.hpp"
 #include "4C_solver_nonlin_nox_interface_jacobian_base.hpp"
 #include "4C_solver_nonlin_nox_interface_required_base.hpp"
 #include "4C_solver_nonlin_nox_vector.hpp"
@@ -26,17 +27,94 @@ namespace NOX
   {
     class MatrixFree : public NOX::Nln::Interface::JacobianBase
     {
+      class SparseOperatorWrapper : public Core::LinAlg::SparseOperator
+      {
+       public:
+        SparseOperatorWrapper(Epetra_Operator& op);
+
+        // Methods of Core::LinAlg::SparseOperator interface
+        Epetra_Operator& epetra_operator() override;
+
+        void zero() override;
+
+        void reset() override;
+
+        void assemble(int eid, const std::vector<int>& lmstride,
+            const Core::LinAlg::SerialDenseMatrix& Aele, const std::vector<int>& lmrow,
+            const std::vector<int>& lmrowowner, const std::vector<int>& lmcol) override;
+
+        void assemble(double val, int rgid, int cgid) override;
+
+        bool filled() const override;
+
+        void complete(Core::LinAlg::OptionsMatrixComplete options_matrix_complete = {}) override;
+
+        void complete(const Core::LinAlg::Map& domainmap, const Core::LinAlg::Map& rangemap,
+            Core::LinAlg::OptionsMatrixComplete options_matrix_complete = {}) override;
+
+        void un_complete() override;
+
+        void apply_dirichlet(
+            const Core::LinAlg::Vector<double>& dbctoggle, bool diagonalblock = true) override;
+
+        void apply_dirichlet(const Core::LinAlg::Map& dbcmap, bool diagonalblock = true) override;
+
+        bool is_dbc_applied(const Core::LinAlg::Map& dbcmap, bool diagonalblock = true,
+            const Core::LinAlg::SparseMatrix* trafo = nullptr) const override;
+
+        const Core::LinAlg::Map& domain_map() const override;
+
+        void add(const Core::LinAlg::SparseOperator& A, const bool transposeA, const double scalarA,
+            const double scalarB) override;
+
+        void add_other(Core::LinAlg::SparseMatrix& A, const bool transposeA, const double scalarA,
+            const double scalarB) const override;
+
+        void add_other(Core::LinAlg::BlockSparseMatrixBase& A, const bool transposeA,
+            const double scalarA, const double scalarB) const override;
+
+        int scale(double ScalarConstant) override;
+
+        int multiply(bool TransA, const Core::LinAlg::MultiVector<double>& X,
+            Core::LinAlg::MultiVector<double>& Y) const override;
+
+        // Methods of Epetra_Operator interface
+        int SetUseTranspose(bool UseTranspose) override;
+
+        int Apply(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const override;
+
+        int ApplyInverse(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const override;
+
+        double NormInf() const override;
+
+        const char* Label() const override;
+
+        bool UseTranspose() const override;
+
+        bool HasNormInf() const override;
+
+        const Epetra_Comm& Comm() const override;
+
+        const Epetra_Map& OperatorDomainMap() const override;
+
+        const Epetra_Map& OperatorRangeMap() const override;
+
+       private:
+        Epetra_Operator& operator_;
+      };
+
      public:
       MatrixFree(Teuchos::ParameterList& printParams,
           const Teuchos::RCP<NOX::Nln::Interface::RequiredBase>& required,
           const NOX::Nln::Vector& cloneVector, double lambda, bool useNewPerturbation = false);
 
-      ::NOX::Epetra::MatrixFree& get_matrix_free();
+      Core::LinAlg::SparseOperator& get_operator();
 
       bool computeJacobian(const Epetra_Vector& x, Epetra_Operator& Jac) override;
 
      private:
       ::NOX::Epetra::MatrixFree matrix_free_;
+      SparseOperatorWrapper wrapper_;
     };
   }  // namespace Nln
 }  // namespace NOX


### PR DESCRIPTION
## Description and Context
In order to proceed with removal of the base inheritances of `NOX::Nln::Interface::RequiredBase` and `NOX::Nln::Interface::JacobianBase` quite substantial modifications are required. This is just one of them and it effectively removes `Epetra_Operator` yet from one more place. It is also required for #1524.

A temporary wrapper `NOX::Nln::MatrixFree::SparseOperatorWrapper` is introduced here. Ultimately, it will be either simplified or completely removed later.

While working on this PR, I noticed that the default interface of `Core::LinAlg::SparseOperator` is excessive: most of the methods should be removed. For instance, 
- `is_dbc_applied()` - it is very specific and is used in a single place of the code.
- `add_other()` - it is odd and not used at all.
This is just what I identified by a quick look.

## Related Issues and Pull Requests
#1524, #1535, #1486
