### PR TITLE
Replace `Epetra_Operator` with `Core::LinAlg::SparseOperator`

### DIFF
--- a/src/cardiovascular0d/4C_cardiovascular0d_nox_nln_linearsystem.cpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_nox_nln_linearsystem.cpp
@@ -24,8 +24,8 @@ NOX::Nln::Cardiovascular0D::LinearSystem::LinearSystem(Teuchos::ParameterList& p
     const std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>& solvers,
     const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
     const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& M, const NOX::Nln::Vector& cloneVector,
+    const std::shared_ptr<Core::LinAlg::SparseOperator>& J,
+    const std::shared_ptr<Core::LinAlg::SparseOperator>& M, const NOX::Nln::Vector& cloneVector,
     const std::shared_ptr<NOX::Nln::Scaling> scalingObject)
     : NOX::Nln::LinearSystem(
           printParams, linearSolverParams, solvers, iReq, iJac, J, M, cloneVector, scalingObject)
@@ -40,8 +40,8 @@ NOX::Nln::Cardiovascular0D::LinearSystem::LinearSystem(Teuchos::ParameterList& p
     const std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>& solvers,
     const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
     const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& M, const NOX::Nln::Vector& cloneVector)
+    const std::shared_ptr<Core::LinAlg::SparseOperator>& J,
+    const std::shared_ptr<Core::LinAlg::SparseOperator>& M, const NOX::Nln::Vector& cloneVector)
     : NOX::Nln::LinearSystem(
           printParams, linearSolverParams, solvers, iReq, iJac, J, M, cloneVector)
 {
@@ -55,7 +55,7 @@ NOX::Nln::Cardiovascular0D::LinearSystem::LinearSystem(Teuchos::ParameterList& p
     const std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>& solvers,
     const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
     const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& J, const NOX::Nln::Vector& cloneVector,
+    const std::shared_ptr<Core::LinAlg::SparseOperator>& J, const NOX::Nln::Vector& cloneVector,
     const std::shared_ptr<NOX::Nln::Scaling> scalingObject)
     : NOX::Nln::LinearSystem(
           printParams, linearSolverParams, solvers, iReq, iJac, J, cloneVector, scalingObject)
@@ -70,7 +70,7 @@ NOX::Nln::Cardiovascular0D::LinearSystem::LinearSystem(Teuchos::ParameterList& p
     const std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>& solvers,
     const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
     const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& J, const NOX::Nln::Vector& cloneVector)
+    const std::shared_ptr<Core::LinAlg::SparseOperator>& J, const NOX::Nln::Vector& cloneVector)
     : NOX::Nln::LinearSystem(printParams, linearSolverParams, solvers, iReq, iJac, J, cloneVector)
 {
   // empty constructor

--- a/src/cardiovascular0d/4C_cardiovascular0d_nox_nln_linearsystem.hpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_nox_nln_linearsystem.hpp
@@ -29,8 +29,8 @@ namespace NOX
             const std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>& solvers,
             const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
             const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
-            const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
-            const Teuchos::RCP<Core::LinAlg::SparseOperator>& M,
+            const std::shared_ptr<Core::LinAlg::SparseOperator>& J,
+            const std::shared_ptr<Core::LinAlg::SparseOperator>& M,
             const NOX::Nln::Vector& cloneVector,
             const std::shared_ptr<NOX::Nln::Scaling> scalingObject);
 
@@ -40,8 +40,8 @@ namespace NOX
             const std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>& solvers,
             const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
             const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
-            const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
-            const Teuchos::RCP<Core::LinAlg::SparseOperator>& M,
+            const std::shared_ptr<Core::LinAlg::SparseOperator>& J,
+            const std::shared_ptr<Core::LinAlg::SparseOperator>& M,
             const NOX::Nln::Vector& cloneVector);
 
         //! Constructor without preconditioner
@@ -50,7 +50,7 @@ namespace NOX
             const std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>& solvers,
             const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
             const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
-            const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
+            const std::shared_ptr<Core::LinAlg::SparseOperator>& J,
             const NOX::Nln::Vector& cloneVector,
             const std::shared_ptr<NOX::Nln::Scaling> scalingObject);
 
@@ -60,7 +60,7 @@ namespace NOX
             const std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>& solvers,
             const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
             const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
-            const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
+            const std::shared_ptr<Core::LinAlg::SparseOperator>& J,
             const NOX::Nln::Vector& cloneVector);
 
         //! sets the options of the underlying solver

--- a/src/constraint/4C_constraint_nox_nln_lagpenconstraint_linearsystem.cpp
+++ b/src/constraint/4C_constraint_nox_nln_lagpenconstraint_linearsystem.cpp
@@ -25,9 +25,9 @@ NOX::Nln::LAGPENCONSTRAINT::LinearSystem::LinearSystem(Teuchos::ParameterList& p
     const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
     const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
     const NOX::Nln::CONSTRAINT::ReqInterfaceMap& iConstr,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
+    const std::shared_ptr<Core::LinAlg::SparseOperator>& J,
     const NOX::Nln::CONSTRAINT::PrecInterfaceMap& iConstrPrec,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& M, const NOX::Nln::Vector& cloneVector,
+    const std::shared_ptr<Core::LinAlg::SparseOperator>& M, const NOX::Nln::Vector& cloneVector,
     const std::shared_ptr<NOX::Nln::Scaling> scalingObject)
     : NOX::Nln::LinearSystem(
           printParams, linearSolverParams, solvers, iReq, iJac, J, M, cloneVector, scalingObject),
