### PR TITLE
[Epetra] Remove comments and code

### DIFF
--- a/src/beaminteraction/src/4C_beaminteraction_beam_to_beam_contact_pair.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_beam_to_beam_contact_pair.cpp
@@ -4995,7 +4995,7 @@ void BeamInteraction::BeamToBeamContactPair<numnodes,
 //
 //  std::cout << "ANALYT_LIN: " << std::endl;
 //
-//  std::cout << (*(stiffmatrix_analyt.EpetraMatrix())) << std::endl;
+//  std::cout << (*(stiffmatrix_analyt)) << std::endl;
 //}
 /*----------------------------------------------------------------------*
 |  end: FD-Check of stiffness matrix

--- a/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_surface_visualization_output_writer.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_surface_visualization_output_writer.cpp
@@ -228,9 +228,7 @@ void BeamInteraction::BeamToSolidSurfaceVisualizationOutputWriter::
   if (nodal_force_visualization != nullptr)
     add_beam_interaction_nodal_forces(nodal_force_visualization, beam_contact->discret_ptr(),
         beam_contact->beam_interaction_data_state().get_dis_np()->as_multi_vector(),
-        Core::LinAlg::Vector<double>(beam_contact->beam_interaction_data_state()
-                .get_force_np()
-                ->get_ref_of_epetra_fevector()),
+        Core::LinAlg::Vector<double>(*beam_contact->beam_interaction_data_state().get_force_np()),
         output_params_ptr_->get_write_unique_ids_flag());
 
 
@@ -289,9 +287,8 @@ void BeamInteraction::BeamToSolidSurfaceVisualizationOutputWriter::
         Core::LinAlg::Matrix<3, 2, double> beam_resultant(Core::LinAlg::Initialization::zero);
         Core::LinAlg::Matrix<3, 2, double> solid_resultant(Core::LinAlg::Initialization::zero);
         get_global_coupling_force_resultants(beam_contact->discret(),
-            Core::LinAlg::MultiVector<double>(beam_contact->beam_interaction_data_state()
-                    .get_force_np()
-                    ->get_ref_of_epetra_fevector()),
+            Core::LinAlg::MultiVector<double>(
+                beam_contact->beam_interaction_data_state().get_force_np()->as_multi_vector()),
             *(beam_contact->beam_interaction_data_state().get_dis_np()), beam_resultant,
             solid_resultant);
 

--- a/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_surface_visualization_output_writer_contact.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_surface_visualization_output_writer_contact.cpp
@@ -212,9 +212,8 @@ void BeamInteraction::BeamToSolidSurfaceVisualizationOutputWriterContact::
   if (nodal_force_visualization != nullptr)
     add_beam_interaction_nodal_forces(nodal_force_visualization, beam_contact->discret_ptr(),
         beam_contact->beam_interaction_data_state().get_dis_np()->as_multi_vector(),
-        Core::LinAlg::MultiVector<double>(beam_contact->beam_interaction_data_state()
-                .get_force_np()
-                ->get_ref_of_epetra_fevector()),
+        Core::LinAlg::MultiVector<double>(
+            beam_contact->beam_interaction_data_state().get_force_np()->as_multi_vector()),
         output_params_ptr_->get_write_unique_ids_flag());
 
   // Loop over the assembly managers and add the visualization for the pairs contained in the

--- a/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_volume_meshtying_visualization_output_writer.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_volume_meshtying_visualization_output_writer.cpp
@@ -180,9 +180,8 @@ void BeamInteraction::BeamToSolidVolumeMeshtyingVisualizationOutputWriter::
   if (visualization != nullptr)
     add_beam_interaction_nodal_forces(visualization, beam_contact->discret_ptr(),
         beam_contact->beam_interaction_data_state().get_dis_np()->as_multi_vector(),
-        Core::LinAlg::MultiVector<double>(beam_contact->beam_interaction_data_state()
-                .get_force_np()
-                ->get_ref_of_epetra_fevector()),
+        Core::LinAlg::MultiVector<double>(
+            beam_contact->beam_interaction_data_state().get_force_np()->as_multi_vector()),
         output_params_ptr_->get_write_unique_ids_flag());
 
 

--- a/src/cardiovascular0d/4C_cardiovascular0d_manager.cpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_manager.cpp
@@ -1135,8 +1135,6 @@ int Utils::Cardiovascular0DManager::solve(Core::LinAlg::SparseMatrix& mat_struct
     solver_params.lin_tol_better = adaptolbetter_;
   }
 
-  // solve with merged matrix
-  // solver_->Solve(mergedmatrix->EpetraMatrix(),mergedsol,mergedrhs,true,counter_==0);
   // solve with BlockMatrix
   solver_params.refactor = true;
   solver_params.reset = counter_ == 0;

--- a/src/contact/src/4C_contact_abstract_strategy.cpp
+++ b/src/contact/src/4C_contact_abstract_strategy.cpp
@@ -980,7 +980,7 @@ void CONTACT::AbstractStrategy::update_global_self_contact_state()
 {
   if (not is_self_contact()) return;
 
-  // reset global slave / master Epetra Maps
+  // reset global slave / master maps
   gsnoderowmap_ = std::make_shared<Core::LinAlg::Map>(0, 0, get_comm());
   gsdofrowmap_ = std::make_shared<Core::LinAlg::Map>(0, 0, get_comm());
   gmdofrowmap_ = std::make_shared<Core::LinAlg::Map>(0, 0, get_comm());

--- a/src/contact/src/4C_contact_meshtying_contact_bridge.hpp
+++ b/src/contact/src/4C_contact_meshtying_contact_bridge.hpp
@@ -76,7 +76,7 @@ namespace CONTACT
     //! @name Access methods
 
     /*!
-    \brief Get Epetra communicator
+    \brief Get MPI communicator
 
     */
     MPI_Comm get_comm() const;

