### PR TITLE
Remove object files after build in GitHub Actions

### DIFF
--- a/.github/actions/build_4C/action.yml
+++ b/.github/actions/build_4C/action.yml
@@ -27,6 +27,10 @@ inputs:
     description: Additional flags to pass to CMake
     required: false
     default: ""
+  cleanup-object-files:
+    description: Clean up object files after the build to reduce the size of the build directory
+    required: false
+    default: "true"
 outputs:
   cache-key:
     description: Key to restore the cache for ccache
@@ -63,3 +67,10 @@ runs:
       env:
         BUILD_DIRECTORY: ${{ inputs.build-directory }}
         BUILD_TARGETS: ${{ inputs.build-targets }}
+    - name: Clean up object files
+      if: ${{ inputs.cleanup-object-files == 'true' }}
+      run: |
+        find $BUILD_DIRECTORY -type f -name '*.o' -delete
+      shell: bash
+      env:
+        BUILD_DIRECTORY: ${{ inputs.build-directory }}


### PR DESCRIPTION
Remove object files after building 4C in the pipeline. This should reduce the size of the build directory after the build. We copy the build directory from one stage to the other, so we should keep the amount of data that we copy small.