@@ -44,9 +44,9 @@ NOX::Nln::LAGPENCONSTRAINT::LinearSystem::LinearSystem(Teuchos::ParameterList& p
     const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
     const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
     const NOX::Nln::CONSTRAINT::ReqInterfaceMap& iConstr,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
+    const std::shared_ptr<Core::LinAlg::SparseOperator>& J,
     const NOX::Nln::CONSTRAINT::PrecInterfaceMap& iConstrPrec,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& M, const NOX::Nln::Vector& cloneVector)
+    const std::shared_ptr<Core::LinAlg::SparseOperator>& M, const NOX::Nln::Vector& cloneVector)
     : NOX::Nln::LinearSystem(
           printParams, linearSolverParams, solvers, iReq, iJac, J, M, cloneVector),
       i_constr_(iConstr),

--- a/src/constraint/4C_constraint_nox_nln_lagpenconstraint_linearsystem.hpp
+++ b/src/constraint/4C_constraint_nox_nln_lagpenconstraint_linearsystem.hpp
@@ -31,9 +31,9 @@ namespace NOX
             const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
             const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
             const NOX::Nln::CONSTRAINT::ReqInterfaceMap& iConstr,
-            const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
+            const std::shared_ptr<Core::LinAlg::SparseOperator>& J,
             const NOX::Nln::CONSTRAINT::PrecInterfaceMap& iConstrPrec,
-            const Teuchos::RCP<Core::LinAlg::SparseOperator>& M,
+            const std::shared_ptr<Core::LinAlg::SparseOperator>& M,
             const NOX::Nln::Vector& cloneVector,
             const std::shared_ptr<NOX::Nln::Scaling> scalingObject);
 
@@ -43,9 +43,9 @@ namespace NOX
             const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
             const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
             const NOX::Nln::CONSTRAINT::ReqInterfaceMap& iConstr,
-            const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
+            const std::shared_ptr<Core::LinAlg::SparseOperator>& J,
             const NOX::Nln::CONSTRAINT::PrecInterfaceMap& iConstrPrec,
-            const Teuchos::RCP<Core::LinAlg::SparseOperator>& M,
+            const std::shared_ptr<Core::LinAlg::SparseOperator>& M,
             const NOX::Nln::Vector& cloneVector);
 
         //! Sets the options of the underlying solver

--- a/src/contact/src/4C_contact_nox_nln_contact_linearsystem.cpp
+++ b/src/contact/src/4C_contact_nox_nln_contact_linearsystem.cpp
@@ -28,9 +28,9 @@ NOX::Nln::CONTACT::LinearSystem::LinearSystem(Teuchos::ParameterList& printParam
     const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
     const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
     const NOX::Nln::CONSTRAINT::ReqInterfaceMap& iConstr,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
+    const std::shared_ptr<Core::LinAlg::SparseOperator>& J,
     const NOX::Nln::CONSTRAINT::PrecInterfaceMap& iConstrPrec,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& M, const NOX::Nln::Vector& cloneVector,
+    const std::shared_ptr<Core::LinAlg::SparseOperator>& M, const NOX::Nln::Vector& cloneVector,
     const std::shared_ptr<NOX::Nln::Scaling> scalingObject)
     : NOX::Nln::LinearSystem(
           printParams, linearSolverParams, solvers, iReq, iJac, J, M, cloneVector, scalingObject),
@@ -48,9 +48,9 @@ NOX::Nln::CONTACT::LinearSystem::LinearSystem(Teuchos::ParameterList& printParam
     const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
     const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
     const NOX::Nln::CONSTRAINT::ReqInterfaceMap& iConstr,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
+    const std::shared_ptr<Core::LinAlg::SparseOperator>& J,
     const NOX::Nln::CONSTRAINT::PrecInterfaceMap& iConstrPrec,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& M, const NOX::Nln::Vector& cloneVector)
+    const std::shared_ptr<Core::LinAlg::SparseOperator>& M, const NOX::Nln::Vector& cloneVector)
     : NOX::Nln::LinearSystem(
           printParams, linearSolverParams, solvers, iReq, iJac, J, M, cloneVector),
       i_constr_(iConstr),

--- a/src/contact/src/4C_contact_nox_nln_contact_linearsystem.hpp
+++ b/src/contact/src/4C_contact_nox_nln_contact_linearsystem.hpp
@@ -37,9 +37,9 @@ namespace NOX
             const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
             const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
             const NOX::Nln::CONSTRAINT::ReqInterfaceMap& iConstr,
-            const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
+            const std::shared_ptr<Core::LinAlg::SparseOperator>& J,
             const NOX::Nln::CONSTRAINT::PrecInterfaceMap& iConstrPrec,
-            const Teuchos::RCP<Core::LinAlg::SparseOperator>& M,
+            const std::shared_ptr<Core::LinAlg::SparseOperator>& M,
             const NOX::Nln::Vector& cloneVector,
             const std::shared_ptr<NOX::Nln::Scaling> scalingObject);
 
