### PR TITLE
Let prescribed prestretch strategy take a field

### DIFF
--- a/src/core/legacy_enum_definitions/4C_legacy_enum_definitions_materials.cpp
+++ b/src/core/legacy_enum_definitions/4C_legacy_enum_definitions_materials.cpp
@@ -367,8 +367,8 @@ std::string_view Core::Materials::to_string(Core::Materials::MaterialType materi
       return "MIX_GrowthStrategy_Anisotropic";
     case mix_growth_strategy_stiffness:
       return "MIX_GrowthStrategy_Stiffness";
-    case mix_prestress_strategy_constant:
-      return "MIX_Prestress_Strategy_Constant";
+    case mix_prestress_strategy_prescribed:
+      return "MIX_Prestress_Strategy_Prescribed";
     case mix_prestress_strategy_cylinder:
       return "MIX_Prestress_Strategy_Cylinder";
     case mix_prestress_strategy_iterative:

--- a/src/core/legacy_enum_definitions/4C_legacy_enum_definitions_materials.hpp
+++ b/src/core/legacy_enum_definitions/4C_legacy_enum_definitions_materials.hpp
@@ -270,7 +270,7 @@ namespace Core::Materials
     mix_rule_growthremodel,           ///< Homogenized constrained mixture
     mix_prestress_strategy_cylinder,  ///< Prestress strategy for a cylinder
     mix_prestress_strategy_iterative,    ///< Iterative prestress strategy for any geometry
-    mix_prestress_strategy_constant,     ///< Constant, predefined prestretch
+    mix_prestress_strategy_prescribed,   ///< Predefined prestretch field for any geometry
     mix_elasthyper,                      ///< Elast Hyper toolbox for constituents
     mix_elasthyper_damage,               ///< Elast hyper toolbox with temporal damage
     mix_elasthyper_elastin_membrane,     ///< Elast Hyper toolbox with temporal damage and 2D

--- a/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
+++ b/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
@@ -4001,11 +4001,11 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
   /*----------------------------------------------------------------------*/
   // Constant predefined prestretch
   {
-    known_materials[Core::Materials::mix_prestress_strategy_constant] =
-        group("MIX_Prestress_Strategy_Constant",
+    known_materials[Core::Materials::mix_prestress_strategy_prescribed] =
+        group("MIX_Prestress_Strategy_Prescribed",
             {
-                parameter<Core::LinAlg::SymmetricTensor<double, 3, 3>>("PRESTRETCH",
-                    {.description = "Definition of the (symmetric) prestretch tensor"}),
+                interpolated_input_field<Core::LinAlg::SymmetricTensor<double, 3, 3>>(
+                    "PRESTRETCH", {.description = "Field of a symmetric prestretch tensor."}),
             },
             {.description = "Simple predefined prestress"});
   }

--- a/src/mat/4C_mat_material_factory.cpp
+++ b/src/mat/4C_mat_material_factory.cpp
@@ -159,9 +159,9 @@
 #include "4C_mixture_growth_strategy_anisotropic.hpp"
 #include "4C_mixture_growth_strategy_isotropic.hpp"
 #include "4C_mixture_growth_strategy_stiffness.hpp"
-#include "4C_mixture_prestress_strategy_constant.hpp"
 #include "4C_mixture_prestress_strategy_isocyl.hpp"
 #include "4C_mixture_prestress_strategy_iterative.hpp"
+#include "4C_mixture_prestress_strategy_prescribed.hpp"
 #include "4C_mixture_rule_function.hpp"
 #include "4C_mixture_rule_growthremodel.hpp"
 #include "4C_mixture_rule_simple.hpp"
@@ -671,9 +671,9 @@ std::unique_ptr<Core::Mat::PAR::Parameter> Mat::make_parameter(
       return make_parameter_impl<FourC::Mixture::PAR::IterativePrestressStrategy>(
           id, type, input_data);
     }
-    case Core::Materials::mix_prestress_strategy_constant:
+    case Core::Materials::mix_prestress_strategy_prescribed:
     {
-      return make_parameter_impl<FourC::Mixture::PAR::ConstantPrestressStrategy>(
+      return make_parameter_impl<FourC::Mixture::PAR::PrescribedPrestressStrategy>(
           id, type, input_data);
     }
     case Core::Materials::m_iterative_prestress:

--- a/src/mat/4C_mat_service.cpp
+++ b/src/mat/4C_mat_service.cpp
@@ -7,24 +7,10 @@
 
 #include "4C_mat_service.hpp"
 
-#include "4C_comm_pack_helpers.hpp"
 #include "4C_linalg_fixedsizematrix_tensor_products.hpp"
 #include "4C_linalg_fixedsizematrix_voigt_notation.hpp"
 #include "4C_linalg_four_tensor.hpp"
 #include "4C_linalg_utils_densematrix_eigen.hpp"
-#include "4C_mat_par_bundle.hpp"
-#include "4C_mixture_constituent_remodelfiber_material_exponential.hpp"
-#include "4C_mixture_constituent_remodelfiber_material_exponential_active.hpp"
-#include "4C_mixture_growth_strategy_anisotropic.hpp"
-#include "4C_mixture_growth_strategy_isotropic.hpp"
-#include "4C_mixture_growth_strategy_stiffness.hpp"
-#include "4C_mixture_prestress_strategy_constant.hpp"
-#include "4C_mixture_prestress_strategy_isocyl.hpp"
-#include "4C_mixture_prestress_strategy_iterative.hpp"
-#include "4C_mixture_rule_function.hpp"
-#include "4C_mixture_rule_growthremodel.hpp"
-#include "4C_mixture_rule_simple.hpp"
-#include "4C_utils_enum.hpp"
 
 #include <Sacado.hpp>
 

--- a/src/mixture/src/4C_mixture_prestress_strategy.cpp
+++ b/src/mixture/src/4C_mixture_prestress_strategy.cpp
@@ -11,9 +11,9 @@
 #include "4C_mat_par_bundle.hpp"
 #include "4C_mat_service.hpp"
 #include "4C_material_parameter_base.hpp"
-#include "4C_mixture_prestress_strategy_constant.hpp"
 #include "4C_mixture_prestress_strategy_isocyl.hpp"
 #include "4C_mixture_prestress_strategy_iterative.hpp"
+#include "4C_mixture_prestress_strategy_prescribed.hpp"
 #include "4C_utils_exceptions.hpp"
 
 FOUR_C_NAMESPACE_OPEN
@@ -51,9 +51,9 @@ Mixture::PAR::PrestressStrategy* Mixture::PAR::PrestressStrategy::factory(int ma
       return Mat::create_material_parameter_instance<Mixture::PAR::IterativePrestressStrategy>(
           curmat);
     }
-    case Core::Materials::mix_prestress_strategy_constant:
+    case Core::Materials::mix_prestress_strategy_prescribed:
     {
-      return Mat::create_material_parameter_instance<Mixture::PAR::ConstantPrestressStrategy>(
+      return Mat::create_material_parameter_instance<Mixture::PAR::PrescribedPrestressStrategy>(
           curmat);
     }
     default:

--- a/src/mixture/src/4C_mixture_prestress_strategy_prescribed.hpp
+++ b/src/mixture/src/4C_mixture_prestress_strategy_prescribed.hpp
@@ -5,11 +5,12 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
-#ifndef FOUR_C_MIXTURE_PRESTRESS_STRATEGY_CONSTANT_HPP
-#define FOUR_C_MIXTURE_PRESTRESS_STRATEGY_CONSTANT_HPP
+#ifndef FOUR_C_MIXTURE_PRESTRESS_STRATEGY_PRESCRIBED_HPP
+#define FOUR_C_MIXTURE_PRESTRESS_STRATEGY_PRESCRIBED_HPP
 
 #include "4C_config.hpp"
 
+#include "4C_io_input_field.hpp"
 #include "4C_linalg_fixedsizematrix.hpp"
 #include "4C_linalg_symmetric_tensor.hpp"
 #include "4C_mixture_elastin_membrane_prestress_strategy.hpp"
@@ -24,24 +25,24 @@ FOUR_C_NAMESPACE_OPEN
 namespace Mixture
 {
   // forward declaration
-  class ConstantPrestressStrategy;
+  class PrescribedPrestressStrategy;
 
   namespace PAR
   {
-    class ConstantPrestressStrategy : public Mixture::PAR::PrestressStrategy
+    class PrescribedPrestressStrategy : public Mixture::PAR::PrestressStrategy
     {
-      friend class Mixture::ConstantPrestressStrategy;
+      friend class Mixture::PrescribedPrestressStrategy;
 
      public:
       /// constructor
-      explicit ConstantPrestressStrategy(const Core::Mat::PAR::Parameter::Data& matdata);
+      explicit PrescribedPrestressStrategy(const Core::Mat::PAR::Parameter::Data& matdata);
 
       /// create prestress strategy instance of matching type with my parameters
       std::unique_ptr<Mixture::PrestressStrategy> create_prestress_strategy() override;
 
       /// @name parameters of the prestress strategy
       /// @{
-      Core::LinAlg::SymmetricTensor<double, 3, 3> prestretch_;
+      Core::IO::InterpolatedInputField<Core::LinAlg::SymmetricTensor<double, 3, 3>> prestretch_;
       /// @}
     };
   }  // namespace PAR
@@ -50,11 +51,11 @@ namespace Mixture
   /*!
    * \brief Prestressing strategy for a constant predefined prestretch tensor.
    */
-  class ConstantPrestressStrategy : public PrestressStrategy
+  class PrescribedPrestressStrategy : public PrestressStrategy
   {
    public:
     /// Constructor for the material given the material parameters
-    explicit ConstantPrestressStrategy(Mixture::PAR::ConstantPrestressStrategy* params);
+    explicit PrescribedPrestressStrategy(Mixture::PAR::PrescribedPrestressStrategy* params);
 
     void setup(Mixture::MixtureConstituent& constituent, const Teuchos::ParameterList& params,
         int gp, int eleGID) override;
@@ -72,7 +73,7 @@ namespace Mixture
 
    private:
     /// Holder for internal parameters
-    const PAR::ConstantPrestressStrategy* params_;
+    const PAR::PrescribedPrestressStrategy* params_;
   };
 }  // namespace Mixture
 

--- a/tests/input_files/homogenized-constrained-mixture-cube-aniso-expl.4C.yaml
+++ b/tests/input_files/homogenized-constrained-mixture-cube-aniso-expl.4C.yaml
@@ -75,8 +75,9 @@ MATERIALS:
     ELAST_VolSussmanBathe:
       KAPPA: 100
   - MAT: 129
-    MIX_Prestress_Strategy_Constant:
-      PRESTRETCH: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    MIX_Prestress_Strategy_Prescribed:
+      PRESTRETCH:
+        constant: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
 DESIGN SURF ROBIN SPRING DASHPOT CONDITIONS:
   - E: 1
     NUMDOF: 3

--- a/tests/input_files/homogenized-constrained-mixture-cube-iso-expl.4C.yaml
+++ b/tests/input_files/homogenized-constrained-mixture-cube-iso-expl.4C.yaml
@@ -73,8 +73,9 @@ MATERIALS:
     ELAST_VolSussmanBathe:
       KAPPA: 100
   - MAT: 129
-    MIX_Prestress_Strategy_Constant:
-      PRESTRETCH: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    MIX_Prestress_Strategy_Prescribed:
+      PRESTRETCH:
+        constant: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
 DESIGN SURF ROBIN SPRING DASHPOT CONDITIONS:
   - E: 1
     NUMDOF: 3

--- a/tests/input_files/homogenized-constrained-mixture-cube-stiffness-expl.4C.yaml
+++ b/tests/input_files/homogenized-constrained-mixture-cube-stiffness-expl.4C.yaml
@@ -71,8 +71,9 @@ MATERIALS:
       K2: 10
       C: 1
   - MAT: 129
-    MIX_Prestress_Strategy_Constant:
-      PRESTRETCH: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    MIX_Prestress_Strategy_Prescribed:
+      PRESTRETCH:
+        constant: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
 DESIGN SURF ROBIN SPRING DASHPOT CONDITIONS:
   - E: 1
     NUMDOF: 3

--- a/tests/input_files/homogenized-constrained-mixture-cube-stiffness-impl.4C.yaml
+++ b/tests/input_files/homogenized-constrained-mixture-cube-stiffness-impl.4C.yaml
@@ -75,8 +75,9 @@ MATERIALS:
       K2: 10
       C: 1
   - MAT: 129
-    MIX_Prestress_Strategy_Constant:
-      PRESTRETCH: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    MIX_Prestress_Strategy_Prescribed:
+      PRESTRETCH:
+        constant: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
 DESIGN SURF ROBIN SPRING DASHPOT CONDITIONS:
   - E: 1
     NUMDOF: 3

--- a/tests/input_files/mat_elasthyper_coupanisoexpoactive.4C.yaml
+++ b/tests/input_files/mat_elasthyper_coupanisoexpoactive.4C.yaml
@@ -60,8 +60,9 @@ MATERIALS:
     ELAST_VolSussmanBathe:
       KAPPA: 100
   - MAT: 129
-    MIX_Prestress_Strategy_Constant:
-      PRESTRETCH: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    MIX_Prestress_Strategy_Prescribed:
+      PRESTRETCH:
+        constant: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
 DESIGN SURF DIRICH CONDITIONS:
   - E: 1
     NUMDOF: 3

--- a/tests/input_files/mat_elasthyper_coupanisoexpoactive_restart.4C.yaml
+++ b/tests/input_files/mat_elasthyper_coupanisoexpoactive_restart.4C.yaml
@@ -59,8 +59,9 @@ MATERIALS:
     ELAST_VolSussmanBathe:
       KAPPA: 100
   - MAT: 129
-    MIX_Prestress_Strategy_Constant:
-      PRESTRETCH: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    MIX_Prestress_Strategy_Prescribed:
+      PRESTRETCH:
+        constant: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
 DESIGN SURF DIRICH CONDITIONS:
   - E: 1
     NUMDOF: 3

--- a/tests/input_files/mixture_growth_expl_remodel_fiber_no_basal_mass_production.4C.yaml
+++ b/tests/input_files/mixture_growth_expl_remodel_fiber_no_basal_mass_production.4C.yaml
@@ -90,8 +90,9 @@ MATERIALS:
     ELAST_VolSussmanBathe:
       KAPPA: 100
   - MAT: 139
-    MIX_Prestress_Strategy_Constant:
-      PRESTRETCH: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    MIX_Prestress_Strategy_Prescribed:
+      PRESTRETCH:
+        constant: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
 DESIGN SURF ROBIN SPRING DASHPOT CONDITIONS:
   - E: 1
     NUMDOF: 3

--- a/tests/input_files/mixture_growth_full_constrained_mixture_fiber_adaptive_higher_order.4C.yaml
+++ b/tests/input_files/mixture_growth_full_constrained_mixture_fiber_adaptive_higher_order.4C.yaml
@@ -78,8 +78,9 @@ MATERIALS:
     ELAST_VolSussmanBathe:
       KAPPA: 100
   - MAT: 129
-    MIX_Prestress_Strategy_Constant:
-      PRESTRETCH: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    MIX_Prestress_Strategy_Prescribed:
+      PRESTRETCH:
+        constant: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
 FUNCT1:
   - COMPONENT: 0
     SYMBOLIC_FUNCTION_OF_SPACE_TIME: "1+0.05*y+0.04*z"

--- a/tests/input_files/mixture_growth_full_constrained_mixture_fiber_adaptive_model_equation.4C.yaml
+++ b/tests/input_files/mixture_growth_full_constrained_mixture_fiber_adaptive_model_equation.4C.yaml
@@ -78,8 +78,9 @@ MATERIALS:
     ELAST_VolSussmanBathe:
       KAPPA: 100
   - MAT: 129
-    MIX_Prestress_Strategy_Constant:
-      PRESTRETCH: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    MIX_Prestress_Strategy_Prescribed:
+      PRESTRETCH:
+        constant: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
 FUNCT1:
   - COMPONENT: 0
     SYMBOLIC_FUNCTION_OF_SPACE_TIME: "1+0.2*y+0.4*z"

--- a/tests/input_files/mixture_growth_full_constrained_mixture_fiber_no_basal_mass_production.4C.yaml
+++ b/tests/input_files/mixture_growth_full_constrained_mixture_fiber_no_basal_mass_production.4C.yaml
@@ -90,8 +90,9 @@ MATERIALS:
     ELAST_VolSussmanBathe:
       KAPPA: 100
   - MAT: 139
-    MIX_Prestress_Strategy_Constant:
-      PRESTRETCH: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    MIX_Prestress_Strategy_Prescribed:
+      PRESTRETCH:
+        constant: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
 DESIGN SURF ROBIN SPRING DASHPOT CONDITIONS:
   - E: 1
     NUMDOF: 3

--- a/tests/input_files/mixture_growth_full_constrained_mixture_fiber_non_adaptive.4C.yaml
+++ b/tests/input_files/mixture_growth_full_constrained_mixture_fiber_non_adaptive.4C.yaml
@@ -76,8 +76,9 @@ MATERIALS:
     ELAST_VolSussmanBathe:
       KAPPA: 100
   - MAT: 129
-    MIX_Prestress_Strategy_Constant:
-      PRESTRETCH: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    MIX_Prestress_Strategy_Prescribed:
+      PRESTRETCH:
+        constant: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
 FUNCT1:
   - COMPONENT: 0
     SYMBOLIC_FUNCTION_OF_SPACE_TIME: "1+0.2*y+0.4*z"

--- a/tests/input_files/mixture_growth_impl_remodel_fiber_no_basal_mass_production.4C.yaml
+++ b/tests/input_files/mixture_growth_impl_remodel_fiber_no_basal_mass_production.4C.yaml
@@ -90,8 +90,9 @@ MATERIALS:
     ELAST_VolSussmanBathe:
       KAPPA: 100
   - MAT: 139
-    MIX_Prestress_Strategy_Constant:
-      PRESTRETCH: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    MIX_Prestress_Strategy_Prescribed:
+      PRESTRETCH:
+        constant: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
 DESIGN SURF ROBIN SPRING DASHPOT CONDITIONS:
   - E: 1
     NUMDOF: 3

--- a/tests/input_files/solid_runtime_gauss_point_quantity_output_element_center.4C.yaml
+++ b/tests/input_files/solid_runtime_gauss_point_quantity_output_element_center.4C.yaml
@@ -73,8 +73,9 @@ MATERIALS:
     ELAST_VolSussmanBathe:
       KAPPA: 100
   - MAT: 129
-    MIX_Prestress_Strategy_Constant:
-      PRESTRETCH: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    MIX_Prestress_Strategy_Prescribed:
+      PRESTRETCH:
+        constant: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
   - MAT: 2
     MAT_ElastHyper:
       NUMMAT: 2

--- a/tests/input_files/solid_runtime_gauss_point_quantity_output_gauss_point.4C.yaml
+++ b/tests/input_files/solid_runtime_gauss_point_quantity_output_gauss_point.4C.yaml
@@ -73,8 +73,9 @@ MATERIALS:
     ELAST_VolSussmanBathe:
       KAPPA: 100
   - MAT: 129
-    MIX_Prestress_Strategy_Constant:
-      PRESTRETCH: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    MIX_Prestress_Strategy_Prescribed:
+      PRESTRETCH:
+        constant: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
   - MAT: 2
     MAT_ElastHyper:
       NUMMAT: 2

--- a/tests/input_files/solid_runtime_gauss_point_quantity_output_nodal.4C.yaml
+++ b/tests/input_files/solid_runtime_gauss_point_quantity_output_nodal.4C.yaml
@@ -72,8 +72,9 @@ MATERIALS:
     ELAST_VolSussmanBathe:
       KAPPA: 100
   - MAT: 129
-    MIX_Prestress_Strategy_Constant:
-      PRESTRETCH: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    MIX_Prestress_Strategy_Prescribed:
+      PRESTRETCH:
+        constant: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
   - MAT: 2
     MAT_ElastHyper:
       NUMMAT: 2

--- a/tests/input_files/solid_runtime_gauss_point_quantity_output_result_test.4C.yaml
+++ b/tests/input_files/solid_runtime_gauss_point_quantity_output_result_test.4C.yaml
@@ -74,8 +74,9 @@ MATERIALS:
     ELAST_VolSussmanBathe:
       KAPPA: 100
   - MAT: 129
-    MIX_Prestress_Strategy_Constant:
-      PRESTRETCH: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    MIX_Prestress_Strategy_Prescribed:
+      PRESTRETCH:
+        constant: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
   - MAT: 2
     MAT_ElastHyper:
       NUMMAT: 2

--- a/tests/tutorials/solid/tutorial_solid_vtu.4C.yaml
+++ b/tests/tutorials/solid/tutorial_solid_vtu.4C.yaml
@@ -73,8 +73,9 @@ MATERIALS:
     ELAST_VolSussmanBathe:
       KAPPA: 720
   - MAT: 129
-    MIX_Prestress_Strategy_Constant:
-      PRESTRETCH: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    MIX_Prestress_Strategy_Prescribed:
+      PRESTRETCH:
+        constant: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
 
 DESIGN SURF NEUMANN CONDITIONS:
   - E: 1


### PR DESCRIPTION
Allow to prescribe an interpolated tensor field as a prescribed prestretch in the mixture framework.

This will allow us to read a vtu-file with defined prestretch for a patient-specific geometry.

Currently, we use a component-wise interpolation of the stretch tensor. We should change this to a consistent tensor interpolation scheme of @abhi-satheesh.