### PR TITLE
Allow det, inv, trace, etc on const TensorViews

### DIFF
--- a/src/core/linalg/src/dense/4C_linalg_tensor.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_tensor.hpp
@@ -504,7 +504,7 @@ namespace Core::LinAlg
     requires(!is_compressed_tensor<decltype(A)>)
   {
     using Tensor = std::remove_cvref_t<decltype(A)>;
-    using value_type = Tensor::value_type;
+    using value_type = std::remove_cv_t<typename Tensor::value_type>;
     constexpr std::size_t n = Tensor::template extent<0>();
 
     return DenseFunctions::determinant<value_type, n, n>(A.data());
@@ -514,7 +514,7 @@ namespace Core::LinAlg
     requires(!is_compressed_tensor<decltype(A)>)
   {
     using Tensor = std::remove_cvref_t<decltype(A)>;
-    using value_type = Tensor::value_type;
+    using value_type = std::remove_cv_t<typename Tensor::value_type>;
     constexpr std::size_t n = Tensor::template extent<0>();
 
     return DenseFunctions::trace<value_type, n, n>(A.data());
@@ -525,7 +525,7 @@ namespace Core::LinAlg
              std::remove_cvref_t<decltype(A)>::rank() == 1)
   {
     using Tensor = std::remove_cvref_t<decltype(A)>;
-    using value_type = Tensor::value_type;
+    using value_type = std::remove_cv_t<typename Tensor::value_type>;
     constexpr std::size_t n = Tensor::template extent<0>();
 
     return DenseFunctions::norm2<value_type, n, 1>(A.data());
@@ -535,7 +535,7 @@ namespace Core::LinAlg
     requires(!is_compressed_tensor<decltype(A)>)
   {
     using Tensor = std::remove_cvref_t<decltype(A)>;
-    using value_type = Tensor::value_type;
+    using value_type = std::remove_cv_t<typename Tensor::value_type>;
     constexpr std::size_t n = Tensor::template extent<0>();
 
     Core::LinAlg::Tensor<value_type, n, n> dest;

--- a/src/core/linalg/tests/4C_linalg_symmetric_tensor_operations_test.cpp
+++ b/src/core/linalg/tests/4C_linalg_symmetric_tensor_operations_test.cpp
@@ -76,6 +76,9 @@ namespace
 
     Core::LinAlg::SymmetricTensor<double, 3, 3> t3_sym = create_symmetric_tensor<3>();
     EXPECT_NEAR(Core::LinAlg::det(t3_sym), -0.3999999999999977, 1e-10);
+
+    Core::LinAlg::SymmetricTensorView<const double, 3, 3> t3_sym_view = t3_sym;
+    EXPECT_NEAR(Core::LinAlg::det(t3_sym_view), -0.3999999999999977, 1e-10);
   }
 
   TEST(SymmetricTensorOperationsTest, trace)
@@ -85,6 +88,9 @@ namespace
 
     Core::LinAlg::SymmetricTensor<double, 3, 3> t_sym = create_symmetric_tensor<3>();
     EXPECT_NEAR(Core::LinAlg::trace(t_sym), 14.4, 1e-10);
+
+    Core::LinAlg::SymmetricTensorView<const double, 3, 3> t_sym_view = t_sym;
+    EXPECT_NEAR(Core::LinAlg::trace(t_sym_view), 14.4, 1e-10);
   }
 
   TEST(SymmetricTensorOperationsTest, inv)
@@ -113,6 +119,21 @@ namespace
     EXPECT_NEAR(t_sym_inv(2, 0), 8.75, 1e-10);
     EXPECT_NEAR(t_sym_inv(2, 1), -11., 1e-10);
     EXPECT_NEAR(t_sym_inv(2, 2), 2.75, 1e-10);
+
+    Core::LinAlg::SymmetricTensorView<const double, 3, 3> t_sym_view = t_sym;
+    Core::LinAlg::SymmetricTensor<double, 3, 3> t_sym_view_inv = Core::LinAlg::inv(t_sym_view);
+
+    EXPECT_NEAR(t_sym_view_inv(0, 0), 24.75, 1e-10);
+    EXPECT_NEAR(t_sym_view_inv(0, 1), -33., 1e-10);
+    EXPECT_NEAR(t_sym_view_inv(0, 2), 8.75, 1e-10);
+
+    EXPECT_NEAR(t_sym_view_inv(1, 0), -33., 1e-10);
+    EXPECT_NEAR(t_sym_view_inv(1, 1), 43., 1e-10);
+    EXPECT_NEAR(t_sym_view_inv(1, 2), -11., 1e-10);
+
+    EXPECT_NEAR(t_sym_view_inv(2, 0), 8.75, 1e-10);
+    EXPECT_NEAR(t_sym_view_inv(2, 1), -11., 1e-10);
+    EXPECT_NEAR(t_sym_view_inv(2, 2), 2.75, 1e-10);
   }
 
   TEST(SymmetricTensorOperationsTest, transpose)


### PR DESCRIPTION
Previously, that was not possible (The return type should not have the `const`).