@@ -49,9 +49,9 @@ namespace NOX
             const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
             const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
             const NOX::Nln::CONSTRAINT::ReqInterfaceMap& iConstr,
-            const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
+            const std::shared_ptr<Core::LinAlg::SparseOperator>& J,
             const NOX::Nln::CONSTRAINT::PrecInterfaceMap& iConstrPrec,
-            const Teuchos::RCP<Core::LinAlg::SparseOperator>& M,
+            const std::shared_ptr<Core::LinAlg::SparseOperator>& M,
             const NOX::Nln::Vector& cloneVector);
 
         //! Sets the options of the underlying solver

--- a/src/contact/src/4C_contact_nox_nln_meshtying_linearsystem.cpp
+++ b/src/contact/src/4C_contact_nox_nln_meshtying_linearsystem.cpp
@@ -27,9 +27,9 @@ NOX::Nln::MeshTying::LinearSystem::LinearSystem(Teuchos::ParameterList& printPar
     const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
     const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
     const NOX::Nln::CONSTRAINT::ReqInterfaceMap& iConstr,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
+    const std::shared_ptr<Core::LinAlg::SparseOperator>& J,
     const NOX::Nln::CONSTRAINT::PrecInterfaceMap& iConstrPrec,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& M, const NOX::Nln::Vector& cloneVector,
+    const std::shared_ptr<Core::LinAlg::SparseOperator>& M, const NOX::Nln::Vector& cloneVector,
     const std::shared_ptr<NOX::Nln::Scaling> scalingObject)
     : NOX::Nln::LinearSystem(
           printParams, linearSolverParams, solvers, iReq, iJac, J, M, cloneVector, scalingObject),
@@ -46,9 +46,9 @@ NOX::Nln::MeshTying::LinearSystem::LinearSystem(Teuchos::ParameterList& printPar
     const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
     const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
     const NOX::Nln::CONSTRAINT::ReqInterfaceMap& iConstr,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
+    const std::shared_ptr<Core::LinAlg::SparseOperator>& J,
     const NOX::Nln::CONSTRAINT::PrecInterfaceMap& iConstrPrec,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& M, const NOX::Nln::Vector& cloneVector)
+    const std::shared_ptr<Core::LinAlg::SparseOperator>& M, const NOX::Nln::Vector& cloneVector)
     : NOX::Nln::LinearSystem(
           printParams, linearSolverParams, solvers, iReq, iJac, J, M, cloneVector),
       i_constr_(iConstr),

--- a/src/contact/src/4C_contact_nox_nln_meshtying_linearsystem.hpp
+++ b/src/contact/src/4C_contact_nox_nln_meshtying_linearsystem.hpp
@@ -37,9 +37,9 @@ namespace NOX
             const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
             const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
             const NOX::Nln::CONSTRAINT::ReqInterfaceMap& iConstr,
-            const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
+            const std::shared_ptr<Core::LinAlg::SparseOperator>& J,
             const NOX::Nln::CONSTRAINT::PrecInterfaceMap& iConstrPrec,
-            const Teuchos::RCP<Core::LinAlg::SparseOperator>& M,
+            const std::shared_ptr<Core::LinAlg::SparseOperator>& M,
             const NOX::Nln::Vector& cloneVector,
             const std::shared_ptr<NOX::Nln::Scaling> scalingObject);
 
@@ -49,9 +49,9 @@ namespace NOX
             const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
             const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
             const NOX::Nln::CONSTRAINT::ReqInterfaceMap& iConstr,
-            const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
+            const std::shared_ptr<Core::LinAlg::SparseOperator>& J,
             const NOX::Nln::CONSTRAINT::PrecInterfaceMap& iConstrPrec,
-            const Teuchos::RCP<Core::LinAlg::SparseOperator>& M,
+            const std::shared_ptr<Core::LinAlg::SparseOperator>& M,
             const NOX::Nln::Vector& cloneVector);
 
         //! Sets the options of the underlying solver

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem.cpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem.cpp
@@ -131,17 +131,18 @@ bool NOX::FSI::LinearSystem::compute_jacobian(const NOX::Nln::Vector& x)
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-Teuchos::RCP<const Epetra_Operator> NOX::FSI::LinearSystem::get_jacobian_operator() const
+std::shared_ptr<const Core::LinAlg::SparseOperator> NOX::FSI::LinearSystem::get_jacobian_operator()
+    const
 {
-  return Teuchos::rcpFromRef(*jac_ptr_);
+  return jac_ptr_;
 }
 
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-Teuchos::RCP<Epetra_Operator> NOX::FSI::LinearSystem::get_jacobian_operator()
+std::shared_ptr<Core::LinAlg::SparseOperator> NOX::FSI::LinearSystem::get_jacobian_operator()
 {
-  return Teuchos::rcpFromRef(*jac_ptr_);
+  return jac_ptr_;
 }
 
 

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem.hpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem.hpp
@@ -71,10 +71,10 @@ namespace NOX::FSI
     bool compute_jacobian(const NOX::Nln::Vector& x) override;
 
     /// Return Jacobian operator.
