### PR TITLE
Enable `restart=last_possible` when previous simulation failed.

### DIFF
--- a/cmake/functions/four_c_testing_functions.cmake
+++ b/cmake/functions/four_c_testing_functions.cmake
@@ -361,7 +361,7 @@ endfunction()
 #
 # required parameters:
 #   BASED_ON:                name of the base test that created the restart files
-#   RESTART_STEP:            number of the restart step to restart from
+#   RESTART_STEP:            number of the restart step to restart from or last_possible
 #   SAME_FILE or TEST_FILE:  either SAME_FILE to indicate that the restart should be done from the same input file
 #                            as the base test, or TEST_FILE to indicate that a different input file should be used for the restart
 #

--- a/doc/documentation/src/analysis_guide_templates/4Csimulation.rst
+++ b/doc/documentation/src/analysis_guide_templates/4Csimulation.rst
@@ -47,23 +47,25 @@ Restarting an analysis
 -----------------------
 
 For restarting an analysis one has to provide restart information in the first simulation by including the parameter
-``RESTARTEVERY  <numsteps>`` in the ``STRUCTURAL DYNAMICS`` section,
-so that the information is written every *numsteps* step.
+``RESTARTEVERY  <numsteps>`` in the relevant section,
+such that the information is written every *numsteps* step.
 
-In the second simulation, no additional parameters have be included. The information that it is a restart, is
+In the second simulation, no additional parameters have to be included. The information that it is a restart, is
 given on the command line:
 
 ::
 
-   ./4C <restart_input_file> <output_basename> [restartfrom=<restart_filename>] restart=<step>
+   ./4C <restart_input_file> <output_basename> [restartfrom=<restart_file_basename>] restart=<step>
 
-Here, one has to provide the step, at which the restart is started from the previous simulation.
-If the parameter ``restartfrom`` is given, the initial configuration is read from this file,
+Here, one has to provide the step at which the restart is started from the previous simulation.
+Note that for a successful restart from step ``n``, there must be a field entry at step ``n``, followed by a result entry at step ``n``, for all relevant fields.
+If ``restart=last_possible``, the last possible restart step is detected automatically.
+If the parameter ``restartfrom`` is given, the initial configuration is read from this simulation,
 otherwise it is read from ``<output_basename>``. In the latter case the filename of the new output is the same with an appended number, e.g., ``outfile-1``.
-Note that the value for ``step`` must be given in the file ``<output_basename>.control`` in one of the step lines: ``step = <step>``.
 
 .. note::
 
+   - If you set ``restart=0``, a regular run is performed and the ``<restartfrom>`` argument is ignored.
    - The parameters RESTART and RESTARTTIME in the PROBLEM TYPE section
      are not needed anymore, and will probably vanish soon.
    - The parameter MAXTIME indicates the maximum time of all simulations,

--- a/src/core/io/src/4C_io_control.hpp
+++ b/src/core/io/src/4C_io_control.hpp
@@ -277,10 +277,18 @@ namespace Core::IO
 
     /**
      * A control file contains a list of entries which may contain the same key. This function
-     * returns the last entry (i.e., the most recent one) with the given key. If no such entry
-     * exists, an invalid ControlFileEntry is returned.
+     * returns the nth last entry (i.e., the nth most recent one) with the given key. If no such
+     * entry exists, an invalid ControlFileEntry is returned.
+     * Defaults to the very last entry (n=1).
      */
-    [[nodiscard]] ControlFileEntry last_entry(const std::string& key) const;
+    [[nodiscard]] ControlFileEntry nth_last_entry(
+        std::optional<std::string> key, size_t n = 1) const;
+
+    /**
+     * A control file contains a list of entries. This function returns the last key in the control
+     * file. If no last key exists, an empty optional is returned.
+     */
+    [[nodiscard]] std::optional<std::string> last_key() const;
 
     /**
      * Find the control file entries for the given discretization and step.

--- a/src/global_data/4C_global_data.cpp
+++ b/src/global_data/4C_global_data.cpp
@@ -120,7 +120,7 @@ Core::Communication::Communicators& Global::Problem::get_communicators() const
 void Global::Problem::open_control_file(MPI_Comm comm, const std::string& inputfile,
     std::string prefix, const std::string& restartkenner)
 {
-  if (restart())
+  if (restartstep_ != 0)
   {
     inputcontrol_ = std::make_shared<Core::IO::InputControl>(restartkenner, comm);
 


### PR DESCRIPTION



As described in #1476, the controlfile is not flushed correctly when the next step throws an error. This leads to the last entry in the control file being a `field` entry, without an accompanying result description.

So far, when using `restart=last_possible` on the command line, the restart is attempted from the last field entry. However, since there is no result description in such cases, this obviously won't work.

This fixes that by (only in such cases) searching the controlfile for the most recent complete restart information, i.e. for the most recent field entry with a step value larger than the very last one (since there are multiple field entries for the same step for coupled problems).

Along the way, I also updated the documentation on restarts slightly, as it was incomplete in my opinion (especially by restricting `last_possible` to pure structure problems.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->

necessary due to #1476