--- a/src/contact/src/4C_contact_nitsche_strategy_ssi.cpp
+++ b/src/contact/src/4C_contact_nitsche_strategy_ssi.cpp
@@ -171,8 +171,7 @@ std::shared_ptr<const Core::LinAlg::Vector<double>> CONTACT::NitscheStrategySsi:
   {
     case CONTACT::VecBlockType::elch:
     case CONTACT::VecBlockType::scatra:
-      return std::make_shared<Core::LinAlg::Vector<double>>(
-          *(fs_->get_ref_of_epetra_fevector())(0));
+      return std::make_shared<Core::LinAlg::Vector<double>>(*(*fs_)(0));
     default:
       return CONTACT::NitscheStrategy::get_rhs_block_ptr(bp);
   }

--- a/src/core/binstrategy/4C_binstrategy.hpp
+++ b/src/core/binstrategy/4C_binstrategy.hpp
@@ -143,7 +143,7 @@ namespace Core::Binstrategy
      *
      * \param[in] binning_params binning parameters from input
      * \param[in] output_control output control file
-     * \param[in] comm Epetra Communicator
+     * \param[in] comm MPI Communicator
      * \param[in] my_rank id of this process
      * \param[in] correct_node should a node be included into binning? If this function is not
      * provided, all nodes are considered relevant.
@@ -422,7 +422,7 @@ namespace Core::Binstrategy
     /*!
      * \brief create linear map with bin ids
      *
-     * \param[in] comm epetra communicator
+     * \param[in] comm MPI communicator
      *
      * \return linear map linear map based on bin ids
      */

--- a/src/core/fem/src/condition/4C_fem_condition_locsys.hpp
+++ b/src/core/fem/src/condition/4C_fem_condition_locsys.hpp
@@ -109,7 +109,7 @@ namespace Core::Conditions
     void print() const;
 
     /*!
-     * \brief Get Epetra communicator
+     * \brief Get MPI communicator
      *
      */
     inline MPI_Comm get_comm() const;

--- a/src/core/fem/src/discretization/4C_fem_discretization.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization.cpp
@@ -52,7 +52,7 @@ void Core::FE::Discretization::check_filled_globally()
   // global filled flag (is true / one if and only if filled_ == true on each processor
   int globalfilled = 0;
 