-    Teuchos::RCP<const Epetra_Operator> get_jacobian_operator() const override;
+    std::shared_ptr<const Core::LinAlg::SparseOperator> get_jacobian_operator() const override;
 
     /// Return Jacobian operator.
-    Teuchos::RCP<Epetra_Operator> get_jacobian_operator() override;
+    std::shared_ptr<Core::LinAlg::SparseOperator> get_jacobian_operator() override;
 
    private:
     /// throw an error
@@ -83,7 +83,7 @@ namespace NOX::FSI
     ::NOX::Utils utils_;
 
     std::shared_ptr<NOX::Nln::Interface::JacobianBase> jac_interface_ptr_;
-    mutable std::shared_ptr<Epetra_Operator> jac_ptr_;
+    mutable std::shared_ptr<Core::LinAlg::SparseOperator> jac_ptr_;
     mutable std::shared_ptr<Core::LinAlg::SparseOperator> operator_;
     std::shared_ptr<NOX::Nln::Scaling> scaling_;
     mutable std::shared_ptr<NOX::Nln::Vector> tmp_vector_ptr_;

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.cpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.cpp
@@ -373,15 +373,16 @@ bool NOX::FSI::LinearSystemGCR::compute_jacobian(const NOX::Nln::Vector& x)
 }
 
 
-Teuchos::RCP<const Epetra_Operator> NOX::FSI::LinearSystemGCR::get_jacobian_operator() const
+std::shared_ptr<const Core::LinAlg::SparseOperator>
+NOX::FSI::LinearSystemGCR::get_jacobian_operator() const
 {
-  return Teuchos::rcpFromRef(*jacPtr);
+  return jacPtr;
 }
 
 
-Teuchos::RCP<Epetra_Operator> NOX::FSI::LinearSystemGCR::get_jacobian_operator()
+std::shared_ptr<Core::LinAlg::SparseOperator> NOX::FSI::LinearSystemGCR::get_jacobian_operator()
 {
-  return Teuchos::rcpFromRef(*jacPtr);
+  return jacPtr;
 }
 
 

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.hpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.hpp
@@ -92,10 +92,10 @@ namespace NOX
       bool compute_jacobian(const NOX::Nln::Vector& x) override;
 
       //! Return Jacobian operator
-      Teuchos::RCP<const Epetra_Operator> get_jacobian_operator() const override;
+      std::shared_ptr<const Core::LinAlg::SparseOperator> get_jacobian_operator() const override;
 
       //! Return Jacobian operator
-      Teuchos::RCP<Epetra_Operator> get_jacobian_operator() override;
+      std::shared_ptr<Core::LinAlg::SparseOperator> get_jacobian_operator() override;
 
      protected:
       /// generalized conjugate residual solver

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.cpp
@@ -37,8 +37,8 @@ NOX::Nln::LinearSystem::LinearSystem(Teuchos::ParameterList& printParams,
     const std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>& solvers,
     const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
     const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& jacobian_op,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& preconditioner,
+    const std::shared_ptr<Core::LinAlg::SparseOperator>& jacobian_op,
+    const std::shared_ptr<Core::LinAlg::SparseOperator>& preconditioner,
     const NOX::Nln::Vector& cloneVector, const std::shared_ptr<NOX::Nln::Scaling> scalingObject)
     : utils_(printParams),
       solvers_(solvers),
@@ -63,8 +63,8 @@ NOX::Nln::LinearSystem::LinearSystem(Teuchos::ParameterList& printParams,
     const std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>& solvers,
     const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
     const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& jacobian_op,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& preconditioner,
+    const std::shared_ptr<Core::LinAlg::SparseOperator>& jacobian_op,
+    const std::shared_ptr<Core::LinAlg::SparseOperator>& preconditioner,
     const NOX::Nln::Vector& cloneVector)
     : utils_(printParams),
       solvers_(solvers),
@@ -89,7 +89,7 @@ NOX::Nln::LinearSystem::LinearSystem(Teuchos::ParameterList& printParams,
     const std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>& solvers,
     const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
     const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& jacobian_op,
+    const std::shared_ptr<Core::LinAlg::SparseOperator>& jacobian_op,
     const NOX::Nln::Vector& cloneVector, const std::shared_ptr<NOX::Nln::Scaling> scalingObject)
     : utils_(printParams),
       solvers_(solvers),
@@ -114,7 +114,7 @@ NOX::Nln::LinearSystem::LinearSystem(Teuchos::ParameterList& printParams,
     const std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>& solvers,
     const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
     const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& jacobian_op,
+    const std::shared_ptr<Core::LinAlg::SparseOperator>& jacobian_op,
     const NOX::Nln::Vector& cloneVector)
     : utils_(printParams),
       solvers_(solvers),
