### PR TITLE
Allow reading bit arrays from vtu files

### DIFF
--- a/src/core/io/src/4C_io_mesh.hpp
+++ b/src/core/io/src/4C_io_mesh.hpp
@@ -62,13 +62,14 @@ namespace Core::IO::MeshInput
 
   /*!
    * @brief These are the supported field data (scalars, vectors, symmetric tensors and tensors)
-   * with scalar types int and double.
+   * with scalar types bool, int and double.
    */
   template <unsigned dim>
-  using EligibleFieldTypes = std::variant<int, double, Core::LinAlg::Tensor<int, dim>,
-      Core::LinAlg::Tensor<double, dim>, Core::LinAlg::SymmetricTensor<int, dim, dim>,
-      Core::LinAlg::SymmetricTensor<double, dim, dim>, Core::LinAlg::Tensor<int, dim, dim>,
-      Core::LinAlg::Tensor<double, dim, dim>>;
+  using EligibleFieldTypes = std::variant<bool, int, double, Core::LinAlg::Tensor<bool, dim>,
+      Core::LinAlg::Tensor<int, dim>, Core::LinAlg::Tensor<double, dim>,
+      Core::LinAlg::SymmetricTensor<bool, dim, dim>, Core::LinAlg::SymmetricTensor<int, dim, dim>,
+      Core::LinAlg::SymmetricTensor<double, dim, dim>, Core::LinAlg::Tensor<bool, dim, dim>,
+      Core::LinAlg::Tensor<int, dim, dim>, Core::LinAlg::Tensor<double, dim, dim>>;
 
   namespace Internal
   {

--- a/tests/input_files/vtu/arc_hex8.vtu
+++ b/tests/input_files/vtu/arc_hex8.vtu
@@ -192,7 +192,7 @@
 0.00000000000e+00 1.00000000000e+00 0.00000000000e+00
 
 </DataArray>
-<DataArray type="Int64" Name="point_set_1" format="ascii">
+<DataArray type="Bit" Name="point_set_1" format="ascii">
 1
 0
 0
@@ -227,7 +227,7 @@
 1
 
 </DataArray>
-<DataArray type="Int64" Name="point_set_2" format="ascii">
+<DataArray type="Bit" Name="point_set_2" format="ascii">
 1
 1
 1
@@ -262,7 +262,7 @@
 0
 
 </DataArray>
-<DataArray type="Int64" Name="point_set_3" format="ascii">
+<DataArray type="Bit" Name="point_set_3" format="ascii">
 0
 0
 0
@@ -297,7 +297,7 @@
 1
 
 </DataArray>
-<DataArray type="Int64" Name="point_set_4" format="ascii">
+<DataArray type="Bit" Name="point_set_4" format="ascii">
 0
 0
 0
@@ -332,7 +332,7 @@
 0
 
 </DataArray>
-<DataArray type="Int64" Name="point_set_5" format="ascii">
+<DataArray type="Bit" Name="point_set_5" format="ascii">
 0
 0
 0


### PR DESCRIPTION
This PR allows to read bit arrays from vtu files. This might be useful for large meshes with a lot of point sets. Bit-arrays only take 1 bit per node, instead of previously at least 8 (or often 64). The reduction in size is, however, a lot less with compression (which is typically activated).

Note, personally, I don't recommend using bit-arrays since you cannot visualize them in paraview.