-  // convert filled_ flag on this processor  into integer (no Epetra communicator for type bool)
+  // convert filled_ flag on this processor into integer (no communicator for type bool)
   int localfilled = (int)filled_;
 
   /*the global filled flag is set to the minimal value of any local filled flag

--- a/src/core/fem/src/discretization/4C_fem_discretization.hpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization.hpp
@@ -448,7 +448,7 @@ namespace Core::FE
     \brief Standard Constructor
 
     \param name: name of this discretization
-    \param comm: Epetra comm object associated with this discretization
+    \param comm: MPI comm object associated with this discretization
     \param n_dim: number of space dimensions of this discretization
     */
     Discretization(const std::string& name, MPI_Comm comm, unsigned int n_dim);
@@ -2403,7 +2403,7 @@ namespace Core::FE
     //! Name of this discretization
     std::string name_;
 
-    //! Epetra_comm
+    //! MPI communicator
     MPI_Comm comm_;
 
     //! DiscretizationWriter

--- a/src/core/fem/src/discretization/4C_fem_discretization_faces.hpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_faces.hpp
@@ -126,7 +126,7 @@ namespace Core::FE
     \brief Standard Constructor
 
     \param name: name of this discretization
-    \param comm: Epetra comm object associated with this discretization
+    \param comm: MPI comm object associated with this discretization
     \param n_dim: number of space dimensions of this discretization
     */
     DiscretizationFaces(const std::string name, MPI_Comm comm, unsigned int n_dim);

--- a/src/core/fem/src/discretization/4C_fem_discretization_hdg.hpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_hdg.hpp
@@ -40,7 +40,7 @@ namespace Core::FE
     \brief Standard Constructor
 
     \param name: name of this discretization
-    \param comm : Epetra comm object associated with this discretization
+    \param comm : MPI comm object associated with this discretization
     \param n_dim: number of space dimensions of this discretization
     */
     DiscretizationHDG(const std::string name, MPI_Comm comm, unsigned int n_dim);

--- a/src/core/fem/src/dofset/4C_fem_dofset_definedmapping_wrapper.cpp
+++ b/src/core/fem/src/dofset/4C_fem_dofset_definedmapping_wrapper.cpp
@@ -140,7 +140,6 @@ int Core::DOFSets::DofSetDefinedMappingWrapper::assign_degrees_of_freedom(
     }
   }
 
-  // Epetra maps
   Core::LinAlg::Map targetnodemap(-1, patchedtargetnodes.size(), patchedtargetnodes.data(), 0, com);
 
   Core::LinAlg::Map permsourcenodemap(-1, permsourcenodes.size(), permsourcenodes.data(), 0, com);

--- a/src/core/fem/src/general/utils/4C_fem_general_utils_superconvergent_patch_recovery.cpp
+++ b/src/core/fem/src/general/utils/4C_fem_general_utils_superconvergent_patch_recovery.cpp
@@ -526,8 +526,7 @@ std::shared_ptr<Core::LinAlg::MultiVector<double>> Core::FE::compute_superconver
 
   // if no pbc are involved leave here
   if (noderowmap.point_same_as(*fullnoderowmap))
-    return std::make_shared<Core::LinAlg::MultiVector<double>>(
-        nodevec.get_ref_of_epetra_fevector());
+    return std::make_shared<Core::LinAlg::MultiVector<double>>(nodevec.as_multi_vector());
 
   // solution vector based on full row map in which the solution of the master node is inserted into
   // slave nodes

--- a/src/core/fem/src/nurbs_discretization/4C_fem_nurbs_discretization.hpp
+++ b/src/core/fem/src/nurbs_discretization/4C_fem_nurbs_discretization.hpp
@@ -47,7 +47,7 @@ namespace Core::FE
       \brief Standard Constructor
 
       \param name: name of this nurbs discretization
-      \param comm: An epetra comm object associated with this discretization
+      \param comm: An MPI comm object associated with this discretization
       \param n_dim: number of space dimensions of this discretization
       */
       NurbsDiscretization(const std::string name, MPI_Comm comm, unsigned int n_dim);

--- a/src/core/linalg/src/sparse/4C_linalg_fevector.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_fevector.cpp
@@ -26,12 +26,6 @@ Core::LinAlg::FEVector<T>::FEVector(const Map& Map, int numVectors, bool ignoreN
 }
 
 template <typename T>