@@ -390,10 +390,9 @@ void NOX::Nln::LinearSystem::adjust_pseudo_time_step(double& delta, const double
   // ---------------------------------------------------------------------
   Core::LinAlg::Vector<double> v(scalingDiagOp);
   v.scale(ptcsolver.get_inverse_pseudo_time_step());
-  Teuchos::RCP<Core::LinAlg::SparseMatrix> jac =
-      Teuchos::rcp_dynamic_cast<Core::LinAlg::SparseMatrix>(jacobian_ptr());
-  if (jac.is_null())
-    throw_error("adjust_pseudo_time_step()", "Cast to Core::LinAlg::SparseMatrix failed!");
+  auto jac = std::dynamic_pointer_cast<Core::LinAlg::SparseMatrix>(jacobian_ptr());
+  FOUR_C_ASSERT(jac, "adjust_pseudo_time_step(): Cast to Core::LinAlg::SparseMatrix failed!");
+
   // get the diagonal terms of the jacobian
   auto diag = std::make_shared<Core::LinAlg::Vector<double>>(jac->row_map(), false);
   jac->extract_diagonal_copy(*diag);
@@ -475,14 +474,15 @@ NOX::Nln::LinearSystem::get_jacobian_interface() const
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-Teuchos::RCP<const Epetra_Operator> NOX::Nln::LinearSystem::get_jacobian_operator() const
+std::shared_ptr<const Core::LinAlg::SparseOperator> NOX::Nln::LinearSystem::get_jacobian_operator()
+    const
 {
   return jacobian_ptr();
 }
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-Teuchos::RCP<Epetra_Operator> NOX::Nln::LinearSystem::get_jacobian_operator()
+std::shared_ptr<Core::LinAlg::SparseOperator> NOX::Nln::LinearSystem::get_jacobian_operator()
 {
   return jacobian_ptr();
 }
@@ -498,7 +498,7 @@ const NOX::Nln::LinSystem::OperatorType& NOX::Nln::LinearSystem::get_jacobian_op
  *----------------------------------------------------------------------*/
 bool NOX::Nln::LinearSystem::destroy_jacobian()
 {
-  jac_ptr_ = Teuchos::null;
+  jac_ptr_ = nullptr;
   return true;
 }
 

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.hpp
@@ -60,8 +60,8 @@ namespace NOX
       LinearSystem(Teuchos::ParameterList& printParams, Teuchos::ParameterList& linearSolverParams,
           const SolverMap& solvers, const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
           const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
-          const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
-          const Teuchos::RCP<Core::LinAlg::SparseOperator>& preconditioner,
+          const std::shared_ptr<Core::LinAlg::SparseOperator>& J,
+          const std::shared_ptr<Core::LinAlg::SparseOperator>& preconditioner,
           const NOX::Nln::Vector& cloneVector,
           const std::shared_ptr<NOX::Nln::Scaling> scalingObject);
 
@@ -69,22 +69,24 @@ namespace NOX
       LinearSystem(Teuchos::ParameterList& printParams, Teuchos::ParameterList& linearSolverParams,
           const SolverMap& solvers, const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
           const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
-          const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
-          const Teuchos::RCP<Core::LinAlg::SparseOperator>& preconditioner,
+          const std::shared_ptr<Core::LinAlg::SparseOperator>& J,
+          const std::shared_ptr<Core::LinAlg::SparseOperator>& preconditioner,
           const NOX::Nln::Vector& cloneVector);
 
       //! Constructor without preconditioner
       LinearSystem(Teuchos::ParameterList& printParams, Teuchos::ParameterList& linearSolverParams,
           const SolverMap& solvers, const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
           const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
-          const Teuchos::RCP<Core::LinAlg::SparseOperator>& J, const NOX::Nln::Vector& cloneVector,
+          const std::shared_ptr<Core::LinAlg::SparseOperator>& J,
+          const NOX::Nln::Vector& cloneVector,
           const std::shared_ptr<NOX::Nln::Scaling> scalingObject);
 
       //! Constructor without preconditioner and scaling object
       LinearSystem(Teuchos::ParameterList& printParams, Teuchos::ParameterList& linearSolverParams,
           const SolverMap& solvers, const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
           const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
-          const Teuchos::RCP<Core::LinAlg::SparseOperator>& J, const NOX::Nln::Vector& cloneVector);
+          const std::shared_ptr<Core::LinAlg::SparseOperator>& J,
+          const NOX::Nln::Vector& cloneVector);
 
       //! reset the linear solver parameters
       void reset(Teuchos::ParameterList& p);
@@ -147,10 +149,10 @@ namespace NOX
           const Core::LinAlg::Vector<double>& new_diag, unsigned diag_bid);
 
       //! Returns Jacobian Epetra_Operator pointer
-      Teuchos::RCP<const Epetra_Operator> get_jacobian_operator() const override;
+      std::shared_ptr<const Core::LinAlg::SparseOperator> get_jacobian_operator() const override;
 
       /// return jacobian operator
-      Teuchos::RCP<Epetra_Operator> get_jacobian_operator() override;
+      std::shared_ptr<Core::LinAlg::SparseOperator> get_jacobian_operator() override;
 
       //! Returns the operator type of the jacobian
       const NOX::Nln::LinSystem::OperatorType& get_jacobian_operator_type() const;
@@ -166,15 +168,15 @@ namespace NOX
       /// access the jacobian
       inline Core::LinAlg::SparseOperator& jacobian() const
       {
-        if (jac_ptr_.is_null()) throw_error("JacPtr", "JacPtr is nullptr!");
+        FOUR_C_ASSERT(jac_ptr_, "JacPtr is nullptr!");
 
         return *jac_ptr_;
       }
 
       /// access the jacobian (read-only)
