### PR TITLE
Clean add() functions in SparseMatrix

### DIFF
--- a/src/adapter/4C_adapter_str_constr_merged.cpp
+++ b/src/adapter/4C_adapter_str_constr_merged.cpp
@@ -12,6 +12,7 @@
 #include "4C_global_data.hpp"
 #include "4C_linalg_utils_sparse_algebra_create.hpp"
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
+#include "4C_linalg_utils_sparse_algebra_math.hpp"
 #include "4C_structure_aux.hpp"
 #include "4C_structure_timint_create.hpp"
 
@@ -192,7 +193,7 @@ std::shared_ptr<Core::LinAlg::SparseMatrix> Adapter::StructureConstrMerged::syst
   constiff->complete();
 
   // Add matrices together
-  mergedmatrix->add(*strustiff, false, 1.0, 0.0);
+  Core::LinAlg::matrix_add(*strustiff, false, 1.0, *mergedmatrix, 0.0);
   mergedmatrix->add(*constiff, false, 1.0, 1.0);
   mergedmatrix->add(*constiff, true, 1.0, 1.0);
   mergedmatrix->complete(*dofrowmap_, *dofrowmap_);

--- a/src/ale/4C_ale_meshsliding.cpp
+++ b/src/ale/4C_ale_meshsliding.cpp
@@ -145,16 +145,16 @@ void ALE::Meshsliding::condensation_operation_block_matrix(
   /**********************************************************************/
 
   sysmatnew->matrix(1, 1).un_complete();
-  sysmatnew->matrix(1, 1).add(*Aco_mm, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*Aco_mm, false, 1.0, sysmatnew->matrix(1, 1), 1.0);
 
   sysmatnew->matrix(1, 2).un_complete();
-  sysmatnew->matrix(1, 2).add(*Aco_ms, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*Aco_ms, false, 1.0, sysmatnew->matrix(1, 2), 1.0);
 
   sysmatnew->matrix(2, 1).un_complete();
-  sysmatnew->matrix(2, 1).add(*Aco_sm, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*Aco_sm, false, 1.0, sysmatnew->matrix(2, 1), 1.0);
 
   sysmatnew->matrix(2, 2).un_complete();
-  sysmatnew->matrix(2, 2).add(*Aco_ss, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*Aco_ss, false, 1.0, sysmatnew->matrix(2, 2), 1.0);
 
   sysmatnew->complete();
 
@@ -191,7 +191,7 @@ void ALE::Meshsliding::condensation_operation_block_matrix(
 
   // Add modification block to mn
   sysmatnew->matrix(1, 0).un_complete();  // sonst kann ich auf den Block nichts neues draufaddieren
-  sysmatnew->matrix(1, 0).add(*Amn_mod, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*Amn_mod, false, 1.0, sysmatnew->matrix(1, 0), 1.0);
 
   // compute modification for block mm       (+ P^T * A_sm)
   std::shared_ptr<Core::LinAlg::SparseMatrix> Amm_mod =
@@ -199,7 +199,7 @@ void ALE::Meshsliding::condensation_operation_block_matrix(
 
   // Add modification block to mm
   sysmatnew->matrix(1, 1).un_complete();
-  sysmatnew->matrix(1, 1).add(*Amm_mod, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*Amm_mod, false, 1.0, sysmatnew->matrix(1, 1), 1.0);
 
   // compute modification for block ms       (+ P^T * A_ss)
   std::shared_ptr<Core::LinAlg::SparseMatrix> Ams_mod =
@@ -207,7 +207,7 @@ void ALE::Meshsliding::condensation_operation_block_matrix(
 
   // Add modification block to ms
   sysmatnew->matrix(1, 2).un_complete();
-  sysmatnew->matrix(1, 2).add(*Ams_mod, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*Ams_mod, false, 1.0, sysmatnew->matrix(1, 2), 1.0);
 
   //----------------------------------------------------------- THIRD LINE
 
@@ -219,7 +219,8 @@ void ALE::Meshsliding::condensation_operation_block_matrix(
 
   // Replace sn block with (negative) modification block
   sysmatnew->matrix(2, 0).un_complete();
-  sysmatnew->matrix(2, 0).add(*Asn_mod, false, -1.0, 0.0);
+  Core::LinAlg::matrix_add(*Asn_mod, false, -1.0, sysmatnew->matrix(2, 0), 0.0);
+
 
   // compute replacement for block sm      - (T * D^(-1) * A_sm)   +  N_m
   std::shared_ptr<Core::LinAlg::SparseMatrix> Asm_mod_intermediate =
@@ -229,8 +230,8 @@ void ALE::Meshsliding::condensation_operation_block_matrix(
 
   // Replace sm block with (negative) modification block
   sysmatnew->matrix(2, 1).un_complete();
-  sysmatnew->matrix(2, 1).add(*Asm_mod, false, -1.0, 0.0);
-  sysmatnew->matrix(2, 1).add(*N_m, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*Asm_mod, false, -1.0, sysmatnew->matrix(2, 1), 0.0);
+  Core::LinAlg::matrix_add(*N_m, false, 1.0, sysmatnew->matrix(2, 1), 1.0);
 
   // compute replacement for block ss      (- T * D^(-1) *A_ss)   +  H  +  N_s
   std::shared_ptr<Core::LinAlg::SparseMatrix> Ass_mod_intermediate =
@@ -240,9 +241,9 @@ void ALE::Meshsliding::condensation_operation_block_matrix(
 
   // Replace ss block with (negative) modification block
   sysmatnew->matrix(2, 2).un_complete();
-  sysmatnew->matrix(2, 2).add(*Ass_mod, false, -1.0, 0.0);
-  sysmatnew->matrix(2, 2).add(*N_s, false, 1.0, 1.0);
-  sysmatnew->matrix(2, 2).add(*H, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*Ass_mod, false, -1.0, sysmatnew->matrix(2, 2), 0.0);
+  Core::LinAlg::matrix_add(*N_s, false, 1.0, sysmatnew->matrix(2, 2), 1.0);
+  Core::LinAlg::matrix_add(*H, false, 1.0, sysmatnew->matrix(2, 2), 1.0);
 
   // complete matrix
   sysmatnew->complete();

--- a/src/ale/4C_ale_meshtying.cpp
+++ b/src/ale/4C_ale_meshtying.cpp
@@ -367,7 +367,7 @@ void ALE::Meshtying::multifield_split(std::shared_ptr<Core::LinAlg::SparseOperat
 
     sysmatnew->matrix(2, 2).un_complete();
     sysmatnew->matrix(2, 2).zero();
-    sysmatnew->matrix(2, 2).add(onesdiag, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(onesdiag, false, 1.0, sysmatnew->matrix(2, 2), 1.0);
 
     sysmatnew->matrix(2, 0).un_complete();
     sysmatnew->matrix(2, 0).zero();
@@ -529,7 +529,7 @@ void ALE::Meshtying::condensation_operation_block_matrix(
 
   // Add transformation matrix to nm
   sysmatnew->matrix(0, 1).un_complete();
-  sysmatnew->matrix(0, 1).add(*knm_mod, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*knm_mod, false, 1.0, sysmatnew->matrix(0, 1), 1.0);
 
   if (dconmaster_ == true and firstnonliniter_ == true)
     knm_mod->multiply(false, *(splitdcmaster[1]), *dcnm);
@@ -543,7 +543,7 @@ void ALE::Meshtying::condensation_operation_block_matrix(
 
   // Add transformation matrix to mn
   sysmatnew->matrix(1, 0).un_complete();
-  sysmatnew->matrix(1, 0).add(*kmn_mod, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*kmn_mod, false, 1.0, sysmatnew->matrix(1, 0), 1.0);
 
   /*--------------------------------------------------------------------*/
   // block mm
@@ -556,7 +556,7 @@ void ALE::Meshtying::condensation_operation_block_matrix(
 
   // Add transformation matrix to mm
   sysmatnew->matrix(1, 1).un_complete();
-  sysmatnew->matrix(1, 1).add(*kmm_mod, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*kmm_mod, false, 1.0, sysmatnew->matrix(1, 1), 1.0);
 
   if (dconmaster_ == true and firstnonliniter_ == true)
     kmm_mod->multiply(false, *(splitdcmaster[1]), *dcmm);

--- a/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_mortar_manager.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_mortar_manager.cpp
@@ -581,8 +581,10 @@ void BeamInteraction::BeamToSolidMortarManager::add_global_force_stiffness_penal
           penalty_regularization_lin_kappa, false, *kappa_lin_beam_, false, false, false, true);
       const auto kappa_lin_solid_scaled = Core::LinAlg::matrix_multiply(
           penalty_regularization_lin_kappa, false, *kappa_lin_solid_, false, false, false, true);
-      regularized_constraint_lin_beam->add(*kappa_lin_beam_scaled, false, 1.0, 1.0);
-      regularized_constraint_lin_solid->add(*kappa_lin_solid_scaled, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(
+          *kappa_lin_beam_scaled, false, 1.0, *regularized_constraint_lin_beam, 1.0);
+      Core::LinAlg::matrix_add(
+          *kappa_lin_solid_scaled, false, 1.0, *regularized_constraint_lin_solid, 1.0);
     }
 
     // Calculate the needed submatrices
@@ -600,10 +602,14 @@ void BeamInteraction::BeamToSolidMortarManager::add_global_force_stiffness_penal
             *regularized_constraint_lin_solid, false, false, false, true);
 
     // Add contributions to the global stiffness matrix
-    stiff->add(*force_beam_lin_lambda_times_constraint_lin_beam, false, 1.0, 1.0);
-    stiff->add(*force_beam_lin_lambda_times_constraint_lin_solid, false, 1.0, 1.0);
-    stiff->add(*force_solid_lin_lambda_times_constraint_lin_beam, false, 1.0, 1.0);
-    stiff->add(*force_solid_lin_lambda_times_constraint_lin_solid, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(
+        *force_beam_lin_lambda_times_constraint_lin_beam, false, 1.0, *stiff, 1.0);
+    Core::LinAlg::matrix_add(
+        *force_beam_lin_lambda_times_constraint_lin_solid, false, 1.0, *stiff, 1.0);
+    Core::LinAlg::matrix_add(
+        *force_solid_lin_lambda_times_constraint_lin_beam, false, 1.0, *stiff, 1.0);
+    Core::LinAlg::matrix_add(
+        *force_solid_lin_lambda_times_constraint_lin_solid, false, 1.0, *stiff, 1.0);
   }
 
   if (force != nullptr)
@@ -757,8 +763,8 @@ void BeamInteraction::BeamToSolidMortarManager::assemble_stiff(
 
   Core::LinAlg::SparseMatrix lm_displ =
       Core::LinAlg::SparseMatrix(*lambda_dof_rowmap_, 81, true, true);
-  lm_displ.add(*constraint_lin_beam_, false, 1.0, 0.0);
-  lm_displ.add(*constraint_lin_solid_, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*constraint_lin_beam_, false, 1.0, lm_displ, 0.0);
+  Core::LinAlg::matrix_add(*constraint_lin_solid_, false, 1.0, lm_displ, 1.0);
   lm_displ.complete(*discret_->dof_row_map(), *lambda_dof_rowmap_);
 
   std::shared_ptr<Core::LinAlg::SparseMatrix> lm_displ_in_global_layout =
@@ -769,8 +775,8 @@ void BeamInteraction::BeamToSolidMortarManager::assemble_stiff(
 
   Core::LinAlg::SparseMatrix displ_lm =
       Core::LinAlg::SparseMatrix(*discret_->dof_row_map(), 81, true, true);
-  displ_lm.add(*force_beam_lin_lambda_, false, 1.0, 0.0);
-  displ_lm.add(*force_solid_lin_lambda_, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*force_beam_lin_lambda_, false, 1.0, displ_lm, 0.0);
+  Core::LinAlg::matrix_add(*force_solid_lin_lambda_, false, 1.0, displ_lm, 1.0);
   displ_lm.complete(*lambda_dof_rowmap_, *discret_->dof_row_map());
   std::shared_ptr<Core::LinAlg::SparseMatrix> displ_lm_in_global_layout =
       Core::LinAlg::matrix_row_col_transform(

--- a/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator.cpp
@@ -33,6 +33,7 @@
 #include "4C_linalg_serialdensevector.hpp"
 #include "4C_linalg_utils_sparse_algebra_assemble.hpp"
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
+#include "4C_linalg_utils_sparse_algebra_math.hpp"
 #include "4C_rebalance_print.hpp"
 #include "4C_rigidsphere.hpp"
 #include "4C_scatra_ele.hpp"
@@ -781,7 +782,7 @@ bool Solid::ModelEvaluator::BeamInteraction::assemble_jacobian(
   check_init_setup();
 
   std::shared_ptr<Core::LinAlg::SparseMatrix> jac_dd_ptr = global_state().extract_displ_block(jac);
-  jac_dd_ptr->add(*stiff_beaminteraction_, false, timefac_np, 1.0);
+  Core::LinAlg::matrix_add(*stiff_beaminteraction_, false, timefac_np, *jac_dd_ptr, 1.0);
 
   if (have_lagrange_dofs())
   {

--- a/src/browniandyn/4C_browniandyn_str_model_evaluator.cpp
+++ b/src/browniandyn/4C_browniandyn_str_model_evaluator.cpp
@@ -15,6 +15,7 @@
 #include "4C_io.hpp"
 #include "4C_linalg_serialdensematrix.hpp"
 #include "4C_linalg_utils_sparse_algebra_assemble.hpp"
+#include "4C_linalg_utils_sparse_algebra_math.hpp"
 #include "4C_linalg_vector.hpp"
 #include "4C_rigidsphere.hpp"
 #include "4C_structure_new_integrator.hpp"
@@ -233,7 +234,7 @@ bool Solid::ModelEvaluator::BrownianDyn::assemble_jacobian(
   check_init_setup();
 
   std::shared_ptr<Core::LinAlg::SparseMatrix> jac_dd_ptr = global_state().extract_displ_block(jac);
-  jac_dd_ptr->add(*stiff_brownian_ptr_, false, timefac_np, 1.0);
+  Core::LinAlg::matrix_add(*stiff_brownian_ptr_, false, timefac_np, *jac_dd_ptr, 1.0);
   // no need to keep it
   stiff_brownian_ptr_->zero();
 

--- a/src/cardiovascular0d/4C_cardiovascular0d_structure_new_model_evaluator.cpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_structure_new_model_evaluator.cpp
@@ -172,7 +172,7 @@ bool Solid::ModelEvaluator::Cardiovascular0D::assemble_jacobian(
 
   // --- Kdd - block - scale with str time-integrator dependent value---
   std::shared_ptr<Core::LinAlg::SparseMatrix> jac_dd_ptr = global_state().extract_displ_block(jac);
-  jac_dd_ptr->add(*stiff_cardio_ptr_, false, timefac_np, 1.0);
+  Core::LinAlg::matrix_add(*stiff_cardio_ptr_, false, timefac_np, *jac_dd_ptr, 1.0);
   // no need to keep it
   stiff_cardio_ptr_->zero();
 

--- a/src/constraint/4C_constraint_solver.cpp
+++ b/src/constraint/4C_constraint_solver.cpp
@@ -11,6 +11,7 @@
 #include "4C_global_data.hpp"
 #include "4C_linalg_utils_sparse_algebra_assemble.hpp"
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
+#include "4C_linalg_utils_sparse_algebra_math.hpp"
 #include "4C_linear_solver_method.hpp"
 #include "4C_linear_solver_method_linalg.hpp"
 #include "4C_linear_solver_method_parameters.hpp"
@@ -274,9 +275,9 @@ void Constraints::ConstraintSolver::solve_direct(Core::LinAlg::SparseMatrix& sti
   if (dirichtoggle_ != nullptr)
     dbcmaps_ = Core::LinAlg::convert_dirichlet_toggle_vector_to_maps(*dirichtoggle_);
   // fill merged matrix using Add
-  mergedmatrix->add(stiff, false, 1.0, 1.0);
-  mergedmatrix->add(constr, false, 1.0, 1.0);
-  mergedmatrix->add(constrT, true, 1.0, 1.0);
+  Core::LinAlg::matrix_add(stiff, false, 1.0, *mergedmatrix, 1.0);
+  Core::LinAlg::matrix_add(constr, false, 1.0, *mergedmatrix, 1.0);
+  Core::LinAlg::matrix_add(constrT, true, 1.0, *mergedmatrix, 1.0);
   mergedmatrix->complete(*mergedmap, *mergedmap);
   // fill merged vectors using Export
   Core::LinAlg::export_to(rhsconstr, *mergedrhs);
@@ -322,7 +323,7 @@ void Constraints::ConstraintSolver::solve_simple(Core::LinAlg::SparseMatrix& sti
 
   // cast constraint operators to matrices and save transpose of constraint matrix
   Core::LinAlg::SparseMatrix constrTrans(*conrowmap, 81, false, true);
-  constrTrans.add(constrT, true, 1.0, 0.0);
+  Core::LinAlg::matrix_add(constrT, true, 1.0, constrTrans, 0.0);
   constrTrans.complete(constrT.range_map(), constrT.domain_map());
 
   // ONLY compatibility

--- a/src/constraint_framework/4C_constraint_framework_embeddedmesh_solid_to_solid_mortar_manager.cpp
+++ b/src/constraint_framework/4C_constraint_framework_embeddedmesh_solid_to_solid_mortar_manager.cpp
@@ -405,10 +405,10 @@ void Constraints::EmbeddedMesh::SolidToSolidMortarManager::
         *global_fbg_l_, false, *global_G_BG_scaled, false, false, false, true);
 
     // Add contributions to the global stiffness matrix.
-    stiff->add(*FBL_L_times_G_BL, false, 1.0, 1.0);
-    stiff->add(*FBL_L_times_G_BG, false, 1.0, 1.0);
-    stiff->add(*FBG_L_times_G_BL, false, 1.0, 1.0);
-    stiff->add(*FBG_L_times_G_BG, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*FBL_L_times_G_BL, false, 1.0, *stiff, 1.0);
+    Core::LinAlg::matrix_add(*FBL_L_times_G_BG, false, 1.0, *stiff, 1.0);
+    Core::LinAlg::matrix_add(*FBG_L_times_G_BL, false, 1.0, *stiff, 1.0);
+    Core::LinAlg::matrix_add(*FBG_L_times_G_BG, false, 1.0, *stiff, 1.0);
   }
 
   if (force != nullptr)

--- a/src/constraint_framework/4C_constraint_framework_model_evaluator.cpp
+++ b/src/constraint_framework/4C_constraint_framework_model_evaluator.cpp
@@ -18,6 +18,7 @@
 #include "4C_io.hpp"
 #include "4C_io_pstream.hpp"
 #include "4C_linalg_utils_sparse_algebra_assemble.hpp"
+#include "4C_linalg_utils_sparse_algebra_math.hpp"
 #include "4C_structure_new_model_evaluator_data.hpp"
 #include "4C_structure_new_timint_base.hpp"
 
@@ -251,7 +252,7 @@ bool Solid::ModelEvaluator::Constraint::assemble_jacobian(
 {
   std::shared_ptr<Core::LinAlg::SparseMatrix> jac_dd_ptr = global_state().extract_displ_block(jac);
 
-  jac_dd_ptr->add(*constraint_stiff_ptr_, false, timefac_np, 1.0);
+  Core::LinAlg::matrix_add(*constraint_stiff_ptr_, false, timefac_np, *jac_dd_ptr, 1.0);
 
   constraint_stiff_ptr_->zero();
   return true;

--- a/src/constraint_framework/4C_constraint_framework_submodelevaluator_base.cpp
+++ b/src/constraint_framework/4C_constraint_framework_submodelevaluator_base.cpp
@@ -47,11 +47,11 @@ bool Constraints::SubmodelEvaluator::ConstraintBase::evaluate_force_stiff(
     // evaluate the stiffness contribution of this some:
     auto some_stiff_ptr = Core::LinAlg::matrix_multiply(*Q_dL_, false, *Q_Ld_, false, false);
     some_stiff_ptr->scale(penalty_parameter_);
-    some_stiff_ptr->add(*Q_dd_, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*Q_dd_, false, 1.0, *some_stiff_ptr, 1.0);
     some_stiff_ptr->complete();
 
     // add it to the modelevaluator stiffness
-    me_stiff_ptr->add(*some_stiff_ptr, false, 1., 1.);
+    Core::LinAlg::matrix_add(*some_stiff_ptr, false, 1., *me_stiff_ptr, 1.);
   }
 
   if (me_force_ptr != nullptr)

--- a/src/contact/src/4C_contact_lagrange_strategy.cpp
+++ b/src/contact/src/4C_contact_lagrange_strategy.cpp
@@ -382,14 +382,14 @@ void CONTACT::LagrangeStrategy::evaluate_friction(
       dinv_dsv2 = Core::LinAlg::matrix_multiply(invdS, false, *inv_det6, false, false, false, true);
 
       // diagonal entries
-      invd->add(invdS, false, 1.0, 1.0);
-      invd->add(invdE, false, 1.0, 1.0);
-      invd->add(invdV, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(invdS, false, 1.0, *invd, 1.0);
+      Core::LinAlg::matrix_add(invdE, false, 1.0, *invd, 1.0);
+      Core::LinAlg::matrix_add(invdV, false, 1.0, *invd, 1.0);
 
-      invd->add(*dinv_dev, false, 1.0, 1.0);
-      invd->add(*dinv_dse, false, 1.0, 1.0);
-      invd->add(*dinv_dsv1, false, 1.0, 1.0);
-      invd->add(*dinv_dsv2, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(*dinv_dev, false, 1.0, *invd, 1.0);
+      Core::LinAlg::matrix_add(*dinv_dse, false, 1.0, *invd, 1.0);
+      Core::LinAlg::matrix_add(*dinv_dsv1, false, 1.0, *invd, 1.0);
+      Core::LinAlg::matrix_add(*dinv_dsv2, false, 1.0, *invd, 1.0);
 
       // complete
       invd->complete();
@@ -681,19 +681,19 @@ void CONTACT::LagrangeStrategy::evaluate_friction(
     // kmn: add T(mhataam)*kan
     std::shared_ptr<Core::LinAlg::SparseMatrix> kmnmod =
         std::make_shared<Core::LinAlg::SparseMatrix>(*gmdofrowmap_, 100);
-    kmnmod->add(*kmn, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kmn, false, 1.0, *kmnmod, 1.0);
     std::shared_ptr<Core::LinAlg::SparseMatrix> kmnadd =
         Core::LinAlg::matrix_multiply(*mhataam, true, *kan, false, false, false, true);
-    kmnmod->add(*kmnadd, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kmnadd, false, 1.0, *kmnmod, 1.0);
     kmnmod->complete(kmn->domain_map(), kmn->row_map());
 
     // kmm: add T(mhataam)*kam
     std::shared_ptr<Core::LinAlg::SparseMatrix> kmmmod =
         std::make_shared<Core::LinAlg::SparseMatrix>(*gmdofrowmap_, 100);
-    kmmmod->add(*kmm, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kmm, false, 1.0, *kmmmod, 1.0);
     std::shared_ptr<Core::LinAlg::SparseMatrix> kmmadd =
         Core::LinAlg::matrix_multiply(*mhataam, true, *kam, false, false, false, true);
-    kmmmod->add(*kmmadd, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kmmadd, false, 1.0, *kmmmod, 1.0);
     kmmmod->complete(kmm->domain_map(), kmm->row_map());
 
     // kmi: add T(mhataam)*kai
@@ -701,10 +701,10 @@ void CONTACT::LagrangeStrategy::evaluate_friction(
     if (iset)
     {
       kmimod = std::make_shared<Core::LinAlg::SparseMatrix>(*gmdofrowmap_, 100);
-      kmimod->add(*kmi, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(*kmi, false, 1.0, *kmimod, 1.0);
       std::shared_ptr<Core::LinAlg::SparseMatrix> kmiadd =
           Core::LinAlg::matrix_multiply(*mhataam, true, *kai, false, false, false, true);
-      kmimod->add(*kmiadd, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(*kmiadd, false, 1.0, *kmimod, 1.0);
       kmimod->complete(kmi->domain_map(), kmi->row_map());
     }
 
@@ -713,10 +713,10 @@ void CONTACT::LagrangeStrategy::evaluate_friction(
     if (aset)
     {
       kmamod = std::make_shared<Core::LinAlg::SparseMatrix>(*gmdofrowmap_, 100);
-      kmamod->add(*kma, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(*kma, false, 1.0, *kmamod, 1.0);
       std::shared_ptr<Core::LinAlg::SparseMatrix> kmaadd =
           Core::LinAlg::matrix_multiply(*mhataam, true, *kaa, false, false, false, true);
-      kmamod->add(*kmaadd, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(*kmaadd, false, 1.0, *kmamod, 1.0);
       kmamod->complete(kma->domain_map(), kma->row_map());
     }
 
@@ -724,24 +724,24 @@ void CONTACT::LagrangeStrategy::evaluate_friction(
     // kin: subtract T(dhat)*kan
     std::shared_ptr<Core::LinAlg::SparseMatrix> kinmod =
         std::make_shared<Core::LinAlg::SparseMatrix>(*gidofs, 100);
-    kinmod->add(*kin, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kin, false, 1.0, *kinmod, 1.0);
     if (aset && iset)
     {
       std::shared_ptr<Core::LinAlg::SparseMatrix> kinadd =
           Core::LinAlg::matrix_multiply(*dhat, true, *kan, false, false, false, true);
-      kinmod->add(*kinadd, false, -1.0, 1.0);
+      Core::LinAlg::matrix_add(*kinadd, false, -1.0, *kinmod, 1.0);
     }
     kinmod->complete(kin->domain_map(), kin->row_map());
 
     // kim: subtract T(dhat)*kam
     std::shared_ptr<Core::LinAlg::SparseMatrix> kimmod =
         std::make_shared<Core::LinAlg::SparseMatrix>(*gidofs, 100);
-    kimmod->add(*kim, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kim, false, 1.0, *kimmod, 1.0);
     if (aset && iset)
     {
       std::shared_ptr<Core::LinAlg::SparseMatrix> kimadd =
           Core::LinAlg::matrix_multiply(*dhat, true, *kam, false, false, false, true);
-      kimmod->add(*kimadd, false, -1.0, 1.0);
+      Core::LinAlg::matrix_add(*kimadd, false, -1.0, *kimmod, 1.0);
     }
     kimmod->complete(kim->domain_map(), kim->row_map());
 
@@ -750,12 +750,12 @@ void CONTACT::LagrangeStrategy::evaluate_friction(
     if (iset)
     {
       kiimod = std::make_shared<Core::LinAlg::SparseMatrix>(*gidofs, 100);
-      kiimod->add(*kii, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(*kii, false, 1.0, *kiimod, 1.0);
       if (aset)
       {
         std::shared_ptr<Core::LinAlg::SparseMatrix> kiiadd =
             Core::LinAlg::matrix_multiply(*dhat, true, *kai, false, false, false, true);
-        kiimod->add(*kiiadd, false, -1.0, 1.0);
+        Core::LinAlg::matrix_add(*kiiadd, false, -1.0, *kiimod, 1.0);
       }
       kiimod->complete(kii->domain_map(), kii->row_map());
     }
@@ -765,10 +765,10 @@ void CONTACT::LagrangeStrategy::evaluate_friction(
     if (iset && aset)
     {
       kiamod = std::make_shared<Core::LinAlg::SparseMatrix>(*gidofs, 100);
-      kiamod->add(*kia, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(*kia, false, 1.0, *kiamod, 1.0);
       std::shared_ptr<Core::LinAlg::SparseMatrix> kiaadd =
           Core::LinAlg::matrix_multiply(*dhat, true, *kaa, false, false, false, true);
-      kiamod->add(*kiaadd, false, -1.0, 1.0);
+      Core::LinAlg::matrix_add(*kiaadd, false, -1.0, *kiamod, 1.0);
       kiamod->complete(kia->domain_map(), kia->row_map());
     }
 
@@ -1083,50 +1083,50 @@ void CONTACT::LagrangeStrategy::evaluate_friction(
 
     //--------------------------------------------------------- FIRST LINE
     // add n submatrices to kteffnew
-    kteffnew->add(*knn, false, 1.0, 1.0);
-    kteffnew->add(*knm, false, 1.0, 1.0);
-    if (sset) kteffnew->add(*kns, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*knn, false, 1.0, *kteffnew, 1.0);
+    Core::LinAlg::matrix_add(*knm, false, 1.0, *kteffnew, 1.0);
+    if (sset) Core::LinAlg::matrix_add(*kns, false, 1.0, *kteffnew, 1.0);
 
     //-------------------------------------------------------- SECOND LINE
     // add m submatrices to kteffnew
-    kteffnew->add(*kmnmod, false, 1.0, 1.0);
-    kteffnew->add(*kmmmod, false, 1.0, 1.0);
-    if (iset) kteffnew->add(*kmimod, false, 1.0, 1.0);
-    if (aset) kteffnew->add(*kmamod, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kmnmod, false, 1.0, *kteffnew, 1.0);
+    Core::LinAlg::matrix_add(*kmmmod, false, 1.0, *kteffnew, 1.0);
+    if (iset) Core::LinAlg::matrix_add(*kmimod, false, 1.0, *kteffnew, 1.0);
+    if (aset) Core::LinAlg::matrix_add(*kmamod, false, 1.0, *kteffnew, 1.0);
 
     //--------------------------------------------------------- THIRD LINE
     // add i submatrices to kteffnew
-    if (iset) kteffnew->add(*kinmod, false, 1.0, 1.0);
-    if (iset) kteffnew->add(*kimmod, false, 1.0, 1.0);
-    if (iset) kteffnew->add(*kiimod, false, 1.0, 1.0);
-    if (iset && aset) kteffnew->add(*kiamod, false, 1.0, 1.0);
+    if (iset) Core::LinAlg::matrix_add(*kinmod, false, 1.0, *kteffnew, 1.0);
+    if (iset) Core::LinAlg::matrix_add(*kimmod, false, 1.0, *kteffnew, 1.0);
+    if (iset) Core::LinAlg::matrix_add(*kiimod, false, 1.0, *kteffnew, 1.0);
+    if (iset && aset) Core::LinAlg::matrix_add(*kiamod, false, 1.0, *kteffnew, 1.0);
 
     //-------------------------------------------------------- FOURTH LINE
 
     // add a submatrices to kteffnew
-    if (aset) kteffnew->add(*smatrix_, false, 1.0, 1.0);
+    if (aset) Core::LinAlg::matrix_add(*smatrix_, false, 1.0, *kteffnew, 1.0);
 
     //--------------------------------------------------------- FIFTH LINE
     // add st submatrices to kteffnew
-    if (stickset) kteffnew->add(*kstnmod, false, 1.0, 1.0);
-    if (stickset) kteffnew->add(*kstmmod, false, 1.0, 1.0);
-    if (stickset && iset) kteffnew->add(*kstimod, false, 1.0, 1.0);
-    if (stickset && slipset) kteffnew->add(*kstslmod, false, 1.0, 1.0);
-    if (stickset) kteffnew->add(*kststmod, false, 1.0, 1.0);
+    if (stickset) Core::LinAlg::matrix_add(*kstnmod, false, 1.0, *kteffnew, 1.0);
+    if (stickset) Core::LinAlg::matrix_add(*kstmmod, false, 1.0, *kteffnew, 1.0);
+    if (stickset && iset) Core::LinAlg::matrix_add(*kstimod, false, 1.0, *kteffnew, 1.0);
+    if (stickset && slipset) Core::LinAlg::matrix_add(*kstslmod, false, 1.0, *kteffnew, 1.0);
+    if (stickset) Core::LinAlg::matrix_add(*kststmod, false, 1.0, *kteffnew, 1.0);
 
     // add terms of linearization of sick condition to kteffnew
-    if (stickset) kteffnew->add(*linstickDIS_, false, -1.0, 1.0);
+    if (stickset) Core::LinAlg::matrix_add(*linstickDIS_, false, -1.0, *kteffnew, 1.0);
 
     //--------------------------------------------------------- SIXTH LINE
     // add sl submatrices to kteffnew
-    if (slipset) kteffnew->add(*kslnmod, false, 1.0, 1.0);
-    if (slipset) kteffnew->add(*kslmmod, false, 1.0, 1.0);
-    if (slipset && iset) kteffnew->add(*kslimod, false, 1.0, 1.0);
-    if (slipset) kteffnew->add(*kslslmod, false, 1.0, 1.0);
-    if (slipset && stickset) kteffnew->add(*kslstmod, false, 1.0, 1.0);
+    if (slipset) Core::LinAlg::matrix_add(*kslnmod, false, 1.0, *kteffnew, 1.0);
+    if (slipset) Core::LinAlg::matrix_add(*kslmmod, false, 1.0, *kteffnew, 1.0);
+    if (slipset && iset) Core::LinAlg::matrix_add(*kslimod, false, 1.0, *kteffnew, 1.0);
+    if (slipset) Core::LinAlg::matrix_add(*kslslmod, false, 1.0, *kteffnew, 1.0);
+    if (slipset && stickset) Core::LinAlg::matrix_add(*kslstmod, false, 1.0, *kteffnew, 1.0);
 
     // add terms of linearization of slip condition to kteffnew and feffnew
-    if (slipset) kteffnew->add(*linslipDIS_, false, -1.0, +1.0);
+    if (slipset) Core::LinAlg::matrix_add(*linslipDIS_, false, -1.0, *kteffnew, +1.0);
 
     // fill_complete kteffnew (square)
     kteffnew->complete();
@@ -2144,14 +2144,14 @@ void CONTACT::LagrangeStrategy::evaluate_contact(
       dinv_dsv2 = Core::LinAlg::matrix_multiply(invdS, false, *inv_det6, false, false, false, true);
 
       // diagonal entries
-      invd->add(invdS, false, 1.0, 1.0);
-      invd->add(invdE, false, 1.0, 1.0);
-      invd->add(invdV, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(invdS, false, 1.0, *invd, 1.0);
+      Core::LinAlg::matrix_add(invdE, false, 1.0, *invd, 1.0);
+      Core::LinAlg::matrix_add(invdV, false, 1.0, *invd, 1.0);
 
-      invd->add(*dinv_dev, false, 1.0, 1.0);
-      invd->add(*dinv_dse, false, 1.0, 1.0);
-      invd->add(*dinv_dsv1, false, 1.0, 1.0);
-      invd->add(*dinv_dsv2, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(*dinv_dev, false, 1.0, *invd, 1.0);
+      Core::LinAlg::matrix_add(*dinv_dse, false, 1.0, *invd, 1.0);
+      Core::LinAlg::matrix_add(*dinv_dsv1, false, 1.0, *invd, 1.0);
+      Core::LinAlg::matrix_add(*dinv_dsv2, false, 1.0, *invd, 1.0);
 
       invd->complete();
     }
@@ -2201,11 +2201,11 @@ void CONTACT::LagrangeStrategy::evaluate_contact(
       Core::LinAlg::SparseMatrix systrafo(*problem_dofs(), 100, false, true);
       std::shared_ptr<Core::LinAlg::SparseMatrix> eye =
           Core::LinAlg::create_identity_matrix(*gndofrowmap_);
-      systrafo.add(*eye, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(*eye, false, 1.0, systrafo, 1.0);
       if (parallel_redistribution_status())
         trafo_ = Core::LinAlg::matrix_row_col_transform(
             *trafo_, *non_redist_gsmdofrowmap_, *non_redist_gsmdofrowmap_);
-      systrafo.add(*trafo_, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(*trafo_, false, 1.0, systrafo, 1.0);
       systrafo.complete();
 
       // apply basis transformation to K and f
@@ -2225,8 +2225,8 @@ void CONTACT::LagrangeStrategy::evaluate_contact(
     }
 
     kteffmatrix->un_complete();
-    kteffmatrix->add(*lindmatrix_, false, 1.0 - alphaf_, 1.0);
-    kteffmatrix->add(*linmmatrix_, false, 1.0 - alphaf_, 1.0);
+    Core::LinAlg::matrix_add(*lindmatrix_, false, 1.0 - alphaf_, *kteffmatrix, 1.0);
+    Core::LinAlg::matrix_add(*linmmatrix_, false, 1.0 - alphaf_, *kteffmatrix, 1.0);
     kteffmatrix->complete();
 
     /**********************************************************************/
@@ -2430,19 +2430,19 @@ void CONTACT::LagrangeStrategy::evaluate_contact(
     // kmn: add T(mhataam)*kan
     std::shared_ptr<Core::LinAlg::SparseMatrix> kmnmod =
         std::make_shared<Core::LinAlg::SparseMatrix>(*gmdofrowmap_, 100);
-    kmnmod->add(*kmn, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kmn, false, 1.0, *kmnmod, 1.0);
     std::shared_ptr<Core::LinAlg::SparseMatrix> kmnadd =
         Core::LinAlg::matrix_multiply(*mhataam, true, *kan, false, false, false, true);
-    kmnmod->add(*kmnadd, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kmnadd, false, 1.0, *kmnmod, 1.0);
     kmnmod->complete(kmn->domain_map(), kmn->row_map());
 
     // kmm: add T(mhataam)*kam
     std::shared_ptr<Core::LinAlg::SparseMatrix> kmmmod =
         std::make_shared<Core::LinAlg::SparseMatrix>(*gmdofrowmap_, 100);
-    kmmmod->add(*kmm, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kmm, false, 1.0, *kmmmod, 1.0);
     std::shared_ptr<Core::LinAlg::SparseMatrix> kmmadd =
         Core::LinAlg::matrix_multiply(*mhataam, true, *kam, false, false, false, true);
-    kmmmod->add(*kmmadd, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kmmadd, false, 1.0, *kmmmod, 1.0);
     kmmmod->complete(kmm->domain_map(), kmm->row_map());
 
     // kmi: add T(mhataam)*kai
@@ -2450,10 +2450,10 @@ void CONTACT::LagrangeStrategy::evaluate_contact(
     if (iset)
     {
       kmimod = std::make_shared<Core::LinAlg::SparseMatrix>(*gmdofrowmap_, 100);
-      kmimod->add(*kmi, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(*kmi, false, 1.0, *kmimod, 1.0);
       std::shared_ptr<Core::LinAlg::SparseMatrix> kmiadd =
           Core::LinAlg::matrix_multiply(*mhataam, true, *kai, false, false, false, true);
-      kmimod->add(*kmiadd, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(*kmiadd, false, 1.0, *kmimod, 1.0);
       kmimod->complete(kmi->domain_map(), kmi->row_map());
     }
 
@@ -2462,10 +2462,10 @@ void CONTACT::LagrangeStrategy::evaluate_contact(
     if (aset)
     {
       kmamod = std::make_shared<Core::LinAlg::SparseMatrix>(*gmdofrowmap_, 100);
-      kmamod->add(*kma, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(*kma, false, 1.0, *kmamod, 1.0);
       std::shared_ptr<Core::LinAlg::SparseMatrix> kmaadd =
           Core::LinAlg::matrix_multiply(*mhataam, true, *kaa, false, false, false, true);
-      kmamod->add(*kmaadd, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(*kmaadd, false, 1.0, *kmamod, 1.0);
       kmamod->complete(kma->domain_map(), kma->row_map());
     }
 
@@ -2474,24 +2474,24 @@ void CONTACT::LagrangeStrategy::evaluate_contact(
     // kin: subtract T(dhat)*kan --
     std::shared_ptr<Core::LinAlg::SparseMatrix> kinmod =
         std::make_shared<Core::LinAlg::SparseMatrix>(*gidofs, 100);
-    kinmod->add(*kin, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kin, false, 1.0, *kinmod, 1.0);
     if (aset && iset)
     {
       std::shared_ptr<Core::LinAlg::SparseMatrix> kinadd =
           Core::LinAlg::matrix_multiply(*dhat, true, *kan, false, false, false, true);
-      kinmod->add(*kinadd, false, -1.0, 1.0);
+      Core::LinAlg::matrix_add(*kinadd, false, -1.0, *kinmod, 1.0);
     }
     kinmod->complete(kin->domain_map(), kin->row_map());
 
     // kim: subtract T(dhat)*kam
     std::shared_ptr<Core::LinAlg::SparseMatrix> kimmod =
         std::make_shared<Core::LinAlg::SparseMatrix>(*gidofs, 100);
-    kimmod->add(*kim, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kim, false, 1.0, *kimmod, 1.0);
     if (aset && iset)
     {
       std::shared_ptr<Core::LinAlg::SparseMatrix> kimadd =
           Core::LinAlg::matrix_multiply(*dhat, true, *kam, false, false, false, true);
-      kimmod->add(*kimadd, false, -1.0, 1.0);
+      Core::LinAlg::matrix_add(*kimadd, false, -1.0, *kimmod, 1.0);
     }
     kimmod->complete(kim->domain_map(), kim->row_map());
 
@@ -2500,12 +2500,12 @@ void CONTACT::LagrangeStrategy::evaluate_contact(
     if (iset)
     {
       kiimod = std::make_shared<Core::LinAlg::SparseMatrix>(*gidofs, 100);
-      kiimod->add(*kii, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(*kii, false, 1.0, *kiimod, 1.0);
       if (aset)
       {
         std::shared_ptr<Core::LinAlg::SparseMatrix> kiiadd =
             Core::LinAlg::matrix_multiply(*dhat, true, *kai, false, false, false, true);
-        kiimod->add(*kiiadd, false, -1.0, 1.0);
+        Core::LinAlg::matrix_add(*kiiadd, false, -1.0, *kiimod, 1.0);
       }
       kiimod->complete(kii->domain_map(), kii->row_map());
     }
@@ -2515,10 +2515,10 @@ void CONTACT::LagrangeStrategy::evaluate_contact(
     if (iset && aset)
     {
       kiamod = std::make_shared<Core::LinAlg::SparseMatrix>(*gidofs, 100);
-      kiamod->add(*kia, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(*kia, false, 1.0, *kiamod, 1.0);
       std::shared_ptr<Core::LinAlg::SparseMatrix> kiaadd =
           Core::LinAlg::matrix_multiply(*dhat, true, *kaa, false, false, false, true);
-      kiamod->add(*kiaadd, false, -1.0, 1.0);
+      Core::LinAlg::matrix_add(*kiaadd, false, -1.0, *kiamod, 1.0);
       kiamod->complete(kia->domain_map(), kia->row_map());
     }
 
@@ -2707,35 +2707,35 @@ void CONTACT::LagrangeStrategy::evaluate_contact(
 
     //----------------------------------------------------------- FIRST LINE
     // add n submatrices to kteffnew
-    kteffnew->add(*knn, false, 1.0, 1.0);
-    kteffnew->add(*knm, false, 1.0, 1.0);
-    if (sset) kteffnew->add(*kns, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*knn, false, 1.0, *kteffnew, 1.0);
+    Core::LinAlg::matrix_add(*knm, false, 1.0, *kteffnew, 1.0);
+    if (sset) Core::LinAlg::matrix_add(*kns, false, 1.0, *kteffnew, 1.0);
 
     //---------------------------------------------------------- SECOND LINE
     // add m submatrices to kteffnew
-    kteffnew->add(*kmnmod, false, 1.0, 1.0);
-    kteffnew->add(*kmmmod, false, 1.0, 1.0);
-    if (iset) kteffnew->add(*kmimod, false, 1.0, 1.0);
-    if (aset) kteffnew->add(*kmamod, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kmnmod, false, 1.0, *kteffnew, 1.0);
+    Core::LinAlg::matrix_add(*kmmmod, false, 1.0, *kteffnew, 1.0);
+    if (iset) Core::LinAlg::matrix_add(*kmimod, false, 1.0, *kteffnew, 1.0);
+    if (aset) Core::LinAlg::matrix_add(*kmamod, false, 1.0, *kteffnew, 1.0);
 
     //----------------------------------------------------------- THIRD LINE
     // add i submatrices to kteffnew
-    if (iset) kteffnew->add(*kinmod, false, 1.0, 1.0);
-    if (iset) kteffnew->add(*kimmod, false, 1.0, 1.0);
-    if (iset) kteffnew->add(*kiimod, false, 1.0, 1.0);
-    if (iset && aset) kteffnew->add(*kiamod, false, 1.0, 1.0);
+    if (iset) Core::LinAlg::matrix_add(*kinmod, false, 1.0, *kteffnew, 1.0);
+    if (iset) Core::LinAlg::matrix_add(*kimmod, false, 1.0, *kteffnew, 1.0);
+    if (iset) Core::LinAlg::matrix_add(*kiimod, false, 1.0, *kteffnew, 1.0);
+    if (iset && aset) Core::LinAlg::matrix_add(*kiamod, false, 1.0, *kteffnew, 1.0);
 
     //---------------------------------------------------------- FOURTH LINE
     // add a submatrices to kteffnew
-    if (aset) kteffnew->add(*smatrix_, false, 1.0, 1.0);
+    if (aset) Core::LinAlg::matrix_add(*smatrix_, false, 1.0, *kteffnew, 1.0);
 
     //----------------------------------------------------------- FIFTH LINE
     // add a submatrices to kteffnew
-    if (aset) kteffnew->add(*kanmod, false, 1.0, 1.0);
-    if (aset) kteffnew->add(*kammod, false, 1.0, 1.0);
-    if (aset && iset) kteffnew->add(*kaimod, false, 1.0, 1.0);
-    if (aset) kteffnew->add(*kaamod, false, 1.0, 1.0);
-    if (aset) kteffnew->add(*tderivmatrix_, false, -1.0, 1.0);
+    if (aset) Core::LinAlg::matrix_add(*kanmod, false, 1.0, *kteffnew, 1.0);
+    if (aset) Core::LinAlg::matrix_add(*kammod, false, 1.0, *kteffnew, 1.0);
+    if (aset && iset) Core::LinAlg::matrix_add(*kaimod, false, 1.0, *kteffnew, 1.0);
+    if (aset) Core::LinAlg::matrix_add(*kaamod, false, 1.0, *kteffnew, 1.0);
+    if (aset) Core::LinAlg::matrix_add(*tderivmatrix_, false, -1.0, *kteffnew, 1.0);
 
     // fill_complete kteffnew (square)
     kteffnew->complete();
@@ -2812,11 +2812,11 @@ void CONTACT::LagrangeStrategy::evaluate_contact(
         Core::LinAlg::SparseMatrix systrafo(*problem_dofs(), 100, false, true);
         std::shared_ptr<Core::LinAlg::SparseMatrix> eye =
             Core::LinAlg::create_identity_matrix(*gndofrowmap_);
-        systrafo.add(*eye, false, 1.0, 1.0);
+        Core::LinAlg::matrix_add(*eye, false, 1.0, systrafo, 1.0);
         if (parallel_redistribution_status())
           trafo_ = Core::LinAlg::matrix_row_col_transform(
               *trafo_, *non_redist_gsmdofrowmap_, *non_redist_gsmdofrowmap_);
-        systrafo.add(*trafo_, false, 1.0, 1.0);
+        Core::LinAlg::matrix_add(*trafo_, false, 1.0, systrafo, 1.0);
         systrafo.complete();
 
         // apply basis transformation to K and f
@@ -2978,8 +2978,8 @@ void CONTACT::LagrangeStrategy::build_saddle_point_system(
   // build matrix and vector blocks
   //**********************************************************************
   // build constraint matrix kdz
-  kdz.add(*dmatrix_, true, 1.0 - alphaf_, 1.0);
-  kdz.add(*mmatrix_, true, -(1.0 - alphaf_), 1.0);
+  Core::LinAlg::matrix_add(*dmatrix_, true, 1.0 - alphaf_, kdz, 1.0);
+  Core::LinAlg::matrix_add(*mmatrix_, true, -(1.0 - alphaf_), kdz, 1.0);
   kdz.complete(*gsdofrowmap_, *gdisprowmap_);
 
   // *** CASE 1: FRICTIONLESS CONTACT ************************************
@@ -2990,14 +2990,16 @@ void CONTACT::LagrangeStrategy::build_saddle_point_system(
     {
       if (gactivedofs_->num_global_elements())
       {
-        kzd.add(*smatrix_, false, 1.0, 1.0);
-        kzd.add(*tderivmatrix_, false, 1.0, 1.0);
+        Core::LinAlg::matrix_add(*smatrix_, false, 1.0, kzd, 1.0);
+        Core::LinAlg::matrix_add(*tderivmatrix_, false, 1.0, kzd, 1.0);
       }
     }
     else
     {
-      if (gactiven_->num_global_elements()) kzd.add(*smatrix_, false, 1.0, 1.0);
-      if (gactivet_->num_global_elements()) kzd.add(*tderivmatrix_, false, 1.0, 1.0);
+      if (gactiven_->num_global_elements())
+        Core::LinAlg::matrix_add(*smatrix_, false, 1.0, kzd, 1.0);
+      if (gactivet_->num_global_elements())
+        Core::LinAlg::matrix_add(*tderivmatrix_, false, 1.0, kzd, 1.0);
     }
     kzd.complete(*gdisprowmap_, *gsdofrowmap_);
 
@@ -3010,8 +3012,8 @@ void CONTACT::LagrangeStrategy::build_saddle_point_system(
     onesdiag.complete();
 
     // build constraint matrix kzz
-    if (gidofs->num_global_elements()) kzz.add(onesdiag, false, 1.0, 1.0);
-    if (gactivet_->num_global_elements()) kzz.add(*tmatrix_, false, 1.0, 1.0);
+    if (gidofs->num_global_elements()) Core::LinAlg::matrix_add(onesdiag, false, 1.0, kzz, 1.0);
+    if (gactivet_->num_global_elements()) Core::LinAlg::matrix_add(*tmatrix_, false, 1.0, kzz, 1.0);
     kzz.complete(*gsdofrowmap_, *gsdofrowmap_);
   }
 
@@ -3029,15 +3031,21 @@ void CONTACT::LagrangeStrategy::build_saddle_point_system(
     // build constraint matrix kzd
     if (constr_direction_ == CONTACT::ConstraintDirection::xyz)
     {
-      if (gactivedofs_->num_global_elements()) kzd.add(*smatrix_, false, 1.0, 1.0);
-      if (gstickdofs->num_global_elements()) kzd.add(*linstickDIS_, false, 1.0, 1.0);
-      if (gslipdofs_->num_global_elements()) kzd.add(*linslipDIS_, false, 1.0, 1.0);
+      if (gactivedofs_->num_global_elements())
+        Core::LinAlg::matrix_add(*smatrix_, false, 1.0, kzd, 1.0);
+      if (gstickdofs->num_global_elements())
+        Core::LinAlg::matrix_add(*linstickDIS_, false, 1.0, kzd, 1.0);
+      if (gslipdofs_->num_global_elements())
+        Core::LinAlg::matrix_add(*linslipDIS_, false, 1.0, kzd, 1.0);
     }
     else
     {
-      if (gactiven_->num_global_elements()) kzd.add(*smatrix_, false, 1.0, 1.0);
-      if (gstickt->num_global_elements()) kzd.add(*linstickDIS_, false, 1.0, 1.0);
-      if (gslipt_->num_global_elements()) kzd.add(*linslipDIS_, false, 1.0, 1.0);
+      if (gactiven_->num_global_elements())
+        Core::LinAlg::matrix_add(*smatrix_, false, 1.0, kzd, 1.0);
+      if (gstickt->num_global_elements())
+        Core::LinAlg::matrix_add(*linstickDIS_, false, 1.0, kzd, 1.0);
+      if (gslipt_->num_global_elements())
+        Core::LinAlg::matrix_add(*linslipDIS_, false, 1.0, kzd, 1.0);
     }
     kzd.complete(*gdisprowmap_, *gsdofrowmap_);
 
@@ -3052,15 +3060,19 @@ void CONTACT::LagrangeStrategy::build_saddle_point_system(
     // build constraint matrix kzz
     if (constr_direction_ == CONTACT::ConstraintDirection::xyz)
     {
-      if (gidofs->num_global_elements()) kzz.add(onesdiag, false, 1.0, 1.0);
-      if (gstickdofs->num_global_elements()) kzz.add(*linstickLM_, false, 1.0, 1.0);
-      if (gslipdofs_->num_global_elements()) kzz.add(*linslipLM_, false, 1.0, 1.0);
+      if (gidofs->num_global_elements()) Core::LinAlg::matrix_add(onesdiag, false, 1.0, kzz, 1.0);
+      if (gstickdofs->num_global_elements())
+        Core::LinAlg::matrix_add(*linstickLM_, false, 1.0, kzz, 1.0);
+      if (gslipdofs_->num_global_elements())
+        Core::LinAlg::matrix_add(*linslipLM_, false, 1.0, kzz, 1.0);
     }
     else
     {
-      if (gidofs->num_global_elements()) kzz.add(onesdiag, false, 1.0, 1.0);
-      if (gstickt->num_global_elements()) kzz.add(*linstickLM_, false, 1.0, 1.0);
-      if (gslipt_->num_global_elements()) kzz.add(*linslipLM_, false, 1.0, 1.0);
+      if (gidofs->num_global_elements()) Core::LinAlg::matrix_add(onesdiag, false, 1.0, kzz, 1.0);
+      if (gstickt->num_global_elements())
+        Core::LinAlg::matrix_add(*linstickLM_, false, 1.0, kzz, 1.0);
+      if (gslipt_->num_global_elements())
+        Core::LinAlg::matrix_add(*linslipLM_, false, 1.0, kzz, 1.0);
     }
     kzz.complete(*gsdofrowmap_, *gsdofrowmap_);
   }
@@ -3402,19 +3414,19 @@ void CONTACT::LagrangeStrategy::evaluate_force(CONTACT::ParamsInterface& cparams
     systrafo_ = std::make_shared<Core::LinAlg::SparseMatrix>(*problem_dofs(), 100, false, true);
     std::shared_ptr<Core::LinAlg::SparseMatrix> eye =
         Core::LinAlg::create_identity_matrix(*gndofrowmap_);
-    systrafo_->add(*eye, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*eye, false, 1.0, *systrafo_, 1.0);
     if (parallel_redistribution_status())
       trafo_ = Core::LinAlg::matrix_row_col_transform(
           *trafo_, *non_redist_gsmdofrowmap_, *non_redist_gsmdofrowmap_);
-    systrafo_->add(*trafo_, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*trafo_, false, 1.0, *systrafo_, 1.0);
     systrafo_->complete();
 
     invsystrafo_ = std::make_shared<Core::LinAlg::SparseMatrix>(*problem_dofs(), 100, false, true);
-    invsystrafo_->add(*eye, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*eye, false, 1.0, *invsystrafo_, 1.0);
     if (parallel_redistribution_status())
       invtrafo_ = Core::LinAlg::matrix_row_col_transform(
           *invtrafo_, *non_redist_gsmdofrowmap_, *non_redist_gsmdofrowmap_);
-    invsystrafo_->add(*invtrafo_, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*invtrafo_, false, 1.0, *invsystrafo_, 1.0);
     invsystrafo_->complete();
   }
 
@@ -3645,14 +3657,14 @@ void CONTACT::LagrangeStrategy::assemble_all_contact_terms_friction()
       dinv_dsv2 = Core::LinAlg::matrix_multiply(invdS, false, *inv_det6, false, false, false, true);
 
       // diagonal entries
-      invd->add(invdS, false, 1.0, 1.0);
-      invd->add(invdE, false, 1.0, 1.0);
-      invd->add(invdV, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(invdS, false, 1.0, *invd, 1.0);
+      Core::LinAlg::matrix_add(invdE, false, 1.0, *invd, 1.0);
+      Core::LinAlg::matrix_add(invdV, false, 1.0, *invd, 1.0);
 
-      invd->add(*dinv_dev, false, 1.0, 1.0);
-      invd->add(*dinv_dse, false, 1.0, 1.0);
-      invd->add(*dinv_dsv1, false, 1.0, 1.0);
-      invd->add(*dinv_dsv2, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(*dinv_dev, false, 1.0, *invd, 1.0);
+      Core::LinAlg::matrix_add(*dinv_dse, false, 1.0, *invd, 1.0);
+      Core::LinAlg::matrix_add(*dinv_dsv1, false, 1.0, *invd, 1.0);
+      Core::LinAlg::matrix_add(*dinv_dsv2, false, 1.0, *invd, 1.0);
 
       // complete
       invd->complete();
@@ -3903,14 +3915,14 @@ void CONTACT::LagrangeStrategy::assemble_all_contact_terms_frictionless()
       dinv_dsv2 = Core::LinAlg::matrix_multiply(invdS, false, *inv_det6, false, false, false, true);
 
       // diagonal entries
-      invd->add(invdS, false, 1.0, 1.0);
-      invd->add(invdE, false, 1.0, 1.0);
-      invd->add(invdV, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(invdS, false, 1.0, *invd, 1.0);
+      Core::LinAlg::matrix_add(invdE, false, 1.0, *invd, 1.0);
+      Core::LinAlg::matrix_add(invdV, false, 1.0, *invd, 1.0);
 
-      invd->add(*dinv_dev, false, 1.0, 1.0);
-      invd->add(*dinv_dse, false, 1.0, 1.0);
-      invd->add(*dinv_dsv1, false, 1.0, 1.0);
-      invd->add(*dinv_dsv2, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(*dinv_dev, false, 1.0, *invd, 1.0);
+      Core::LinAlg::matrix_add(*dinv_dse, false, 1.0, *invd, 1.0);
+      Core::LinAlg::matrix_add(*dinv_dsv1, false, 1.0, *invd, 1.0);
+      Core::LinAlg::matrix_add(*dinv_dsv2, false, 1.0, *invd, 1.0);
 
       invd->complete();
     }
@@ -4134,10 +4146,10 @@ std::shared_ptr<Core::LinAlg::SparseMatrix> CONTACT::LagrangeStrategy::get_matri
           slave_master_dof_row_map(true), 100, false, true);
 
       // build matrix kdd
-      mat_ptr->add(*lindmatrix_, false, 1.0, 1.0);
-      mat_ptr->add(*linmmatrix_, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(*lindmatrix_, false, 1.0, *mat_ptr, 1.0);
+      Core::LinAlg::matrix_add(*linmmatrix_, false, 1.0, *mat_ptr, 1.0);
       if (nonSmoothContact_ && nonsmooth_Penalty_stiff_)
-        mat_ptr->add(*nonsmooth_Penalty_stiff_, false, 1.0, 1.0);
+        Core::LinAlg::matrix_add(*nonsmooth_Penalty_stiff_, false, 1.0, *mat_ptr, 1.0);
       mat_ptr->complete();
 
       // transform parallel row/column distribution of matrix kdd
@@ -4148,7 +4160,7 @@ std::shared_ptr<Core::LinAlg::SparseMatrix> CONTACT::LagrangeStrategy::get_matri
 
       std::shared_ptr<Core::LinAlg::SparseMatrix> full_mat_ptr =
           std::make_shared<Core::LinAlg::SparseMatrix>(*problem_dofs(), 100, false, true);
-      full_mat_ptr->add(*mat_ptr, false, 1., 1.);
+      Core::LinAlg::matrix_add(*mat_ptr, false, 1., *full_mat_ptr, 1.);
       full_mat_ptr->complete();
       if (is_dual_quad_slave_trafo() && lagmultquad == Inpar::Mortar::lagmult_lin)
         full_mat_ptr = Core::LinAlg::matrix_multiply(
@@ -4163,8 +4175,8 @@ std::shared_ptr<Core::LinAlg::SparseMatrix> CONTACT::LagrangeStrategy::get_matri
       // build constraint matrix kdz
       Core::LinAlg::SparseMatrix kdz_ptr(*gdisprowmap_, 100, false, true);
 
-      kdz_ptr.add(*dmatrix_, true, 1.0, 1.0);
-      kdz_ptr.add(*mmatrix_, true, -1.0, 1.0);
+      Core::LinAlg::matrix_add(*dmatrix_, true, 1.0, kdz_ptr, 1.0);
+      Core::LinAlg::matrix_add(*mmatrix_, true, -1.0, kdz_ptr, 1.0);
       kdz_ptr.complete(*gsdofrowmap_, *gdisprowmap_);
 
       // transform constraint matrix kzd to lmdofmap (matrix_col_transform)
@@ -4186,16 +4198,16 @@ std::shared_ptr<Core::LinAlg::SparseMatrix> CONTACT::LagrangeStrategy::get_matri
       // build constraint matrix kzd
       if (gactiven_->num_global_elements())
       {
-        kzd_ptr.add(*smatrix_, false, 1.0, 1.0);
+        Core::LinAlg::matrix_add(*smatrix_, false, 1.0, kzd_ptr, 1.0);
 
         // frictionless contact
-        if (!is_friction()) kzd_ptr.add(*tderivmatrix_, false, 1.0, 1.0);
+        if (!is_friction()) Core::LinAlg::matrix_add(*tderivmatrix_, false, 1.0, kzd_ptr, 1.0);
 
         // frictional contact
         else
         {
-          kzd_ptr.add(*linslipDIS_, false, 1.0, 1.0);
-          kzd_ptr.add(*linstickDIS_, false, 1.0, 1.0);
+          Core::LinAlg::matrix_add(*linslipDIS_, false, 1.0, kzd_ptr, 1.0);
+          Core::LinAlg::matrix_add(*linstickDIS_, false, 1.0, kzd_ptr, 1.0);
         }
       }
       kzd_ptr.complete(*gdisprowmap_, *gsdofrowmap_);
@@ -4241,16 +4253,18 @@ std::shared_ptr<Core::LinAlg::SparseMatrix> CONTACT::LagrangeStrategy::get_matri
       onesdiag.complete();
 
       // build constraint matrix kzz
-      if (gidofs->num_global_elements()) kzz_ptr->add(onesdiag, false, 1.0, 1.0);
+      if (gidofs->num_global_elements())
+        Core::LinAlg::matrix_add(onesdiag, false, 1.0, *kzz_ptr, 1.0);
 
       if (!is_friction())
       {
-        if (gactivet_->num_global_elements()) kzz_ptr->add(*tmatrix_, false, 1.0, 1.0);
+        if (gactivet_->num_global_elements())
+          Core::LinAlg::matrix_add(*tmatrix_, false, 1.0, *kzz_ptr, 1.0);
       }
       else
       {
-        kzz_ptr->add(*linslipLM_, false, 1., 1.);
-        kzz_ptr->add(*linstickLM_, false, 1., 1.);
+        Core::LinAlg::matrix_add(*linslipLM_, false, 1., *kzz_ptr, 1.);
+        Core::LinAlg::matrix_add(*linstickLM_, false, 1., *kzz_ptr, 1.);
       }
 
       // transform constraint matrix kzz to lmdofmap
@@ -4455,7 +4469,7 @@ void CONTACT::LagrangeStrategy::recover(std::shared_ptr<Core::LinAlg::Vector<dou
     Core::LinAlg::split_matrix2x2(
         invd_, gactivedofs_, tempmap, gactivedofs_, tempmap, invda, tempmtx1, tempmtx2, tempmtx3);
     Core::LinAlg::SparseMatrix invdmod(*gsdofrowmap_, 10);
-    invdmod.add(*invda, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*invda, false, 1.0, invdmod, 1.0);
     invdmod.complete();
 
     /**********************************************************************/
@@ -4468,11 +4482,11 @@ void CONTACT::LagrangeStrategy::recover(std::shared_ptr<Core::LinAlg::Vector<dou
       Core::LinAlg::SparseMatrix systrafo(*problem_dofs(), 100, false, true);
       std::shared_ptr<Core::LinAlg::SparseMatrix> eye =
           Core::LinAlg::create_identity_matrix(*gndofrowmap_);
-      systrafo.add(*eye, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(*eye, false, 1.0, systrafo, 1.0);
       if (parallel_redistribution_status())
         trafo_ = Core::LinAlg::matrix_row_col_transform(
             *trafo_, *non_redist_gsmdofrowmap_, *non_redist_gsmdofrowmap_);
-      systrafo.add(*trafo_, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(*trafo_, false, 1.0, systrafo, 1.0);
       systrafo.complete();
       Core::LinAlg::Vector<double> disinew(*disi);
       systrafo.multiply(false, disinew, *disi);
@@ -4551,11 +4565,11 @@ void CONTACT::LagrangeStrategy::recover(std::shared_ptr<Core::LinAlg::Vector<dou
       Core::LinAlg::SparseMatrix systrafo(*problem_dofs(), 100, false, true);
       std::shared_ptr<Core::LinAlg::SparseMatrix> eye =
           Core::LinAlg::create_identity_matrix(*gndofrowmap_);
-      systrafo.add(*eye, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(*eye, false, 1.0, systrafo, 1.0);
       if (parallel_redistribution_status())
         trafo_ = Core::LinAlg::matrix_row_col_transform(
             *trafo_, *non_redist_gsmdofrowmap_, *non_redist_gsmdofrowmap_);
-      systrafo.add(*trafo_, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(*trafo_, false, 1.0, systrafo, 1.0);
       systrafo.complete();
       Core::LinAlg::Vector<double> disinew(*disi);
       systrafo.multiply(false, disinew, *disi);
@@ -5467,19 +5481,19 @@ void CONTACT::LagrangeStrategy::condense_friction(
   // kmn: add T(mhataam)*kan
   std::shared_ptr<Core::LinAlg::SparseMatrix> kmnmod =
       std::make_shared<Core::LinAlg::SparseMatrix>(*gmdofrowmap_, 100);
-  kmnmod->add(*kmn, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*kmn, false, 1.0, *kmnmod, 1.0);
   std::shared_ptr<Core::LinAlg::SparseMatrix> kmnadd =
       Core::LinAlg::matrix_multiply(*mhataam, true, *kan, false, false, false, true);
-  kmnmod->add(*kmnadd, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*kmnadd, false, 1.0, *kmnmod, 1.0);
   kmnmod->complete(kmn->domain_map(), kmn->row_map());
 
   // kmm: add T(mhataam)*kam
   std::shared_ptr<Core::LinAlg::SparseMatrix> kmmmod =
       std::make_shared<Core::LinAlg::SparseMatrix>(*gmdofrowmap_, 100);
-  kmmmod->add(*kmm, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*kmm, false, 1.0, *kmmmod, 1.0);
   std::shared_ptr<Core::LinAlg::SparseMatrix> kmmadd =
       Core::LinAlg::matrix_multiply(*mhataam, true, *kam, false, false, false, true);
-  kmmmod->add(*kmmadd, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*kmmadd, false, 1.0, *kmmmod, 1.0);
   kmmmod->complete(kmm->domain_map(), kmm->row_map());
 
   // kmi: add T(mhataam)*kai
@@ -5487,10 +5501,10 @@ void CONTACT::LagrangeStrategy::condense_friction(
   if (iset)
   {
     kmimod = std::make_shared<Core::LinAlg::SparseMatrix>(*gmdofrowmap_, 100);
-    kmimod->add(*kmi, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kmi, false, 1.0, *kmimod, 1.0);
     std::shared_ptr<Core::LinAlg::SparseMatrix> kmiadd =
         Core::LinAlg::matrix_multiply(*mhataam, true, *kai, false, false, false, true);
-    kmimod->add(*kmiadd, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kmiadd, false, 1.0, *kmimod, 1.0);
     kmimod->complete(kmi->domain_map(), kmi->row_map());
   }
 
@@ -5499,10 +5513,10 @@ void CONTACT::LagrangeStrategy::condense_friction(
   if (aset)
   {
     kmamod = std::make_shared<Core::LinAlg::SparseMatrix>(*gmdofrowmap_, 100);
-    kmamod->add(*kma, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kma, false, 1.0, *kmamod, 1.0);
     std::shared_ptr<Core::LinAlg::SparseMatrix> kmaadd =
         Core::LinAlg::matrix_multiply(*mhataam, true, *kaa, false, false, false, true);
-    kmamod->add(*kmaadd, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kmaadd, false, 1.0, *kmamod, 1.0);
     kmamod->complete(kma->domain_map(), kma->row_map());
   }
 
@@ -5510,24 +5524,24 @@ void CONTACT::LagrangeStrategy::condense_friction(
   // kin: subtract T(dhat)*kan
   std::shared_ptr<Core::LinAlg::SparseMatrix> kinmod =
       std::make_shared<Core::LinAlg::SparseMatrix>(*gidofs, 100);
-  kinmod->add(*kin, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*kin, false, 1.0, *kinmod, 1.0);
   if (aset && iset)
   {
     std::shared_ptr<Core::LinAlg::SparseMatrix> kinadd =
         Core::LinAlg::matrix_multiply(*dhat, true, *kan, false, false, false, true);
-    kinmod->add(*kinadd, false, -1.0, 1.0);
+    Core::LinAlg::matrix_add(*kinadd, false, -1.0, *kinmod, 1.0);
   }
   kinmod->complete(kin->domain_map(), kin->row_map());
 
   // kim: subtract T(dhat)*kam
   std::shared_ptr<Core::LinAlg::SparseMatrix> kimmod =
       std::make_shared<Core::LinAlg::SparseMatrix>(*gidofs, 100);
-  kimmod->add(*kim, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*kim, false, 1.0, *kimmod, 1.0);
   if (aset && iset)
   {
     std::shared_ptr<Core::LinAlg::SparseMatrix> kimadd =
         Core::LinAlg::matrix_multiply(*dhat, true, *kam, false, false, false, true);
-    kimmod->add(*kimadd, false, -1.0, 1.0);
+    Core::LinAlg::matrix_add(*kimadd, false, -1.0, *kimmod, 1.0);
   }
   kimmod->complete(kim->domain_map(), kim->row_map());
 
@@ -5536,12 +5550,12 @@ void CONTACT::LagrangeStrategy::condense_friction(
   if (iset)
   {
     kiimod = std::make_shared<Core::LinAlg::SparseMatrix>(*gidofs, 100);
-    kiimod->add(*kii, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kii, false, 1.0, *kiimod, 1.0);
     if (aset)
     {
       std::shared_ptr<Core::LinAlg::SparseMatrix> kiiadd =
           Core::LinAlg::matrix_multiply(*dhat, true, *kai, false, false, false, true);
-      kiimod->add(*kiiadd, false, -1.0, 1.0);
+      Core::LinAlg::matrix_add(*kiiadd, false, -1.0, *kiimod, 1.0);
     }
     kiimod->complete(kii->domain_map(), kii->row_map());
   }
@@ -5551,10 +5565,10 @@ void CONTACT::LagrangeStrategy::condense_friction(
   if (iset && aset)
   {
     kiamod = std::make_shared<Core::LinAlg::SparseMatrix>(*gidofs, 100);
-    kiamod->add(*kia, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kia, false, 1.0, *kiamod, 1.0);
     std::shared_ptr<Core::LinAlg::SparseMatrix> kiaadd =
         Core::LinAlg::matrix_multiply(*dhat, true, *kaa, false, false, false, true);
-    kiamod->add(*kiaadd, false, -1.0, 1.0);
+    Core::LinAlg::matrix_add(*kiaadd, false, -1.0, *kiamod, 1.0);
     kiamod->complete(kia->domain_map(), kia->row_map());
   }
 
@@ -5804,50 +5818,50 @@ void CONTACT::LagrangeStrategy::condense_friction(
 
   //--------------------------------------------------------- FIRST LINE
   // add n submatrices to kteffnew
-  kteffnew.add(*knn, false, 1.0, 1.0);
-  kteffnew.add(*knm, false, 1.0, 1.0);
-  if (sset) kteffnew.add(*kns, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*knn, false, 1.0, kteffnew, 1.0);
+  Core::LinAlg::matrix_add(*knm, false, 1.0, kteffnew, 1.0);
+  if (sset) Core::LinAlg::matrix_add(*kns, false, 1.0, kteffnew, 1.0);
 
   //-------------------------------------------------------- SECOND LINE
   // add m submatrices to kteffnew
-  kteffnew.add(*kmnmod, false, 1.0, 1.0);
-  kteffnew.add(*kmmmod, false, 1.0, 1.0);
-  if (iset) kteffnew.add(*kmimod, false, 1.0, 1.0);
-  if (aset) kteffnew.add(*kmamod, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*kmnmod, false, 1.0, kteffnew, 1.0);
+  Core::LinAlg::matrix_add(*kmmmod, false, 1.0, kteffnew, 1.0);
+  if (iset) Core::LinAlg::matrix_add(*kmimod, false, 1.0, kteffnew, 1.0);
+  if (aset) Core::LinAlg::matrix_add(*kmamod, false, 1.0, kteffnew, 1.0);
 
   //--------------------------------------------------------- THIRD LINE
   // add i submatrices to kteffnew
-  if (iset) kteffnew.add(*kinmod, false, 1.0, 1.0);
-  if (iset) kteffnew.add(*kimmod, false, 1.0, 1.0);
-  if (iset) kteffnew.add(*kiimod, false, 1.0, 1.0);
-  if (iset && aset) kteffnew.add(*kiamod, false, 1.0, 1.0);
+  if (iset) Core::LinAlg::matrix_add(*kinmod, false, 1.0, kteffnew, 1.0);
+  if (iset) Core::LinAlg::matrix_add(*kimmod, false, 1.0, kteffnew, 1.0);
+  if (iset) Core::LinAlg::matrix_add(*kiimod, false, 1.0, kteffnew, 1.0);
+  if (iset && aset) Core::LinAlg::matrix_add(*kiamod, false, 1.0, kteffnew, 1.0);
 
   //-------------------------------------------------------- FOURTH LINE
 
   // add a submatrices to kteffnew
-  if (aset) kteffnew.add(*smatrix_, false, 1.0, 1.0);
+  if (aset) Core::LinAlg::matrix_add(*smatrix_, false, 1.0, kteffnew, 1.0);
 
   //--------------------------------------------------------- FIFTH LINE
   // add st submatrices to kteffnew
-  if (stickset) kteffnew.add(*kstnmod, false, 1.0, 1.0);
-  if (stickset) kteffnew.add(*kstmmod, false, 1.0, 1.0);
-  if (stickset && iset) kteffnew.add(*kstimod, false, 1.0, 1.0);
-  if (stickset && slipset) kteffnew.add(*kstslmod, false, 1.0, 1.0);
-  if (stickset) kteffnew.add(*kststmod, false, 1.0, 1.0);
+  if (stickset) Core::LinAlg::matrix_add(*kstnmod, false, 1.0, kteffnew, 1.0);
+  if (stickset) Core::LinAlg::matrix_add(*kstmmod, false, 1.0, kteffnew, 1.0);
+  if (stickset && iset) Core::LinAlg::matrix_add(*kstimod, false, 1.0, kteffnew, 1.0);
+  if (stickset && slipset) Core::LinAlg::matrix_add(*kstslmod, false, 1.0, kteffnew, 1.0);
+  if (stickset) Core::LinAlg::matrix_add(*kststmod, false, 1.0, kteffnew, 1.0);
 
   // add terms of linearization of sick condition to kteffnew
-  if (stickset) kteffnew.add(*linstickDIS_, false, -1.0, 1.0);
+  if (stickset) Core::LinAlg::matrix_add(*linstickDIS_, false, -1.0, kteffnew, 1.0);
 
   //--------------------------------------------------------- SIXTH LINE
   // add sl submatrices to kteffnew
-  if (slipset) kteffnew.add(*kslnmod, false, 1.0, 1.0);
-  if (slipset) kteffnew.add(*kslmmod, false, 1.0, 1.0);
-  if (slipset && iset) kteffnew.add(*kslimod, false, 1.0, 1.0);
-  if (slipset) kteffnew.add(*kslslmod, false, 1.0, 1.0);
-  if (slipset && stickset) kteffnew.add(*kslstmod, false, 1.0, 1.0);
+  if (slipset) Core::LinAlg::matrix_add(*kslnmod, false, 1.0, kteffnew, 1.0);
+  if (slipset) Core::LinAlg::matrix_add(*kslmmod, false, 1.0, kteffnew, 1.0);
+  if (slipset && iset) Core::LinAlg::matrix_add(*kslimod, false, 1.0, kteffnew, 1.0);
+  if (slipset) Core::LinAlg::matrix_add(*kslslmod, false, 1.0, kteffnew, 1.0);
+  if (slipset && stickset) Core::LinAlg::matrix_add(*kslstmod, false, 1.0, kteffnew, 1.0);
 
   // add terms of linearization of slip condition to kteffnew and feffnew
-  if (slipset) kteffnew.add(*linslipDIS_, false, -1.0, +1.0);
+  if (slipset) Core::LinAlg::matrix_add(*linslipDIS_, false, -1.0, kteffnew, +1.0);
 
   // add diagonal entries to sparsity pattern for dbc
   for (int i = 0; i < kteffnew.row_map().num_my_elements(); ++i)
@@ -6278,19 +6292,19 @@ void CONTACT::LagrangeStrategy::condense_frictionless(
   // kmn: add T(mhataam)*kan
   std::shared_ptr<Core::LinAlg::SparseMatrix> kmnmod =
       std::make_shared<Core::LinAlg::SparseMatrix>(*gmdofrowmap_, 100);
-  kmnmod->add(*kmn, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*kmn, false, 1.0, *kmnmod, 1.0);
   std::shared_ptr<Core::LinAlg::SparseMatrix> kmnadd =
       Core::LinAlg::matrix_multiply(*mhataam, true, *kan, false, false, false, true);
-  kmnmod->add(*kmnadd, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*kmnadd, false, 1.0, *kmnmod, 1.0);
   kmnmod->complete(kmn->domain_map(), kmn->row_map());
 
   // kmm: add T(mhataam)*kam
   std::shared_ptr<Core::LinAlg::SparseMatrix> kmmmod =
       std::make_shared<Core::LinAlg::SparseMatrix>(*gmdofrowmap_, 100);
-  kmmmod->add(*kmm, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*kmm, false, 1.0, *kmmmod, 1.0);
   std::shared_ptr<Core::LinAlg::SparseMatrix> kmmadd =
       Core::LinAlg::matrix_multiply(*mhataam, true, *kam, false, false, false, true);
-  kmmmod->add(*kmmadd, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*kmmadd, false, 1.0, *kmmmod, 1.0);
   kmmmod->complete(kmm->domain_map(), kmm->row_map());
 
   // kmi: add T(mhataam)*kai
@@ -6298,10 +6312,10 @@ void CONTACT::LagrangeStrategy::condense_frictionless(
   if (iset)
   {
     kmimod = std::make_shared<Core::LinAlg::SparseMatrix>(*gmdofrowmap_, 100);
-    kmimod->add(*kmi, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kmi, false, 1.0, *kmimod, 1.0);
     std::shared_ptr<Core::LinAlg::SparseMatrix> kmiadd =
         Core::LinAlg::matrix_multiply(*mhataam, true, *kai, false, false, false, true);
-    kmimod->add(*kmiadd, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kmiadd, false, 1.0, *kmimod, 1.0);
     kmimod->complete(kmi->domain_map(), kmi->row_map());
   }
 
@@ -6310,10 +6324,10 @@ void CONTACT::LagrangeStrategy::condense_frictionless(
   if (aset)
   {
     kmamod = std::make_shared<Core::LinAlg::SparseMatrix>(*gmdofrowmap_, 100);
-    kmamod->add(*kma, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kma, false, 1.0, *kmamod, 1.0);
     std::shared_ptr<Core::LinAlg::SparseMatrix> kmaadd =
         Core::LinAlg::matrix_multiply(*mhataam, true, *kaa, false, false, false, true);
-    kmamod->add(*kmaadd, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kmaadd, false, 1.0, *kmamod, 1.0);
     kmamod->complete(kma->domain_map(), kma->row_map());
   }
 
@@ -6322,24 +6336,24 @@ void CONTACT::LagrangeStrategy::condense_frictionless(
   // kin: subtract T(dhat)*kan --
   std::shared_ptr<Core::LinAlg::SparseMatrix> kinmod =
       std::make_shared<Core::LinAlg::SparseMatrix>(*gidofs, 100);
-  kinmod->add(*kin, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*kin, false, 1.0, *kinmod, 1.0);
   if (aset && iset)
   {
     std::shared_ptr<Core::LinAlg::SparseMatrix> kinadd =
         Core::LinAlg::matrix_multiply(*dhat, true, *kan, false, false, false, true);
-    kinmod->add(*kinadd, false, -1.0, 1.0);
+    Core::LinAlg::matrix_add(*kinadd, false, -1.0, *kinmod, 1.0);
   }
   kinmod->complete(kin->domain_map(), kin->row_map());
 
   // kim: subtract T(dhat)*kam
   std::shared_ptr<Core::LinAlg::SparseMatrix> kimmod =
       std::make_shared<Core::LinAlg::SparseMatrix>(*gidofs, 100);
-  kimmod->add(*kim, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*kim, false, 1.0, *kimmod, 1.0);
   if (aset && iset)
   {
     std::shared_ptr<Core::LinAlg::SparseMatrix> kimadd =
         Core::LinAlg::matrix_multiply(*dhat, true, *kam, false, false, false, true);
-    kimmod->add(*kimadd, false, -1.0, 1.0);
+    Core::LinAlg::matrix_add(*kimadd, false, -1.0, *kimmod, 1.0);
   }
   kimmod->complete(kim->domain_map(), kim->row_map());
 
@@ -6348,12 +6362,12 @@ void CONTACT::LagrangeStrategy::condense_frictionless(
   if (iset)
   {
     kiimod = std::make_shared<Core::LinAlg::SparseMatrix>(*gidofs, 100);
-    kiimod->add(*kii, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kii, false, 1.0, *kiimod, 1.0);
     if (aset)
     {
       std::shared_ptr<Core::LinAlg::SparseMatrix> kiiadd =
           Core::LinAlg::matrix_multiply(*dhat, true, *kai, false, false, false, true);
-      kiimod->add(*kiiadd, false, -1.0, 1.0);
+      Core::LinAlg::matrix_add(*kiiadd, false, -1.0, *kiimod, 1.0);
     }
     kiimod->complete(kii->domain_map(), kii->row_map());
   }
@@ -6363,10 +6377,10 @@ void CONTACT::LagrangeStrategy::condense_frictionless(
   if (iset && aset)
   {
     kiamod = std::make_shared<Core::LinAlg::SparseMatrix>(*gidofs, 100);
-    kiamod->add(*kia, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kia, false, 1.0, *kiamod, 1.0);
     std::shared_ptr<Core::LinAlg::SparseMatrix> kiaadd =
         Core::LinAlg::matrix_multiply(*dhat, true, *kaa, false, false, false, true);
-    kiamod->add(*kiaadd, false, -1.0, 1.0);
+    Core::LinAlg::matrix_add(*kiaadd, false, -1.0, *kiamod, 1.0);
     kiamod->complete(kia->domain_map(), kia->row_map());
   }
 
@@ -6498,35 +6512,35 @@ void CONTACT::LagrangeStrategy::condense_frictionless(
 
   //----------------------------------------------------------- FIRST LINE
   // add n submatrices to kteffnew
-  kteffnew.add(*knn, false, 1.0, 1.0);
-  kteffnew.add(*knm, false, 1.0, 1.0);
-  if (sset) kteffnew.add(*kns, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*knn, false, 1.0, kteffnew, 1.0);
+  Core::LinAlg::matrix_add(*knm, false, 1.0, kteffnew, 1.0);
+  if (sset) Core::LinAlg::matrix_add(*kns, false, 1.0, kteffnew, 1.0);
 
   //---------------------------------------------------------- SECOND LINE
   // add m submatrices to kteffnew
-  kteffnew.add(*kmnmod, false, 1.0, 1.0);
-  kteffnew.add(*kmmmod, false, 1.0, 1.0);
-  if (iset) kteffnew.add(*kmimod, false, 1.0, 1.0);
-  if (aset) kteffnew.add(*kmamod, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*kmnmod, false, 1.0, kteffnew, 1.0);
+  Core::LinAlg::matrix_add(*kmmmod, false, 1.0, kteffnew, 1.0);
+  if (iset) Core::LinAlg::matrix_add(*kmimod, false, 1.0, kteffnew, 1.0);
+  if (aset) Core::LinAlg::matrix_add(*kmamod, false, 1.0, kteffnew, 1.0);
 
   //----------------------------------------------------------- THIRD LINE
   // add i submatrices to kteffnew
-  if (iset) kteffnew.add(*kinmod, false, 1.0, 1.0);
-  if (iset) kteffnew.add(*kimmod, false, 1.0, 1.0);
-  if (iset) kteffnew.add(*kiimod, false, 1.0, 1.0);
-  if (iset && aset) kteffnew.add(*kiamod, false, 1.0, 1.0);
+  if (iset) Core::LinAlg::matrix_add(*kinmod, false, 1.0, kteffnew, 1.0);
+  if (iset) Core::LinAlg::matrix_add(*kimmod, false, 1.0, kteffnew, 1.0);
+  if (iset) Core::LinAlg::matrix_add(*kiimod, false, 1.0, kteffnew, 1.0);
+  if (iset && aset) Core::LinAlg::matrix_add(*kiamod, false, 1.0, kteffnew, 1.0);
 
   //---------------------------------------------------------- FOURTH LINE
   // add a submatrices to kteffnew
-  if (aset) kteffnew.add(*smatrix_, false, 1.0, 1.0);
+  if (aset) Core::LinAlg::matrix_add(*smatrix_, false, 1.0, kteffnew, 1.0);
 
   //----------------------------------------------------------- FIFTH LINE
   // add a submatrices to kteffnew
-  if (aset) kteffnew.add(*kanmod, false, 1.0, 1.0);
-  if (aset) kteffnew.add(*kammod, false, 1.0, 1.0);
-  if (aset && iset) kteffnew.add(*kaimod, false, 1.0, 1.0);
-  if (aset) kteffnew.add(*kaamod, false, 1.0, 1.0);
-  if (aset) kteffnew.add(*tderivmatrix_, false, -1.0, 1.0);
+  if (aset) Core::LinAlg::matrix_add(*kanmod, false, 1.0, kteffnew, 1.0);
+  if (aset) Core::LinAlg::matrix_add(*kammod, false, 1.0, kteffnew, 1.0);
+  if (aset && iset) Core::LinAlg::matrix_add(*kaimod, false, 1.0, kteffnew, 1.0);
+  if (aset) Core::LinAlg::matrix_add(*kaamod, false, 1.0, kteffnew, 1.0);
+  if (aset) Core::LinAlg::matrix_add(*tderivmatrix_, false, -1.0, kteffnew, 1.0);
 
   // fill_complete kteffnew (square)
   kteffnew.complete();
@@ -6690,7 +6704,7 @@ void CONTACT::LagrangeStrategy::run_post_apply_jacobian_inverse(
     Core::LinAlg::split_matrix2x2(
         invd_, gactivedofs_, tempmap, gactivedofs_, tempmap, invda, tempmtx1, tempmtx2, tempmtx3);
     Core::LinAlg::SparseMatrix invdmod(*gsdofrowmap_, 10);
-    invdmod.add(*invda, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*invda, false, 1.0, invdmod, 1.0);
     invdmod.complete();
 
     /**********************************************************************/

--- a/src/contact/src/4C_contact_lagrange_strategy_poro.cpp
+++ b/src/contact/src/4C_contact_lagrange_strategy_poro.cpp
@@ -463,10 +463,10 @@ void CONTACT::LagrangeStrategyPoro::evaluate_mat_poro_no_pen(
   }
 
   k_fseff->un_complete();
-  k_fseff->add(*fporolindmatrix_, false, (1.0 - nopenalpha_) * 1.0, 1.0);
+  Core::LinAlg::matrix_add(*fporolindmatrix_, false, (1.0 - nopenalpha_) * 1.0, *k_fseff, 1.0);
 
   if (poromaster_)
-    k_fseff->add(*fporolinmmatrix_, false, (1.0 - nopenalpha_) * 1.0,
+    Core::LinAlg::matrix_add(*fporolinmmatrix_, false, (1.0 - nopenalpha_) * 1.0, *k_fseff,
         1.0);  // is needed only for twosided poro contact or meshtying
 
   k_fseff->complete(*problem_dofs(), *falldofrowmap_);  // gets bigger because of linearisation
@@ -623,28 +623,28 @@ void CONTACT::LagrangeStrategyPoro::evaluate_mat_poro_no_pen(
   {
     // kmn: add T(mhataam)*kan
     k_fs_mnmod = std::make_shared<Core::LinAlg::SparseMatrix>(*fgmdofrowmap_, 100);
-    k_fs_mnmod->add(*k_fs_mn, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*k_fs_mn, false, 1.0, *k_fs_mnmod, 1.0);
     std::shared_ptr<Core::LinAlg::SparseMatrix> k_fs_mnadd =
         Core::LinAlg::matrix_multiply(*fmhataam_, true, *k_fs_an, false, false, false, true);
-    k_fs_mnmod->add(*k_fs_mnadd, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*k_fs_mnadd, false, 1.0, *k_fs_mnmod, 1.0);
     k_fs_mnmod->complete(k_fs_mn->domain_map(), k_fs_mn->row_map());
 
     // kmm: add T(mhataam)*kam
     k_fs_mmmod = std::make_shared<Core::LinAlg::SparseMatrix>(*fgmdofrowmap_, 100);
-    k_fs_mmmod->add(*k_fs_mm, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*k_fs_mm, false, 1.0, *k_fs_mmmod, 1.0);
     std::shared_ptr<Core::LinAlg::SparseMatrix> k_fs_mmadd =
         Core::LinAlg::matrix_multiply(*fmhataam_, true, *k_fs_am, false, false, false, true);
-    k_fs_mmmod->add(*k_fs_mmadd, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*k_fs_mmadd, false, 1.0, *k_fs_mmmod, 1.0);
     k_fs_mmmod->complete(k_fs_mm->domain_map(), k_fs_mm->row_map());
 
     // kmi: add T(mhataam)*kai
     if (iset)
     {
       k_fs_mimod = std::make_shared<Core::LinAlg::SparseMatrix>(*fgmdofrowmap_, 100);
-      k_fs_mimod->add(*k_fs_mi, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(*k_fs_mi, false, 1.0, *k_fs_mimod, 1.0);
       std::shared_ptr<Core::LinAlg::SparseMatrix> k_fs_miadd =
           Core::LinAlg::matrix_multiply(*fmhataam_, true, *k_fs_ai, false, false, false, true);
-      k_fs_mimod->add(*k_fs_miadd, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(*k_fs_miadd, false, 1.0, *k_fs_mimod, 1.0);
       k_fs_mimod->complete(k_fs_mi->domain_map(), k_fs_mi->row_map());
     }
 
@@ -652,10 +652,10 @@ void CONTACT::LagrangeStrategyPoro::evaluate_mat_poro_no_pen(
     if (aset)
     {
       k_fs_mamod = std::make_shared<Core::LinAlg::SparseMatrix>(*fgmdofrowmap_, 100);
-      k_fs_mamod->add(*k_fs_ma, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(*k_fs_ma, false, 1.0, *k_fs_mamod, 1.0);
       std::shared_ptr<Core::LinAlg::SparseMatrix> k_fs_maadd =
           Core::LinAlg::matrix_multiply(*fmhataam_, true, *k_fs_aa, false, false, false, true);
-      k_fs_mamod->add(*k_fs_maadd, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(*k_fs_maadd, false, 1.0, *k_fs_mamod, 1.0);
       k_fs_mamod->complete(k_fs_ma->domain_map(), k_fs_ma->row_map());
     }
   }
@@ -665,18 +665,18 @@ void CONTACT::LagrangeStrategyPoro::evaluate_mat_poro_no_pen(
   // fdhat is expected to be zero here but still used for condensation
   // kin: subtract T(dhat)*kan --
   Core::LinAlg::SparseMatrix k_fs_inmod(*fgidofs, 100);
-  k_fs_inmod.add(*k_fs_in, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*k_fs_in, false, 1.0, k_fs_inmod, 1.0);
   std::shared_ptr<Core::LinAlg::SparseMatrix> k_fs_inadd =
       Core::LinAlg::matrix_multiply(*fdhat_, true, *k_fs_an, false, false, false, true);
-  k_fs_inmod.add(*k_fs_inadd, false, -1.0, 1.0);
+  Core::LinAlg::matrix_add(*k_fs_inadd, false, -1.0, k_fs_inmod, 1.0);
   k_fs_inmod.complete(k_fs_in->domain_map(), k_fs_in->row_map());
 
   // kim: subtract T(dhat)*kam
   Core::LinAlg::SparseMatrix k_fs_immod(*fgidofs, 100);
-  k_fs_immod.add(*k_fs_im, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*k_fs_im, false, 1.0, k_fs_immod, 1.0);
   std::shared_ptr<Core::LinAlg::SparseMatrix> k_fs_imadd =
       Core::LinAlg::matrix_multiply(*fdhat_, true, *k_fs_am, false, false, false, true);
-  k_fs_immod.add(*k_fs_imadd, false, -1.0, 1.0);
+  Core::LinAlg::matrix_add(*k_fs_imadd, false, -1.0, k_fs_immod, 1.0);
   k_fs_immod.complete(k_fs_im->domain_map(), k_fs_im->row_map());
 
   // kii: subtract T(dhat)*kai
@@ -684,10 +684,10 @@ void CONTACT::LagrangeStrategyPoro::evaluate_mat_poro_no_pen(
   if (iset)
   {
     k_fs_iimod = std::make_shared<Core::LinAlg::SparseMatrix>(*fgidofs, 100);
-    k_fs_iimod->add(*k_fs_ii, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*k_fs_ii, false, 1.0, *k_fs_iimod, 1.0);
     std::shared_ptr<Core::LinAlg::SparseMatrix> k_fs_iiadd =
         Core::LinAlg::matrix_multiply(*fdhat_, true, *k_fs_ai, false, false, false, true);
-    k_fs_iimod->add(*k_fs_iiadd, false, -1.0, 1.0);
+    Core::LinAlg::matrix_add(*k_fs_iiadd, false, -1.0, *k_fs_iimod, 1.0);
     k_fs_iimod->complete(k_fs_ii->domain_map(), k_fs_ii->row_map());
   }
 
@@ -696,10 +696,10 @@ void CONTACT::LagrangeStrategyPoro::evaluate_mat_poro_no_pen(
   if (iset && aset)
   {
     k_fs_iamod = std::make_shared<Core::LinAlg::SparseMatrix>(*fgidofs, 100);
-    k_fs_iamod->add(*k_fs_ia, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*k_fs_ia, false, 1.0, *k_fs_iamod, 1.0);
     std::shared_ptr<Core::LinAlg::SparseMatrix> k_fs_iaadd =
         Core::LinAlg::matrix_multiply(*fdhat_, true, *k_fs_aa, false, false, false, true);
-    k_fs_iamod->add(*k_fs_iaadd, false, -1.0, 1.0);
+    Core::LinAlg::matrix_add(*k_fs_iaadd, false, -1.0, *k_fs_iamod, 1.0);
     k_fs_iamod->complete(k_fs_ia->domain_map(), k_fs_ia->row_map());
   }
 
@@ -851,38 +851,38 @@ void CONTACT::LagrangeStrategyPoro::evaluate_mat_poro_no_pen(
 
   //----------------------------------------------------------- FIRST LINE
   // add n submatrices to kteffnew
-  k_fs_effnew->add(*k_fs_nn, false, 1.0, 1.0);
-  k_fs_effnew->add(*k_fs_nm, false, 1.0, 1.0);
-  if (sset) k_fs_effnew->add(*k_fs_ns, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*k_fs_nn, false, 1.0, *k_fs_effnew, 1.0);
+  Core::LinAlg::matrix_add(*k_fs_nm, false, 1.0, *k_fs_effnew, 1.0);
+  if (sset) Core::LinAlg::matrix_add(*k_fs_ns, false, 1.0, *k_fs_effnew, 1.0);
 
   //---------------------------------------------------------- SECOND LINE
   // add m submatrices to kteffnew
   if (mset)
   {
-    k_fs_effnew->add(*k_fs_mnmod, false, 1.0, 1.0);
-    k_fs_effnew->add(*k_fs_mmmod, false, 1.0, 1.0);
-    if (iset) k_fs_effnew->add(*k_fs_mimod, false, 1.0, 1.0);
-    if (aset) k_fs_effnew->add(*k_fs_mamod, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*k_fs_mnmod, false, 1.0, *k_fs_effnew, 1.0);
+    Core::LinAlg::matrix_add(*k_fs_mmmod, false, 1.0, *k_fs_effnew, 1.0);
+    if (iset) Core::LinAlg::matrix_add(*k_fs_mimod, false, 1.0, *k_fs_effnew, 1.0);
+    if (aset) Core::LinAlg::matrix_add(*k_fs_mamod, false, 1.0, *k_fs_effnew, 1.0);
   }
 
   //----------------------------------------------------------- THIRD LINE
   // add i submatrices to kteffnew
-  if (iset) k_fs_effnew->add(k_fs_inmod, false, 1.0, 1.0);
-  if (iset) k_fs_effnew->add(k_fs_immod, false, 1.0, 1.0);
-  if (iset) k_fs_effnew->add(*k_fs_iimod, false, 1.0, 1.0);
-  if (iset && aset) k_fs_effnew->add(*k_fs_iamod, false, 1.0, 1.0);
+  if (iset) Core::LinAlg::matrix_add(k_fs_inmod, false, 1.0, *k_fs_effnew, 1.0);
+  if (iset) Core::LinAlg::matrix_add(k_fs_immod, false, 1.0, *k_fs_effnew, 1.0);
+  if (iset) Core::LinAlg::matrix_add(*k_fs_iimod, false, 1.0, *k_fs_effnew, 1.0);
+  if (iset && aset) Core::LinAlg::matrix_add(*k_fs_iamod, false, 1.0, *k_fs_effnew, 1.0);
 
   //---------------------------------------------------------- FOURTH LINE
   // add a submatrices to kteffnew
-  if (aset) k_fs_effnew->add(*fNCoup_lindisp_, false, 1.0, 1.0);
+  if (aset) Core::LinAlg::matrix_add(*fNCoup_lindisp_, false, 1.0, *k_fs_effnew, 1.0);
 
   //----------------------------------------------------------- FIFTH LINE
   // add a submatrices to kteffnew
-  if (aset) k_fs_effnew->add(*k_fs_anmod, false, -1.0, 1.0);
-  if (aset) k_fs_effnew->add(*k_fs_ammod, false, -1.0, 1.0);
-  if (aset && iset) k_fs_effnew->add(*k_fs_aimod, false, -1.0, 1.0);
-  if (aset) k_fs_effnew->add(*k_fs_aamod, false, -1.0, 1.0);
-  if (aset) k_fs_effnew->add(*flinTangentiallambda_, false, 1.0, 1.0);
+  if (aset) Core::LinAlg::matrix_add(*k_fs_anmod, false, -1.0, *k_fs_effnew, 1.0);
+  if (aset) Core::LinAlg::matrix_add(*k_fs_ammod, false, -1.0, *k_fs_effnew, 1.0);
+  if (aset && iset) Core::LinAlg::matrix_add(*k_fs_aimod, false, -1.0, *k_fs_effnew, 1.0);
+  if (aset) Core::LinAlg::matrix_add(*k_fs_aamod, false, -1.0, *k_fs_effnew, 1.0);
+  if (aset) Core::LinAlg::matrix_add(*flinTangentiallambda_, false, 1.0, *k_fs_effnew, 1.0);
 
   // fill_complete kteffnew (square)
   k_fs_effnew->complete(*problem_dofs(), *falldofrowmap_);
@@ -1052,12 +1052,12 @@ void CONTACT::LagrangeStrategyPoro::evaluate_other_mat_poro_no_pen(
   // starting with two-sided poro contact!!!
   // km: add T(mhataam)*kan
   Core::LinAlg::SparseMatrix F_mmod(*fgmdofrowmap_, 100);
-  F_mmod.add(*F_m, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*F_m, false, 1.0, F_mmod, 1.0);
   if (aset && mset)
   {
     std::shared_ptr<Core::LinAlg::SparseMatrix> F_madd =
         Core::LinAlg::matrix_multiply(*fmhataam_, true, *F_a, false, false, false, true);
-    F_mmod.add(*F_madd, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*F_madd, false, 1.0, F_mmod, 1.0);
   }
   F_mmod.complete(F_m->domain_map(), F_m->row_map());
 
@@ -1069,12 +1069,12 @@ void CONTACT::LagrangeStrategyPoro::evaluate_other_mat_poro_no_pen(
 
   // kin: subtract T(dhat)*kan --
   Core::LinAlg::SparseMatrix F_imod(*fgidofs, 100);
-  F_imod.add(*F_i, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*F_i, false, 1.0, F_imod, 1.0);
   if (aset)
   {
     std::shared_ptr<Core::LinAlg::SparseMatrix> F_iadd =
         Core::LinAlg::matrix_multiply(*fdhat_, true, *F_a, false, false, false, true);
-    F_imod.add(*F_iadd, false, -1.0, 1.0);
+    Core::LinAlg::matrix_add(*F_iadd, false, -1.0, F_imod, 1.0);
   }
   F_imod.complete(F_i->domain_map(), F_i->row_map());
 
@@ -1111,21 +1111,22 @@ void CONTACT::LagrangeStrategyPoro::evaluate_other_mat_poro_no_pen(
 
   //----------------------------------------------------------- FIRST LINE
   // add n submatrices to kteffnew
-  F_effnew->add(*F_n, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*F_n, false, 1.0, *F_effnew, 1.0);
 
   //---------------------------------------------------------- SECOND LINE
   // add m submatrices to kteffnew
-  if (mset) F_effnew->add(F_mmod, false, 1.0, 1.0);
+  if (mset) Core::LinAlg::matrix_add(F_mmod, false, 1.0, *F_effnew, 1.0);
   //----------------------------------------------------------- THIRD LINE
   // add i submatrices to kteffnew
-  if (iset) F_effnew->add(F_imod, false, 1.0, 1.0);
+  if (iset) Core::LinAlg::matrix_add(F_imod, false, 1.0, *F_effnew, 1.0);
   //---------------------------------------------------------- FOURTH LINE
   // add a submatrices to kteffnew //assume that Column_Block_Id==0 is the porofluid coupling
   // block!!!
-  if (Column_Block_Id == 0 && aset) F_effnew->add(*fNCoup_linvel_, false, 1.0, 1.0);
+  if (Column_Block_Id == 0 && aset)
+    Core::LinAlg::matrix_add(*fNCoup_linvel_, false, 1.0, *F_effnew, 1.0);
   //----------------------------------------------------------- FIFTH LINE
   // add a submatrices to kteffnew
-  if (aset) F_effnew->add(*F_amod, false, -1.0, 1.0);
+  if (aset) Core::LinAlg::matrix_add(*F_amod, false, -1.0, *F_effnew, 1.0);
 
   // fill_complete kteffnew (square)
   F_effnew->complete(*domainmap, *falldofrowmap_);
@@ -1194,7 +1195,7 @@ void CONTACT::LagrangeStrategyPoro::recover_poro_no_pen(Core::LinAlg::Vector<dou
     Core::LinAlg::split_matrix2x2(finvda_, fgactivedofs_, tempmap1, gactivedofs_, tempmap2, finvda,
         tempmtx1, tempmtx2, tempmtx3);
     Core::LinAlg::SparseMatrix finvdmod(*fgsdofrowmap_, 10);
-    finvdmod.add(*finvda, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*finvda, false, 1.0, finvdmod, 1.0);
     finvdmod.complete(*gsdofrowmap_, *fgsdofrowmap_);
 
     /**********************************************************************/

--- a/src/contact/src/4C_contact_lagrange_strategy_wear.cpp
+++ b/src/contact/src/4C_contact_lagrange_strategy_wear.cpp
@@ -887,19 +887,19 @@ void Wear::LagrangeStrategyWear::condense_wear_impl_expl(
   // kmn: add T(mhataam)*kan
   std::shared_ptr<Core::LinAlg::SparseMatrix> kmnmod =
       std::make_shared<Core::LinAlg::SparseMatrix>(*gmdofrowmap_, 100);
-  kmnmod->add(*kmn, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*kmn, false, 1.0, *kmnmod, 1.0);
   std::shared_ptr<Core::LinAlg::SparseMatrix> kmnadd =
       Core::LinAlg::matrix_multiply(*mhataam, true, *kan, false, false, false, true);
-  kmnmod->add(*kmnadd, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*kmnadd, false, 1.0, *kmnmod, 1.0);
   kmnmod->complete(kmn->domain_map(), kmn->row_map());
 
   // kmm: add T(mhataam)*kam
   std::shared_ptr<Core::LinAlg::SparseMatrix> kmmmod =
       std::make_shared<Core::LinAlg::SparseMatrix>(*gmdofrowmap_, 100);
-  kmmmod->add(*kmm, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*kmm, false, 1.0, *kmmmod, 1.0);
   std::shared_ptr<Core::LinAlg::SparseMatrix> kmmadd =
       Core::LinAlg::matrix_multiply(*mhataam, true, *kam, false, false, false, true);
-  kmmmod->add(*kmmadd, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*kmmadd, false, 1.0, *kmmmod, 1.0);
   kmmmod->complete(kmm->domain_map(), kmm->row_map());
 
   // kmi: add T(mhataam)*kai
@@ -907,10 +907,10 @@ void Wear::LagrangeStrategyWear::condense_wear_impl_expl(
   if (iset)
   {
     kmimod = std::make_shared<Core::LinAlg::SparseMatrix>(*gmdofrowmap_, 100);
-    kmimod->add(*kmi, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kmi, false, 1.0, *kmimod, 1.0);
     std::shared_ptr<Core::LinAlg::SparseMatrix> kmiadd =
         Core::LinAlg::matrix_multiply(*mhataam, true, *kai, false, false, false, true);
-    kmimod->add(*kmiadd, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kmiadd, false, 1.0, *kmimod, 1.0);
     kmimod->complete(kmi->domain_map(), kmi->row_map());
   }
 
@@ -919,10 +919,10 @@ void Wear::LagrangeStrategyWear::condense_wear_impl_expl(
   if (aset)
   {
     kmamod = std::make_shared<Core::LinAlg::SparseMatrix>(*gmdofrowmap_, 100);
-    kmamod->add(*kma, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kma, false, 1.0, *kmamod, 1.0);
     std::shared_ptr<Core::LinAlg::SparseMatrix> kmaadd =
         Core::LinAlg::matrix_multiply(*mhataam, true, *kaa, false, false, false, true);
-    kmamod->add(*kmaadd, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kmaadd, false, 1.0, *kmamod, 1.0);
     kmamod->complete(kma->domain_map(), kma->row_map());
   }
 
@@ -930,24 +930,24 @@ void Wear::LagrangeStrategyWear::condense_wear_impl_expl(
   // kin: subtract T(dhat)*kan
   std::shared_ptr<Core::LinAlg::SparseMatrix> kinmod =
       std::make_shared<Core::LinAlg::SparseMatrix>(*gidofs, 100);
-  kinmod->add(*kin, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*kin, false, 1.0, *kinmod, 1.0);
   if (aset && iset)
   {
     std::shared_ptr<Core::LinAlg::SparseMatrix> kinadd =
         Core::LinAlg::matrix_multiply(*dhat, true, *kan, false, false, false, true);
-    kinmod->add(*kinadd, false, -1.0, 1.0);
+    Core::LinAlg::matrix_add(*kinadd, false, -1.0, *kinmod, 1.0);
   }
   kinmod->complete(kin->domain_map(), kin->row_map());
 
   // kim: subtract T(dhat)*kam
   std::shared_ptr<Core::LinAlg::SparseMatrix> kimmod =
       std::make_shared<Core::LinAlg::SparseMatrix>(*gidofs, 100);
-  kimmod->add(*kim, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*kim, false, 1.0, *kimmod, 1.0);
   if (aset && iset)
   {
     std::shared_ptr<Core::LinAlg::SparseMatrix> kimadd =
         Core::LinAlg::matrix_multiply(*dhat, true, *kam, false, false, false, true);
-    kimmod->add(*kimadd, false, -1.0, 1.0);
+    Core::LinAlg::matrix_add(*kimadd, false, -1.0, *kimmod, 1.0);
   }
   kimmod->complete(kim->domain_map(), kim->row_map());
 
@@ -956,12 +956,12 @@ void Wear::LagrangeStrategyWear::condense_wear_impl_expl(
   if (iset)
   {
     kiimod = std::make_shared<Core::LinAlg::SparseMatrix>(*gidofs, 100);
-    kiimod->add(*kii, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kii, false, 1.0, *kiimod, 1.0);
     if (aset)
     {
       std::shared_ptr<Core::LinAlg::SparseMatrix> kiiadd =
           Core::LinAlg::matrix_multiply(*dhat, true, *kai, false, false, false, true);
-      kiimod->add(*kiiadd, false, -1.0, 1.0);
+      Core::LinAlg::matrix_add(*kiiadd, false, -1.0, *kiimod, 1.0);
     }
     kiimod->complete(kii->domain_map(), kii->row_map());
   }
@@ -971,10 +971,10 @@ void Wear::LagrangeStrategyWear::condense_wear_impl_expl(
   if (iset && aset)
   {
     kiamod = std::make_shared<Core::LinAlg::SparseMatrix>(*gidofs, 100);
-    kiamod->add(*kia, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kia, false, 1.0, *kiamod, 1.0);
     std::shared_ptr<Core::LinAlg::SparseMatrix> kiaadd =
         Core::LinAlg::matrix_multiply(*dhat, true, *kaa, false, false, false, true);
-    kiamod->add(*kiaadd, false, -1.0, 1.0);
+    Core::LinAlg::matrix_add(*kiaadd, false, -1.0, *kiamod, 1.0);
     kiamod->complete(kia->domain_map(), kia->row_map());
   }
 
@@ -1375,70 +1375,70 @@ void Wear::LagrangeStrategyWear::condense_wear_impl_expl(
 
   //--------------------------------------------------------- FIRST LINE
   // add n submatrices to kteffnew
-  kteffnew->add(*knn, false, 1.0, 1.0);
-  kteffnew->add(*knm, false, 1.0, 1.0);
-  if (sset) kteffnew->add(*kns, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*knn, false, 1.0, *kteffnew, 1.0);
+  Core::LinAlg::matrix_add(*knm, false, 1.0, *kteffnew, 1.0);
+  if (sset) Core::LinAlg::matrix_add(*kns, false, 1.0, *kteffnew, 1.0);
 
   //-------------------------------------------------------- SECOND LINE
   // add m submatrices to kteffnew
-  kteffnew->add(*kmnmod, false, 1.0, 1.0);
-  kteffnew->add(*kmmmod, false, 1.0, 1.0);
-  if (iset) kteffnew->add(*kmimod, false, 1.0, 1.0);
-  if (aset) kteffnew->add(*kmamod, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*kmnmod, false, 1.0, *kteffnew, 1.0);
+  Core::LinAlg::matrix_add(*kmmmod, false, 1.0, *kteffnew, 1.0);
+  if (iset) Core::LinAlg::matrix_add(*kmimod, false, 1.0, *kteffnew, 1.0);
+  if (aset) Core::LinAlg::matrix_add(*kmamod, false, 1.0, *kteffnew, 1.0);
 
   //--------------------------------------------------------- THIRD LINE
   // add i submatrices to kteffnew
-  if (iset) kteffnew->add(*kinmod, false, 1.0, 1.0);
-  if (iset) kteffnew->add(*kimmod, false, 1.0, 1.0);
-  if (iset) kteffnew->add(*kiimod, false, 1.0, 1.0);
-  if (iset && aset) kteffnew->add(*kiamod, false, 1.0, 1.0);
+  if (iset) Core::LinAlg::matrix_add(*kinmod, false, 1.0, *kteffnew, 1.0);
+  if (iset) Core::LinAlg::matrix_add(*kimmod, false, 1.0, *kteffnew, 1.0);
+  if (iset) Core::LinAlg::matrix_add(*kiimod, false, 1.0, *kteffnew, 1.0);
+  if (iset && aset) Core::LinAlg::matrix_add(*kiamod, false, 1.0, *kteffnew, 1.0);
 
   //-------------------------------------------------------- FOURTH LINE
 
   // add a submatrices to kteffnew
-  if (aset) kteffnew->add(*smatrix_, false, 1.0, 1.0);
+  if (aset) Core::LinAlg::matrix_add(*smatrix_, false, 1.0, *kteffnew, 1.0);
 
   // implicit wear
   if (wearimpl_)
   {
     // if (aset) kteffnew->Add(*wlinmatrix_,false,1.0,1.0);
-    if (aset) kteffnew->add(*kgnmod, false, -1.0, 1.0);
-    if (aset) kteffnew->add(*kgmmod, false, -1.0, 1.0);
-    if (aset and iset) kteffnew->add(*kgimod, false, -1.0, 1.0);
-    if (aset) kteffnew->add(*kgaamod, false, -1.0, 1.0);
+    if (aset) Core::LinAlg::matrix_add(*kgnmod, false, -1.0, *kteffnew, 1.0);
+    if (aset) Core::LinAlg::matrix_add(*kgmmod, false, -1.0, *kteffnew, 1.0);
+    if (aset and iset) Core::LinAlg::matrix_add(*kgimod, false, -1.0, *kteffnew, 1.0);
+    if (aset) Core::LinAlg::matrix_add(*kgaamod, false, -1.0, *kteffnew, 1.0);
     // if (aset and stickset) kteffnew->Add(*kgstmod,false,1.0,1.0);
   }
 
   //--------------------------------------------------------- FIFTH LINE
   // add st submatrices to kteffnew
-  if (stickset) kteffnew->add(*kstnmod, false, 1.0, 1.0);
-  if (stickset) kteffnew->add(*kstmmod, false, 1.0, 1.0);
-  if (stickset && iset) kteffnew->add(*kstimod, false, 1.0, 1.0);
-  if (stickset && slipset) kteffnew->add(*kstslmod, false, 1.0, 1.0);
-  if (stickset) kteffnew->add(*kststmod, false, 1.0, 1.0);
+  if (stickset) Core::LinAlg::matrix_add(*kstnmod, false, 1.0, *kteffnew, 1.0);
+  if (stickset) Core::LinAlg::matrix_add(*kstmmod, false, 1.0, *kteffnew, 1.0);
+  if (stickset && iset) Core::LinAlg::matrix_add(*kstimod, false, 1.0, *kteffnew, 1.0);
+  if (stickset && slipset) Core::LinAlg::matrix_add(*kstslmod, false, 1.0, *kteffnew, 1.0);
+  if (stickset) Core::LinAlg::matrix_add(*kststmod, false, 1.0, *kteffnew, 1.0);
 
   // add terms of linearization of sick condition to kteffnew
-  if (stickset) kteffnew->add(*linstickDIS_, false, -1.0, 1.0);
+  if (stickset) Core::LinAlg::matrix_add(*linstickDIS_, false, -1.0, *kteffnew, 1.0);
 
   //--------------------------------------------------------- SIXTH LINE
   // add sl submatrices to kteffnew
-  if (slipset) kteffnew->add(*kslnmod, false, 1.0, 1.0);
-  if (slipset) kteffnew->add(*kslmmod, false, 1.0, 1.0);
-  if (slipset && iset) kteffnew->add(*kslimod, false, 1.0, 1.0);
-  if (slipset) kteffnew->add(*kslslmod, false, 1.0, 1.0);
-  if (slipset && stickset) kteffnew->add(*kslstmod, false, 1.0, 1.0);
+  if (slipset) Core::LinAlg::matrix_add(*kslnmod, false, 1.0, *kteffnew, 1.0);
+  if (slipset) Core::LinAlg::matrix_add(*kslmmod, false, 1.0, *kteffnew, 1.0);
+  if (slipset && iset) Core::LinAlg::matrix_add(*kslimod, false, 1.0, *kteffnew, 1.0);
+  if (slipset) Core::LinAlg::matrix_add(*kslslmod, false, 1.0, *kteffnew, 1.0);
+  if (slipset && stickset) Core::LinAlg::matrix_add(*kslstmod, false, 1.0, *kteffnew, 1.0);
 
   // add terms of linearization of slip condition to kteffnew and feffnew
-  if (slipset) kteffnew->add(*linslipDIS_, false, -1.0, +1.0);
+  if (slipset) Core::LinAlg::matrix_add(*linslipDIS_, false, -1.0, *kteffnew, +1.0);
 
   // implicit wear
   if (wearimpl_)
   {
     // if (slipset) kteffnew->Add(*wlinmatrixsl_,false,1.0,1.0);
-    if (slipset) kteffnew->add(*kslwnmod, false, 1.0, 1.0);
-    if (slipset) kteffnew->add(*kslwmmod, false, 1.0, 1.0);
-    if (slipset and iset) kteffnew->add(*kslwimod, false, 1.0, 1.0);
-    if (slipset) kteffnew->add(*kslwaamod, false, 1.0, 1.0);
+    if (slipset) Core::LinAlg::matrix_add(*kslwnmod, false, 1.0, *kteffnew, 1.0);
+    if (slipset) Core::LinAlg::matrix_add(*kslwmmod, false, 1.0, *kteffnew, 1.0);
+    if (slipset and iset) Core::LinAlg::matrix_add(*kslwimod, false, 1.0, *kteffnew, 1.0);
+    if (slipset) Core::LinAlg::matrix_add(*kslwaamod, false, 1.0, *kteffnew, 1.0);
     // if (slipset and stickset) kteffnew->Add(*kslwstmod,false,1.0,1.0);
   }
 
@@ -1888,7 +1888,7 @@ void Wear::LagrangeStrategyWear::condense_wear_discr(
   linetdis->un_complete();
 
   // add E-part
-  linetdis->add(*linedis_, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*linedis_, false, 1.0, *linetdis, 1.0);
 
   // complete
   linetdis->complete(*gsmdofrowmap_, *gslipn_);
@@ -1966,7 +1966,7 @@ void Wear::LagrangeStrategyWear::condense_wear_discr(
       std::shared_ptr<Core::LinAlg::SparseMatrix> inve_te;
       inve_te = Core::LinAlg::matrix_multiply(inve, false, *linte_a, false, false, false, true);
 
-      wear_da->add(*inve_te, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(*inve_te, false, 1.0, *wear_da, 1.0);
       wear_da->complete(*gactivedofs_, *gslipn_);
       wear_da->scale(-1.0);
     }
@@ -1979,7 +1979,7 @@ void Wear::LagrangeStrategyWear::condense_wear_discr(
       std::shared_ptr<Core::LinAlg::SparseMatrix> inve_te;
       inve_te = Core::LinAlg::matrix_multiply(inve, false, *linte_i, false, false, false, true);
 
-      wear_di->add(*inve_te, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(*inve_te, false, 1.0, *wear_di, 1.0);
       wear_di->complete(*gidofs, *gslipn_);
       wear_di->scale(-1.0);
     }
@@ -2044,19 +2044,19 @@ void Wear::LagrangeStrategyWear::condense_wear_discr(
   // kmn: add T(mhataam)*kan
   std::shared_ptr<Core::LinAlg::SparseMatrix> kmnmod =
       std::make_shared<Core::LinAlg::SparseMatrix>(*gmdofrowmap_, 100);
-  kmnmod->add(*kmn, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*kmn, false, 1.0, *kmnmod, 1.0);
   std::shared_ptr<Core::LinAlg::SparseMatrix> kmnadd =
       Core::LinAlg::matrix_multiply(*mhataam, true, *kan, false, false, false, true);
-  kmnmod->add(*kmnadd, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*kmnadd, false, 1.0, *kmnmod, 1.0);
   kmnmod->complete(kmn->domain_map(), kmn->row_map());
 
   // kmm: add T(mhataam)*kam
   std::shared_ptr<Core::LinAlg::SparseMatrix> kmmmod =
       std::make_shared<Core::LinAlg::SparseMatrix>(*gmdofrowmap_, 100);
-  kmmmod->add(*kmm, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*kmm, false, 1.0, *kmmmod, 1.0);
   std::shared_ptr<Core::LinAlg::SparseMatrix> kmmadd =
       Core::LinAlg::matrix_multiply(*mhataam, true, *kam, false, false, false, true);
-  kmmmod->add(*kmmadd, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*kmmadd, false, 1.0, *kmmmod, 1.0);
   kmmmod->complete(kmm->domain_map(), kmm->row_map());
 
   // kmi: add T(mhataam)*kai
@@ -2064,10 +2064,10 @@ void Wear::LagrangeStrategyWear::condense_wear_discr(
   if (iset)
   {
     kmimod = std::make_shared<Core::LinAlg::SparseMatrix>(*gmdofrowmap_, 100);
-    kmimod->add(*kmi, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kmi, false, 1.0, *kmimod, 1.0);
     std::shared_ptr<Core::LinAlg::SparseMatrix> kmiadd =
         Core::LinAlg::matrix_multiply(*mhataam, true, *kai, false, false, false, true);
-    kmimod->add(*kmiadd, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kmiadd, false, 1.0, *kmimod, 1.0);
     kmimod->complete(kmi->domain_map(), kmi->row_map());
   }
 
@@ -2076,10 +2076,10 @@ void Wear::LagrangeStrategyWear::condense_wear_discr(
   if (aset)
   {
     kmamod = std::make_shared<Core::LinAlg::SparseMatrix>(*gmdofrowmap_, 100);
-    kmamod->add(*kma, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kma, false, 1.0, *kmamod, 1.0);
     std::shared_ptr<Core::LinAlg::SparseMatrix> kmaadd =
         Core::LinAlg::matrix_multiply(*mhataam, true, *kaa, false, false, false, true);
-    kmamod->add(*kmaadd, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kmaadd, false, 1.0, *kmamod, 1.0);
     kmamod->complete(kma->domain_map(), kma->row_map());
   }
 
@@ -2088,24 +2088,24 @@ void Wear::LagrangeStrategyWear::condense_wear_discr(
   // kin: subtract T(dhat)*kan
   std::shared_ptr<Core::LinAlg::SparseMatrix> kinmod =
       std::make_shared<Core::LinAlg::SparseMatrix>(*gidofs, 100);
-  kinmod->add(*kin, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*kin, false, 1.0, *kinmod, 1.0);
   if (aset && iset)
   {
     std::shared_ptr<Core::LinAlg::SparseMatrix> kinadd =
         Core::LinAlg::matrix_multiply(*dhat, true, *kan, false, false, false, true);
-    kinmod->add(*kinadd, false, -1.0, 1.0);
+    Core::LinAlg::matrix_add(*kinadd, false, -1.0, *kinmod, 1.0);
   }
   kinmod->complete(Core::LinAlg::Map(kin->domain_map()), kin->row_map());
 
   // kim: subtract T(dhat)*kam
   std::shared_ptr<Core::LinAlg::SparseMatrix> kimmod =
       std::make_shared<Core::LinAlg::SparseMatrix>(*gidofs, 100);
-  kimmod->add(*kim, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*kim, false, 1.0, *kimmod, 1.0);
   if (aset && iset)
   {
     std::shared_ptr<Core::LinAlg::SparseMatrix> kimadd =
         Core::LinAlg::matrix_multiply(*dhat, true, *kam, false, false, false, true);
-    kimmod->add(*kimadd, false, -1.0, 1.0);
+    Core::LinAlg::matrix_add(*kimadd, false, -1.0, *kimmod, 1.0);
   }
   kimmod->complete(Core::LinAlg::Map(kim->domain_map()), kim->row_map());
 
@@ -2114,12 +2114,12 @@ void Wear::LagrangeStrategyWear::condense_wear_discr(
   if (iset)
   {
     kiimod = std::make_shared<Core::LinAlg::SparseMatrix>(*gidofs, 100);
-    kiimod->add(*kii, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kii, false, 1.0, *kiimod, 1.0);
     if (aset)
     {
       std::shared_ptr<Core::LinAlg::SparseMatrix> kiiadd =
           Core::LinAlg::matrix_multiply(*dhat, true, *kai, false, false, false, true);
-      kiimod->add(*kiiadd, false, -1.0, 1.0);
+      Core::LinAlg::matrix_add(*kiiadd, false, -1.0, *kiimod, 1.0);
     }
     kiimod->complete(Core::LinAlg::Map(kii->domain_map()), kii->row_map());
   }
@@ -2129,10 +2129,10 @@ void Wear::LagrangeStrategyWear::condense_wear_discr(
   if (iset && aset)
   {
     kiamod = std::make_shared<Core::LinAlg::SparseMatrix>(*gidofs, 100);
-    kiamod->add(*kia, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kia, false, 1.0, *kiamod, 1.0);
     std::shared_ptr<Core::LinAlg::SparseMatrix> kiaadd =
         Core::LinAlg::matrix_multiply(*dhat, true, *kaa, false, false, false, true);
-    kiamod->add(*kiaadd, false, -1.0, 1.0);
+    Core::LinAlg::matrix_add(*kiaadd, false, -1.0, *kiamod, 1.0);
     kiamod->complete(Core::LinAlg::Map(kia->domain_map()), kia->row_map());
   }
 
@@ -2482,60 +2482,60 @@ void Wear::LagrangeStrategyWear::condense_wear_discr(
 
   //--------------------------------------------------------- FIRST LINE
   // add n submatrices to kteffnew
-  kteffnew->add(*knn, false, 1.0, 1.0);
-  kteffnew->add(*knm, false, 1.0, 1.0);
-  if (sset) kteffnew->add(*kns, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*knn, false, 1.0, *kteffnew, 1.0);
+  Core::LinAlg::matrix_add(*knm, false, 1.0, *kteffnew, 1.0);
+  if (sset) Core::LinAlg::matrix_add(*kns, false, 1.0, *kteffnew, 1.0);
 
   //-------------------------------------------------------- SECOND LINE
   // add m submatrices to kteffnew
-  kteffnew->add(*kmnmod, false, 1.0, 1.0);
-  kteffnew->add(*kmmmod, false, 1.0, 1.0);
-  if (iset) kteffnew->add(*kmimod, false, 1.0, 1.0);
-  if (aset) kteffnew->add(*kmamod, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*kmnmod, false, 1.0, *kteffnew, 1.0);
+  Core::LinAlg::matrix_add(*kmmmod, false, 1.0, *kteffnew, 1.0);
+  if (iset) Core::LinAlg::matrix_add(*kmimod, false, 1.0, *kteffnew, 1.0);
+  if (aset) Core::LinAlg::matrix_add(*kmamod, false, 1.0, *kteffnew, 1.0);
 
   //--------------------------------------------------------- THIRD LINE
   // add i submatrices to kteffnew
-  if (iset) kteffnew->add(*kinmod, false, 1.0, 1.0);
-  if (iset) kteffnew->add(*kimmod, false, 1.0, 1.0);
-  if (iset) kteffnew->add(*kiimod, false, 1.0, 1.0);
-  if (iset && aset) kteffnew->add(*kiamod, false, 1.0, 1.0);
+  if (iset) Core::LinAlg::matrix_add(*kinmod, false, 1.0, *kteffnew, 1.0);
+  if (iset) Core::LinAlg::matrix_add(*kimmod, false, 1.0, *kteffnew, 1.0);
+  if (iset) Core::LinAlg::matrix_add(*kiimod, false, 1.0, *kteffnew, 1.0);
+  if (iset && aset) Core::LinAlg::matrix_add(*kiamod, false, 1.0, *kteffnew, 1.0);
 
   //-------------------------------------------------------- FOURTH LINE
   // WEAR - STUFF
   // add a submatrices to kteffnew
-  if (aset) kteffnew->add(*smatrix_, false, 1.0, 1.0);
-  if (aset && slipset) kteffnew->add(*kgnw, false, 1.0, 1.0);
-  if (aset && slipset) kteffnew->add(*kgmw, false, 1.0, 1.0);
-  if (aset && slipset && iset) kteffnew->add(*kgiw, false, 1.0, 1.0);
-  if (aset && slipset) kteffnew->add(*kgaw, false, 1.0, 1.0);
+  if (aset) Core::LinAlg::matrix_add(*smatrix_, false, 1.0, *kteffnew, 1.0);
+  if (aset && slipset) Core::LinAlg::matrix_add(*kgnw, false, 1.0, *kteffnew, 1.0);
+  if (aset && slipset) Core::LinAlg::matrix_add(*kgmw, false, 1.0, *kteffnew, 1.0);
+  if (aset && slipset && iset) Core::LinAlg::matrix_add(*kgiw, false, 1.0, *kteffnew, 1.0);
+  if (aset && slipset) Core::LinAlg::matrix_add(*kgaw, false, 1.0, *kteffnew, 1.0);
 
   //--------------------------------------------------------- FIFTH LINE
   // add st submatrices to kteffnew
-  if (stickset) kteffnew->add(*kstnmod, false, 1.0, 1.0);
-  if (stickset) kteffnew->add(*kstmmod, false, 1.0, 1.0);
-  if (stickset && iset) kteffnew->add(*kstimod, false, 1.0, 1.0);
-  if (stickset && slipset) kteffnew->add(*kstslmod, false, 1.0, 1.0);
-  if (stickset) kteffnew->add(*kststmod, false, 1.0, 1.0);
+  if (stickset) Core::LinAlg::matrix_add(*kstnmod, false, 1.0, *kteffnew, 1.0);
+  if (stickset) Core::LinAlg::matrix_add(*kstmmod, false, 1.0, *kteffnew, 1.0);
+  if (stickset && iset) Core::LinAlg::matrix_add(*kstimod, false, 1.0, *kteffnew, 1.0);
+  if (stickset && slipset) Core::LinAlg::matrix_add(*kstslmod, false, 1.0, *kteffnew, 1.0);
+  if (stickset) Core::LinAlg::matrix_add(*kststmod, false, 1.0, *kteffnew, 1.0);
 
   // add terms of linearization of sick condition to kteffnew
-  if (stickset) kteffnew->add(*linstickDIS_, false, -1.0, 1.0);
+  if (stickset) Core::LinAlg::matrix_add(*linstickDIS_, false, -1.0, *kteffnew, 1.0);
 
   //--------------------------------------------------------- SIXTH LINE
   // add sl submatrices to kteffnew
-  if (slipset) kteffnew->add(*kslnmod, false, 1.0, 1.0);
-  if (slipset) kteffnew->add(*kslmmod, false, 1.0, 1.0);
-  if (slipset && iset) kteffnew->add(*kslimod, false, 1.0, 1.0);
-  if (slipset) kteffnew->add(*kslslmod, false, 1.0, 1.0);
-  if (slipset && stickset) kteffnew->add(*kslstmod, false, 1.0, 1.0);
+  if (slipset) Core::LinAlg::matrix_add(*kslnmod, false, 1.0, *kteffnew, 1.0);
+  if (slipset) Core::LinAlg::matrix_add(*kslmmod, false, 1.0, *kteffnew, 1.0);
+  if (slipset && iset) Core::LinAlg::matrix_add(*kslimod, false, 1.0, *kteffnew, 1.0);
+  if (slipset) Core::LinAlg::matrix_add(*kslslmod, false, 1.0, *kteffnew, 1.0);
+  if (slipset && stickset) Core::LinAlg::matrix_add(*kslstmod, false, 1.0, *kteffnew, 1.0);
 
   // add terms of linearization of slip condition to kteffnew and feffnew
-  if (slipset) kteffnew->add(*linslipDIS_, false, -1.0, +1.0);
+  if (slipset) Core::LinAlg::matrix_add(*linslipDIS_, false, -1.0, *kteffnew, +1.0);
 
   // WEAR - STUFF
-  if (slipset) kteffnew->add(*kslnw, false, -1.0, 1.0);
-  if (slipset) kteffnew->add(*kslmw, false, -1.0, 1.0);
-  if (slipset && (iset)) kteffnew->add(*ksliw, false, -1.0, 1.0);
-  if (slipset) kteffnew->add(*kslaw, false, -1.0, 1.0);
+  if (slipset) Core::LinAlg::matrix_add(*kslnw, false, -1.0, *kteffnew, 1.0);
+  if (slipset) Core::LinAlg::matrix_add(*kslmw, false, -1.0, *kteffnew, 1.0);
+  if (slipset && (iset)) Core::LinAlg::matrix_add(*ksliw, false, -1.0, *kteffnew, 1.0);
+  if (slipset) Core::LinAlg::matrix_add(*kslaw, false, -1.0, *kteffnew, 1.0);
 
   // fill_complete kteffnew (square)
   kteffnew->complete();
@@ -3262,8 +3262,8 @@ void Wear::LagrangeStrategyWear::build_saddle_point_system(
 
     // build constraint matrix kdz
     Core::LinAlg::SparseMatrix kdz(*gdisprowmap_, 100, false, true);
-    kdz.add(*dmatrix_, true, 1.0 - alphaf_, 1.0);
-    kdz.add(*mmatrix_, true, -(1.0 - alphaf_), 1.0);
+    Core::LinAlg::matrix_add(*dmatrix_, true, 1.0 - alphaf_, kdz, 1.0);
+    Core::LinAlg::matrix_add(*mmatrix_, true, -(1.0 - alphaf_), kdz, 1.0);
     kdz.complete(*gsdofrowmap_, *gdisprowmap_);
 
     // transform constraint matrix kzd to lmdofmap (matrix_col_transform)
@@ -3276,9 +3276,11 @@ void Wear::LagrangeStrategyWear::build_saddle_point_system(
 
     // build constraint matrix kzd
     Core::LinAlg::SparseMatrix kzd(*gsdofrowmap_, 100, false, true);
-    if (gactiven_->num_global_elements()) kzd.add(*smatrix_, false, 1.0, 1.0);
-    if (gstickt->num_global_elements()) kzd.add(*linstickDIS_, false, 1.0, 1.0);
-    if (gslipt_->num_global_elements()) kzd.add(*linslipDIS_, false, 1.0, 1.0);
+    if (gactiven_->num_global_elements()) Core::LinAlg::matrix_add(*smatrix_, false, 1.0, kzd, 1.0);
+    if (gstickt->num_global_elements())
+      Core::LinAlg::matrix_add(*linstickDIS_, false, 1.0, kzd, 1.0);
+    if (gslipt_->num_global_elements())
+      Core::LinAlg::matrix_add(*linslipDIS_, false, 1.0, kzd, 1.0);
     kzd.complete(*gdisprowmap_, *gsdofrowmap_);
 
     // transform constraint matrix kzd to lmdofmap (MatrixRowTransform)
@@ -3299,15 +3301,18 @@ void Wear::LagrangeStrategyWear::build_saddle_point_system(
 
     // build constraint matrix kzz
     Core::LinAlg::SparseMatrix kzz(*gsdofrowmap_, 100, false, true);
-    if (gidofs->num_global_elements()) kzz.add(onesdiag, false, 1.0, 1.0);
-    if (gstickt->num_global_elements()) kzz.add(*linstickLM_, false, 1.0, 1.0);
-    if (gslipt_->num_global_elements()) kzz.add(*linslipLM_, false, 1.0, 1.0);
+    if (gidofs->num_global_elements()) Core::LinAlg::matrix_add(onesdiag, false, 1.0, kzz, 1.0);
+    if (gstickt->num_global_elements())
+      Core::LinAlg::matrix_add(*linstickLM_, false, 1.0, kzz, 1.0);
+    if (gslipt_->num_global_elements()) Core::LinAlg::matrix_add(*linslipLM_, false, 1.0, kzz, 1.0);
 
     if (wearimpl_)
     {
       // add C-fnc. derivatives w.r.t. lm-values to kzz
-      if (gactiven_->num_global_elements()) kzz.add(*wlinmatrix_, false, 1.0, 1.0);
-      if (gslipt_->num_global_elements()) kzz.add(*wlinmatrixsl_, false, 1.0, 1.0);
+      if (gactiven_->num_global_elements())
+        Core::LinAlg::matrix_add(*wlinmatrix_, false, 1.0, kzz, 1.0);
+      if (gslipt_->num_global_elements())
+        Core::LinAlg::matrix_add(*wlinmatrixsl_, false, 1.0, kzz, 1.0);
 
 #ifdef CONSISTENTSTICK
       if (gstickt->NumGlobalElements()) kzz->Add(*wlinmatrixst_, false, 1.0, 1.0);
@@ -3372,8 +3377,8 @@ void Wear::LagrangeStrategyWear::build_saddle_point_system(
 
     // build constraint matrix kdz
     Core::LinAlg::SparseMatrix kdz(*gdisprowmap_, 100, false, true);
-    kdz.add(*dmatrix_, true, 1.0 - alphaf_, 1.0);
-    kdz.add(*mmatrix_, true, -(1.0 - alphaf_), 1.0);
+    Core::LinAlg::matrix_add(*dmatrix_, true, 1.0 - alphaf_, kdz, 1.0);
+    Core::LinAlg::matrix_add(*mmatrix_, true, -(1.0 - alphaf_), kdz, 1.0);
     kdz.complete(*gsdofrowmap_, *gdisprowmap_);
 
     // transform constraint matrix kzd to lmdofmap (matrix_col_transform)
@@ -3386,9 +3391,11 @@ void Wear::LagrangeStrategyWear::build_saddle_point_system(
 
     // build constraint matrix kzd
     Core::LinAlg::SparseMatrix kzd(*gsdofrowmap_, 100, false, true);
-    if (gactiven_->num_global_elements()) kzd.add(*smatrix_, false, 1.0, 1.0);
-    if (gstickt->num_global_elements()) kzd.add(*linstickDIS_, false, 1.0, 1.0);
-    if (gslipt_->num_global_elements()) kzd.add(*linslipDIS_, false, 1.0, 1.0);
+    if (gactiven_->num_global_elements()) Core::LinAlg::matrix_add(*smatrix_, false, 1.0, kzd, 1.0);
+    if (gstickt->num_global_elements())
+      Core::LinAlg::matrix_add(*linstickDIS_, false, 1.0, kzd, 1.0);
+    if (gslipt_->num_global_elements())
+      Core::LinAlg::matrix_add(*linslipDIS_, false, 1.0, kzd, 1.0);
     kzd.complete(*gdisprowmap_, *gsdofrowmap_);
 
     // transform constraint matrix kzd to lmdofmap (MatrixRowTransform)
@@ -3409,9 +3416,10 @@ void Wear::LagrangeStrategyWear::build_saddle_point_system(
 
     // build constraint matrix kzz
     Core::LinAlg::SparseMatrix kzz(*gsdofrowmap_, 100, false, true);
-    if (gidofs->num_global_elements()) kzz.add(onesdiag, false, 1.0, 1.0);
-    if (gstickt->num_global_elements()) kzz.add(*linstickLM_, false, 1.0, 1.0);
-    if (gslipt_->num_global_elements()) kzz.add(*linslipLM_, false, 1.0, 1.0);
+    if (gidofs->num_global_elements()) Core::LinAlg::matrix_add(onesdiag, false, 1.0, kzz, 1.0);
+    if (gstickt->num_global_elements())
+      Core::LinAlg::matrix_add(*linstickLM_, false, 1.0, kzz, 1.0);
+    if (gslipt_->num_global_elements()) Core::LinAlg::matrix_add(*linslipLM_, false, 1.0, kzz, 1.0);
 
     kzz.complete(*gsdofrowmap_, *gsdofrowmap_);
 
@@ -3426,14 +3434,17 @@ void Wear::LagrangeStrategyWear::build_saddle_point_system(
     Core::LinAlg::SparseMatrix kwd(*gsdofnrowmap_, 100, false, true);
     if (sswear_)
     {
-      if (gactiven_->num_global_elements()) kwd.add(*lintdis_, false, -wcoeff, 1.0);
-      if (gactiven_->num_global_elements()) kwd.add(*linedis_, false, 1.0, 1.0);
+      if (gactiven_->num_global_elements())
+        Core::LinAlg::matrix_add(*lintdis_, false, -wcoeff, kwd, 1.0);
+      if (gactiven_->num_global_elements())
+        Core::LinAlg::matrix_add(*linedis_, false, 1.0, kwd, 1.0);
       if (gactiven_->num_global_elements()) kwd.complete(*gdisprowmap_, *gsdofnrowmap_);
     }
     else
     {
-      if (gslipn_->num_global_elements()) kwd.add(*lintdis_, false, -wcoeff, 1.0);
-      if (gslipn_->num_global_elements()) kwd.add(*linedis_, false, 1.0, 1.0);
+      if (gslipn_->num_global_elements())
+        Core::LinAlg::matrix_add(*lintdis_, false, -wcoeff, kwd, 1.0);
+      if (gslipn_->num_global_elements()) Core::LinAlg::matrix_add(*linedis_, false, 1.0, kwd, 1.0);
       if (gslipn_->num_global_elements()) kwd.complete(*gdisprowmap_, *gsdofnrowmap_);
     }
 
@@ -3450,11 +3461,13 @@ void Wear::LagrangeStrategyWear::build_saddle_point_system(
     Core::LinAlg::SparseMatrix kwz(*gsdofnrowmap_, 100, false, true);
     if (sswear_)
     {
-      if (gactiven_->num_global_elements()) kwz.add(*lintlm_, false, -wcoeff, 1.0);
+      if (gactiven_->num_global_elements())
+        Core::LinAlg::matrix_add(*lintlm_, false, -wcoeff, kwz, 1.0);
     }
     else
     {
-      if (gslipn_->num_global_elements()) kwz.add(*lintlm_, false, -wcoeff, 1.0);
+      if (gslipn_->num_global_elements())
+        Core::LinAlg::matrix_add(*lintlm_, false, -wcoeff, kwz, 1.0);
     }
 
     kwz.complete(*gsdofrowmap_, *gsdofnrowmap_);
@@ -3467,11 +3480,12 @@ void Wear::LagrangeStrategyWear::build_saddle_point_system(
     Core::LinAlg::SparseMatrix kww(*gsdofnrowmap_, 100, false, true);
     if (sswear_)
     {
-      if (gactiven_->num_global_elements()) kww.add(*ematrix_, false, 1.0, 1.0);
+      if (gactiven_->num_global_elements())
+        Core::LinAlg::matrix_add(*ematrix_, false, 1.0, kww, 1.0);
     }
     else
     {
-      if (gslipn_->num_global_elements()) kww.add(*ematrix_, false, 1.0, 1.0);
+      if (gslipn_->num_global_elements()) Core::LinAlg::matrix_add(*ematrix_, false, 1.0, kww, 1.0);
     }
 
     // build unity matrix for inactive dofs
@@ -3480,7 +3494,7 @@ void Wear::LagrangeStrategyWear::build_saddle_point_system(
     Core::LinAlg::SparseMatrix onesdiagw(onesw);
     onesdiagw.complete();
     // build constraint matrix kzz
-    if (gwinact_->num_global_elements()) kww.add(onesdiagw, false, 1.0, 1.0);
+    if (gwinact_->num_global_elements()) Core::LinAlg::matrix_add(onesdiagw, false, 1.0, kww, 1.0);
 
     kww.complete(*gsdofnrowmap_, *gsdofnrowmap_);
 
@@ -3490,8 +3504,9 @@ void Wear::LagrangeStrategyWear::build_saddle_point_system(
     // *********************************
     // build wear matrix kzw
     Core::LinAlg::SparseMatrix kzw(*gsdofrowmap_, 100, false, true);
-    if (gactiven_->num_global_elements()) kzw.add(*smatrixW_, false, 1.0, 1.0);
-    if (gslipt_->num_global_elements()) kzw.add(*linslip_w_, false, 1.0, 1.0);
+    if (gactiven_->num_global_elements())
+      Core::LinAlg::matrix_add(*smatrixW_, false, 1.0, kzw, 1.0);
+    if (gslipt_->num_global_elements()) Core::LinAlg::matrix_add(*linslip_w_, false, 1.0, kzw, 1.0);
     kzw.complete(*gsdofnrowmap_, *gsdofrowmap_);
 
     // transform constraint matrix kzd to lmdofmap (MatrixRowTransform)
@@ -3569,8 +3584,8 @@ void Wear::LagrangeStrategyWear::build_saddle_point_system(
 
     // build constraint matrix kdz
     Core::LinAlg::SparseMatrix kdz(*gdisprowmap_, 100, false, true);
-    kdz.add(*dmatrix_, true, 1.0 - alphaf_, 1.0);
-    kdz.add(*mmatrix_, true, -(1.0 - alphaf_), 1.0);
+    Core::LinAlg::matrix_add(*dmatrix_, true, 1.0 - alphaf_, kdz, 1.0);
+    Core::LinAlg::matrix_add(*mmatrix_, true, -(1.0 - alphaf_), kdz, 1.0);
     kdz.complete(*gsdofrowmap_, *gdisprowmap_);
 
     // transform constraint matrix kzd to lmdofmap (matrix_col_transform)
@@ -3583,9 +3598,11 @@ void Wear::LagrangeStrategyWear::build_saddle_point_system(
 
     // build constraint matrix kzd
     Core::LinAlg::SparseMatrix kzd(*gsdofrowmap_, 100, false, true);
-    if (gactiven_->num_global_elements()) kzd.add(*smatrix_, false, 1.0, 1.0);
-    if (gstickt->num_global_elements()) kzd.add(*linstickDIS_, false, 1.0, 1.0);
-    if (gslipt_->num_global_elements()) kzd.add(*linslipDIS_, false, 1.0, 1.0);
+    if (gactiven_->num_global_elements()) Core::LinAlg::matrix_add(*smatrix_, false, 1.0, kzd, 1.0);
+    if (gstickt->num_global_elements())
+      Core::LinAlg::matrix_add(*linstickDIS_, false, 1.0, kzd, 1.0);
+    if (gslipt_->num_global_elements())
+      Core::LinAlg::matrix_add(*linslipDIS_, false, 1.0, kzd, 1.0);
     kzd.complete(*gdisprowmap_, *gsdofrowmap_);
 
     // transform constraint matrix kzd to lmdofmap (MatrixRowTransform)
@@ -3606,9 +3623,10 @@ void Wear::LagrangeStrategyWear::build_saddle_point_system(
 
     // build constraint matrix kzz
     Core::LinAlg::SparseMatrix kzz(*gsdofrowmap_, 100, false, true);
-    if (gidofs->num_global_elements()) kzz.add(onesdiag, false, 1.0, 1.0);
-    if (gstickt->num_global_elements()) kzz.add(*linstickLM_, false, 1.0, 1.0);
-    if (gslipt_->num_global_elements()) kzz.add(*linslipLM_, false, 1.0, 1.0);
+    if (gidofs->num_global_elements()) Core::LinAlg::matrix_add(onesdiag, false, 1.0, kzz, 1.0);
+    if (gstickt->num_global_elements())
+      Core::LinAlg::matrix_add(*linstickLM_, false, 1.0, kzz, 1.0);
+    if (gslipt_->num_global_elements()) Core::LinAlg::matrix_add(*linslipLM_, false, 1.0, kzz, 1.0);
 
     kzz.complete(*gsdofrowmap_, *gsdofrowmap_);
 
@@ -3621,8 +3639,9 @@ void Wear::LagrangeStrategyWear::build_saddle_point_system(
     // ***************************************************************************************************
     // build wear matrix kwd
     Core::LinAlg::SparseMatrix kwd(*gsdofnrowmap_, 100, false, true);
-    if (gslipn_->num_global_elements()) kwd.add(*lintdis_, false, -wcoeff, 1.0);
-    if (gslipn_->num_global_elements()) kwd.add(*linedis_, false, 1.0, 1.0);
+    if (gslipn_->num_global_elements())
+      Core::LinAlg::matrix_add(*lintdis_, false, -wcoeff, kwd, 1.0);
+    if (gslipn_->num_global_elements()) Core::LinAlg::matrix_add(*linedis_, false, 1.0, kwd, 1.0);
     if (gslipn_->num_global_elements()) kwd.complete(*gdisprowmap_, *gsdofnrowmap_);
 
     // transform constraint matrix kzd to lmdofmap (MatrixRowTransform)
@@ -3636,7 +3655,8 @@ void Wear::LagrangeStrategyWear::build_saddle_point_system(
     // *********************************
     // build wear matrix kwz
     Core::LinAlg::SparseMatrix kwz(*gsdofnrowmap_, 100, false, true);
-    if (gslipn_->num_global_elements()) kwz.add(*lintlm_, false, -wcoeff, 1.0);
+    if (gslipn_->num_global_elements())
+      Core::LinAlg::matrix_add(*lintlm_, false, -wcoeff, kwz, 1.0);
     kwz.complete(*gsdofrowmap_, *gsdofnrowmap_);
 
     // transform constraint matrix kzd to lmdofmap (MatrixRowTransform)
@@ -3645,7 +3665,7 @@ void Wear::LagrangeStrategyWear::build_saddle_point_system(
     // *********************************
     // build wear matrix kww
     Core::LinAlg::SparseMatrix kww(*gsdofnrowmap_, 100, false, true);
-    if (gslipn_->num_global_elements()) kww.add(*ematrix_, false, 1.0, 1.0);
+    if (gslipn_->num_global_elements()) Core::LinAlg::matrix_add(*ematrix_, false, 1.0, kww, 1.0);
 
     // build unity matrix for inactive dofs
     Core::LinAlg::Vector<double> onesw(*gwinact_);
@@ -3653,7 +3673,7 @@ void Wear::LagrangeStrategyWear::build_saddle_point_system(
     Core::LinAlg::SparseMatrix onesdiagw(onesw);
     onesdiagw.complete();
     // build constraint matrix kzz
-    if (gwinact_->num_global_elements()) kww.add(onesdiagw, false, 1.0, 1.0);
+    if (gwinact_->num_global_elements()) Core::LinAlg::matrix_add(onesdiagw, false, 1.0, kww, 1.0);
 
     kww.complete(*gsdofnrowmap_, *gsdofnrowmap_);
 
@@ -3664,8 +3684,9 @@ void Wear::LagrangeStrategyWear::build_saddle_point_system(
     // ********************************* S+M
     // build wear matrix kzw
     Core::LinAlg::SparseMatrix kzw(*gsdofrowmap_, 100, false, true);
-    if (gactiven_->num_global_elements()) kzw.add(*smatrixW_, false, 1.0, 1.0);
-    if (gslipt_->num_global_elements()) kzw.add(*linslip_w_, false, 1.0, 1.0);
+    if (gactiven_->num_global_elements())
+      Core::LinAlg::matrix_add(*smatrixW_, false, 1.0, kzw, 1.0);
+    if (gslipt_->num_global_elements()) Core::LinAlg::matrix_add(*linslip_w_, false, 1.0, kzw, 1.0);
     kzw.complete(*galldofnrowmap_, *gsdofrowmap_);
 
     // transform constraint matrix kzd to lmdofmap (MatrixRowTransform)
@@ -3676,8 +3697,10 @@ void Wear::LagrangeStrategyWear::build_saddle_point_system(
     // ***************************************************************************************************
     // build wear matrix kwmd
     Core::LinAlg::SparseMatrix kwmd(*gmdofnrowmap_, 100, false, true);
-    if (gmslipn_->num_global_elements()) kwmd.add(*lintdis_m_, false, -wcoeffM, 1.0);
-    if (gmslipn_->num_global_elements()) kwmd.add(*linedis_m_, false, 1.0, 1.0);
+    if (gmslipn_->num_global_elements())
+      Core::LinAlg::matrix_add(*lintdis_m_, false, -wcoeffM, kwmd, 1.0);
+    if (gmslipn_->num_global_elements())
+      Core::LinAlg::matrix_add(*linedis_m_, false, 1.0, kwmd, 1.0);
     if (gmslipn_->num_global_elements()) kwmd.complete(*gdisprowmap_, *gmdofnrowmap_);
 
     // transform constraint matrix kzd to lmdofmap (MatrixRowTransform)
@@ -3691,7 +3714,8 @@ void Wear::LagrangeStrategyWear::build_saddle_point_system(
     // *********************************
     // build wear matrix kwmz
     Core::LinAlg::SparseMatrix kwmz(*gmdofnrowmap_, 100, false, true);
-    if (gmslipn_->num_global_elements()) kwmz.add(*lintlm_m_, false, -wcoeffM, 1.0);
+    if (gmslipn_->num_global_elements())
+      Core::LinAlg::matrix_add(*lintlm_m_, false, -wcoeffM, kwmz, 1.0);
     kwmz.complete(*gsdofrowmap_, *gmdofnrowmap_);
 
     // transform constraint matrix kzd to lmdofmap (MatrixRowTransform)
@@ -3700,7 +3724,8 @@ void Wear::LagrangeStrategyWear::build_saddle_point_system(
     // *********************************
     // build wear matrix kwmwm
     Core::LinAlg::SparseMatrix kwmwm(*gmdofnrowmap_, 100, false, true);
-    if (gmslipn_->num_global_elements()) kwmwm.add(*ematrix_m_, false, 1.0, 1.0);
+    if (gmslipn_->num_global_elements())
+      Core::LinAlg::matrix_add(*ematrix_m_, false, 1.0, kwmwm, 1.0);
 
     // build unity matrix for inactive dofs
     Core::LinAlg::Vector<double> oneswm(*gwminact_);
@@ -3708,7 +3733,8 @@ void Wear::LagrangeStrategyWear::build_saddle_point_system(
     Core::LinAlg::SparseMatrix onesdiagwm(oneswm);
     onesdiagwm.complete();
     // build constraint matrix kzz
-    if (gwminact_->num_global_elements()) kwmwm.add(onesdiagwm, false, 1.0, 1.0);
+    if (gwminact_->num_global_elements())
+      Core::LinAlg::matrix_add(onesdiagwm, false, 1.0, kwmwm, 1.0);
 
     kwmwm.complete(*gmdofnrowmap_, *gmdofnrowmap_);
 
@@ -3852,13 +3878,13 @@ void Wear::LagrangeStrategyWear::build_saddle_point_system(
         trkgd = std::make_shared<Core::LinAlg::SparseMatrix>(*gmap, 100, false, true);
         trkgg = std::make_shared<Core::LinAlg::SparseMatrix>(*gmap, 100, false, true);
 
-        trkgd->add(*trkzd, false, 1.0, 1.0);
-        trkgd->add(*trkwd, false, 1.0, 1.0);
+        Core::LinAlg::matrix_add(*trkzd, false, 1.0, *trkgd, 1.0);
+        Core::LinAlg::matrix_add(*trkwd, false, 1.0, *trkgd, 1.0);
 
-        trkgg->add(*trkzz, false, 1.0, 1.0);
-        trkgg->add(*trkwz, false, 1.0, 1.0);
-        trkgg->add(*trkww, false, 1.0, 1.0);
-        trkgg->add(*trkzw, false, 1.0, 1.0);
+        Core::LinAlg::matrix_add(*trkzz, false, 1.0, *trkgg, 1.0);
+        Core::LinAlg::matrix_add(*trkwz, false, 1.0, *trkgg, 1.0);
+        Core::LinAlg::matrix_add(*trkww, false, 1.0, *trkgg, 1.0);
+        Core::LinAlg::matrix_add(*trkzw, false, 1.0, *trkgg, 1.0);
 
         trkgd->complete(*problem_dofs(), *gmap);
         trkgg->complete(*gmap, *gmap);
@@ -3897,16 +3923,16 @@ void Wear::LagrangeStrategyWear::build_saddle_point_system(
         trkgd = std::make_shared<Core::LinAlg::SparseMatrix>(*gmap, 100, false, true);
         trkgg = std::make_shared<Core::LinAlg::SparseMatrix>(*gmap, 100, false, true);
 
-        trkgd->add(*trkzd, false, 1.0, 1.0);
-        trkgd->add(*trkwd, false, 1.0, 1.0);
-        trkgd->add(*trkwmd, false, 1.0, 1.0);
+        Core::LinAlg::matrix_add(*trkzd, false, 1.0, *trkgd, 1.0);
+        Core::LinAlg::matrix_add(*trkwd, false, 1.0, *trkgd, 1.0);
+        Core::LinAlg::matrix_add(*trkwmd, false, 1.0, *trkgd, 1.0);
 
-        trkgg->add(*trkzz, false, 1.0, 1.0);
-        trkgg->add(*trkwz, false, 1.0, 1.0);
-        trkgg->add(*trkww, false, 1.0, 1.0);
-        trkgg->add(*trkzw, false, 1.0, 1.0);
-        trkgg->add(*trkwmz, false, 1.0, 1.0);
-        trkgg->add(*trkwmwm, false, 1.0, 1.0);
+        Core::LinAlg::matrix_add(*trkzz, false, 1.0, *trkgg, 1.0);
+        Core::LinAlg::matrix_add(*trkwz, false, 1.0, *trkgg, 1.0);
+        Core::LinAlg::matrix_add(*trkww, false, 1.0, *trkgg, 1.0);
+        Core::LinAlg::matrix_add(*trkzw, false, 1.0, *trkgg, 1.0);
+        Core::LinAlg::matrix_add(*trkwmz, false, 1.0, *trkgg, 1.0);
+        Core::LinAlg::matrix_add(*trkwmwm, false, 1.0, *trkgg, 1.0);
 
         trkgd->complete(*problem_dofs(), *gmap);
         trkgg->complete(*gmap, *gmap);
@@ -4397,7 +4423,7 @@ void Wear::LagrangeStrategyWear::recover(std::shared_ptr<Core::LinAlg::Vector<do
     Core::LinAlg::split_matrix2x2(
         invd_, gactivedofs_, tempmap, gactivedofs_, tempmap, invda, tempmtx1, tempmtx2, tempmtx3);
     Core::LinAlg::SparseMatrix invdmod(*gsdofrowmap_, 10);
-    invdmod.add(*invda, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*invda, false, 1.0, invdmod, 1.0);
     invdmod.complete();
 
     // approximate update
@@ -4509,7 +4535,7 @@ void Wear::LagrangeStrategyWear::recover(std::shared_ptr<Core::LinAlg::Vector<do
     Core::LinAlg::split_matrix2x2(
         invd_, gactivedofs_, tempmap, gactivedofs_, tempmap, invda, tempmtx1, tempmtx2, tempmtx3);
     Core::LinAlg::SparseMatrix invdmod(*gsdofrowmap_, 10);
-    invdmod.add(*invda, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*invda, false, 1.0, invdmod, 1.0);
     invdmod.complete();
 
     /**********************************************************************/

--- a/src/contact/src/4C_contact_meshtying_penalty_strategy.cpp
+++ b/src/contact/src/4C_contact_meshtying_penalty_strategy.cpp
@@ -110,10 +110,10 @@ void CONTACT::MtPenaltyStrategy::mortar_coupling(
   double pp = params().get<double>("PENALTYPARAM");
 
   // add penalty meshtying stiffness terms
-  stiff_->add(*mtm_, false, pp, 1.0);
-  stiff_->add(*mtd_, false, -pp, 1.0);
-  stiff_->add(*dtm_, false, -pp, 1.0);
-  stiff_->add(*dtd_, false, pp, 1.0);
+  Core::LinAlg::matrix_add(*mtm_, false, pp, *stiff_, 1.0);
+  Core::LinAlg::matrix_add(*mtd_, false, -pp, *stiff_, 1.0);
+  Core::LinAlg::matrix_add(*dtm_, false, -pp, *stiff_, 1.0);
+  Core::LinAlg::matrix_add(*dtd_, false, pp, *stiff_, 1.0);
   stiff_->complete();
 
   // time measurement

--- a/src/contact/src/4C_contact_meshtying_poro_lagrange_strategy.cpp
+++ b/src/contact/src/4C_contact_meshtying_poro_lagrange_strategy.cpp
@@ -123,10 +123,10 @@ void CONTACT::PoroMtLagrangeStrategy::evaluate_meshtying_poro_off_diag(
 
     // cm: add T(mbar)*cs
     Core::LinAlg::SparseMatrix cmmod(*gmdofrowmap_, 100);
-    cmmod.add(*cm, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*cm, false, 1.0, cmmod, 1.0);
     std::shared_ptr<Core::LinAlg::SparseMatrix> cmadd =
         Core::LinAlg::matrix_multiply(*get_m_hat(), true, *cs, false, false, false, true);
-    cmmod.add(*cmadd, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*cmadd, false, 1.0, cmmod, 1.0);
     cmmod.complete(cm->domain_map(), cm->row_map());
 
     // cs: nothing to do as it remains zero
@@ -139,10 +139,10 @@ void CONTACT::PoroMtLagrangeStrategy::evaluate_meshtying_poro_off_diag(
             *problem_dofs(), 81, true, false, kteffmatrix->get_matrixtype());
 
     // add n matrix row
-    kteffoffdiagnew->add(*cn, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*cn, false, 1.0, *kteffoffdiagnew, 1.0);
 
     // add m matrix row
-    kteffoffdiagnew->add(cmmod, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(cmmod, false, 1.0, *kteffoffdiagnew, 1.0);
 
     // s matrix row remains zero (thats what it was all about)
 

--- a/src/contact/src/4C_contact_monocoupled_lagrange_strategy.cpp
+++ b/src/contact/src/4C_contact_monocoupled_lagrange_strategy.cpp
@@ -183,12 +183,12 @@ void CONTACT::MonoCoupledLagrangeStrategy::evaluate_off_diag_contact(
     //---------------------------------------------------------- SECOND LINE
     // km: add T(mhataam)*kan
     Core::LinAlg::SparseMatrix kmmod(*gmdofrowmap_, 100);
-    kmmod.add(*km, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*km, false, 1.0, kmmod, 1.0);
     if (aset)
     {
       std::shared_ptr<Core::LinAlg::SparseMatrix> kmadd =
           Core::LinAlg::matrix_multiply(*mhataam_, true, *ka, false, false, false, true);
-      kmmod.add(*kmadd, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(*kmadd, false, 1.0, kmmod, 1.0);
     }
     kmmod.complete(Core::LinAlg::Map(kteff->domain_map()), km->row_map());
 
@@ -200,12 +200,12 @@ void CONTACT::MonoCoupledLagrangeStrategy::evaluate_off_diag_contact(
 
     // kin: subtract T(dhat)*kan --
     Core::LinAlg::SparseMatrix kimod(*gidofs, 100);
-    kimod.add(*ki, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*ki, false, 1.0, kimod, 1.0);
     if (aset)
     {
       std::shared_ptr<Core::LinAlg::SparseMatrix> kiadd =
           Core::LinAlg::matrix_multiply(*dhat_, true, *ka, false, false, false, true);
-      kimod.add(*kiadd, false, -1.0, 1.0);
+      Core::LinAlg::matrix_add(*kiadd, false, -1.0, kimod, 1.0);
     }
     kimod.complete(Core::LinAlg::Map(kteff->domain_map()), ki->row_map());
 
@@ -245,20 +245,20 @@ void CONTACT::MonoCoupledLagrangeStrategy::evaluate_off_diag_contact(
 
     //----------------------------------------------------------- FIRST LINE
     // add n submatrices to kteffnew
-    kteffnew->add(*kn, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*kn, false, 1.0, *kteffnew, 1.0);
     //---------------------------------------------------------- SECOND LINE
     // add m submatrices to kteffnew
-    kteffnew->add(kmmod, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(kmmod, false, 1.0, *kteffnew, 1.0);
     //----------------------------------------------------------- THIRD LINE
     // add i submatrices to kteffnew
-    if (iset) kteffnew->add(kimod, false, 1.0, 1.0);
+    if (iset) Core::LinAlg::matrix_add(kimod, false, 1.0, *kteffnew, 1.0);
 
     //---------------------------------------------------------- FOURTH LINE
     // for off diag blocks this line is empty (weighted normal = f(disp))
 
     //----------------------------------------------------------- FIFTH LINE
     // add a submatrices to kteffnew
-    if (aset) kteffnew->add(*kamod, false, 1.0, 1.0);
+    if (aset) Core::LinAlg::matrix_add(*kamod, false, 1.0, *kteffnew, 1.0);
 
     // fill_complete kteffnew (square)
     kteffnew->complete(*domainmap, *gdisprowmap_);
@@ -321,7 +321,7 @@ void CONTACT::MonoCoupledLagrangeStrategy::recover_coupled(
     Core::LinAlg::split_matrix2x2(
         invd_, gactivedofs_, tempmap, gactivedofs_, tempmap, invda, tempmtx1, tempmtx2, tempmtx3);
     Core::LinAlg::SparseMatrix invdmod(*gsdofrowmap_, 10);
-    invdmod.add(*invda, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*invda, false, 1.0, invdmod, 1.0);
     invdmod.complete();
 
     std::map<int, std::shared_ptr<Core::LinAlg::SparseOperator>>::iterator matiter;

--- a/src/contact/src/4C_contact_penalty_strategy.cpp
+++ b/src/contact/src/4C_contact_penalty_strategy.cpp
@@ -871,8 +871,8 @@ void CONTACT::PenaltyStrategy::assemble()
   }
 
   // add to kteff
-  kc_->add(*lindmatrix_, false, 1.0, 1.0);
-  kc_->add(*linmmatrix_, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*lindmatrix_, false, 1.0, *kc_, 1.0);
+  Core::LinAlg::matrix_add(*linmmatrix_, false, 1.0, *kc_, 1.0);
 
   // **********************************************************************
   // Build Contact Stiffness #2
@@ -894,8 +894,8 @@ void CONTACT::PenaltyStrategy::assemble()
   }
 
   // add to kteff
-  kc_->add(*dtilde, false, 1.0, 1.0);
-  kc_->add(*mtilde, false, -(1.0), 1.0);
+  Core::LinAlg::matrix_add(*dtilde, false, 1.0, *kc_, 1.0);
+  Core::LinAlg::matrix_add(*mtilde, false, -(1.0), *kc_, 1.0);
 
   // **********************************************************************
   // Build RHS

--- a/src/core/linalg/src/sparse/4C_linalg_blocksparsematrix.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_blocksparsematrix.cpp
@@ -9,6 +9,7 @@
 
 #include "4C_linalg_utils_densematrix_communication.hpp"
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
+#include "4C_linalg_utils_sparse_algebra_math.hpp"
 
 #include <Teuchos_TimeMonitor.hpp>
 
@@ -45,7 +46,7 @@ std::shared_ptr<Core::LinAlg::SparseMatrix> Core::LinAlg::BlockSparseMatrixBase:
       std::make_shared<SparseMatrix>(*fullrowmap_, m00.max_num_entries(), explicitdirichlet);
   for (const auto& block : blocks_)
   {
-    sparse->add(block, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(block, false, 1.0, *sparse, 1.0);
   }
   if (filled())
   {
@@ -299,9 +300,9 @@ void Core::LinAlg::BlockSparseMatrixBase::add(const Core::LinAlg::BlockSparseMat
     for (int j = 0; j < cols(); j++)
     {
       if (transposeA)
-        matrix(i, j).add(A.matrix(j, i), transposeA, scalarA, scalarB);
+        Core::LinAlg::matrix_add(A.matrix(j, i), transposeA, scalarA, matrix(i, j), scalarB);
       else
-        matrix(i, j).add(A.matrix(i, j), transposeA, scalarA, scalarB);
+        Core::LinAlg::matrix_add(A.matrix(i, j), transposeA, scalarA, matrix(i, j), scalarB);
     }
   }
 }

--- a/src/core/linalg/src/sparse/4C_linalg_krylov_projector.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_krylov_projector.cpp
@@ -316,15 +316,15 @@ Core::LinAlg::SparseMatrix Core::LinAlg::KrylovProjector::to_reduced(
     // here: matvec = A^T c_;
     A.multiply(true, *c_, matvec);
     Core::LinAlg::SparseMatrix mat2 = multiply_multi_vector_multi_vector(w_invwTc, matvec, 2, true);
-    mat1.add(mat2, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(mat2, false, 1.0, mat1, 1.0);
     mat1.complete();
   }
 
   // here: matvec = w (c^T w)^-1 (c^T A c);
   matvec = multiply_multi_vector_dense_matrix(w_invwTc, cTAc);
   Core::LinAlg::SparseMatrix mat3 = multiply_multi_vector_multi_vector(matvec, w_invwTc, 1, false);
-  mat3.add(mat1, false, -1.0, 1.0);
-  mat3.add(A, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(mat1, false, -1.0, mat3, 1.0);
+  Core::LinAlg::matrix_add(A, false, 1.0, mat3, 1.0);
 
   mat3.complete();
   return mat3;

--- a/src/core/linalg/src/sparse/4C_linalg_sparsematrix.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_sparsematrix.cpp
@@ -1558,18 +1558,10 @@ void Core::LinAlg::SparseMatrix::add(const Core::LinAlg::SparseOperator& A, cons
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void Core::LinAlg::SparseMatrix::add(const Core::LinAlg::SparseMatrix& A, const bool transposeA,
-    const double scalarA, const double scalarB)
-{
-  Core::LinAlg::add(A, transposeA, scalarA, *this, scalarB);
-}
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
 void Core::LinAlg::SparseMatrix::add_other(Core::LinAlg::SparseMatrix& B, const bool transposeA,
     const double scalarA, const double scalarB) const
 {
-  B.add(*this, transposeA, scalarA, scalarB);
+  Core::LinAlg::matrix_add(*this, transposeA, scalarA, B, scalarB);
 }
 
 /*----------------------------------------------------------------------*

--- a/src/core/linalg/src/sparse/4C_linalg_sparsematrix.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_sparsematrix.hpp
@@ -614,10 +614,6 @@ namespace Core::LinAlg
     void add(const Core::LinAlg::SparseOperator& A, const bool transposeA, const double scalarA,
         const double scalarB) override;
 
-    void add(
-        const SparseMatrix& A, const bool transposeA, const double scalarA, const double scalarB);
-
-
     /// Add one SparseMatrixBase to another
     void add_other(Core::LinAlg::SparseMatrix& B, const bool transposeA, const double scalarA,
         const double scalarB) const override;

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_math.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_math.cpp
@@ -136,7 +136,7 @@ namespace Core::LinAlg
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void Core::LinAlg::add(const Core::LinAlg::SparseMatrix& A, const bool transposeA,
+void Core::LinAlg::matrix_add(const Core::LinAlg::SparseMatrix& A, const bool transposeA,
     const double scalarA, Core::LinAlg::SparseMatrix& B, const double scalarB)
 {
   if (!A.filled()) FOUR_C_THROW("fill_complete was not called on A");

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_math.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_math.hpp
@@ -52,7 +52,7 @@ namespace Core::LinAlg
    \param B          (in/out) : Matrix to be added to (must have Filled()==false)
    \param scalarB    (in)     : scaling factor for B
    */
-  void add(const Core::LinAlg::SparseMatrix& A, const bool transposeA, const double scalarA,
+  void matrix_add(const Core::LinAlg::SparseMatrix& A, const bool transposeA, const double scalarA,
       Core::LinAlg::SparseMatrix& B, const double scalarB);
 
   /*!

--- a/src/coupling/src/volmortar/4C_coupling_volmortar.cpp
+++ b/src/coupling/src/volmortar/4C_coupling_volmortar.cpp
@@ -1365,16 +1365,16 @@ void Coupling::VolMortar::VolMortarCoupl::mesh_init()
     omega = 1.0;
 
     Core::LinAlg::SparseMatrix k(*mergedmap_, 100, false, true);
-    k.add(*dmatrix_xa_, false, -1.0 * omega, 1.0);
-    k.add(*mmatrix_xa_, false, 1.0 * omega, 1.0);
-    k.add(*dmatrix_xb_, false, -1.0 * omega, 1.0);
-    k.add(*mmatrix_xb_, false, 1.0 * omega, 1.0);
+    Core::LinAlg::matrix_add(*dmatrix_xa_, false, -1.0 * omega, k, 1.0);
+    Core::LinAlg::matrix_add(*mmatrix_xa_, false, 1.0 * omega, k, 1.0);
+    Core::LinAlg::matrix_add(*dmatrix_xb_, false, -1.0 * omega, k, 1.0);
+    Core::LinAlg::matrix_add(*mmatrix_xb_, false, 1.0 * omega, k, 1.0);
 
     Core::LinAlg::Vector<double> ones(*mergedmap_);
     ones.put_scalar(1.0);
     Core::LinAlg::SparseMatrix onesdiag(ones);
     onesdiag.complete();
-    k.add(onesdiag, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(onesdiag, false, 1.0, k, 1.0);
     k.complete();
 
     // solve with default solver

--- a/src/fbi/4C_fbi_beam_to_fluid_mortar_manager.cpp
+++ b/src/fbi/4C_fbi_beam_to_fluid_mortar_manager.cpp
@@ -514,13 +514,13 @@ void BeamInteraction::BeamToFluidMortarManager::add_global_force_stiffness_contr
   std::shared_ptr<Core::LinAlg::SparseMatrix> Mt_kappa_M =
       Core::LinAlg::matrix_multiply(*global_m_, true, *global_M_scaled, false, false, false, true);
 
-  if (kff != nullptr) kff->add(*Mt_kappa_M, false, 1.0, 1.0);
+  if (kff != nullptr) Core::LinAlg::matrix_add(*Mt_kappa_M, false, 1.0, *kff, 1.0);
 
-  if (kfb != nullptr) kbf->add(*Dt_kappa_M, true, -1.0, 1.0);
+  if (kfb != nullptr) Core::LinAlg::matrix_add(*Dt_kappa_M, true, -1.0, *kbf, 1.0);
 
-  if (kbf != nullptr) kfb->add(*Dt_kappa_M, false, -1.0, 1.0);
+  if (kfb != nullptr) Core::LinAlg::matrix_add(*Dt_kappa_M, false, -1.0, *kfb, 1.0);
 
-  if (kbb != nullptr) kbb->add(*Dt_kappa_D, false, 1.0, 1.0);
+  if (kbb != nullptr) Core::LinAlg::matrix_add(*Dt_kappa_D, false, 1.0, *kbb, 1.0);
 
 
   if (fluid_force != nullptr)

--- a/src/fluid/4C_fluid_implicit_integration.cpp
+++ b/src/fluid/4C_fluid_implicit_integration.cpp
@@ -1997,10 +1997,10 @@ void FLD::FluidImplicitTimeInt::evaluate_fluid_edge_based(
     Core::LinAlg::split_matrix2x2(
         sysmat_linalg, domainmap_00, domainmap_11, domainmap_00, domainmap_11, f00, f01, f10, f11);
     // add the blocks subsequently
-    block_sysmat->matrix(0, 0).add(*f00, false, 1.0, 1.0);
-    block_sysmat->matrix(0, 1).add(*f01, false, 1.0, 1.0);
-    block_sysmat->matrix(1, 0).add(*f10, false, 1.0, 1.0);
-    block_sysmat->matrix(1, 1).add(*f11, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*f00, false, 1.0, block_sysmat->matrix(0, 0), 1.0);
+    Core::LinAlg::matrix_add(*f01, false, 1.0, block_sysmat->matrix(0, 1), 1.0);
+    Core::LinAlg::matrix_add(*f10, false, 1.0, block_sysmat->matrix(1, 0), 1.0);
+    Core::LinAlg::matrix_add(*f11, false, 1.0, block_sysmat->matrix(1, 1), 1.0);
   }
 
   //------------------------------------------------------------

--- a/src/fluid/4C_fluid_meshtying.cpp
+++ b/src/fluid/4C_fluid_meshtying.cpp
@@ -913,10 +913,10 @@ void FLD::Meshtying::condensation_operation_sparse_matrix(
   /*--------------------------------------------------------------------*/
   // knm: add kns*P
   Core::LinAlg::SparseMatrix knm_mod(*gndofrowmap_, 100);
-  knm_mod.add(splitmatrix.matrix(0, 1), false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(splitmatrix.matrix(0, 1), false, 1.0, knm_mod, 1.0);
   std::shared_ptr<Core::LinAlg::SparseMatrix> knm_add =
       matrix_multiply(splitmatrix.matrix(0, 2), false, *P, false, false, false, true);
-  knm_mod.add(*knm_add, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*knm_add, false, 1.0, knm_mod, 1.0);
   knm_mod.complete(splitmatrix.matrix(0, 1).domain_map(), splitmatrix.matrix(0, 1).row_map());
 
   sysmat.add(knm_mod, false, 1.0, 1.0);
@@ -928,10 +928,10 @@ void FLD::Meshtying::condensation_operation_sparse_matrix(
   /*--------------------------------------------------------------------*/
   // kmn: add P^T*ksn
   Core::LinAlg::SparseMatrix kmn_mod(*gmdofrowmap_, 100);
-  kmn_mod.add(splitmatrix.matrix(1, 0), false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(splitmatrix.matrix(1, 0), false, 1.0, kmn_mod, 1.0);
   std::shared_ptr<Core::LinAlg::SparseMatrix> kmn_add =
       matrix_multiply(*P, true, splitmatrix.matrix(2, 0), false, false, false, true);
-  kmn_mod.add(*kmn_add, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*kmn_add, false, 1.0, kmn_mod, 1.0);
   kmn_mod.complete(splitmatrix.matrix(1, 0).domain_map(), splitmatrix.matrix(1, 0).row_map());
 
   sysmat.add(kmn_mod, false, 1.0, 1.0);
@@ -941,12 +941,12 @@ void FLD::Meshtying::condensation_operation_sparse_matrix(
   /*--------------------------------------------------------------------*/
   // kms: add P^T*kss, kmm: add kms*P + kmm
   Core::LinAlg::SparseMatrix kmm_mod(*gmdofrowmap_, 100);
-  kmm_mod.add(splitmatrix.matrix(1, 1), false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(splitmatrix.matrix(1, 1), false, 1.0, kmm_mod, 1.0);
   std::shared_ptr<Core::LinAlg::SparseMatrix> kms =
       matrix_multiply(*P, true, splitmatrix.matrix(2, 2), false, false, false, true);
   std::shared_ptr<Core::LinAlg::SparseMatrix> kmm_add =
       matrix_multiply(*kms, false, *P, false, false, false, true);
-  kmm_mod.add(*kmm_add, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*kmm_add, false, 1.0, kmm_mod, 1.0);
   kmm_mod.complete(splitmatrix.matrix(1, 1).domain_map(), splitmatrix.matrix(1, 1).row_map());
 
   sysmat.add(kmm_mod, false, 1.0, 1.0);
@@ -1100,7 +1100,7 @@ void FLD::Meshtying::condensation_operation_block_matrix(
 
   // Add transformation matrix to nm
   sysmatnew->matrix(0, 1).un_complete();
-  sysmatnew->matrix(0, 1).add(*knm_mod, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*knm_mod, false, 1.0, sysmatnew->matrix(0, 1), 1.0);
 
   if (dconmaster_ and firstnonliniter_) knm_mod->multiply(false, *(splitdcmaster[1]), *dcnm);
 
@@ -1113,7 +1113,7 @@ void FLD::Meshtying::condensation_operation_block_matrix(
 
   // Add transformation matrix to mn
   sysmatnew->matrix(1, 0).un_complete();
-  sysmatnew->matrix(1, 0).add(*kmn_mod, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*kmn_mod, false, 1.0, sysmatnew->matrix(1, 0), 1.0);
 
   /*--------------------------------------------------------------------*/
   // block mm
@@ -1126,7 +1126,7 @@ void FLD::Meshtying::condensation_operation_block_matrix(
 
   // Add transformation matrix to mm
   sysmatnew->matrix(1, 1).un_complete();
-  sysmatnew->matrix(1, 1).add(*kmm_mod, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*kmm_mod, false, 1.0, sysmatnew->matrix(1, 1), 1.0);
 
   if (dconmaster_ and firstnonliniter_) kmm_mod->multiply(false, *(splitdcmaster[1]), *dcmm);
 
@@ -1496,7 +1496,7 @@ void FLD::Meshtying::multifield_split(std::shared_ptr<Core::LinAlg::SparseOperat
 
     sysmatnew->matrix(2, 2).un_complete();
     sysmatnew->matrix(2, 2).zero();
-    sysmatnew->matrix(2, 2).add(onesdiag, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(onesdiag, false, 1.0, sysmatnew->matrix(2, 2), 1.0);
 
     sysmatnew->matrix(2, 0).un_complete();
     sysmatnew->matrix(2, 0).zero();
@@ -1549,7 +1549,7 @@ void FLD::Meshtying::multifield_split_shape(
 
     shapederivatives->matrix(2, 2).un_complete();
     shapederivatives->matrix(2, 2).zero();
-    shapederivatives->matrix(2, 2).add(onesdiag, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(onesdiag, false, 1.0, shapederivatives->matrix(2, 2), 1.0);
 
     shapederivatives->matrix(2, 0).un_complete();
     shapederivatives->matrix(2, 0).zero();
@@ -1630,7 +1630,7 @@ void FLD::Meshtying::condensation_operation_block_matrix_shape(
 
   // Add transformation matrix to nm
   shapederivatives.matrix(0, 1).un_complete();
-  shapederivatives.matrix(0, 1).add(*knm_mod, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*knm_mod, false, 1.0, shapederivatives.matrix(0, 1), 1.0);
 
   if (dconmaster_ and firstnonliniter_) knm_mod->multiply(false, *(splitdcmaster[1]), *dcnm);  //???
 
@@ -1643,7 +1643,7 @@ void FLD::Meshtying::condensation_operation_block_matrix_shape(
 
   // Add transformation matrix to mn
   shapederivatives.matrix(1, 0).un_complete();
-  shapederivatives.matrix(1, 0).add(*kmn_mod, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*kmn_mod, false, 1.0, shapederivatives.matrix(1, 0), 1.0);
 
   /*--------------------------------------------------------------------*/
   // block mm
@@ -1656,7 +1656,7 @@ void FLD::Meshtying::condensation_operation_block_matrix_shape(
 
   // Add transformation matrix to mm
   shapederivatives.matrix(1, 1).un_complete();
-  shapederivatives.matrix(1, 1).add(*kmm_mod, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*kmm_mod, false, 1.0, shapederivatives.matrix(1, 1), 1.0);
 
   if (dconmaster_ and firstnonliniter_) kmm_mod->multiply(false, *(splitdcmaster[1]), *dcmm);
 

--- a/src/fluid_xfluid/4C_fluid_xfluid_fluid.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid_fluid.cpp
@@ -433,7 +433,8 @@ void FLD::XFluidFluid::assemble_mat_and_rhs(int itnum  ///< iteration number
     sysmat_block->assign(1, 0, Core::LinAlg::DataAccess::Share, *coup_state->C_xs_);
     sysmat_block->assign(0, 1, Core::LinAlg::DataAccess::Share, *coup_state->C_sx_);
     embedded_fluid_->system_matrix()->un_complete();
-    embedded_fluid_->system_matrix()->add(*coup_state->C_ss_, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(
+        *coup_state->C_ss_, false, 1.0, *(embedded_fluid_->system_matrix()), 1.0);
     std::shared_ptr<Core::LinAlg::SparseMatrix> alesysmat_sparse =
         std::dynamic_pointer_cast<Core::LinAlg::SparseMatrix>(embedded_fluid_->system_matrix());
     sysmat_block->assign(0, 0, Core::LinAlg::DataAccess::Share, *alesysmat_sparse);
@@ -528,7 +529,7 @@ void FLD::XFluidFluid::add_eos_pres_stab_to_emb_layer()
   sysmat_linalg->complete();
   embedded_fluid_->system_matrix()->un_complete();
 
-  (embedded_fluid_->system_matrix())->add(*sysmat_linalg, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*sysmat_linalg, false, 1.0, *(embedded_fluid_->system_matrix()), 1.0);
   embedded_fluid_->system_matrix()->complete();
   //------------------------------------------------------------
   // need to export residual_col to embedded fluid residual

--- a/src/fpsi/4C_fpsi_monolithic_plain.cpp
+++ b/src/fpsi/4C_fpsi_monolithic_plain.cpp
@@ -23,6 +23,7 @@
 #include "4C_io_control.hpp"
 #include "4C_linalg_utils_sparse_algebra_create.hpp"
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
+#include "4C_linalg_utils_sparse_algebra_math.hpp"
 #include "4C_linear_solver_method_linalg.hpp"
 #include "4C_poroelast_base.hpp"
 #include "4C_poroelast_monolithic.hpp"
@@ -283,10 +284,11 @@ void FPSI::MonolithicPlain::setup_system_matrix(Core::LinAlg::BlockSparseMatrixB
   p->add(fpsi_coupl()->c_pp(), false, 1.0, 1.0);
 
   // Fluid Coupling Matrix is created as BlockMatrix, to enable condensation procedure ...
-  f->add(fpsi_coupl()->c_ff().matrix(fidx_other, fidx_other), false, 1.0, 1.0);
-  f->add(fpsi_coupl()->c_ff().matrix(fidx_other, fidx_fsi), false, 1.0, 1.0);
-  f->add(fpsi_coupl()->c_ff().matrix(fidx_fsi, fidx_other), false, 1.0, 1.0);
-  f->add(fpsi_coupl()->c_ff().matrix(fidx_fsi, fidx_fsi), false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(
+      fpsi_coupl()->c_ff().matrix(fidx_other, fidx_other), false, 1.0, *f, 1.0);
+  Core::LinAlg::matrix_add(fpsi_coupl()->c_ff().matrix(fidx_other, fidx_fsi), false, 1.0, *f, 1.0);
+  Core::LinAlg::matrix_add(fpsi_coupl()->c_ff().matrix(fidx_fsi, fidx_other), false, 1.0, *f, 1.0);
+  Core::LinAlg::matrix_add(fpsi_coupl()->c_ff().matrix(fidx_fsi, fidx_fsi), false, 1.0, *f, 1.0);
 
   f->complete();
 
@@ -358,7 +360,7 @@ void FPSI::MonolithicPlain::setup_system_matrix(Core::LinAlg::BlockSparseMatrixB
 
     // As the Fluid Block Matrix is used here, the already to the f-SparseMatrix
     // added FPSI-Coupling terms have to be added again!!!
-    fgi.add(fpsi_coupl()->c_ff().matrix(fidx_fsi, fidx_other), false, 1.0,
+    Core::LinAlg::matrix_add(fpsi_coupl()->c_ff().matrix(fidx_fsi, fidx_other), false, 1.0, fgi,
         1.0);  // is missing in old implementation
     // fg_gfpsi.Add(FPSICoupl()->C_ff().Matrix(fidx_fsi,fidx_fpsi),false,1.0,1.0);  //is missing in
     // old implementation fgg.Add(FPSICoupl()->C_ff().Matrix(fidx_fsi,fidx_fsi),false,1.0,1.0);

--- a/src/fs3i/4C_fs3i.cpp
+++ b/src/fs3i/4C_fs3i.cpp
@@ -21,6 +21,7 @@
 #include "4C_inpar_fs3i.hpp"
 #include "4C_linalg_utils_sparse_algebra_assemble.hpp"
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
+#include "4C_linalg_utils_sparse_algebra_math.hpp"
 #include "4C_linear_solver_method_linalg.hpp"
 #include "4C_scatra_algorithm.hpp"
 #include "4C_scatra_timint_implicit.hpp"
@@ -690,8 +691,8 @@ void FS3I::FS3IBase::setup_coupled_scatra_matrix() const
     std::shared_ptr<Core::LinAlg::SparseMatrix> coup1 = scatracoupmat_[0];
     std::shared_ptr<Core::LinAlg::SparseMatrix> coup2 = scatracoupmat_[1];
 
-    scatrasystemmatrix_->matrix(0, 0).add(*coup1, false, 1.0, 1.0);
-    scatrasystemmatrix_->matrix(1, 1).add(*coup2, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*coup1, false, 1.0, scatrasystemmatrix_->matrix(0, 0), 1.0);
+    Core::LinAlg::matrix_add(*coup2, false, 1.0, scatrasystemmatrix_->matrix(1, 1), 1.0);
 
     // contribution of the respective other field
     // first split the matrix into 2x2 blocks (boundary vs. inner dofs)

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_fluidfluidmonolithic_structuresplit_nonox.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_fluidfluidmonolithic_structuresplit_nonox.cpp
@@ -25,6 +25,7 @@
 #include "4C_io_control.hpp"
 #include "4C_io_pstream.hpp"
 #include "4C_linalg_utils_sparse_algebra_create.hpp"
+#include "4C_linalg_utils_sparse_algebra_math.hpp"
 #include "4C_linear_solver_method_linalg.hpp"
 #include "4C_structure_aux.hpp"
 
@@ -399,8 +400,8 @@ void FSI::FluidFluidMonolithicStructureSplitNoNOX::setup_system_matrix()
     Core::LinAlg::SparseMatrix& fmgi = mmm->matrix(1, 0);
     Core::LinAlg::SparseMatrix& fmgg = mmm->matrix(1, 1);
 
-    systemmatrix_->matrix(1, 1).add(fmgg, false, 1. / timescale, 1.0);
-    systemmatrix_->matrix(1, 1).add(fmig, false, 1. / timescale, 1.0);
+    Core::LinAlg::matrix_add(fmgg, false, 1. / timescale, systemmatrix_->matrix(1, 1), 1.0);
+    Core::LinAlg::matrix_add(fmig, false, 1. / timescale, systemmatrix_->matrix(1, 1), 1.0);
 
     Core::LinAlg::SparseMatrix lfmgi(f->row_map(), 81, false);
     (*fmgitransform_)(mmm->full_row_map(), mmm->full_col_map(), fmgi, 1.,

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_monolithicfluidsplit.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_monolithicfluidsplit.cpp
@@ -659,7 +659,7 @@ void FSI::MonolithicFluidSplit::setup_system_matrix(Core::LinAlg::BlockSparseMat
     lfgi = Core::LinAlg::matrix_multiply(*stcmat, true, *lfgi, false, true, true, true);
 
   mat.matrix(0, 1).un_complete();
-  mat.matrix(0, 1).add(*lfgi, false, 1., 0.0);
+  Core::LinAlg::matrix_add(*lfgi, false, 1., mat.matrix(0, 1), 0.0);
 
   if (stcalgo == Inpar::Solid::stc_inactive)
   {
@@ -679,13 +679,13 @@ void FSI::MonolithicFluidSplit::setup_system_matrix(Core::LinAlg::BlockSparseMat
     lfig = Core::LinAlg::matrix_multiply(*lfig, false, *stcmat, false, false, false, true);
 
     mat.matrix(1, 0).un_complete();
-    mat.matrix(1, 0).add(*lfig, false, 1., 0.0);
+    Core::LinAlg::matrix_add(*lfig, false, 1., mat.matrix(1, 0), 0.0);
   }
 
-  mat.matrix(1, 1).add(fii, false, 1., 0.0);
+  Core::LinAlg::matrix_add(fii, false, 1., mat.matrix(1, 1), 0.0);
   std::shared_ptr<Core::LinAlg::SparseMatrix> eye =
       Core::LinAlg::create_identity_matrix(*fluid_field()->interface()->fsi_cond_map());
-  mat.matrix(1, 1).add(*eye, false, 1., 1.0);
+  Core::LinAlg::matrix_add(*eye, false, 1., mat.matrix(1, 1), 1.0);
 
   if (stcalgo == Inpar::Solid::stc_inactive)
   {
@@ -745,7 +745,7 @@ void FSI::MonolithicFluidSplit::setup_system_matrix(Core::LinAlg::BlockSparseMat
         lfmig = Core::LinAlg::matrix_multiply(*lfmig, false, *stcmat, false, false, false, true);
       }
 
-      mat.matrix(1, 0).add(*lfmig, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(*lfmig, false, 1.0, mat.matrix(1, 0), 1.0);
     }
 
     (*fmggtransform_)(fmgg, (1.0 - stiparam) / (1.0 - ftiparam) * scale,
@@ -770,7 +770,7 @@ void FSI::MonolithicFluidSplit::setup_system_matrix(Core::LinAlg::BlockSparseMat
         lfmgi = Core::LinAlg::matrix_multiply(*stcmat, true, *lfmgi, false, true, true, true);
 
       mat.matrix(0, 2).un_complete();
-      mat.matrix(0, 2).add(*lfmgi, false, 1., 0.0);
+      Core::LinAlg::matrix_add(*lfmgi, false, 1., mat.matrix(0, 2), 0.0);
     }
   }
 

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_monolithicstructuresplit.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_monolithicstructuresplit.cpp
@@ -22,6 +22,7 @@
 #include "4C_io.hpp"
 #include "4C_io_control.hpp"
 #include "4C_linalg_utils_sparse_algebra_create.hpp"
+#include "4C_linalg_utils_sparse_algebra_math.hpp"
 #include "4C_structure_aux.hpp"
 
 #include <Teuchos_TimeMonitor.hpp>
@@ -680,8 +681,8 @@ void FSI::MonolithicStructureSplit::setup_system_matrix(Core::LinAlg::BlockSpars
     const Core::LinAlg::SparseMatrix& fmgi = mmm->matrix(1, 0);
     const Core::LinAlg::SparseMatrix& fmgg = mmm->matrix(1, 1);
 
-    f->add(fmgg, false, 1. / timescale, 1.0);
-    f->add(fmig, false, 1. / timescale, 1.0);
+    Core::LinAlg::matrix_add(fmgg, false, 1. / timescale, *f, 1.0);
+    Core::LinAlg::matrix_add(fmig, false, 1. / timescale, *f, 1.0);
 
     Core::LinAlg::SparseMatrix lfmgi(f->row_map(), 81, false);
     (*fmgitransform_)(mmm->full_row_map(), mmm->full_col_map(), fmgi, 1.,

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_fluidsplit.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_fluidsplit.cpp
@@ -809,7 +809,8 @@ void FSI::MortarMonolithicFluidSplit::setup_system_matrix(Core::LinAlg::BlockSpa
       matrix_multiply(f->matrix(1, 1), false, *mortarp, false, false, false, true);
   fgg = matrix_multiply(*mortarp, true, *fgg, false, false, false, true);
 
-  s->add(*fgg, false, scale * timescale * (1. - stiparam) / (1. - ftiparam), 1.0);
+  Core::LinAlg::matrix_add(
+      *fgg, false, scale * timescale * (1. - stiparam) / (1. - ftiparam), *s, 1.0);
 
   // ---------Addressing contribution to block (2,3)
   std::shared_ptr<Core::LinAlg::SparseMatrix> fgi =
@@ -817,14 +818,14 @@ void FSI::MortarMonolithicFluidSplit::setup_system_matrix(Core::LinAlg::BlockSpa
   std::shared_ptr<Core::LinAlg::SparseMatrix> lfgi =
       std::make_shared<Core::LinAlg::SparseMatrix>(s->row_map(), 81, false);
 
-  lfgi->add(*fgi, false, scale, 0.0);
+  Core::LinAlg::matrix_add(*fgi, false, scale, *lfgi, 0.0);
   lfgi->complete(fgi->domain_map(), s->range_map());
 
   if (stcalgo == Inpar::Solid::stc_currsym)
     lfgi = Core::LinAlg::matrix_multiply(*stcmat, true, *lfgi, false, true, true, true);
 
   mat.matrix(0, 1).un_complete();
-  mat.matrix(0, 1).add(*lfgi, false, (1. - stiparam) / (1. - ftiparam), 0.0);
+  Core::LinAlg::matrix_add(*lfgi, false, (1. - stiparam) / (1. - ftiparam), mat.matrix(0, 1), 0.0);
 
   // ---------Addressing contribution to block (3,2)
   std::shared_ptr<Core::LinAlg::SparseMatrix> fig =
@@ -832,7 +833,7 @@ void FSI::MortarMonolithicFluidSplit::setup_system_matrix(Core::LinAlg::BlockSpa
   std::shared_ptr<Core::LinAlg::SparseMatrix> lfig =
       std::make_shared<Core::LinAlg::SparseMatrix>(fig->row_map(), 81, false);
 
-  lfig->add(*fig, false, timescale, 0.0);
+  Core::LinAlg::matrix_add(*fig, false, timescale, *lfig, 0.0);
   lfig->complete(s->domain_map(), fig->range_map());
 
   if (stcalgo != Inpar::Solid::stc_inactive)
@@ -841,14 +842,14 @@ void FSI::MortarMonolithicFluidSplit::setup_system_matrix(Core::LinAlg::BlockSpa
   }
 
   mat.matrix(1, 0).un_complete();
-  mat.matrix(1, 0).add(*lfig, false, 1., 0.0);
+  Core::LinAlg::matrix_add(*lfig, false, 1., mat.matrix(1, 0), 0.0);
 
   // ---------Addressing contribution to block (3,3)
   mat.matrix(1, 1).un_complete();
-  mat.matrix(1, 1).add(fii, false, 1., 0.0);
+  Core::LinAlg::matrix_add(fii, false, 1., mat.matrix(1, 1), 0.0);
   std::shared_ptr<Core::LinAlg::SparseMatrix> eye =
       Core::LinAlg::create_identity_matrix(*fluid_field()->interface()->fsi_cond_map());
-  mat.matrix(1, 1).add(*eye, false, 1., 1.0);
+  Core::LinAlg::matrix_add(*eye, false, 1., mat.matrix(1, 1), 1.0);
 
   // ---------Addressing contribution to block (4,2)
   std::shared_ptr<Core::LinAlg::SparseMatrix> laig =
@@ -861,7 +862,7 @@ void FSI::MortarMonolithicFluidSplit::setup_system_matrix(Core::LinAlg::BlockSpa
       matrix_multiply(*laig, false, *mortarp, false, false, false, true);
   laig = std::make_shared<Core::LinAlg::SparseMatrix>(llaig->row_map(), 81, false);
 
-  laig->add(*llaig, false, 1.0, 0.0);
+  Core::LinAlg::matrix_add(*llaig, false, 1.0, *laig, 0.0);
   laig->complete(s->domain_map(), llaig->range_map());
 
   if (stcalgo != Inpar::Solid::stc_inactive)
@@ -891,10 +892,10 @@ void FSI::MortarMonolithicFluidSplit::setup_system_matrix(Core::LinAlg::BlockSpa
     fmgg = matrix_multiply(*mortarp, true, *fmgg, false, false, false, true);
 
     Core::LinAlg::SparseMatrix lfmgg(fmgg->row_map(), 81, false);
-    lfmgg.add(*fmgg, false, 1.0, 0.0);
+    Core::LinAlg::matrix_add(*fmgg, false, 1.0, lfmgg, 0.0);
     lfmgg.complete(s->domain_map(), fmgg->range_map());
 
-    s->add(lfmgg, false, scale * (1. - stiparam) / (1. - ftiparam), 1.0);
+    Core::LinAlg::matrix_add(lfmgg, false, scale * (1. - stiparam) / (1. - ftiparam), *s, 1.0);
 
     // ---------Addressing contribution to block (3,2)
     std::shared_ptr<Core::LinAlg::SparseMatrix> fmig =
@@ -902,7 +903,7 @@ void FSI::MortarMonolithicFluidSplit::setup_system_matrix(Core::LinAlg::BlockSpa
     std::shared_ptr<Core::LinAlg::SparseMatrix> lfmig =
         std::make_shared<Core::LinAlg::SparseMatrix>(fmig->row_map(), 81, false);
 
-    lfmig->add(*fmig, false, 1.0, 0.0);
+    Core::LinAlg::matrix_add(*fmig, false, 1.0, *lfmig, 0.0);
     lfmig->complete(s->domain_map(), fmig->range_map());
 
     if (stcalgo != Inpar::Solid::stc_inactive)
@@ -910,7 +911,7 @@ void FSI::MortarMonolithicFluidSplit::setup_system_matrix(Core::LinAlg::BlockSpa
       lfmig = Core::LinAlg::matrix_multiply(*lfmig, false, *stcmat, false, false, false, true);
     }
 
-    mat.matrix(1, 0).add(*lfmig, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*lfmig, false, 1.0, mat.matrix(1, 0), 1.0);
 
     // We cannot copy the pressure value. It is not used anyway. So no exact
     // match here.
@@ -928,7 +929,7 @@ void FSI::MortarMonolithicFluidSplit::setup_system_matrix(Core::LinAlg::BlockSpa
         matrix_multiply(*mortarp, true, *lfmgi, false, false, false, true);
     lfmgi = std::make_shared<Core::LinAlg::SparseMatrix>(s->row_map(), 81, false);
 
-    lfmgi->add(*llfmgi, false, scale, 0.0);
+    Core::LinAlg::matrix_add(*llfmgi, false, scale, *lfmgi, 0.0);
     lfmgi->complete(aii.domain_map(), s->range_map());
 
     if (stcalgo == Inpar::Solid::stc_currsym)

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_structuresplit.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_structuresplit.cpp
@@ -768,7 +768,7 @@ void FSI::MortarMonolithicStructureSplit::setup_system_matrix(
       matrix_multiply(s->matrix(0, 1), false, *mortarp, false, false, false, true);
   Core::LinAlg::SparseMatrix lsig(sig->row_map(), 81, false);
 
-  lsig.add(*sig, false, 1. / timescale, 0.0);
+  Core::LinAlg::matrix_add(*sig, false, 1. / timescale, lsig, 0.0);
   lsig.complete(f->domain_map(), sig->range_map());
 
   mat.assign(0, 1, Core::LinAlg::DataAccess::Share, lsig);
@@ -778,7 +778,7 @@ void FSI::MortarMonolithicStructureSplit::setup_system_matrix(
       matrix_multiply(*mortarp, true, s->matrix(1, 0), false, false, false, true);
   Core::LinAlg::SparseMatrix lsgi(f->row_map(), 81, false);
 
-  lsgi.add(*sgi, false, (1. - ftiparam) / ((1. - stiparam) * scale), 0.0);
+  Core::LinAlg::matrix_add(*sgi, false, (1. - ftiparam) / ((1. - stiparam) * scale), lsgi, 0.0);
   lsgi.complete(sgi->domain_map(), f->range_map());
 
   mat.assign(1, 0, Core::LinAlg::DataAccess::Share, lsgi);
@@ -788,7 +788,8 @@ void FSI::MortarMonolithicStructureSplit::setup_system_matrix(
       matrix_multiply(s->matrix(1, 1), false, *mortarp, false, false, false, true);
   sgg = matrix_multiply(*mortarp, true, *sgg, false, false, false, true);
 
-  f->add(*sgg, false, (1. - ftiparam) / ((1. - stiparam) * scale * timescale), 1.0);
+  Core::LinAlg::matrix_add(
+      *sgg, false, (1. - ftiparam) / ((1. - stiparam) * scale * timescale), *f, 1.0);
   mat.assign(1, 1, Core::LinAlg::DataAccess::Share, *f);
 
   (*aigtransform_)(a->full_row_map(), a->full_col_map(), aig, 1. / timescale,
@@ -808,10 +809,10 @@ void FSI::MortarMonolithicStructureSplit::setup_system_matrix(
     const Core::LinAlg::SparseMatrix& fmgg = mmm->matrix(1, 1);
 
     // ----------Addressing contribution to block (3,3)
-    mat.matrix(1, 1).add(fmgg, false, 1. / timescale, 1.0);
+    Core::LinAlg::matrix_add(fmgg, false, 1. / timescale, mat.matrix(1, 1), 1.0);
 
     // ----------Addressing contribution to block (2,3)
-    mat.matrix(1, 1).add(fmig, false, 1. / timescale, 1.0);
+    Core::LinAlg::matrix_add(fmig, false, 1. / timescale, mat.matrix(1, 1), 1.0);
 
     const Coupling::Adapter::Coupling& coupfa = fluid_ale_coupling();
 

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_slidingmonolithic_structuresplit.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_slidingmonolithic_structuresplit.cpp
@@ -734,7 +734,7 @@ void FSI::SlidingMonolithicStructureSplit::setup_system_matrix(
       matrix_multiply(s->matrix(0, 1), false, *mortarp, false, false, false, true);
   Core::LinAlg::SparseMatrix lsig(sig->row_map(), 81, false);
 
-  lsig.add(*sig, false, 1. / timescale, 0.0);
+  Core::LinAlg::matrix_add(*sig, false, 1. / timescale, lsig, 0.0);
   lsig.complete(f->domain_map(), sig->range_map());
 
   mat.assign(0, 1, Core::LinAlg::DataAccess::Share, lsig);
@@ -744,7 +744,7 @@ void FSI::SlidingMonolithicStructureSplit::setup_system_matrix(
       matrix_multiply(*mortarp, true, s->matrix(1, 0), false, false, false, true);
   Core::LinAlg::SparseMatrix lsgi(f->row_map(), 81, false);
 
-  lsgi.add(*sgi, false, (1. - ftiparam) / ((1. - stiparam) * scale), 0.0);
+  Core::LinAlg::matrix_add(*sgi, false, (1. - ftiparam) / ((1. - stiparam) * scale), lsgi, 0.0);
   lsgi.complete(sgi->domain_map(), f->range_map());
 
   mat.assign(1, 0, Core::LinAlg::DataAccess::Share, lsgi);
@@ -754,7 +754,8 @@ void FSI::SlidingMonolithicStructureSplit::setup_system_matrix(
       matrix_multiply(s->matrix(1, 1), false, *mortarp, false, false, false, true);
   sgg = matrix_multiply(*mortarp, true, *sgg, false, false, false, true);
 
-  f->add(*sgg, false, (1. - ftiparam) / ((1. - stiparam) * scale * timescale), 1.0);
+  Core::LinAlg::matrix_add(
+      *sgg, false, (1. - ftiparam) / ((1. - stiparam) * scale * timescale), *f, 1.0);
   mat.assign(1, 1, Core::LinAlg::DataAccess::Share, *f);
 
   (*aigtransform_)(a->full_row_map(), a->full_col_map(), aig, 1. / timescale,
@@ -774,10 +775,10 @@ void FSI::SlidingMonolithicStructureSplit::setup_system_matrix(
     const Core::LinAlg::SparseMatrix& fmgg = mmm->matrix(1, 1);
 
     // ----------Addressing contribution to block (3,3)
-    mat.matrix(1, 1).add(fmgg, false, 1. / timescale, 1.0);
+    Core::LinAlg::matrix_add(fmgg, false, 1. / timescale, mat.matrix(1, 1), 1.0);
 
     // ----------Addressing contribution to block (2,3)
-    mat.matrix(1, 1).add(fmig, false, 1. / timescale, 1.0);
+    Core::LinAlg::matrix_add(fmig, false, 1. / timescale, mat.matrix(1, 1), 1.0);
 
     const Coupling::Adapter::Coupling& coupfa = fluid_ale_coupling();
 

--- a/src/fsi_xfem/4C_fsi_xfem_XFFcoupling_manager.cpp
+++ b/src/fsi_xfem/4C_fsi_xfem_XFFcoupling_manager.cpp
@@ -10,8 +10,10 @@
 #include "4C_fluid_xfluid.hpp"
 #include "4C_linalg_mapextractor.hpp"
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
+#include "4C_linalg_utils_sparse_algebra_math.hpp"
 #include "4C_xfem_condition_manager.hpp"
 #include "4C_xfem_discretization.hpp"
+
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -101,13 +103,13 @@ void XFEM::XffCouplingManager::add_coupling_matrix(
   /*----------------------------------------------------------------------*/
 
   // add the coupling block C_ss on the already existing diagonal block
-  C_ff_block.add(*xfluid_->c_ss_matrix(cond_name_), false, scaling, 1.0);
+  Core::LinAlg::matrix_add(*xfluid_->c_ss_matrix(cond_name_), false, scaling, C_ff_block, 1.0);
 
   Core::LinAlg::SparseMatrix& C_xff_block = (systemmatrix)(idx_[1], idx_[0]);
   Core::LinAlg::SparseMatrix& C_fxf_block = (systemmatrix)(idx_[0], idx_[1]);
 
-  C_fxf_block.add(*xfluid_->c_sx_matrix(cond_name_), false, scaling, 1.0);
-  C_xff_block.add(*xfluid_->c_xs_matrix(cond_name_), false, scaling, 1.0);
+  Core::LinAlg::matrix_add(*xfluid_->c_sx_matrix(cond_name_), false, scaling, C_fxf_block, 1.0);
+  Core::LinAlg::matrix_add(*xfluid_->c_xs_matrix(cond_name_), false, scaling, C_xff_block, 1.0);
 }
 
 /*-----------------------------------------------------------------------------------------*

--- a/src/fsi_xfem/4C_fsi_xfem_XFPcoupling_manager.cpp
+++ b/src/fsi_xfem/4C_fsi_xfem_XFPcoupling_manager.cpp
@@ -13,6 +13,7 @@
 #include "4C_fluid_xfluid.hpp"
 #include "4C_io.hpp"
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
+#include "4C_linalg_utils_sparse_algebra_math.hpp"
 #include "4C_poroelast_base.hpp"
 #include "4C_xfem_condition_manager.hpp"
 
@@ -142,9 +143,12 @@ void XFEM::XfpCouplingManager::add_coupling_matrix(
     Core::LinAlg::SparseMatrix& C_sf_block = (systemmatrix)(idx_[0], idx_[1]);
 
     // 1// Add Blocks f-ps(2), ps-f(3), ps-ps(4)
-    C_ss_block.add(*xfluid_->c_ss_matrix(cond_name_ps_ps_), false, scaling * scaling_disp_vel, 1.0);
-    C_sf_block.add(*xfluid_->c_sx_matrix(cond_name_ps_ps_), false, scaling, 1.0);
-    C_fs_block.add(*xfluid_->c_xs_matrix(cond_name_ps_ps_), false, scaling * scaling_disp_vel, 1.0);
+    Core::LinAlg::matrix_add(*xfluid_->c_ss_matrix(cond_name_ps_ps_), false,
+        scaling * scaling_disp_vel, C_ss_block, 1.0);
+    Core::LinAlg::matrix_add(
+        *xfluid_->c_sx_matrix(cond_name_ps_ps_), false, scaling, C_sf_block, 1.0);
+    Core::LinAlg::matrix_add(*xfluid_->c_xs_matrix(cond_name_ps_ps_), false,
+        scaling * scaling_disp_vel, C_fs_block, 1.0);
 
     // 2// Add Blocks f-pf(5), ps-pf(6)
     Core::LinAlg::SparseMatrix C_ps_pf(
@@ -156,8 +160,8 @@ void XFEM::XfpCouplingManager::add_coupling_matrix(
     insert_matrix(-1, 0, *xfluid_->c_xs_matrix(cond_name_ps_pf_), 1, C_f_pf,
         CouplingCommManager::col, 1, true, false);
     C_f_pf.complete(*get_map_extractor(1)->map(1), C_fs_block.range_map());
-    C_fs_block.add(C_f_pf, false, scaling, 1.0);
-    C_ss_block.add(C_ps_pf, false, scaling, 1.0);
+    Core::LinAlg::matrix_add(C_f_pf, false, scaling, C_fs_block, 1.0);
+    Core::LinAlg::matrix_add(C_ps_pf, false, scaling, C_ss_block, 1.0);
 
     // 3// Add Blocks pf-f(7), pf-ps(8)
     Core::LinAlg::SparseMatrix C_pf_ps(*get_map_extractor(1)->map(1), 81, false);
@@ -168,15 +172,15 @@ void XFEM::XfpCouplingManager::add_coupling_matrix(
     insert_matrix(-1, 0, *xfluid_->c_sx_matrix(cond_name_pf_ps_), 1, C_pf_f,
         CouplingCommManager::row, 1, true, false);
     C_pf_f.complete(*xfluid_->dof_row_map(), *get_map_extractor(1)->map(1));
-    C_ss_block.add(C_pf_ps, false, scaling * scaling_disp_vel * dt, 1.0);
-    C_sf_block.add(C_pf_f, false, scaling * dt, 1.0);
+    Core::LinAlg::matrix_add(C_pf_ps, false, scaling * scaling_disp_vel * dt, C_ss_block, 1.0);
+    Core::LinAlg::matrix_add(C_pf_f, false, scaling * dt, C_sf_block, 1.0);
 
     // 4// Add Block pf-pf(9)
     Core::LinAlg::SparseMatrix C_pf_pf(*get_map_extractor(1)->map(1), 81, false);
     insert_matrix(-1, 0, *xfluid_->c_ss_matrix(cond_name_pf_pf_), 1, C_pf_pf,
         CouplingCommManager::row_and_col);
     C_pf_pf.complete(*get_map_extractor(1)->map(1), *get_map_extractor(1)->map(1));
-    C_ss_block.add(C_pf_pf, false, scaling * dt, 1.0);
+    Core::LinAlg::matrix_add(C_pf_pf, false, scaling * dt, C_ss_block, 1.0);
   }
   else if (idx_.size() == 3)
   {
@@ -192,9 +196,12 @@ void XFEM::XfpCouplingManager::add_coupling_matrix(
     Core::LinAlg::SparseMatrix& C_spf_block = (systemmatrix)(idx_[0], idx_[2]);
 
     // 1// Add Blocks f-ps(2), ps-f(3), ps-ps(4)
-    C_ss_block.add(*xfluid_->c_ss_matrix(cond_name_ps_ps_), false, scaling * scaling_disp_vel, 1.0);
-    C_sf_block.add(*xfluid_->c_sx_matrix(cond_name_ps_ps_), false, scaling, 1.0);
-    C_fs_block.add(*xfluid_->c_xs_matrix(cond_name_ps_ps_), false, scaling * scaling_disp_vel, 1.0);
+    Core::LinAlg::matrix_add(*xfluid_->c_ss_matrix(cond_name_ps_ps_), false,
+        scaling * scaling_disp_vel, C_ss_block, 1.0);
+    Core::LinAlg::matrix_add(
+        *xfluid_->c_sx_matrix(cond_name_ps_ps_), false, scaling, C_sf_block, 1.0);
+    Core::LinAlg::matrix_add(*xfluid_->c_xs_matrix(cond_name_ps_ps_), false,
+        scaling * scaling_disp_vel, C_fs_block, 1.0);
 
     // 2// Add Blocks f-pf(5), ps-pf(6)
     insert_matrix(-1, 0, *xfluid_->c_ss_matrix(cond_name_ps_pf_), 1, C_spf_block,

--- a/src/fsi_xfem/4C_fsi_xfem_XFScoupling_manager.cpp
+++ b/src/fsi_xfem/4C_fsi_xfem_XFScoupling_manager.cpp
@@ -13,6 +13,7 @@
 #include "4C_global_data.hpp"
 #include "4C_io.hpp"
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
+#include "4C_linalg_utils_sparse_algebra_math.hpp"
 #include "4C_xfem_condition_manager.hpp"
 
 FOUR_C_NAMESPACE_OPEN
@@ -132,7 +133,8 @@ void XFEM::XfsCouplingManager::add_coupling_matrix(
 
   // C_ss_block scaled with 1/(theta_f*dt) * 1/(theta_FSI*dt) = 1/weight(t^f_np) *
   // 1/weight(t^FSI_np) add the coupling block C_ss on the already existing diagonal block
-  C_ss_block.add(*xfluid_->c_ss_matrix(cond_name_), false, scaling * scaling_FSI, 1.0);
+  Core::LinAlg::matrix_add(
+      *xfluid_->c_ss_matrix(cond_name_), false, scaling * scaling_FSI, C_ss_block, 1.0);
 
 
   Core::ProblemType probtype = Global::Problem::instance()->get_problem_type();
@@ -161,8 +163,9 @@ void XFEM::XfsCouplingManager::add_coupling_matrix(
     Core::LinAlg::SparseMatrix& C_fs_block = (systemmatrix)(idx_[1], idx_[0]);
     Core::LinAlg::SparseMatrix& C_sf_block = (systemmatrix)(idx_[0], idx_[1]);
 
-    C_sf_block.add(*xfluid_->c_sx_matrix(cond_name_), false, scaling, 1.0);
-    C_fs_block.add(*xfluid_->c_xs_matrix(cond_name_), false, scaling * scaling_FSI, 1.0);
+    Core::LinAlg::matrix_add(*xfluid_->c_sx_matrix(cond_name_), false, scaling, C_sf_block, 1.0);
+    Core::LinAlg::matrix_add(
+        *xfluid_->c_xs_matrix(cond_name_), false, scaling * scaling_FSI, C_fs_block, 1.0);
   }
   else
   {

--- a/src/mortar/src/4C_mortar_utils.cpp
+++ b/src/mortar/src/4C_mortar_utils.cpp
@@ -643,23 +643,31 @@ void Mortar::Utils::mortar_matrix_condensation(std::shared_ptr<Core::LinAlg::Spa
           k->row_map(), 81, true, false, k->get_matrixtype());
 
   // build new stiffness matrix
-  kteffnew->add(*knn, false, 1.0, 1.0);
-  kteffnew->add(*knm, false, 1.0, 1.0);
-  kteffnew->add(*kmn, false, 1.0, 1.0);
-  kteffnew->add(*kmm, false, 1.0, 1.0);
-  kteffnew->add(
-      *Core::LinAlg::matrix_multiply(*kns, false, *p_col, false, true, false, true), false, 1., 1.);
-  kteffnew->add(
-      *Core::LinAlg::matrix_multiply(*p_row, true, *ksn, false, true, false, true), false, 1., 1.);
-  kteffnew->add(
-      *Core::LinAlg::matrix_multiply(*kms, false, *p_col, false, true, false, true), false, 1., 1.);
-  kteffnew->add(
-      *Core::LinAlg::matrix_multiply(*p_row, true, *ksm, false, true, false, true), false, 1., 1.);
-  kteffnew->add(*Core::LinAlg::matrix_multiply(*p_row, true,
-                    *Core::LinAlg::matrix_multiply(*kss, false, *p_col, false, true, false, true),
-                    false, true, false, true),
-      false, 1., 1.);
-  if (p_row == p_col) kteffnew->add(*Core::LinAlg::create_identity_matrix(*gsrow), false, 1., 1.);
+  Core::LinAlg::matrix_add(*knn, false, 1.0, *kteffnew, 1.0);
+  Core::LinAlg::matrix_add(*knm, false, 1.0, *kteffnew, 1.0);
+  Core::LinAlg::matrix_add(*kmn, false, 1.0, *kteffnew, 1.0);
+  Core::LinAlg::matrix_add(*kmm, false, 1.0, *kteffnew, 1.0);
+  Core::LinAlg::matrix_add(
+      *Core::LinAlg::matrix_multiply(*kns, false, *p_col, false, true, false, true), false, 1.,
+      *kteffnew, 1.);
+  Core::LinAlg::matrix_add(
+      *Core::LinAlg::matrix_multiply(*p_row, true, *ksn, false, true, false, true), false, 1.,
+      *kteffnew, 1.);
+  Core::LinAlg::matrix_add(
+      *Core::LinAlg::matrix_multiply(*kms, false, *p_col, false, true, false, true), false, 1.,
+      *kteffnew, 1.);
+  Core::LinAlg::matrix_add(
+      *Core::LinAlg::matrix_multiply(*p_row, true, *ksm, false, true, false, true), false, 1.,
+      *kteffnew, 1.);
+  Core::LinAlg::matrix_add(
+      *Core::LinAlg::matrix_multiply(*p_row, true,
+          *Core::LinAlg::matrix_multiply(*kss, false, *p_col, false, true, false, true), false,
+          true, false, true),
+      false, 1., *kteffnew, 1.);
+
+  if (p_row == p_col)
+    Core::LinAlg::matrix_add(
+        *Core::LinAlg::create_identity_matrix(*gsrow), false, 1., *kteffnew, 1.);
 
   kteffnew->complete(k->domain_map(), k->range_map());
 

--- a/src/poroelast/4C_poroelast_monolithicsplit_nopenetration.cpp
+++ b/src/poroelast/4C_poroelast_monolithicsplit_nopenetration.cpp
@@ -296,10 +296,10 @@ void PoroElast::MonolithicSplitNoPenetration::setup_system_matrix(
   mat.assign(0, 0, Core::LinAlg::DataAccess::Share, *s);
 
   // structure coupling part
-  mat.matrix(0, 1).add(k_sf->matrix(sidx_other, fidx_other), false, 1.0, 0.0);
-  mat.matrix(0, 1).add(k_sf->matrix(sidx_other, fidx_nopen), false, 1.0, 1.0);
-  mat.matrix(0, 1).add(k_sf->matrix(sidx_nopen, fidx_other), false, 1.0, 1.0);
-  mat.matrix(0, 1).add(k_sf->matrix(sidx_nopen, fidx_nopen), false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(k_sf->matrix(sidx_other, fidx_other), false, 1.0, mat.matrix(0, 1), 0.0);
+  Core::LinAlg::matrix_add(k_sf->matrix(sidx_other, fidx_nopen), false, 1.0, mat.matrix(0, 1), 1.0);
+  Core::LinAlg::matrix_add(k_sf->matrix(sidx_nopen, fidx_other), false, 1.0, mat.matrix(0, 1), 1.0);
+  Core::LinAlg::matrix_add(k_sf->matrix(sidx_nopen, fidx_nopen), false, 1.0, mat.matrix(0, 1), 1.0);
   /*----------------------------------------------------------------------*/
   // pure fluid part
   // uncomplete because the fluid interface can have more connections than the
@@ -307,12 +307,12 @@ void PoroElast::MonolithicSplitNoPenetration::setup_system_matrix(
   // this just once...
   // f->UnComplete();
 
-  mat.matrix(1, 1).add(f->matrix(fidx_other, fidx_other), false, 1.0, 0.0);
-  mat.matrix(1, 1).add(f->matrix(fidx_other, fidx_nopen), false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(f->matrix(fidx_other, fidx_other), false, 1.0, mat.matrix(1, 1), 0.0);
+  Core::LinAlg::matrix_add(f->matrix(fidx_other, fidx_nopen), false, 1.0, mat.matrix(1, 1), 1.0);
 
   // fluid coupling part
-  mat.matrix(1, 0).add(k_fs->matrix(fidx_other, fidx_other), false, 1.0, 0.0);
-  mat.matrix(1, 0).add(k_fs->matrix(fidx_other, fidx_nopen), false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(k_fs->matrix(fidx_other, fidx_other), false, 1.0, mat.matrix(1, 0), 0.0);
+  Core::LinAlg::matrix_add(k_fs->matrix(fidx_other, fidx_nopen), false, 1.0, mat.matrix(1, 0), 1.0);
 
   /*----------------------------------------------------------------------*/
   /*Add lines for poro nopenetration condition*/
@@ -331,14 +331,14 @@ void PoroElast::MonolithicSplitNoPenetration::setup_system_matrix(
   std::shared_ptr<Core::LinAlg::SparseMatrix> tanginvDkfsgg = Core::LinAlg::matrix_multiply(
       *k_lambdainv_d_, false, *cfsggcur_, false, true);  // T*D^-1*K^FS_gg;
 
-  mat.matrix(1, 0).add(*tanginvDkfsgi, false, -1.0, 1.0);
-  mat.matrix(1, 0).add(*tanginvDkfsgg, false, -1.0, 1.0);
+  Core::LinAlg::matrix_add(*tanginvDkfsgi, false, -1.0, mat.matrix(1, 0), 1.0);
+  Core::LinAlg::matrix_add(*tanginvDkfsgg, false, -1.0, mat.matrix(1, 0), 1.0);
   mat.matrix(1, 0).add(*k_struct_, false, 1.0, 1.0);
-  mat.matrix(1, 0).add(k_porodisp_->matrix(1, 0), false, 1.0, 1.0);
-  mat.matrix(1, 0).add(k_porodisp_->matrix(1, 1), false, 1.0, 1.0);
-  mat.matrix(1, 1).add(*tanginvDfgi, false, -1.0, 1.0);
+  Core::LinAlg::matrix_add(k_porodisp_->matrix(1, 0), false, 1.0, mat.matrix(1, 0), 1.0);
+  Core::LinAlg::matrix_add(k_porodisp_->matrix(1, 1), false, 1.0, mat.matrix(1, 0), 1.0);
+  Core::LinAlg::matrix_add(*tanginvDfgi, false, -1.0, mat.matrix(1, 1), 1.0);
   mat.matrix(1, 1).add(*k_fluid_, false, 1.0, 1.0);
-  mat.matrix(1, 1).add(*tanginvDfgg, false, -1.0, 1.0);
+  Core::LinAlg::matrix_add(*tanginvDfgg, false, -1.0, mat.matrix(1, 1), 1.0);
   mat.matrix(1, 1).add(*k_porofluid_, false, 1.0, 1.0);
 
   /*----------------------------------------------------------------------*/

--- a/src/poroelast/4C_poroelast_monolithicstructuresplit.cpp
+++ b/src/poroelast/4C_poroelast_monolithicstructuresplit.cpp
@@ -13,6 +13,7 @@
 #include "4C_fluid_utils_mapextractor.hpp"
 #include "4C_linalg_utils_sparse_algebra_assemble.hpp"
 #include "4C_linalg_utils_sparse_algebra_create.hpp"
+#include "4C_linalg_utils_sparse_algebra_math.hpp"
 #include "4C_structure_aux.hpp"
 
 #include <Teuchos_TimeMonitor.hpp>
@@ -174,18 +175,18 @@ void PoroElast::MonolithicStructureSplit::setup_system_matrix(
 
   /*----------------------------------------------------------------------*/
   // pure structural part
-  mat.matrix(0, 0).add(s->matrix(0, 0), false, 1., 0.0);
+  Core::LinAlg::matrix_add(s->matrix(0, 0), false, 1., mat.matrix(0, 0), 0.0);
 
   // structure coupling part
-  mat.matrix(0, 1).add(k_sf->matrix(0, 0), false, 1.0, 0.0);
-  mat.matrix(0, 1).add(k_sf->matrix(0, 1), false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(k_sf->matrix(0, 0), false, 1.0, mat.matrix(0, 1), 0.0);
+  Core::LinAlg::matrix_add(k_sf->matrix(0, 1), false, 1.0, mat.matrix(0, 1), 1.0);
 
   // pure fluid part
   mat.assign(1, 1, Core::LinAlg::DataAccess::Share, *f);
 
   // fluid coupling part
-  mat.matrix(1, 0).add(k_fs->matrix(0, 0), false, 1.0, 0.0);
-  mat.matrix(1, 0).add(k_fs->matrix(1, 0), false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(k_fs->matrix(0, 0), false, 1.0, mat.matrix(1, 0), 0.0);
+  Core::LinAlg::matrix_add(k_fs->matrix(1, 0), false, 1.0, mat.matrix(1, 0), 1.0);
   /*----------------------------------------------------------------------*/
   // done. make sure all blocks are filled.
   mat.complete();

--- a/src/poroelast_scatra/4C_poroelast_scatra_monolithic.cpp
+++ b/src/poroelast_scatra/4C_poroelast_scatra_monolithic.cpp
@@ -17,6 +17,7 @@
 #include "4C_linalg_utils_sparse_algebra_assemble.hpp"
 #include "4C_linalg_utils_sparse_algebra_create.hpp"
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
+#include "4C_linalg_utils_sparse_algebra_math.hpp"
 #include "4C_linear_solver_method.hpp"
 #include "4C_linear_solver_method_linalg.hpp"
 #include "4C_poroelast_scatra_utils.hpp"
@@ -1331,7 +1332,7 @@ void PoroElastScaTra::PoroScatraMono::fd_check()
 
   Core::LinAlg::SparseMatrix stiff_approx_sparse(stiff_approx);
 
-  stiff_approx_sparse.add(sparse_copy, false, -1.0, 1.0);
+  Core::LinAlg::matrix_add(sparse_copy, false, -1.0, stiff_approx_sparse, 1.0);
 
   Core::LinAlg::SparseMatrix sparse_crs(sparse_copy);
   Core::LinAlg::SparseMatrix error_crs(stiff_approx_sparse);

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_monolithic.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_monolithic.cpp
@@ -1168,7 +1168,7 @@ void PoroPressureBased::PorofluidElastMonolithicAlgorithm::poro_fd_check()
 
   auto stiff_approx_sparse = std::make_shared<Core::LinAlg::SparseMatrix>(stiff_approx);
 
-  stiff_approx_sparse->add(sparse_copy, false, -1.0, 1.0);
+  Core::LinAlg::matrix_add(sparse_copy, false, -1.0, *stiff_approx_sparse, 1.0);
 
   Core::LinAlg::SparseMatrix sparse_crs(sparse_copy);
   std::shared_ptr<Core::LinAlg::SparseMatrix> error_crs = stiff_approx_sparse;

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_nonconforming.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_nonconforming.cpp
@@ -208,8 +208,8 @@ void PoroPressureBased::PorofluidElastScatraArteryCouplingNonConformingAlgorithm
   sysmat.matrix(1, 0).apply_dirichlet((dbcmap_artery_with_collapsed), false);
 
   // 3) add the main-diagonal terms into the global sysmat
-  sysmat.matrix(0, 0).add(sysmat_homogenized, false, 1.0, 1.0);
-  sysmat.matrix(1, 1).add(sysmat_artery, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(sysmat_homogenized, false, 1.0, sysmat.matrix(0, 0), 1.0);
+  Core::LinAlg::matrix_add(sysmat_artery, false, 1.0, sysmat.matrix(1, 1), 1.0);
   sysmat.matrix(0, 0).complete();
   sysmat.matrix(1, 1).complete();
   // and apply DBC
@@ -502,10 +502,10 @@ void PoroPressureBased::PorofluidElastScatraArteryCouplingNonConformingAlgorithm
           *coupling_matrix_, *global_extractor_, *global_extractor_);
 
   artery_block->complete();
-  sysmat->matrix(1, 0).add(artery_block->matrix(1, 0), false, 1.0, 0.0);
-  sysmat->matrix(0, 1).add(artery_block->matrix(0, 1), false, 1.0, 0.0);
-  sysmat->matrix(0, 0).add(artery_block->matrix(0, 0), false, 1.0, 0.0);
-  sysmat->matrix(1, 1).add(artery_block->matrix(1, 1), false, 1.0, 0.0);
+  Core::LinAlg::matrix_add(artery_block->matrix(1, 0), false, 1.0, sysmat->matrix(1, 0), 0.0);
+  Core::LinAlg::matrix_add(artery_block->matrix(0, 1), false, 1.0, sysmat->matrix(0, 1), 0.0);
+  Core::LinAlg::matrix_add(artery_block->matrix(0, 0), false, 1.0, sysmat->matrix(0, 0), 0.0);
+  Core::LinAlg::matrix_add(artery_block->matrix(1, 1), false, 1.0, sysmat->matrix(1, 1), 0.0);
 
   // assemble D and M contributions into global force and stiffness
   if (artery_coupling_method_ ==
@@ -621,14 +621,14 @@ void PoroPressureBased::PorofluidElastScatraArteryCouplingNonConformingAlgorithm
       *mortar_matrix_m_, true, *kappa_inv_M, false, false, false, true);
 
   // add matrices
-  sysmat.matrix(0, 0).add(
-      *M_transpose_kappa_inv_M, false, penalty_parameter_ * timefacrhs_homogenized_, 1.0);
-  sysmat.matrix(1, 1).add(
-      *D_transpose_kappa_inv_D, false, penalty_parameter_ * timefacrhs_artery_, 1.0);
-  sysmat.matrix(1, 0).add(
-      *D_transpose_kappa_inv_M, false, -penalty_parameter_ * timefacrhs_artery_, 1.0);
-  sysmat.matrix(0, 1).add(
-      *D_transpose_kappa_inv_M, true, -penalty_parameter_ * timefacrhs_homogenized_, 1.0);
+  Core::LinAlg::matrix_add(*M_transpose_kappa_inv_M, false,
+      penalty_parameter_ * timefacrhs_homogenized_, sysmat.matrix(0, 0), 1.0);
+  Core::LinAlg::matrix_add(*D_transpose_kappa_inv_D, false, penalty_parameter_ * timefacrhs_artery_,
+      sysmat.matrix(1, 1), 1.0);
+  Core::LinAlg::matrix_add(*D_transpose_kappa_inv_M, false,
+      -penalty_parameter_ * timefacrhs_artery_, sysmat.matrix(1, 0), 1.0);
+  Core::LinAlg::matrix_add(*D_transpose_kappa_inv_M, true,
+      -penalty_parameter_ * timefacrhs_homogenized_, sysmat.matrix(0, 1), 1.0);
 
   // add vector
   const auto artery_contribution =

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_monolithic.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_monolithic.cpp
@@ -1192,7 +1192,7 @@ void PoroPressureBased::PorofluidElastScatraMonolithicAlgorithm::poro_multi_phas
 
   auto stiff_approx_sparse = std::make_shared<Core::LinAlg::SparseMatrix>(stiff_approx);
 
-  stiff_approx_sparse->add(sparse_copy, false, -1.0, 1.0);
+  Core::LinAlg::matrix_add(sparse_copy, false, -1.0, *stiff_approx_sparse, 1.0);
 
   Core::LinAlg::SparseMatrix sparse_crs(sparse_copy);
   std::shared_ptr<Core::LinAlg::SparseMatrix> error_crs = stiff_approx_sparse;

--- a/src/scatra/4C_scatra_timint_elch_scl.cpp
+++ b/src/scatra/4C_scatra_timint_elch_scl.cpp
@@ -20,6 +20,7 @@
 #include "4C_linalg_utils_sparse_algebra_assemble.hpp"
 #include "4C_linalg_utils_sparse_algebra_create.hpp"
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
+#include "4C_linalg_utils_sparse_algebra_math.hpp"
 #include "4C_linear_solver_method_linalg.hpp"
 #include "4C_linear_solver_method_parameters.hpp"
 #include "4C_scatra_ele_action.hpp"
@@ -933,7 +934,7 @@ void ScaTra::ScaTraTimIntElchSCL::assemble_and_apply_mesh_tying()
       auto sparse_systemmatrix =
           Core::LinAlg::cast_to_sparse_matrix_and_check_success(system_matrix_elch_scl_);
 
-      sparse_systemmatrix->add(*system_matrix(), false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(*system_matrix(), false, 1.0, *sparse_systemmatrix, 1.0);
 
       Coupling::Adapter::CouplingSlaveConverter micro_side_converter(
           *macro_micro_coupling_adapter_);
@@ -964,7 +965,7 @@ void ScaTra::ScaTraTimIntElchSCL::assemble_and_apply_mesh_tying()
       auto block_systemmatrix =
           Core::LinAlg::cast_to_block_sparse_matrix_base_and_check_success(system_matrix_elch_scl_);
 
-      block_systemmatrix->matrix(0, 0).add(*system_matrix(), false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(*system_matrix(), false, 1.0, block_systemmatrix->matrix(0, 0), 1.0);
 
       Coupling::Adapter::CouplingSlaveConverter micro_side_converter(
           *macro_micro_coupling_adapter_);

--- a/src/scatra/4C_scatra_timint_implicit_service.cpp
+++ b/src/scatra/4C_scatra_timint_implicit_service.cpp
@@ -1390,7 +1390,7 @@ void ScaTra::ScaTraTimIntImpl::avm3_scaling(Teuchos::ParameterList& eleparams)
 
   // add the subgrid-viscosity-scaled fine-scale matrix to obtain complete matrix
   std::shared_ptr<Core::LinAlg::SparseMatrix> sysmat = system_matrix();
-  sysmat->add(*sysmat_sd_, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*sysmat_sd_, false, 1.0, *sysmat, 1.0);
 
   // set subgrid-diffusivity vector to zero after scaling procedure
   subgrdiff_->put_scalar(0.0);

--- a/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
+++ b/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
@@ -162,25 +162,26 @@ void ScaTra::MeshtyingStrategyS2I::condense_mat_and_rhs(
         {
           // replace slave-side rows of global system matrix by projected slave-side rows including
           // interface contributions
-          sparsematrix->add(*Core::LinAlg::matrix_multiply(
-                                *Q_, true, sparsematrixrowsslave, false, false, false, true),
-              false, 1., 1.);
+          Core::LinAlg::matrix_add(*Core::LinAlg::matrix_multiply(
+                                       *Q_, true, sparsematrixrowsslave, false, false, false, true),
+              false, 1., *sparsematrix, 1.);
           // during calculation of initial time derivative, standard global system matrix is
           // replaced by global mass matrix, and hence interface contributions must not be included
-          if (!calcinittimederiv) sparsematrix->add(*islavematrix_, false, 1., 1.);
+          if (!calcinittimederiv)
+            Core::LinAlg::matrix_add(*islavematrix_, false, 1., *sparsematrix, 1.);
         }
 
         // apply standard meshtying
         else
         {
-          sparsematrix->add(*D_, false, 1., 1.);
-          sparsematrix->add(*M_, false, -1., 1.);
+          Core::LinAlg::matrix_add(*D_, false, 1., *sparsematrix, 1.);
+          Core::LinAlg::matrix_add(*M_, false, -1., *sparsematrix, 1.);
         }
 
         // add projected slave-side rows to master-side rows of global system matrix
-        sparsematrix->add(*Core::LinAlg::matrix_multiply(
-                              *P_, true, sparsematrixrowsslave, false, false, false, true),
-            false, 1., 1.);
+        Core::LinAlg::matrix_add(*Core::LinAlg::matrix_multiply(
+                                     *P_, true, sparsematrixrowsslave, false, false, false, true),
+            false, 1., *sparsematrix, 1.);
 
         // extract slave-side entries of global residual vector
         std::shared_ptr<Core::LinAlg::Vector<double>> residualslave =
@@ -226,17 +227,18 @@ void ScaTra::MeshtyingStrategyS2I::condense_mat_and_rhs(
         // contributions
         sparsematrix->complete();
         sparsematrix->apply_dirichlet(*interfacemaps_->map(2), false);
-        sparsematrix->add(*Core::LinAlg::matrix_multiply(
-                              *Q_, true, sparsematrixrowsmaster, false, false, false, true),
-            false, 1., 1.);
+        Core::LinAlg::matrix_add(*Core::LinAlg::matrix_multiply(
+                                     *Q_, true, sparsematrixrowsmaster, false, false, false, true),
+            false, 1., *sparsematrix, 1.);
         // during calculation of initial time derivative, standard global system matrix is replaced
         // by global mass matrix, and hence interface contributions must not be included
-        if (!calcinittimederiv) sparsematrix->add(*imastermatrix_, false, 1., 1.);
+        if (!calcinittimederiv)
+          Core::LinAlg::matrix_add(*imastermatrix_, false, 1., *sparsematrix, 1.);
 
         // add projected master-side rows to slave-side rows of global system matrix
-        sparsematrix->add(*Core::LinAlg::matrix_multiply(
-                              *P_, true, sparsematrixrowsmaster, false, false, false, true),
-            false, 1., 1.);
+        Core::LinAlg::matrix_add(*Core::LinAlg::matrix_multiply(
+                                     *P_, true, sparsematrixrowsmaster, false, false, false, true),
+            false, 1., *sparsematrix, 1.);
 
         // extract master-side entries of global residual vector
         std::shared_ptr<Core::LinAlg::Vector<double>> residualmaster =
@@ -351,7 +353,7 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
           FOUR_C_ASSERT(systemmatrix != nullptr, "System matrix is not a sparse matrix!");
 
           // assemble linearizations of slave fluxes w.r.t. slave dofs into global system matrix
-          systemmatrix->add(*islavematrix_, false, 1., 1.);
+          Core::LinAlg::matrix_add(*islavematrix_, false, 1., *systemmatrix, 1.);
 
           if (not slaveonly_)
           {
@@ -666,8 +668,8 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
                   not imortarredistribution_
                       ? imastermatrix_
                       : Core::LinAlg::matrix_row_transform(*imastermatrix_, *imastermap_);
-              systemmatrix->add(*islavematrix, false, 1., 1.);
-              systemmatrix->add(*imastermatrix, false, 1., 1.);
+              Core::LinAlg::matrix_add(*islavematrix, false, 1., *systemmatrix, 1.);
+              Core::LinAlg::matrix_add(*imastermatrix, false, 1., *systemmatrix, 1.);
               interfacemaps_->add_vector(*islaveresidual_, 1, *scatratimint_->residual());
               interfacemaps_->add_vector(
                   Core::LinAlg::MultiVector<double>(imasterresidual_->get_ref_of_epetra_fevector()),
@@ -725,10 +727,10 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
             {
               if (lmside_ == Inpar::S2I::side_slave)
               {
-                systemmatrix->add(*islavematrix_, false, 1., 1.);
-                systemmatrix->add(*Core::LinAlg::matrix_multiply(
-                                      *P_, true, *islavematrix_, false, false, false, true),
-                    false, -1., 1.);
+                Core::LinAlg::matrix_add(*islavematrix_, false, 1., *systemmatrix, 1.);
+                Core::LinAlg::matrix_add(*Core::LinAlg::matrix_multiply(
+                                             *P_, true, *islavematrix_, false, false, false, true),
+                    false, -1., *systemmatrix, 1.);
                 interfacemaps_->add_vector(*islaveresidual_, 1, *scatratimint_->residual());
                 Core::LinAlg::Vector<double> imasterresidual(*interfacemaps_->map(2));
                 P_->multiply(true, *islaveresidual_, imasterresidual);
@@ -736,10 +738,10 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
               }
               else
               {
-                systemmatrix->add(*Core::LinAlg::matrix_multiply(
-                                      *P_, true, *imastermatrix_, false, false, false, true),
-                    false, -1., 1.);
-                systemmatrix->add(*imastermatrix_, false, 1., 1.);
+                Core::LinAlg::matrix_add(*Core::LinAlg::matrix_multiply(
+                                             *P_, true, *imastermatrix_, false, false, false, true),
+                    false, -1., *systemmatrix, 1.);
+                Core::LinAlg::matrix_add(*imastermatrix_, false, 1., *systemmatrix, 1.);
                 Core::LinAlg::Vector<double> islaveresidual(*interfacemaps_->map(1));
                 if (P_->multiply(true,
                         Core::LinAlg::MultiVector<double>(
@@ -760,7 +762,7 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
               // assemble interface contributions into global system of equations
               if (slaveonly_)
               {
-                systemmatrix->add(*islavematrix_, false, 1., 1.);
+                Core::LinAlg::matrix_add(*islavematrix_, false, 1., *systemmatrix, 1.);
                 interfacemaps_->add_vector(*islaveresidual_, 1, *scatratimint_->residual());
               }
 
@@ -1050,7 +1052,7 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
                 // assemble linearizations of slave fluxes associated with scatra-scatra interface
                 // coupling w.r.t. scatra-scatra interface layer thicknesses into global matrix
                 // block
-                scatragrowthblock->add(*islavematrix, false, 1., 0.);
+                Core::LinAlg::matrix_add(*islavematrix, false, 1., *scatragrowthblock, 0.);
 
                 // derive linearizations of master fluxes associated with scatra-scatra interface
                 // coupling w.r.t. scatra-scatra interface layer thicknesses and assemble into
@@ -1133,7 +1135,7 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
 
                 // assemble linearizations of scatra-scatra interface layer growth residuals w.r.t.
                 // slave-side scalar transport degrees of freedom into global matrix block
-                growthscatrablock->add(*islavematrix, false, 1., 0.);
+                Core::LinAlg::matrix_add(*islavematrix, false, 1., *growthscatrablock, 0.);
 
                 // derive linearizations of scatra-scatra interface layer growth residuals w.r.t.
                 // master-side scalar transport degrees of freedom and assemble into global matrix
@@ -1401,7 +1403,7 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_and_assemble_capacitive_contribution
 
       // assemble additional components of linearizations of slave fluxes due to capacitance
       // w.r.t. slave dofs into the global system matrix
-      systemmatrix->add(*islavematrix_, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(*islavematrix_, false, 1.0, *systemmatrix, 1.0);
 
       // assemble additional components of linearizations of slave fluxes due to capacitance
       // w.r.t. master dofs into the global system matrix
@@ -3727,21 +3729,21 @@ void ScaTra::MeshtyingStrategyS2I::solve(const std::shared_ptr<Core::LinAlg::Sol
           extendedsystemmatrix.assign(0, 0, Core::LinAlg::DataAccess::Share, *sparsematrix);
           if (lmside_ == Inpar::S2I::side_slave)
           {
-            extendedsystemmatrix.matrix(0, 1).add(*D_, true, 1., 0.);
-            extendedsystemmatrix.matrix(0, 1).add(*M_, true, -1., 1.);
-            extendedsystemmatrix.matrix(1, 0).add(
+            Core::LinAlg::matrix_add(*D_, true, 1., extendedsystemmatrix.matrix(0, 1), 0.);
+            Core::LinAlg::matrix_add(*M_, true, -1., extendedsystemmatrix.matrix(0, 1), 1.);
+            Core::LinAlg::matrix_add(
                 *Core::LinAlg::matrix_row_transform_gids(*islavematrix_, *extendedmaps_->map(1)),
-                false, 1., 0.);
+                false, 1., extendedsystemmatrix.matrix(1, 0), 0.);
           }
           else
           {
-            extendedsystemmatrix.matrix(0, 1).add(*M_, true, -1., 0.);
-            extendedsystemmatrix.matrix(0, 1).add(*D_, true, 1., 1.);
-            extendedsystemmatrix.matrix(1, 0).add(
+            Core::LinAlg::matrix_add(*M_, true, -1., extendedsystemmatrix.matrix(0, 1), 0.);
+            Core::LinAlg::matrix_add(*D_, true, 1., extendedsystemmatrix.matrix(0, 1), 1.);
+            Core::LinAlg::matrix_add(
                 *Core::LinAlg::matrix_row_transform_gids(*imastermatrix_, *extendedmaps_->map(1)),
-                false, 1., 0.);
+                false, 1., extendedsystemmatrix.matrix(1, 0), 0.);
           }
-          extendedsystemmatrix.matrix(1, 1).add(*E_, true, -1., 0.);
+          Core::LinAlg::matrix_add(*E_, true, -1., extendedsystemmatrix.matrix(1, 1), 0.);
           extendedsystemmatrix.complete();
           extendedsystemmatrix.matrix(0, 1).apply_dirichlet(
               *scatratimint_->dirich_maps()->cond_map(), false);

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_solver_ptc.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_solver_ptc.cpp
@@ -10,6 +10,7 @@
 #include "4C_fem_geometry_intersection_math.hpp"
 #include "4C_linalg_sparsematrix.hpp"
 #include "4C_linalg_utils_sparse_algebra_create.hpp"
+#include "4C_linalg_utils_sparse_algebra_math.hpp"
 #include "4C_linalg_vector.hpp"
 #include "4C_solver_nonlin_nox_aux.hpp"
 #include "4C_solver_nonlin_nox_direction_factory.hpp"
@@ -854,7 +855,7 @@ void NOX::Nln::LinSystem::PrePostOp::PseudoTransient::modify_jacobian(
        *        (\delta^{-1} \boldsymbol{V} + \boldsymbol{J}) */
 
       scaling_matrix_op_ptr_->complete();
-      jac.add(*scaling_matrix_op_ptr_, false, scaleFactor * deltaInv, 1.0);
+      Core::LinAlg::matrix_add(*scaling_matrix_op_ptr_, false, scaleFactor * deltaInv, jac, 1.0);
       jac.complete();
 
       break;

--- a/src/ssi/4C_ssi_contact_strategy.cpp
+++ b/src/ssi/4C_ssi_contact_strategy.cpp
@@ -10,6 +10,7 @@
 #include "4C_contact_nitsche_strategy_ssi.hpp"
 #include "4C_linalg_blocksparsematrix.hpp"
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
+#include "4C_linalg_utils_sparse_algebra_math.hpp"
 #include "4C_ssi_utils.hpp"
 
 FOUR_C_NAMESPACE_OPEN
@@ -61,7 +62,8 @@ void SSI::ContactStrategySparse::apply_contact_to_scatra_scatra(
   const auto& scatra_scatra_sparsematrix =
       nitsche_strategy_ssi()->get_matrix_block_ptr(CONTACT::MatBlockType::scatra_scatra);
 
-  scatra_scatra_matrix_sparse->add(*scatra_scatra_sparsematrix, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(
+      *scatra_scatra_sparsematrix, false, 1.0, *scatra_scatra_matrix_sparse, 1.0);
 }
 
 /*-------------------------------------------------------------------------*
@@ -95,7 +97,7 @@ void SSI::ContactStrategySparse::apply_contact_to_scatra_structure(
   const auto& scatra_struct_matrix =
       nitsche_strategy_ssi()->get_matrix_block_ptr(CONTACT::MatBlockType::scatra_displ);
 
-  scatra_structure_matrix_sparse->add(*scatra_struct_matrix, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*scatra_struct_matrix, false, 1.0, *scatra_structure_matrix_sparse, 1.0);
 }
 
 /*-------------------------------------------------------------------------*
@@ -130,7 +132,7 @@ void SSI::ContactStrategySparse::apply_contact_to_structure_scatra(
   const auto& struct_scatra_matrix =
       nitsche_strategy_ssi()->get_matrix_block_ptr(CONTACT::MatBlockType::displ_scatra);
 
-  structure_scatra_matrix_sparse->add(*struct_scatra_matrix, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*struct_scatra_matrix, false, 1.0, *structure_scatra_matrix_sparse, 1.0);
 }
 
 /*-------------------------------------------------------------------------*

--- a/src/ssi/4C_ssi_manifold_utils.cpp
+++ b/src/ssi/4C_ssi_manifold_utils.cpp
@@ -18,6 +18,7 @@
 #include "4C_io_runtime_csv_writer.hpp"
 #include "4C_linalg_utils_sparse_algebra_create.hpp"
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
+#include "4C_linalg_utils_sparse_algebra_math.hpp"
 #include "4C_scatra_ele_action.hpp"
 #include "4C_scatra_ele_parameter_boundary.hpp"
 #include "4C_scatra_timint_implicit.hpp"
@@ -470,8 +471,8 @@ void SSI::ScaTraManifoldScaTraFluxEvaluator::evaluate_bulk_side(
           *full_map_structure_, *full_map_scatra_);
 
       // Add slave side disp. contributions
-      matrix_scatra_structure_cond_->add(
-          matrix_scatra_structure_cond_slave_side_disp, false, 1.0, 0.0);
+      Core::LinAlg::matrix_add(matrix_scatra_structure_cond_slave_side_disp, false, 1.0,
+          *matrix_scatra_structure_cond_, 0.0);
 
       // Add master side disp. contributions
       for (const auto& meshtying : ssi_structure_meshtying_->mesh_tying_handlers())
@@ -1253,7 +1254,8 @@ void SSI::ManifoldMeshTyingStrategySparse::apply_meshtying_to_manifold_structure
   if (do_uncomplete) ssi_manifold_structure_sparse->un_complete();
   temp_manifold_structure->complete(
       *ssi_maps_->structure_dof_row_map(), *ssi_maps_->scatra_manifold_dof_row_map());
-  ssi_manifold_structure_sparse->add(*temp_manifold_structure, false, 1.0, 0.0);
+  Core::LinAlg::matrix_add(
+      *temp_manifold_structure, false, 1.0, *ssi_manifold_structure_sparse, 0.0);
 }
 
 /*----------------------------------------------------------------------*

--- a/src/ssi/4C_ssi_monolithic_meshtying_strategy.cpp
+++ b/src/ssi/4C_ssi_monolithic_meshtying_strategy.cpp
@@ -13,6 +13,7 @@
 #include "4C_linalg_blocksparsematrix.hpp"
 #include "4C_linalg_map.hpp"
 #include "4C_linalg_utils_sparse_algebra_create.hpp"
+#include "4C_linalg_utils_sparse_algebra_math.hpp"
 #include "4C_scatra_timint_meshtying_strategy_s2i.hpp"
 #include "4C_ssi_monolithic.hpp"
 #include "4C_ssi_utils.hpp"
@@ -236,7 +237,8 @@ void SSI::MeshtyingStrategySparse::apply_meshtying_to_scatra_manifold_structure(
       *ssi_maps.structure_dof_row_map(), *ssi_maps.scatra_manifold_dof_row_map());
 
   if (do_uncomplete) manifold_structure_sparse_matrix->un_complete();
-  manifold_structure_sparse_matrix->add(*temp_scatramanifold_struct_sparse_matrix, false, 1.0, 0.0);
+  Core::LinAlg::matrix_add(*temp_scatramanifold_struct_sparse_matrix, false, 1.0,
+      *manifold_structure_sparse_matrix, 0.0);
 }
 
 /*-------------------------------------------------------------------------*
@@ -286,7 +288,8 @@ void SSI::MeshtyingStrategySparse::apply_meshtying_to_scatra_structure(
       *ssi_maps.structure_dof_row_map(), *ssi_maps.scatra_dof_row_map());
 
   if (do_uncomplete) scatra_structure_matrix_sparse->un_complete();
-  scatra_structure_matrix_sparse->add(*temp_scatra_struct_domain_sparse_matrix, false, 1.0, 0.0);
+  Core::LinAlg::matrix_add(
+      *temp_scatra_struct_domain_sparse_matrix, false, 1.0, *scatra_structure_matrix_sparse, 0.0);
 }
 
 /*-------------------------------------------------------------------------*
@@ -337,7 +340,8 @@ void SSI::MeshtyingStrategySparse::apply_meshtying_to_structure_scatra(
       *ssi_maps.scatra_dof_row_map(), *ssi_maps.structure_dof_row_map());
 
   if (do_uncomplete) struct_scatra_sparse_matrix->un_complete();
-  struct_scatra_sparse_matrix->add(*temp_struct_scatra_sparse_matrix, false, 1.0, 0.0);
+  Core::LinAlg::matrix_add(
+      *temp_struct_scatra_sparse_matrix, false, 1.0, *struct_scatra_sparse_matrix, 0.0);
 }
 
 /*-------------------------------------------------------------------------*

--- a/src/ssti/4C_ssti_monolithic_assemble_strategy.cpp
+++ b/src/ssti/4C_ssti_monolithic_assemble_strategy.cpp
@@ -82,8 +82,8 @@ void SSTI::AssembleStrategyBlockBlock::assemble_scatra(
       auto& systemmatrix_block_iscatra_jscatra = systemmatrix_block->matrix(
           block_position_scatra().at(iblock), block_position_scatra().at(jblock));
 
-      systemmatrix_block_iscatra_jscatra.add(
-          scatradomain_block->matrix(iblock, jblock), false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(scatradomain_block->matrix(iblock, jblock), false, 1.0,
+          systemmatrix_block_iscatra_jscatra, 1.0);
     }
   }
 }
@@ -102,7 +102,7 @@ void SSTI::AssembleStrategyBlockSparse::assemble_scatra(
   auto& systemmatrix_block_scatra_scatra =
       systemmatrix_block->matrix(block_position_scatra().at(0), block_position_scatra().at(0));
 
-  systemmatrix_block_scatra_scatra.add(*scatradomain_sparse, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*scatradomain_sparse, false, 1.0, systemmatrix_block_scatra_scatra, 1.0);
 }
 
 /*----------------------------------------------------------------------*
@@ -116,7 +116,7 @@ void SSTI::AssembleStrategySparse::assemble_scatra(
       Core::LinAlg::cast_to_const_sparse_matrix_and_check_success(scatradomain);
 
   // add scalar transport system matrix to global system matrix
-  systemmatrix_sparse->add(*scatradomain_sparse, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*scatradomain_sparse, false, 1.0, *systemmatrix_sparse, 1.0);
 }
 
 /*----------------------------------------------------------------------*
@@ -139,7 +139,7 @@ void SSTI::AssembleStrategyBlockBlock::assemble_structure(
     auto& systemmatrix_block_struct_struct =
         systemmatrix_block->matrix(position_structure(), position_structure());
 
-    systemmatrix_block_struct_struct.add(*structuredomain, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*structuredomain, false, 1.0, systemmatrix_block_struct_struct, 1.0);
   }
 }
 
@@ -163,7 +163,7 @@ void SSTI::AssembleStrategyBlockSparse::assemble_structure(
     auto& systemmatrix_block_struct_struct =
         systemmatrix_block->matrix(position_structure(), position_structure());
 
-    systemmatrix_block_struct_struct.add(*structuredomain, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*structuredomain, false, 1.0, systemmatrix_block_struct_struct, 1.0);
   }
 }
 
@@ -179,7 +179,7 @@ void SSTI::AssembleStrategySparse::assemble_structure(
   if (interface_meshtying())
     assemble_structure_meshtying(*systemmatrix_sparse, structuredomain);
   else
-    systemmatrix_sparse->add(*structuredomain, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*structuredomain, false, 1.0, *systemmatrix_sparse, 1.0);
 }
 
 /*----------------------------------------------------------------------*
@@ -282,8 +282,8 @@ void SSTI::AssembleStrategyBlockBlock::assemble_thermo(
       auto& systemmatrix_block_ithermo_jthermo = systemmatrix_block->matrix(
           block_position_thermo().at(iblock), block_position_thermo().at(jblock));
 
-      systemmatrix_block_ithermo_jthermo.add(
-          thermodomain_block->matrix(iblock, jblock), false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(thermodomain_block->matrix(iblock, jblock), false, 1.0,
+          systemmatrix_block_ithermo_jthermo, 1.0);
     }
   }
 }
@@ -302,7 +302,7 @@ void SSTI::AssembleStrategyBlockSparse::assemble_thermo(
   auto& systemmatrix_block_thermo_thermo =
       systemmatrix_block->matrix(block_position_thermo().at(0), block_position_thermo().at(0));
 
-  systemmatrix_block_thermo_thermo.add(*thermodomain_sparse, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*thermodomain_sparse, false, 1.0, systemmatrix_block_thermo_thermo, 1.0);
 }
 
 /*----------------------------------------------------------------------*
@@ -316,7 +316,7 @@ void SSTI::AssembleStrategySparse::assemble_thermo(
       Core::LinAlg::cast_to_const_sparse_matrix_and_check_success(thermodomain);
 
   // add scalar transport system matrix to global system matrix
-  systemmatrix_sparse->add(*thermodomain_sparse, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*thermodomain_sparse, false, 1.0, *systemmatrix_sparse, 1.0);
 }
 
 /*----------------------------------------------------------------------*
@@ -356,7 +356,8 @@ void SSTI::AssembleStrategyBlockBlock::assemble_scatra_structure(
       auto& systemmatrix_block_iscatra_struct =
           systemmatrix_block->matrix(block_position_scatra().at(iblock), position_structure());
 
-      systemmatrix_block_iscatra_struct.add(scatrastructuredomain_subblock, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(
+          scatrastructuredomain_subblock, false, 1.0, systemmatrix_block_iscatra_struct, 1.0);
     }
   }
 }
@@ -393,7 +394,8 @@ void SSTI::AssembleStrategyBlockSparse::assemble_scatra_structure(
     auto& systemmatrix_block_scatra_struct =
         systemmatrix_block->matrix(block_position_scatra().at(0), position_structure());
 
-    systemmatrix_block_scatra_struct.add(*scatrastructuredomain_sparse, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(
+        *scatrastructuredomain_sparse, false, 1.0, systemmatrix_block_scatra_struct, 1.0);
   }
 }
 
@@ -420,7 +422,7 @@ void SSTI::AssembleStrategySparse::assemble_scatra_structure(
   }
 
   else
-    systemmatrix_sparse->add(*scatrastructuredomain_sparse, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*scatrastructuredomain_sparse, false, 1.0, *systemmatrix_sparse, 1.0);
 }
 
 /*----------------------------------------------------------------------*
@@ -474,7 +476,7 @@ void SSTI::AssembleStrategyBlockBlock::assemble_scatra_thermo_domain(
       auto systemmatrix_subblock = systemmatrix_block->matrix(
           block_position_scatra().at(iblock), block_position_thermo().at(jblock));
       systemmatrix_subblock.un_complete();
-      systemmatrix_subblock.add(scatrathermodomain_subblock, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(scatrathermodomain_subblock, false, 1.0, systemmatrix_subblock, 1.0);
     }
   }
 }
@@ -492,7 +494,7 @@ void SSTI::AssembleStrategyBlockSparse::assemble_scatra_thermo_domain(
       Core::LinAlg::cast_to_sparse_matrix_and_check_success(scatrathermodomain);
 
   systemmatrix_subblock.un_complete();
-  systemmatrix_subblock.add(*scatrathermodomain_sparse, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*scatrathermodomain_sparse, false, 1.0, systemmatrix_subblock, 1.0);
 }
 
 /*----------------------------------------------------------------------*
@@ -506,7 +508,7 @@ void SSTI::AssembleStrategySparse::assemble_scatra_thermo_domain(
       Core::LinAlg::cast_to_sparse_matrix_and_check_success(scatrathermodomain);
 
   // add scalar transport-thermo matrix into global system matrix
-  systemmatrix_sparse->add(*scatrathermodomain_sparse, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*scatrathermodomain_sparse, false, 1.0, *systemmatrix_sparse, 1.0);
 }
 
 /*----------------------------------------------------------------------*
@@ -533,7 +535,8 @@ void SSTI::AssembleStrategyBlockBlock::assemble_scatra_thermo_interface(
       // into system matrix
       auto& systemmatrix_block_iscatra_jthermo =
           systemmatrix_block->matrix(block_position_scatra().at(i), block_position_thermo().at(j));
-      systemmatrix_block_iscatra_jthermo.add(scatrathermointerface_subblock, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(
+          scatrathermointerface_subblock, false, 1.0, systemmatrix_block_iscatra_jthermo, 1.0);
 
       // assemble linearizations of slave- and master side scatra fluxes w.r.t. master temperatures
       // into system matrix
@@ -564,7 +567,8 @@ void SSTI::AssembleStrategyBlockBlock::assemble_scatra_thermo_interface(
       // into system matrix
       auto& systemmatrix_block_iscatra_jthermo =
           systemmatrix_block->matrix(block_position_scatra().at(i), block_position_thermo().at(j));
-      systemmatrix_block_iscatra_jthermo.add(blockmasterderiv->matrix(i, j), false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(
+          blockmasterderiv->matrix(i, j), false, 1.0, systemmatrix_block_iscatra_jthermo, 1.0);
     }
   }
 }
@@ -584,7 +588,8 @@ void SSTI::AssembleStrategyBlockSparse::assemble_scatra_thermo_interface(
   // system matrix
   auto& systemmatrix_block_scatra_thermo =
       systemmatrix_block->matrix(block_position_scatra().at(0), block_position_thermo().at(0));
-  systemmatrix_block_scatra_thermo.add(*scatrathermointerface_sparse, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(
+      *scatrathermointerface_sparse, false, 1.0, systemmatrix_block_scatra_thermo, 1.0);
 
   // assemble linearizations of slave- and master side scatra fluxes w.r.t. master temperatures into
   // system matrix
@@ -610,7 +615,7 @@ void SSTI::AssembleStrategySparse::assemble_scatra_thermo_interface(
 
   // assemble linearizations of slave- and master side scatra fluxes w.r.t. slave temperatures into
   // system matrix
-  systemmatrix_sparse->add(*scatrathermointerface_sparse, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*scatrathermointerface_sparse, false, 1.0, *systemmatrix_sparse, 1.0);
 
   // assemble linearizations of slave- and master side scatra fluxes w.r.t. master temperatures into
   // system matrix
@@ -651,7 +656,8 @@ void SSTI::AssembleStrategyBlockBlock::assemble_structure_scatra(
       auto& systemmatrix_block_struct_iscatra =
           systemmatrix_block->matrix(position_structure(), block_position_scatra().at(iblock));
 
-      systemmatrix_block_struct_iscatra.add(structurescatradomain_subblock, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(
+          structurescatradomain_subblock, false, 1.0, systemmatrix_block_struct_iscatra, 1.0);
     }
   }
 }
@@ -679,7 +685,8 @@ void SSTI::AssembleStrategyBlockSparse::assemble_structure_scatra(
     auto& systemmatrix_block_struct_scatra =
         systemmatrix_block->matrix(position_structure(), block_position_scatra().at(0));
 
-    systemmatrix_block_struct_scatra.add(*structurescatradomain_sparse, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(
+        *structurescatradomain_sparse, false, 1.0, systemmatrix_block_struct_scatra, 1.0);
   }
 }
 
@@ -697,7 +704,7 @@ void SSTI::AssembleStrategySparse::assemble_structure_scatra(
   if (interface_meshtying())
     assemble_structure_xxx_meshtying(*systemmatrix_sparse, *structurescatradomain_sparse);
   else
-    systemmatrix_sparse->add(*structurescatradomain_sparse, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*structurescatradomain_sparse, false, 1.0, *systemmatrix_sparse, 1.0);
 }
 
 
@@ -751,8 +758,8 @@ void SSTI::AssembleStrategyBlockBlock::assemble_thermo_scatra(
       auto systemmatrix_block_ithermo_jscatra = systemmatrix_block->matrix(
           block_position_thermo().at(iblock), block_position_scatra().at(jblock));
       systemmatrix_block_ithermo_jscatra.un_complete();
-      systemmatrix_block_ithermo_jscatra.add(
-          thermoscatradomain_block->matrix(iblock, jblock), false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(thermoscatradomain_block->matrix(iblock, jblock), false, 1.0,
+          systemmatrix_block_ithermo_jscatra, 1.0);
     }
   }
 
@@ -774,7 +781,8 @@ void SSTI::AssembleStrategyBlockSparse::assemble_thermo_scatra(
   auto& systemmatrix_block_thermo_scatra =
       systemmatrix_block->matrix(block_position_thermo().at(0), block_position_scatra().at(0));
   systemmatrix_block_thermo_scatra.un_complete();
-  systemmatrix_block_thermo_scatra.add(*thermoscatradomain_sparse, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(
+      *thermoscatradomain_sparse, false, 1.0, systemmatrix_block_thermo_scatra, 1.0);
 
   if (interface_meshtying()) assemble_thermo_scatra_interface(systemmatrix, thermoscatrainterface);
 }
@@ -791,7 +799,7 @@ void SSTI::AssembleStrategySparse::assemble_thermo_scatra(
       Core::LinAlg::cast_to_const_sparse_matrix_and_check_success(thermoscatradomain);
 
   // add scalar transport system matrix to global system matrix
-  systemmatrix_sparse->add(*thermoscatradomain_sparse, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*thermoscatradomain_sparse, false, 1.0, *systemmatrix_sparse, 1.0);
 
   if (interface_meshtying()) assemble_thermo_scatra_interface(systemmatrix, thermoscatrainterface);
 }
@@ -821,7 +829,8 @@ void SSTI::AssembleStrategyBlockBlock::assemble_thermo_scatra_interface(
       // into system matrix
       auto& systemmatrix_block_ithermo_jscatra =
           systemmatrix_block->matrix(block_position_thermo().at(i), block_position_scatra().at(j));
-      systemmatrix_block_ithermo_jscatra.add(thermoscatrainterface_subblock, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(
+          thermoscatrainterface_subblock, false, 1.0, systemmatrix_block_ithermo_jscatra, 1.0);
 
       // assemble linearizations of master side thermo fluxes w.r.t. slave and master side elch
       // into system matrix
@@ -861,7 +870,8 @@ void SSTI::AssembleStrategyBlockBlock::assemble_thermo_scatra_interface(
       auto& systemmatrix_block_ithermo_jscatra =
           systemmatrix_block->matrix(block_position_thermo().at(i), block_position_scatra().at(j));
 
-      systemmatrix_block_ithermo_jscatra.add(blockmasterflux->matrix(i, j), false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(
+          blockmasterflux->matrix(i, j), false, 1.0, systemmatrix_block_ithermo_jscatra, 1.0);
     }
   }
 }
@@ -882,7 +892,8 @@ void SSTI::AssembleStrategyBlockSparse::assemble_thermo_scatra_interface(
   // into system matrix
   auto& systemmatrix_block_thermo_scatra =
       systemmatrix_block->matrix(block_position_thermo().at(0), block_position_scatra().at(0));
-  systemmatrix_block_thermo_scatra.add(*thermoscatrainterface_sparse, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(
+      *thermoscatrainterface_sparse, false, 1.0, systemmatrix_block_thermo_scatra, 1.0);
 
   // assemble linearizations of master side thermo fluxes w.r.t. slave and master side elch
   // into system matrix
@@ -909,7 +920,7 @@ void SSTI::AssembleStrategySparse::assemble_thermo_scatra_interface(
 
   // assemble linearizations of slave side scatra fluxes w.r.t. slave and master side elch
   // into system matrix
-  systemmatrix_sparse->add(*thermoscatrainterface_sparse, false, 1.0, 1.0);
+  Core::LinAlg::matrix_add(*thermoscatrainterface_sparse, false, 1.0, *systemmatrix_sparse, 1.0);
 
   // assemble linearizations of master side scatra fluxes w.r.t. slave and master side elch
   // into system matrix
@@ -959,7 +970,8 @@ void SSTI::AssembleStrategyBlockBlock::assemble_thermo_structure(
       auto& systemmatrix_block_ithermo_struct =
           systemmatrix_block->matrix(block_position_thermo().at(iblock), position_structure());
 
-      systemmatrix_block_ithermo_struct.add(thermostructuredomain_subblock, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(
+          thermostructuredomain_subblock, false, 1.0, systemmatrix_block_ithermo_struct, 1.0);
     }
   }
 }
@@ -995,7 +1007,8 @@ void SSTI::AssembleStrategyBlockSparse::assemble_thermo_structure(
     auto& sytemmatrix_block_thermo_structure =
         systemmatrix_block->matrix(block_position_thermo().at(0), position_structure());
 
-    sytemmatrix_block_thermo_structure.add(*thermostructuredomain_sparse, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(
+        *thermostructuredomain_sparse, false, 1.0, sytemmatrix_block_thermo_structure, 1.0);
   }
 }
 
@@ -1020,7 +1033,7 @@ void SSTI::AssembleStrategySparse::assemble_thermo_structure(
     assemble_xxx_structure_meshtying(*systemmatrix_sparse, *thermostructureinterface_sparse);
   }
   else
-    systemmatrix_sparse->add(*thermostructuredomain_sparse, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*thermostructuredomain_sparse, false, 1.0, *systemmatrix_sparse, 1.0);
 }
 
 /*----------------------------------------------------------------------*
@@ -1051,7 +1064,8 @@ void SSTI::AssembleStrategyBlockBlock::assemble_structure_thermo(
       auto& systemmatrix_block_struct_ithermo =
           systemmatrix_block->matrix(position_structure(), block_position_thermo().at(iblock));
 
-      systemmatrix_block_struct_ithermo.add(structurethermodomain_subblock, false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(
+          structurethermodomain_subblock, false, 1.0, systemmatrix_block_struct_ithermo, 1.0);
     }
   }
 }
@@ -1079,7 +1093,8 @@ void SSTI::AssembleStrategyBlockSparse::assemble_structure_thermo(
     auto& systemmatrix_block_struct_thermo =
         systemmatrix_block->matrix(position_structure(), block_position_thermo().at(0));
 
-    systemmatrix_block_struct_thermo.add(*structurethermodomain_sparse, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(
+        *structurethermodomain_sparse, false, 1.0, systemmatrix_block_struct_thermo, 1.0);
   }
 }
 
@@ -1097,7 +1112,7 @@ void SSTI::AssembleStrategySparse::assemble_structure_thermo(
   if (interface_meshtying())
     assemble_structure_xxx_meshtying(*systemmatrix_sparse, *structurethermodomain_sparse);
   else
-    systemmatrix_sparse->add(*structurethermodomain_sparse, false, 1.0, 1.0);
+    Core::LinAlg::matrix_add(*structurethermodomain_sparse, false, 1.0, *systemmatrix_sparse, 1.0);
 }
 
 /*----------------------------------------------------------------------*

--- a/src/sti/4C_sti_monolithic.cpp
+++ b/src/sti/4C_sti_monolithic.cpp
@@ -834,10 +834,9 @@ void STI::Monolithic::assemble_mat_and_rhs()
 
                   // transform and assemble temporary matrix for slave-side columns of current
                   // matrix block
-                  blocksystemmatrix->matrix(iblock, nblockmapsscatra)
-                      .add(*Core::LinAlg::matrix_multiply(
-                               scatrathermocolsslave, false, *strategythermo_->p(), false, true),
-                          false, 1.0, 1.0);
+                  Core::LinAlg::matrix_add(*Core::LinAlg::matrix_multiply(scatrathermocolsslave,
+                                               false, *strategythermo_->p(), false, true),
+                      false, 1.0, blocksystemmatrix->matrix(iblock, nblockmapsscatra), 1.0);
 
                   break;
                 }
@@ -907,10 +906,9 @@ void STI::Monolithic::assemble_mat_and_rhs()
 
                 // transform and assemble temporary matrix for slave-side columns of thermo-thermo
                 // matrix block
-                blocksystemmatrix->matrix(nblockmapsscatra, nblockmapsscatra)
-                    .add(*Core::LinAlg::matrix_multiply(
-                             thermothermocolsslave, false, *strategythermo_->p(), false, true),
-                        false, 1.0, 1.0);
+                Core::LinAlg::matrix_add(*Core::LinAlg::matrix_multiply(thermothermocolsslave,
+                                             false, *strategythermo_->p(), false, true),
+                    false, 1.0, blocksystemmatrix->matrix(nblockmapsscatra, nblockmapsscatra), 1.0);
                 break;
               }
               default:
@@ -991,10 +989,9 @@ void STI::Monolithic::assemble_mat_and_rhs()
 
                 // transform and assemble temporary matrix for slave-side columns of scatra-thermo
                 // matrix block
-                blocksystemmatrix->matrix(0, 1).add(
-                    *Core::LinAlg::matrix_multiply(
-                        scatrathermocolsslave, false, *strategythermo_->p(), false, true),
-                    false, 1.0, 1.0);
+                Core::LinAlg::matrix_add(*Core::LinAlg::matrix_multiply(scatrathermocolsslave,
+                                             false, *strategythermo_->p(), false, true),
+                    false, 1.0, blocksystemmatrix->matrix(0, 1), 1.0);
 
                 // initialize temporary matrix for slave-side columns of thermo-thermo matrix block
                 Core::LinAlg::SparseMatrix thermothermocolsslave(*maps_->map(1), 81);
@@ -1011,10 +1008,9 @@ void STI::Monolithic::assemble_mat_and_rhs()
 
                 // transform and assemble temporary matrix for slave-side columns of thermo-thermo
                 // matrix block
-                blocksystemmatrix->matrix(1, 1).add(
-                    *Core::LinAlg::matrix_multiply(
-                        thermothermocolsslave, false, *strategythermo_->p(), false, true),
-                    false, 1.0, 1.0);
+                Core::LinAlg::matrix_add(*Core::LinAlg::matrix_multiply(thermothermocolsslave,
+                                             false, *strategythermo_->p(), false, true),
+                    false, 1.0, blocksystemmatrix->matrix(1, 1), 1.0);
                 break;
               }
 
@@ -1063,7 +1059,7 @@ void STI::Monolithic::assemble_mat_and_rhs()
       if (systemmatrix == nullptr) FOUR_C_THROW("System matrix is not a sparse matrix!");
 
       // construct global system matrix by adding matrix blocks
-      systemmatrix->add(*scatra_field()->system_matrix(), false, 1.0, 0.0);
+      Core::LinAlg::matrix_add(*scatra_field()->system_matrix(), false, 1.0, *systemmatrix, 0.0);
 
       // perform second condensation before adding matrix blocks
       if (condensationthermo_)
@@ -1120,9 +1116,9 @@ void STI::Monolithic::assemble_mat_and_rhs()
 
             // transform and assemble temporary matrix for slave-side columns of global system
             // matrix
-            systemmatrix->add(*Core::LinAlg::matrix_multiply(
-                                  systemmatrixcolsslave, false, *strategythermo_->p(), false, true),
-                false, 1.0, 1.0);
+            Core::LinAlg::matrix_add(*Core::LinAlg::matrix_multiply(systemmatrixcolsslave, false,
+                                         *strategythermo_->p(), false, true),
+                false, 1.0, *systemmatrix, 1.0);
             break;
           }
 
@@ -1139,7 +1135,7 @@ void STI::Monolithic::assemble_mat_and_rhs()
       {
         systemmatrix->add(*scatrathermo_domain_interface, false, 1.0, 1.0);
         systemmatrix->add(*thermoscatra_domain_interface, false, 1.0, 1.0);
-        systemmatrix->add(*thermo_field()->system_matrix(), false, 1.0, 1.0);
+        Core::LinAlg::matrix_add(*thermo_field()->system_matrix(), false, 1.0, *systemmatrix, 1.0);
       }
       break;
     }
@@ -1725,9 +1721,9 @@ void STI::Monolithic::assemble_domain_interface_off_diag(
 
       // add projected slave-side rows of thermo-scatra matrix block to corresponding
       // master-side rows
-      thermoscatrablock.add(*Core::LinAlg::matrix_multiply(*strategythermo_->p(), true,
-                                thermoscatrarowsslave, false, false, false, true),
-          false, 1.0, 1.0);
+      Core::LinAlg::matrix_add(*Core::LinAlg::matrix_multiply(*strategythermo_->p(), true,
+                                   thermoscatrarowsslave, false, false, false, true),
+          false, 1.0, thermoscatrablock, 1.0);
     }
   }
 

--- a/src/structure/4C_structure_timint.cpp
+++ b/src/structure/4C_structure_timint.cpp
@@ -1282,8 +1282,8 @@ void Solid::TimInt::update_step_contact_vum()
         M = Mmat;
         D = Dmat;
       }
-      Bc.add(*M, true, -1.0, 1.0);
-      Bc.add(*D, true, 1.0, 1.0);
+      Core::LinAlg::matrix_add(*M, true, -1.0, Bc, 1.0);
+      Core::LinAlg::matrix_add(*D, true, 1.0, Bc, 1.0);
       Bc.complete(slavedofmap, *dofmap);
       Bc.apply_dirichlet(*(dbcmaps_->cond_map()), false);
 

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_contact.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_contact.cpp
@@ -13,6 +13,7 @@
 #include "4C_io.hpp"
 #include "4C_linalg_utils_sparse_algebra_assemble.hpp"
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
+#include "4C_linalg_utils_sparse_algebra_math.hpp"
 #include "4C_solver_nonlin_nox_group.hpp"
 #include "4C_solver_nonlin_nox_solver_linesearchbased.hpp"
 #include "4C_solver_nonlin_nox_vector.hpp"
@@ -270,7 +271,7 @@ bool Solid::ModelEvaluator::Contact::assemble_jacobian(
         strategy().get_matrix_block_ptr(CONTACT::MatBlockType::displ_displ, &eval_contact());
     if (strategy().is_penalty() && block_ptr == nullptr) return true;
     std::shared_ptr<Core::LinAlg::SparseMatrix> jac_dd = global_state().extract_displ_block(jac);
-    jac_dd->add(*block_ptr, false, timefac_np, 1.0);
+    Core::LinAlg::matrix_add(*block_ptr, false, timefac_np, *jac_dd, 1.0);
   }
   // ---------------------------------------------------------------------
   // condensed system of equations
@@ -284,7 +285,7 @@ bool Solid::ModelEvaluator::Contact::assemble_jacobian(
     {
       std::shared_ptr<Core::LinAlg::SparseMatrix> jac_dd_ptr =
           global_state().extract_displ_block(jac);
-      jac_dd_ptr->add(*block_ptr, false, timefac_np, 1.0);
+      Core::LinAlg::matrix_add(*block_ptr, false, timefac_np, *jac_dd_ptr, 1.0);
       // reset the block pointers, just to be on the safe side
       block_ptr = nullptr;
     }
@@ -301,7 +302,7 @@ bool Solid::ModelEvaluator::Contact::assemble_jacobian(
     {
       std::shared_ptr<Core::LinAlg::SparseMatrix> jac_dd_ptr =
           global_state().extract_displ_block(jac);
-      jac_dd_ptr->add(*block_ptr, false, timefac_np, 1.0);
+      Core::LinAlg::matrix_add(*block_ptr, false, timefac_np, *jac_dd_ptr, 1.0);
       // reset the block pointers, just to be on the safe side
       block_ptr = nullptr;
     }

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_lagpenconstraint.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_lagpenconstraint.cpp
@@ -178,7 +178,7 @@ bool Solid::ModelEvaluator::LagPenConstraint::assemble_jacobian(
 
   // --- Kdd - block ---------------------------------------------------
   std::shared_ptr<Core::LinAlg::SparseMatrix> jac_dd_ptr = global_state().extract_displ_block(jac);
-  jac_dd_ptr->add(*stiff_constr_ptr_, false, timefac_np, 1.0);
+  Core::LinAlg::matrix_add(*stiff_constr_ptr_, false, timefac_np, *jac_dd_ptr, 1.0);
   // no need to keep it
   stiff_constr_ptr_->zero();
 

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_meshtying.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_meshtying.cpp
@@ -18,6 +18,7 @@
 #include "4C_linalg_utils_sparse_algebra_assemble.hpp"
 #include "4C_linalg_utils_sparse_algebra_create.hpp"
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
+#include "4C_linalg_utils_sparse_algebra_math.hpp"
 #include "4C_linalg_vector.hpp"
 #include "4C_solver_nonlin_nox_group.hpp"
 #include "4C_solver_nonlin_nox_group_prepostoperator.hpp"
@@ -218,7 +219,7 @@ bool Solid::ModelEvaluator::Meshtying::assemble_jacobian(
     block_ptr = strategy().get_matrix_block_ptr(CONTACT::MatBlockType::displ_displ);
     if (strategy().is_penalty() && block_ptr == nullptr) return true;
     std::shared_ptr<Core::LinAlg::SparseMatrix> jac_dd = global_state().extract_displ_block(jac);
-    jac_dd->add(*block_ptr, false, timefac_np, 1.0);
+    Core::LinAlg::matrix_add(*block_ptr, false, timefac_np, *jac_dd, 1.0);
   }
   // ---------------------------------------------------------------------
   // condensed system of equations
@@ -231,7 +232,7 @@ bool Solid::ModelEvaluator::Meshtying::assemble_jacobian(
     {
       std::shared_ptr<Core::LinAlg::SparseMatrix> jac_dd_ptr =
           global_state().extract_displ_block(jac);
-      jac_dd_ptr->add(*block_ptr, false, timefac_np, 1.0);
+      Core::LinAlg::matrix_add(*block_ptr, false, timefac_np, *jac_dd_ptr, 1.0);
       // reset the block pointers, just to be on the safe side
       block_ptr = nullptr;
     }
@@ -247,7 +248,7 @@ bool Solid::ModelEvaluator::Meshtying::assemble_jacobian(
     {
       std::shared_ptr<Core::LinAlg::SparseMatrix> jac_dd_ptr =
           global_state().extract_displ_block(jac);
-      jac_dd_ptr->add(*block_ptr, false, timefac_np, 1.0);
+      Core::LinAlg::matrix_add(*block_ptr, false, timefac_np, *jac_dd_ptr, 1.0);
       // reset the block pointers, just to be on the safe side
       block_ptr = nullptr;
     }

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_springdashpot.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_springdashpot.cpp
@@ -15,6 +15,7 @@
 #include "4C_io_visualization_parameters.hpp"
 #include "4C_linalg_sparsematrix.hpp"
 #include "4C_linalg_utils_sparse_algebra_assemble.hpp"
+#include "4C_linalg_utils_sparse_algebra_math.hpp"
 #include "4C_linalg_vector.hpp"
 #include "4C_structure_new_model_evaluator_data.hpp"
 #include "4C_structure_new_timint_base.hpp"
@@ -223,7 +224,7 @@ bool Solid::ModelEvaluator::SpringDashpot::assemble_jacobian(
     Core::LinAlg::SparseOperator& jac, const double& timefac_np) const
 {
   std::shared_ptr<Core::LinAlg::SparseMatrix> jac_dd_ptr = global_state().extract_displ_block(jac);
-  jac_dd_ptr->add(*stiff_spring_ptr_, false, timefac_np, 1.0);
+  Core::LinAlg::matrix_add(*stiff_spring_ptr_, false, timefac_np, *jac_dd_ptr, 1.0);
   // no need to keep it
   stiff_spring_ptr_->zero();
   // nothing to do

--- a/src/xfem/4C_xfem_multi_field_mapextractor.cpp
+++ b/src/xfem/4C_xfem_multi_field_mapextractor.cpp
@@ -14,6 +14,7 @@
 #include "4C_global_data.hpp"
 #include "4C_linalg_mapextractor.hpp"
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
+#include "4C_linalg_utils_sparse_algebra_math.hpp"
 #include "4C_utils_enum.hpp"
 #include "4C_xfem_discretization.hpp"
 #include "4C_xfem_xfield_field_coupling.hpp"
@@ -1114,8 +1115,9 @@ void XFEM::MultiFieldMapExtractor::add_matrix(
    *      of direct assignment for the non-interface DoF's? The current
    *      implementation makes it necessary to allocate almost the double
    *      amount of memory!                                        hiermeier */
-  full_mat.add(partial_mat.matrix(MultiField::block_non_interface, MultiField::block_non_interface),
-      false, scale, 1.0);
+  Core::LinAlg::matrix_add(
+      partial_mat.matrix(MultiField::block_non_interface, MultiField::block_non_interface), false,
+      scale, full_mat, 1.0);
 
   // --------------------------------------------------------------------------
   // interface DoF's


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
Following #136, `SparseMatrix` has some entangled calls to add(...) functions. These functions call other functions that end up calling the free function add(...) in 4C_linalg_utils_sparse_algebra_math.hpp. 

In this PR, the free function `add(...)` is renamed to `matrix_add(...)`. Furthermore,  one of the add(...) functions in SparseMatrix is deleted and instead the matrix_add(...) is called directly. 

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
Related to #136 