-Core::LinAlg::FEVector<T>::FEVector(const Epetra_FEVector& Source)
-    : vector_(Utils::make_owner<Epetra_FEVector>(Source))
-{
-}
-
-template <typename T>
 Core::LinAlg::FEVector<T>::FEVector(const FEVector& other)
     : vector_(Utils::make_owner<Epetra_FEVector>(other.get_ref_of_epetra_fevector()))
 {

--- a/src/core/linalg/src/sparse/4C_linalg_fevector.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_fevector.hpp
@@ -40,12 +40,6 @@ namespace Core::LinAlg
 
     explicit FEVector(const Map& Map, bool zeroOut = true);
 
-    /// Copy constructor from epetra to vector
-    explicit FEVector(const Epetra_FEVector& Source);
-
-    explicit FEVector(const Epetra_Vector& Source);
-
-
     // Rule of five: We currently need to take care to make a deep copy of the Epetra_FEVector.
     FEVector(const FEVector& other);
 

--- a/src/core/linalg/src/sparse/4C_linalg_multi_vector.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_multi_vector.cpp
@@ -14,12 +14,6 @@
 FOUR_C_NAMESPACE_OPEN
 
 template <typename T>
-Core::LinAlg::MultiVector<T>::MultiVector(const Epetra_BlockMap& Map, int num_columns, bool zeroOut)
-    : vector_(Utils::make_owner<Epetra_MultiVector>(Map, num_columns, zeroOut))
-{
-}
-
-template <typename T>
 Core::LinAlg::MultiVector<T>::MultiVector(
     const Core::LinAlg::Map& Map, int num_columns, bool zeroOut)
     : vector_(
@@ -29,12 +23,6 @@ Core::LinAlg::MultiVector<T>::MultiVector(
 
 template <typename T>
 Core::LinAlg::MultiVector<T>::MultiVector(const Epetra_MultiVector& source)
-    : vector_(Utils::make_owner<Epetra_MultiVector>(source))
-{
-}
-
-template <typename T>
-Core::LinAlg::MultiVector<T>::MultiVector(const Epetra_FEVector& source)
     : vector_(Utils::make_owner<Epetra_MultiVector>(source))
 {
 }
@@ -171,9 +159,9 @@ void Core::LinAlg::MultiVector<T>::multiply(char TransA, char TransB, double Sca
 }
 
 template <typename T>
-void Core::LinAlg::MultiVector<T>::reciprocal(const Epetra_MultiVector& A)
+void Core::LinAlg::MultiVector<T>::reciprocal(const MultiVector& A)
 {
-  ASSERT_EPETRA_CALL(vector_->Reciprocal(A));
+  ASSERT_EPETRA_CALL(vector_->Reciprocal(A.get_epetra_multi_vector()));
 }
 
 template <typename T>

--- a/src/core/linalg/src/sparse/4C_linalg_multi_vector.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_multi_vector.hpp
@@ -35,16 +35,9 @@ namespace Core::LinAlg
     static_assert(std::is_same_v<T, double>, "Only double is supported for now");
 
    public:
-    /// Basic multi-vector constructor to create vector based on a map and initialize memory with
-    /// zeros.
-    explicit MultiVector(const Epetra_BlockMap& Map, int num_columns, bool zeroOut = true);
-
     explicit MultiVector(const Map& Map, int num_columns, bool zeroOut = true);
 
     explicit MultiVector(const Epetra_MultiVector& source);
-
-    explicit MultiVector(const Epetra_FEVector& source);
-
 
     MultiVector(const MultiVector& other);
 
@@ -92,7 +85,7 @@ namespace Core::LinAlg
     //! Initialize all values in a multi-vector with const value.
     void put_scalar(double ScalarConstant);
 
-    //! Returns a view of the EpetraMap as type Map for this multi-vector.
+    //! Returns a view of the underlying map as type Map for this multi-vector.
     const Map& get_map() const { return map_.sync(vector_->Map()); };
 
     //! Returns the MPI_Comm for this multi-vector.
@@ -130,7 +123,7 @@ namespace Core::LinAlg
 
     void replace_global_value(long long GlobalRow, int VectorIndex, double ScalarValue);
 
-    //! Multiply a Epetra_MultiVector with another, element-by-element.
+    //! Multiply a MultiVector with another, element-by-element.
     void multiply(double ScalarAB, const MultiVector& A, const MultiVector& B, double ScalarThis);
 
     //! Matrix-Matrix multiplication, \e this = ScalarThis*\e this + ScalarAB*A*B.
@@ -138,13 +131,13 @@ namespace Core::LinAlg
         const MultiVector& B, double ScalarThis);
 
     //! Puts element-wise reciprocal values of input Multi-vector in target.
-    void reciprocal(const Epetra_MultiVector& A);
+    void reciprocal(const MultiVector& A);
 
-    //! Imports an Epetra_DistObject using the Core::LinAlg::Import object.
+    //! Imports an MultiVector using the Core::LinAlg::Import object.
     void import(const MultiVector& A, const Core::LinAlg::Import& Importer,
         Core::LinAlg::CombineMode CombineMode);
 
-    //! Imports an Epetra_DistObject using the Core::LinAlg::Export object.
+    //! Imports an MultiVector using the Core::LinAlg::Export object.
     void import(const MultiVector& A, const Core::LinAlg::Export& Exporter,
         Core::LinAlg::CombineMode CombineMode);
 

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_create.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_create.hpp
@@ -16,8 +16,6 @@
 #include "4C_linalg_vector.hpp"
 #include "4C_utils_parameter_list.fwd.hpp"
 
-#include <Epetra_CrsMatrix.h>
-
 #include <memory>
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/core/linalg/src/sparse/4C_linalg_vector.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_vector.cpp
@@ -25,12 +25,6 @@ Core::LinAlg::Vector<T>::Vector(const Map& Map, bool zeroOut)
 }
 
 template <typename T>
-Core::LinAlg::Vector<T>::Vector(const Epetra_BlockMap& Map, bool zeroOut)
-    : vector_(Utils::make_owner<Epetra_Vector>(Map, zeroOut))
-{
-}
-
-template <typename T>
 Core::LinAlg::Vector<T>::Vector(const Epetra_Vector& Source)
     : vector_(Utils::make_owner<Epetra_Vector>(Source))
 {

--- a/src/core/linalg/src/sparse/4C_linalg_vector.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_vector.hpp
@@ -33,9 +33,6 @@ namespace Core::LinAlg
     static_assert(std::is_same_v<T, double>, "Only double is supported for now");
 
    public:
-    /// Basic vector constructor to create vector based on a map and initialize memory with zeros
-    explicit Vector(const Epetra_BlockMap& Map, bool zeroOut = true);
-
     explicit Vector(const Map& Map, bool zeroOut = true);
 
     /// Copy constructor from epetra to vector
@@ -253,8 +250,6 @@ namespace Core::LinAlg
   class Vector<int>
   {
    public:
-    explicit Vector(const Epetra_BlockMap& map, bool zeroOut = true);
-
     explicit Vector(const Map& map, bool zeroOut = true);
 
     Vector(const Map& map, int* values);
@@ -291,19 +286,19 @@ namespace Core::LinAlg
     const Map& get_map() const { return map_.sync(vector_->Map()); };
 
 
-    //! Imports an Epetra_DistObject using the Core::LinAlg::Import object.
+    //! Imports an Vector using the Core::LinAlg::Import object.
     void import(const Vector& A, const Core::LinAlg::Import& Importer,
         Core::LinAlg::CombineMode CombineMode);
 
-    //! Imports an Epetra_DistObject using the Core::LinAlg::Export object.
+    //! Imports an Vector using the Core::LinAlg::Export object.
     void import(const Vector& A, const Core::LinAlg::Export& Exporter,
         Core::LinAlg::CombineMode CombineMode);
 
-    //! Exports an Epetra_DistObject using the Epetra_Import object.
+    //! Exports an Vector using the Core::LinAlg::Import object.
     void export_to(const Vector& A, const Core::LinAlg::Import& Importer,
         Core::LinAlg::CombineMode CombineMode);
 
-    //! Exports an Epetra_DistObject using the Epetra_Import object.
+    //! Exports an Vector using the Core::LinAlg::Export object.
     void export_to(const Vector& A, const Core::LinAlg::Export& Exporter,
         Core::LinAlg::CombineMode CombineMode);
 

--- a/src/core/linalg/tests/4C_linalg_map_test.np2.cpp
+++ b/src/core/linalg/tests/4C_linalg_map_test.np2.cpp
@@ -31,7 +31,7 @@ namespace
     Core::LinAlg::Map starting_map(NumGlobalElements, 0, comm);
 
     // create a vector
-    auto vector = Core::LinAlg::Vector<double>(starting_map.get_epetra_map(), true);
+    auto vector = Core::LinAlg::Vector<double>(starting_map, true);
 
     const Epetra_Map& expected_map = starting_map.get_epetra_map();
     const Epetra_BlockMap& actual_map = vector.get_map().get_epetra_block_map();

--- a/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_muelu.hpp
+++ b/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_muelu.hpp
@@ -52,7 +52,7 @@ namespace Core::LinearSolver
      * it re-uses the existing preconditioner and only updates the fine level matrix
      * for the Krylov solver.
      *
-     * @param matrix Epetra_Operator to be used as input for the preconditioner
+     * @param matrix Sparse operator to be used as input for the preconditioner
      * @param x Solution of the linear system
      * @param b Right-hand side of the linear system
      */

--- a/src/fluid/4C_fluid_impedancecondition.cpp
+++ b/src/fluid/4C_fluid_impedancecondition.cpp
@@ -440,7 +440,6 @@ void FLD::Utils::FluidImpedanceBc::calculate_impedance_tractions_and_update_resi
     }
 
     impedancetbcsysmat_->complete();
-    //  std::cout<<__FILE__<<__LINE__<<*((std::dynamic_pointer_cast<Core::LinAlg::SparseMatrix>(impedancetbcsysmat_))->EpetraMatrix())<<std::endl;
 
     // NOTE: since the building of the linearization is very expensive and since it only
     // changes due to the deformation of the BCs domain (the linearization is independent

--- a/src/fluid_xfluid/4C_fluid_xfluid.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid.cpp
@@ -2901,7 +2901,7 @@ void FLD::XFluid::check_matrix_nullspace()
 
     Core::LinAlg::Vector<double> result(c->get_map(), false);
 
-    state_->sysmat_->Apply(c->get_epetra_multi_vector(), result);
+    state_->sysmat_->multiply(false, *c, result);
 
     double norm = 1e9;
 

--- a/src/fluid_xfluid/4C_fluid_xfluid_state.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid_state.cpp
@@ -83,11 +83,6 @@ void FLD::XFluidState::CouplingState::complete_coupling_matrices_and_rhs(
   C_sx_->complete(xfluiddofrowmap, slavedofrowmap);
   C_ss_->complete(slavedofrowmap, slavedofrowmap);
 
-  //  std::cout << "number of nonzeros: C_xs" << C_xs_->EpetraMatrix()->MaxNumEntries() <<
-  //  std::endl; std::cout << "number of nonzeros: C_sx" << C_sx_->EpetraMatrix()->MaxNumEntries()
-  //  << std::endl; std::cout << "number of nonzeros: C_ss" <<
-  //  C_ss_->EpetraMatrix()->MaxNumEntries() << std::endl;
-  //-------------------------------------------------------------------------------
   // export the rhs coupling vector to a row vector
   Core::LinAlg::Vector<double> rhC_s_tmp(rhC_s_->get_map(), true);
   Core::LinAlg::Export exporter_rhC_s_col(rhC_s_col_->get_map(), rhC_s_tmp.get_map());

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.cpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.cpp
@@ -83,7 +83,7 @@ bool NOX::FSI::LinearSystemGCR::apply_jacobian_inverse(
   // Zero out the delta X of the linear problem if requested by user.
   if (zeroInitialGuess) result.init(0.0);
 
-  // Create Epetra linear problem object for the linear solve
+  // Create linear problem object for the linear solve
   NOX::Nln::LinearProblem problem{jacPtr,
       Core::Utils::shared_ptr_from_ref(result.get_linalg_vector()),
       Core::Utils::shared_ptr_from_ref(nonConstInput.get_linalg_vector())};

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.hpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.hpp
@@ -15,10 +15,7 @@
 #include "4C_solver_nonlin_nox_interface_required_base.hpp"
 #include "4C_solver_nonlin_nox_linearsystem_base.hpp"
 #include "4C_solver_nonlin_nox_scaling.hpp"
-#include "4C_utils_parameter_list.fwd.hpp"
 
-#include <NOX_Common.H>
-#include <NOX_Epetra_Scaling.H>
 #include <NOX_Utils.H>
 #include <Teuchos_Time.hpp>
 

--- a/src/fsi/src/partitioned/model_evaluator/4C_fsi_dirichletneumann_factory.hpp
+++ b/src/fsi/src/partitioned/model_evaluator/4C_fsi_dirichletneumann_factory.hpp
@@ -41,7 +41,7 @@ namespace FSI
      * This function is static so that it can be called without creating a factory object first.
      * It can be called directly.
      *
-     * \param[in] comm Epetra Communicator used in FSI::Partitioned for Terminal Output
+     * \param[in] comm MPI Communicator used in FSI::Partitioned for Terminal Output
      * \param[in] fsidyn List of FSI Input parameters
      *
      * \return Coupling algorithm based on Dirichlet-Neumann partitioning

--- a/src/red_airways/4C_red_airways_implicitintegration.cpp
+++ b/src/red_airways/4C_red_airways_implicitintegration.cpp
@@ -992,7 +992,7 @@ void Airway::RedAirwayImplicitTimeInt::solve(
   A_debug = std::dynamic_pointer_cast<Core::LinAlg::SparseMatrix>(sysmat_); if (A_debug !=
   nullptr)
   {
-     (A_debug->EpetraMatrix())->print(std::cout);
+     A_debug->print(std::cout);
   }
    //               std::cout<<"Map is:
   ("<<myrank_<<")"<<std::endl<<*(discret_->dof_row_map())<<std::endl;
@@ -1818,7 +1818,7 @@ bool Airway::RedAirwayImplicitTimeInt::sum_all_col_elem_val(
   // Since the acinar_volume vector is a ColMap, we first need to export
   // it to a RowMap and eliminate the ghosted values
   {
-    // define epetra exporter
+    // define exporter
     Core::LinAlg::Export exporter(vec.get_map(), qexp_->get_map());
     // export from ColMap to RowMap
     qexp_->export_to(vec, exporter, Core::LinAlg::CombineMode::zero);

--- a/src/rigidsphere/4C_rigidsphere_evaluate.cpp
+++ b/src/rigidsphere/4C_rigidsphere_evaluate.cpp
@@ -392,7 +392,7 @@ void Discret::Elements::Rigidsphere::calc_stochastic_force(
   // damping coefficient
   double gamma = my_damping_constant();
 
-  /*get pointer at Epetra multivector in parameter list linking to random numbers for stochastic
+  /*get pointer at multivector in parameter list linking to random numbers for stochastic
    * forces with zero mean and standard deviation (2*kT / dt)^0.5*/
   std::shared_ptr<Core::LinAlg::MultiVector<double>> randomnumbers =
       params_interface().get_brownian_dyn_param_interface()->get_random_forces();

--- a/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
+++ b/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
@@ -248,8 +248,7 @@ void ScaTra::MeshtyingStrategyS2I::condense_mat_and_rhs(
         Q_->multiply(true, *residualmaster, Q_residualmaster);
         interfacemaps_->insert_vector(Q_residualmaster, 2, *scatratimint_->residual());
         interfacemaps_->add_vector(
-            Core::LinAlg::MultiVector<double>(imasterresidual_->get_ref_of_epetra_fevector()), 2,
-            *scatratimint_->residual());
+            imasterresidual_->as_multi_vector(), 2, *scatratimint_->residual());
 
         // add projected master-side entries to slave-side entries of global residual vector
         Core::LinAlg::Vector<double> P_residualmaster(*interfacemaps_->map(1));
@@ -670,8 +669,7 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
               systemmatrix->add(*imastermatrix, false, 1., 1.);
               interfacemaps_->add_vector(*islaveresidual_, 1, *scatratimint_->residual());
               interfacemaps_->add_vector(
-                  Core::LinAlg::MultiVector<double>(imasterresidual_->get_ref_of_epetra_fevector()),
-                  2, *scatratimint_->residual());
+                  imasterresidual_->as_multi_vector(), 2, *scatratimint_->residual());
 
               break;
             }
@@ -741,15 +739,10 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
                     false, -1., 1.);
                 systemmatrix->add(*imastermatrix_, false, 1., 1.);
                 Core::LinAlg::Vector<double> islaveresidual(*interfacemaps_->map(1));
-                if (P_->multiply(true,
-                        Core::LinAlg::MultiVector<double>(
-                            imasterresidual_->get_ref_of_epetra_fevector()),
-                        islaveresidual))
-                  FOUR_C_THROW("Matrix-vector multiplication failed!");
+                P_->multiply(true, imasterresidual_->as_multi_vector(), islaveresidual);
                 interfacemaps_->add_vector(islaveresidual, 1, *scatratimint_->residual(), -1.);
-                interfacemaps_->add_vector(Core::LinAlg::MultiVector<double>(
-                                               imasterresidual_->get_ref_of_epetra_fevector()),
-                    2, *scatratimint_->residual());
+                interfacemaps_->add_vector(
+                    imasterresidual_->as_multi_vector(), 2, *scatratimint_->residual());
               }
 
               break;
@@ -819,8 +812,8 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
               // assemble interface residual vectors into global residual vector
               interfacemaps_->add_vector(*islaveresidual_, 1, *scatratimint_->residual());
               interfacemaps_->add_vector(
-                  Core::LinAlg::MultiVector<double>(imasterresidual_->get_ref_of_epetra_fevector()),
-                  2, *scatratimint_->residual());
+                  Core::LinAlg::MultiVector<double>(imasterresidual_->as_multi_vector()), 2,
+                  *scatratimint_->residual());
 
               break;
             }

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_base.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_base.hpp
@@ -12,7 +12,6 @@
 
 #include "4C_linalg_sparseoperator.hpp"
 
-#include <Epetra_Operator.h>
 #include <NOX_Utils.H>
 #include <Teuchos_ParameterList.hpp>
 

--- a/src/structure_new/src/4C_structure_new_timint_base.cpp
+++ b/src/structure_new/src/4C_structure_new_timint_base.cpp
@@ -47,7 +47,6 @@ Solid::TimeInt::Base::Base()
       int_ptr_(nullptr),
       dbc_ptr_(nullptr)
 {
-  Epetra_Object::SetTracebackMode(1);
   // empty constructor
 }
 

--- a/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.cpp
+++ b/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.cpp
@@ -555,7 +555,7 @@ void Solid::TimeInt::BaseDataGlobalState::setup_rot_vec_map_extractor(
 
   }  // loop over row nodes
 
-  // create the required Epetra maps
+  // create the required maps
   std::vector<int> additdofmapvec;
   additdofmapvec.reserve(additdofset.size());
   additdofmapvec.assign(additdofset.begin(), additdofset.end());

--- a/src/structure_new/src/implicit/4C_structure_new_timint_implicit.cpp
+++ b/src/structure_new/src/implicit/4C_structure_new_timint_implicit.cpp
@@ -519,9 +519,6 @@ void Solid::TimeInt::Implicit::print_jacobian_in_matlab_format(
           NOX::Nln::LinSystem::operator_type_to_string(jac_type));
     }
   }