-      inline const Teuchos::RCP<Core::LinAlg::SparseOperator>& jacobian_ptr() const
+      inline const std::shared_ptr<Core::LinAlg::SparseOperator>& jacobian_ptr() const
       {
-        if (jac_ptr_.is_null()) throw_error("JacPtr", "JacPtr is nullptr!");
+        FOUR_C_ASSERT(jac_ptr_, "JacPtr is nullptr!");
 
         return jac_ptr_;
       }
@@ -273,7 +275,7 @@ namespace NOX
        *
        *  Use the provided accessors to access this member. Direct access is prohibited
        *  due to the pointer management by changing states (e.g. XFEM). */
-      Teuchos::RCP<Core::LinAlg::SparseOperator> jac_ptr_;
+      std::shared_ptr<Core::LinAlg::SparseOperator> jac_ptr_;
     };
   }  // namespace Nln
 }  // namespace NOX

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_base.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_base.hpp
@@ -10,6 +10,8 @@
 
 #include "4C_config.hpp"
 
+#include "4C_linalg_sparseoperator.hpp"
+
 #include <Epetra_Operator.h>
 #include <NOX_Utils.H>
 #include <Teuchos_ParameterList.hpp>
@@ -65,12 +67,12 @@ namespace NOX
       /**
        * \brief Return Jacobian operator
        */
-      virtual Teuchos::RCP<const Epetra_Operator> get_jacobian_operator() const = 0;
+      virtual std::shared_ptr<const Core::LinAlg::SparseOperator> get_jacobian_operator() const = 0;
 
       /**
        * \brief Return Jacobian operator
        */
-      virtual Teuchos::RCP<Epetra_Operator> get_jacobian_operator() = 0;
+      virtual std::shared_ptr<Core::LinAlg::SparseOperator> get_jacobian_operator() = 0;
     };
   }  // namespace Nln
 }  // namespace NOX

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_factory.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_factory.cpp
@@ -36,8 +36,8 @@ NOX::Nln::LinSystem::Factory::Factory()
  *----------------------------------------------------------------------------*/
 Teuchos::RCP<NOX::Nln::LinearSystemBase> NOX::Nln::LinSystem::Factory::build_linear_system(
     const NOX::Nln::LinSystem::LinearSystemType& linsystype, NOX::Nln::GlobalData& noxNlnGlobalData,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& jac, NOX::Nln::Vector& cloneVector,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& precMat,
+    const std::shared_ptr<Core::LinAlg::SparseOperator>& jac, NOX::Nln::Vector& cloneVector,
+    const std::shared_ptr<Core::LinAlg::SparseOperator>& precMat,
     const std::shared_ptr<NOX::Nln::Scaling>& scalingObject) const
 {
   Teuchos::RCP<NOX::Nln::LinearSystemBase> linSys = Teuchos::null;
@@ -127,8 +127,8 @@ Teuchos::RCP<NOX::Nln::LinearSystemBase> NOX::Nln::LinSystem::Factory::build_lin
  *----------------------------------------------------------------------------*/
 Teuchos::RCP<NOX::Nln::LinearSystemBase> NOX::Nln::LinSystem::build_linear_system(
     const NOX::Nln::LinSystem::LinearSystemType& linsystype, NOX::Nln::GlobalData& noxNlnGlobalData,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& jac, NOX::Nln::Vector& cloneVector,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& precMat,
+    const std::shared_ptr<Core::LinAlg::SparseOperator>& jac, NOX::Nln::Vector& cloneVector,
+    const std::shared_ptr<Core::LinAlg::SparseOperator>& precMat,
     const std::shared_ptr<NOX::Nln::Scaling>& scalingObject)
 {
   Factory factory;

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_factory.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_factory.hpp
@@ -47,8 +47,8 @@ namespace NOX
         Teuchos::RCP<NOX::Nln::LinearSystemBase> build_linear_system(
             const NOX::Nln::LinSystem::LinearSystemType& linsystype,
             NOX::Nln::GlobalData& noxNlnGlobalData,
-            const Teuchos::RCP<Core::LinAlg::SparseOperator>& jac, NOX::Nln::Vector& cloneVector,
-            const Teuchos::RCP<Core::LinAlg::SparseOperator>& precMat,
+            const std::shared_ptr<Core::LinAlg::SparseOperator>& jac, NOX::Nln::Vector& cloneVector,
+            const std::shared_ptr<Core::LinAlg::SparseOperator>& precMat,
             const std::shared_ptr<NOX::Nln::Scaling>& scalingObject) const;
       };
 
@@ -60,8 +60,8 @@ namespace NOX
       Teuchos::RCP<NOX::Nln::LinearSystemBase> build_linear_system(
           const NOX::Nln::LinSystem::LinearSystemType& linsystype,
           NOX::Nln::GlobalData& noxNlnGlobalData,
-          const Teuchos::RCP<Core::LinAlg::SparseOperator>& jac, NOX::Nln::Vector& cloneVector,
-          const Teuchos::RCP<Core::LinAlg::SparseOperator>& precMat,
+          const std::shared_ptr<Core::LinAlg::SparseOperator>& jac, NOX::Nln::Vector& cloneVector,
+          const std::shared_ptr<Core::LinAlg::SparseOperator>& precMat,
           const std::shared_ptr<NOX::Nln::Scaling>& scalingObject);
     }  // namespace LinSystem
   }  // namespace Nln

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_problem.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_problem.hpp
@@ -50,12 +50,12 @@ namespace NOX
 
       //! standard constructor
       Problem(const Teuchos::RCP<NOX::Nln::GlobalData>& noxNlnGlobalData,
-          const Teuchos::RCP<NOX::Nln::Vector>& x,
-          const Teuchos::RCP<Core::LinAlg::SparseOperator>& A);
+          const std::shared_ptr<NOX::Nln::Vector> x,
+          const std::shared_ptr<Core::LinAlg::SparseOperator> A);
 
       //! initialize stuff
