### PR TITLE
Enable vtu input by default on lnm cluster

### DIFF
--- a/presets/lnm/cluster/CMakePresets.json
+++ b/presets/lnm/cluster/CMakePresets.json
@@ -14,7 +14,8 @@
         "FOUR_C_QHULL_ROOT": "/lnm/packages/qhull/2012-1",
         "FOUR_C_TRILINOS_ROOT": "/lnm/packages/trilinos/2025-6/release",
         "FOUR_C_ENABLE_METADATA_GENERATION": "OFF",
-        "FOUR_C_BUILD_SHARED_LIBS": "OFF"
+        "FOUR_C_BUILD_SHARED_LIBS": "OFF",
+        "FOUR_C_WITH_VTK": "ON"
       }
     },
     {
@@ -26,7 +27,8 @@
       ],
       "cacheVariables": {
         "FOUR_C_BOOST_ROOT": "/cluster/lib/gcc/9.1.0/boost_1_86_0",
-        "FOUR_C_PYTHON_ROOT": "/lnm/miniconda3/envs/python_3_12_env/bin"
+        "FOUR_C_PYTHON_ROOT": "/lnm/miniconda3/envs/python_3_12_env/bin",
+        "FOUR_C_VTK_ROOT": "/lnm/packages/vtk/9-5-2/release"
       }
     },
     {


### PR DESCRIPTION
Enable vtu mesh input by default on LNM clusters.