-
-  // print sparsity pattern to file
-  //  Core::LinAlg::PrintSparsityToPostscript( *(system_matrix()->EpetraMatrix()) );
 }
 
 

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_data.hpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_data.hpp
@@ -936,7 +936,7 @@ namespace Solid
       //! read-only access to the timint object
       std::shared_ptr<const Solid::TimeInt::Base> timint_ptr_;
 
-      //! read-only access to the epetra communicator
+      //! read-only access to the MPI communicator
       MPI_Comm comm_;
 
       //! beam data container pointer

--- a/src/thermo/src/implicit/4C_thermo_timint_impl.cpp
+++ b/src/thermo/src/implicit/4C_thermo_timint_impl.cpp
@@ -97,8 +97,7 @@ Thermo::TimIntImpl::TimIntImpl(const Teuchos::ParameterList& ioparams,
   {
     for (size_t col = 0; col < columns; col++)
     {
-      Core::LinAlg::Vector<double> element_material(
-          *overlapping_element_material_vector.get_ref_of_epetra_fevector()(col));
+      Core::LinAlg::Vector<double> element_material(*overlapping_element_material_vector(col));
       double nodal_material = 0.0;
 
       for (auto ele : node.adjacent_elements())


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
As the title states, this PR refactors `Epetra` related comments and removes some constructors taking in `Epetra` based objects. In addition, this PR cleans up the use of getting the underlying `Epetra` object reference and reworks the respective contructor calls.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
Closes #1150