-      void initialize(const Teuchos::RCP<NOX::Nln::Vector>& x,
-          const Teuchos::RCP<Core::LinAlg::SparseOperator>& A);
+      void initialize(const std::shared_ptr<NOX::Nln::Vector>& x,
+          const std::shared_ptr<Core::LinAlg::SparseOperator>& A);
 
       //! create the linear system for the NOX framework
       Teuchos::RCP<NOX::Nln::LinearSystemBase> create_linear_system() const;
@@ -95,15 +95,11 @@ namespace NOX
 
       Teuchos::RCP<NOX::Nln::GlobalData> nox_global_data_;
 
-      /** ptr to the state vector RCP. In this way the strong_count is neither lost
-       *  nor increased. */
-      const Teuchos::RCP<NOX::Nln::Vector>* x_vector_;
+      std::shared_ptr<NOX::Nln::Vector> x_vector_;
 
-      /** ptr to the state matrix RCP. In this way the strong_count is neither lost
-       *  nor increased. */
-      const Teuchos::RCP<Core::LinAlg::SparseOperator>* jac_;
+      std::shared_ptr<Core::LinAlg::SparseOperator> jac_;
 
-      Teuchos::RCP<Core::LinAlg::SparseOperator> preconditionner_;
+      std::shared_ptr<Core::LinAlg::SparseOperator> preconditionner_;
     };
   }  // namespace Nln
 }  // namespace NOX

--- a/src/structure_new/src/4C_structure_new_integrator.cpp
+++ b/src/structure_new/src/4C_structure_new_integrator.cpp
@@ -281,8 +281,8 @@ void Solid::Integrator::compute_mass_matrix_and_init_acc()
   // ToDo Get the actual tolerance value
   p_ls.set<double>("Wanted Tolerance", 1.0e-6);
 
-  NOX::Nln::Solid::LinearSystem linsys(
-      p_print, p_ls, str_linsolver, nullptr, nullptr, Teuchos::rcpFromRef(mass_matrix), nox_soln);
+  NOX::Nln::Solid::LinearSystem linsys(p_print, p_ls, str_linsolver, nullptr, nullptr,
+      Core::Utils::shared_ptr_from_ref(mass_matrix), nox_soln);
 
   linsys.apply_jacobian_inverse(p_ls, *rhs_solid, nox_soln);
   nox_soln.scale(-1.0);

--- a/src/structure_new/src/implicit/4C_structure_new_timint_implicit.cpp
+++ b/src/structure_new/src/implicit/4C_structure_new_timint_implicit.cpp
@@ -495,22 +495,20 @@ void Solid::TimeInt::Implicit::print_jacobian_in_matlab_format(
 
   const NOX::Nln::LinSystem::OperatorType jac_type = nln_lin_system->get_jacobian_operator_type();
 
-  Teuchos::RCP<const Epetra_Operator> jac_ptr = nln_lin_system->get_jacobian_operator();
+  auto jac_ptr = nln_lin_system->get_jacobian_operator();
 
   switch (jac_type)
   {
     case NOX::Nln::LinSystem::LinalgSparseMatrix:
     {
-      Teuchos::RCP<const Core::LinAlg::SparseMatrix> sparse_matrix =
-          Teuchos::rcp_dynamic_cast<const Core::LinAlg::SparseMatrix>(jac_ptr, true);
+      auto sparse_matrix = std::dynamic_pointer_cast<const Core::LinAlg::SparseMatrix>(jac_ptr);
       Core::LinAlg::print_matrix_in_matlab_format(filename.str().c_str(), *sparse_matrix);
 
       break;
     }
     case NOX::Nln::LinSystem::LinalgBlockSparseMatrix:
     {
-      Teuchos::RCP<const LinalgBlockSparseMatrix> block_matrix =
-          Teuchos::rcp_dynamic_cast<const LinalgBlockSparseMatrix>(jac_ptr, true);
+      auto block_matrix = std::dynamic_pointer_cast<const LinalgBlockSparseMatrix>(jac_ptr);
       Core::LinAlg::print_block_matrix_in_matlab_format(filename.str(), *block_matrix);
 
       break;

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_nox.cpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_nox.cpp
@@ -89,9 +89,8 @@ Solid::Nln::SOLVER::Nox::Nox(const Teuchos::ParameterList& default_params,
   // -------------------------------------------------------------------------
   // Create NOX control class: NoxProblem()
   // -------------------------------------------------------------------------
-  Teuchos::RCP<NOX::Nln::Vector> soln = Teuchos::rcp(data_global_state().create_global_vector());
-  Teuchos::RCP<Core::LinAlg::SparseOperator> jac =
-      Teuchos::rcp(data_global_state().create_jacobian());
+  auto soln = data_global_state().create_global_vector();
+  auto jac = data_global_state().create_jacobian();
   problem_ = Teuchos::make_rcp<NOX::Nln::Problem>(nlnglobaldata_, soln, jac);
 
   // -------------------------------------------------------------------------

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nox_nln_str_linearsystem.cpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nox_nln_str_linearsystem.cpp
@@ -23,8 +23,8 @@ NOX::Nln::Solid::LinearSystem::LinearSystem(Teuchos::ParameterList& printParams,
     const std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>& solvers,
     const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
     const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& M, const NOX::Nln::Vector& cloneVector,
+    const std::shared_ptr<Core::LinAlg::SparseOperator>& J,
+    const std::shared_ptr<Core::LinAlg::SparseOperator>& M, const NOX::Nln::Vector& cloneVector,
     const std::shared_ptr<NOX::Nln::Scaling> scalingObject)
     : NOX::Nln::LinearSystem(
           printParams, linearSolverParams, solvers, iReq, iJac, J, M, cloneVector, scalingObject)
@@ -39,8 +39,8 @@ NOX::Nln::Solid::LinearSystem::LinearSystem(Teuchos::ParameterList& printParams,
     const std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>& solvers,
     const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
     const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& M, const NOX::Nln::Vector& cloneVector)
+    const std::shared_ptr<Core::LinAlg::SparseOperator>& J,
+    const std::shared_ptr<Core::LinAlg::SparseOperator>& M, const NOX::Nln::Vector& cloneVector)
     : NOX::Nln::LinearSystem(
           printParams, linearSolverParams, solvers, iReq, iJac, J, M, cloneVector)
 {
@@ -54,7 +54,7 @@ NOX::Nln::Solid::LinearSystem::LinearSystem(Teuchos::ParameterList& printParams,
     const std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>& solvers,
     const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
     const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& J, const NOX::Nln::Vector& cloneVector,
+    const std::shared_ptr<Core::LinAlg::SparseOperator>& J, const NOX::Nln::Vector& cloneVector,
     const std::shared_ptr<NOX::Nln::Scaling> scalingObject)
     : NOX::Nln::LinearSystem(
           printParams, linearSolverParams, solvers, iReq, iJac, J, cloneVector, scalingObject)
@@ -69,7 +69,7 @@ NOX::Nln::Solid::LinearSystem::LinearSystem(Teuchos::ParameterList& printParams,
     const std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>& solvers,
     const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
     const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
-    const Teuchos::RCP<Core::LinAlg::SparseOperator>& J, const NOX::Nln::Vector& cloneVector)
+    const std::shared_ptr<Core::LinAlg::SparseOperator>& J, const NOX::Nln::Vector& cloneVector)
     : NOX::Nln::LinearSystem(printParams, linearSolverParams, solvers, iReq, iJac, J, cloneVector)
 {
   // empty constructor

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nox_nln_str_linearsystem.hpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nox_nln_str_linearsystem.hpp
@@ -29,8 +29,8 @@ namespace NOX
             const std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>& solvers,
             const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
             const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
-            const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
-            const Teuchos::RCP<Core::LinAlg::SparseOperator>& M,
+            const std::shared_ptr<Core::LinAlg::SparseOperator>& J,
+            const std::shared_ptr<Core::LinAlg::SparseOperator>& M,
             const NOX::Nln::Vector& cloneVector,
             const std::shared_ptr<NOX::Nln::Scaling> scalingObject);
 
@@ -40,8 +40,8 @@ namespace NOX
             const std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>& solvers,
             const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
             const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
-            const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
-            const Teuchos::RCP<Core::LinAlg::SparseOperator>& M,
+            const std::shared_ptr<Core::LinAlg::SparseOperator>& J,
+            const std::shared_ptr<Core::LinAlg::SparseOperator>& M,
             const NOX::Nln::Vector& cloneVector);
 
         //! Constructor without preconditioner
@@ -50,7 +50,7 @@ namespace NOX
             const std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>& solvers,
             const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
             const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
-            const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
+            const std::shared_ptr<Core::LinAlg::SparseOperator>& J,
             const NOX::Nln::Vector& cloneVector,
             const std::shared_ptr<NOX::Nln::Scaling> scalingObject);
 
@@ -60,7 +60,7 @@ namespace NOX
             const std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>& solvers,
             const std::shared_ptr<NOX::Nln::Interface::RequiredBase> iReq,
             const std::shared_ptr<NOX::Nln::Interface::JacobianBase> iJac,
-            const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
+            const std::shared_ptr<Core::LinAlg::SparseOperator>& J,
             const NOX::Nln::Vector& cloneVector);
 
 


### PR DESCRIPTION
## Description and Context
This removes another large bunch of `Epetra_Operator`s, mainly, in linear systems. I also replaced RCPs with shared pointers and also removed strange pointers to RCPs in `NOX::Nln::Problem`. 

This PR is based on #1584 and #1568. The PR is crucial to proceed with #1524.

## Related Issues and Pull Requests
#1568, #1584, #1524
