### PR TITLE
[EpetraExt] Move CrsMatrix input to utils

### DIFF
--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_print.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_print.cpp
@@ -9,6 +9,8 @@
 
 #include "4C_linalg_blocksparsematrix.hpp"
 
+#include <EpetraExt_CrsMatrixIn.h>
+
 #include <fstream>
 
 FOUR_C_NAMESPACE_OPEN
@@ -226,6 +228,20 @@ void Core::LinAlg::print_map_in_matlab_format(
     // wait, until proc 0 has written
     Core::Communication::barrier(comm);
   }
+}
+
+
+/*----------------------------------------------------------------------*/
+/*----------------------------------------------------------------------*/
+Core::LinAlg::SparseMatrix Core::LinAlg::read_matrix_market_file_as_sparse_matrix(
+    const std::string& filename, MPI_Comm comm)
+{
+  Epetra_CrsMatrix* crs_marix;
+
+  ASSERT_EPETRA_CALL(EpetraExt::MatrixMarketFileToCrsMatrix(
+      filename.c_str(), Core::Communication::as_epetra_comm(comm), crs_marix));
+
+  return SparseMatrix(std::shared_ptr<Epetra_CrsMatrix>(crs_marix), DataAccess::Share);
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_print.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_print.hpp
@@ -44,6 +44,26 @@ namespace Core::LinAlg
   void print_map_in_matlab_format(
       const std::string& filename, const Core::LinAlg::Map& map, const bool newfile = true);
 
+  /**
+   * @brief Read a Matrix Market file and construct a distributed sparse matrix.
+   *
+   * This function reads a matrix stored in the standard **Matrix Market (.mtx)**
+   * format from disk and converts it into a Core::LinAlg::SparseMatrix.
+   * The matrix is distributed across MPI processes according to the communicator provided.
+   *
+   * The function assumes the Matrix Market file represents a sparse matrix and that all MPI ranks
+   * in the communicator collectively participate in the read and construction process.
+   *
+   * @param filename Path to the Matrix Market (.mtx) file to be read.
+   * @param comm MPI communicator over which the sparse matrix will be distributed.
+   *
+   * @return A Core::LinAlg::SparseMatrix containing the data read from the file, distributed
+   *         across the given MPI communicator.
+   */
+  Core::LinAlg::SparseMatrix read_matrix_market_file_as_sparse_matrix(
+      const std::string& filename, MPI_Comm comm);
+
+
 }  // namespace Core::LinAlg
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/linalg/tests/4C_linalg_utils_sparse_algebra_manipulation_test.np2.cpp
+++ b/src/core/linalg/tests/4C_linalg_utils_sparse_algebra_manipulation_test.np2.cpp
@@ -11,9 +11,8 @@
 
 #include "4C_comm_mpi_utils.hpp"
 #include "4C_linalg_utils_sparse_algebra_math.hpp"
+#include "4C_linalg_utils_sparse_algebra_print.hpp"
 #include "4C_unittest_utils_support_files_test.hpp"
-
-#include <EpetraExt_CrsMatrixIn.h>
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -37,18 +36,11 @@ namespace
    */
   TEST_F(SparseAlgebraManipulationTest, ThresholdMatrix1)
   {
-    Epetra_CrsMatrix* A;
-
-    int err = EpetraExt::MatrixMarketFileToCrsMatrix(
-        TESTING::get_support_file_path("test_matrices/poisson1d.mm").c_str(),
-        Core::Communication::as_epetra_comm(comm_), A);
-    if (err != 0) FOUR_C_THROW("Matrix read failed.");
-    std::shared_ptr<Epetra_CrsMatrix> A_crs = Core::Utils::shared_ptr_from_ref(*A);
-    Core::LinAlg::SparseMatrix A_sparse(A_crs, Core::LinAlg::DataAccess::Copy);
+    Core::LinAlg::SparseMatrix A = Core::LinAlg::read_matrix_market_file_as_sparse_matrix(
+        TESTING::get_support_file_path("test_matrices/poisson1d.mm").c_str(), comm_);
 
     const double tol = 1.1;
-    std::shared_ptr<Core::LinAlg::SparseMatrix> A_thresh =
-        Core::LinAlg::threshold_matrix(A_sparse, tol);
+    auto A_thresh = Core::LinAlg::threshold_matrix(A, tol);
 
     // Check for global entries
     const int A_thresh_nnz = A_thresh->num_global_nonzeros();
@@ -64,18 +56,11 @@ namespace
    */
   TEST_F(SparseAlgebraManipulationTest, ThresholdMatrix2)
   {
-    Epetra_CrsMatrix* A;
-
-    int err = EpetraExt::MatrixMarketFileToCrsMatrix(
-        TESTING::get_support_file_path("test_matrices/filter.mm").c_str(),
-        Core::Communication::as_epetra_comm(comm_), A);
-    if (err != 0) FOUR_C_THROW("Matrix read failed.");
-    std::shared_ptr<Epetra_CrsMatrix> A_crs = Core::Utils::shared_ptr_from_ref(*A);
-    Core::LinAlg::SparseMatrix A_sparse(A_crs, Core::LinAlg::DataAccess::Copy);
+    Core::LinAlg::SparseMatrix A = Core::LinAlg::read_matrix_market_file_as_sparse_matrix(
+        TESTING::get_support_file_path("test_matrices/filter.mm").c_str(), comm_);
 
     const double tol = 1e-5;
-    std::shared_ptr<Core::LinAlg::SparseMatrix> A_thresh =
-        Core::LinAlg::threshold_matrix(A_sparse, tol);
+    auto A_thresh = Core::LinAlg::threshold_matrix(A, tol);
 
     // Check for global entries
     const int A_thresh_nnz = A_thresh->num_global_nonzeros();
@@ -91,17 +76,11 @@ namespace
    */
   TEST_F(SparseAlgebraManipulationTest, ThresholdMatrixGraph)
   {
-    Epetra_CrsMatrix* A;
-
-    int err = EpetraExt::MatrixMarketFileToCrsMatrix(
-        TESTING::get_support_file_path("test_matrices/filter.mm").c_str(),
-        Core::Communication::as_epetra_comm(comm_), A);
-    if (err != 0) FOUR_C_THROW("Matrix read failed.");
-    std::shared_ptr<Epetra_CrsMatrix> A_crs = Core::Utils::shared_ptr_from_ref(*A);
-    Core::LinAlg::SparseMatrix A_sparse(A_crs, Core::LinAlg::DataAccess::Copy);
+    Core::LinAlg::SparseMatrix A = Core::LinAlg::read_matrix_market_file_as_sparse_matrix(
+        TESTING::get_support_file_path("test_matrices/filter.mm").c_str(), comm_);
 
     const double tol = 1e-5;
-    std::shared_ptr<Core::LinAlg::Graph> G = Core::LinAlg::threshold_matrix_graph(A_sparse, tol);
+    std::shared_ptr<Core::LinAlg::Graph> G = Core::LinAlg::threshold_matrix_graph(A, tol);
 
     // Check for global entries
     const int A_thresh_nnz = G->num_global_nonzeros();
@@ -116,19 +95,13 @@ namespace
    */
   TEST_F(SparseAlgebraManipulationTest, EnrichMatrixGraph1)
   {
-    Epetra_CrsMatrix* A;
-
-    int err = EpetraExt::MatrixMarketFileToCrsMatrix(
-        TESTING::get_support_file_path("test_matrices/poisson1d.mm").c_str(),
-        Core::Communication::as_epetra_comm(comm_), A);
-    if (err != 0) FOUR_C_THROW("Matrix read failed.");
-    std::shared_ptr<Epetra_CrsMatrix> A_crs = Core::Utils::shared_ptr_from_ref(*A);
-    Core::LinAlg::SparseMatrix A_sparse(A_crs, Core::LinAlg::DataAccess::Copy);
+    Core::LinAlg::SparseMatrix A = Core::LinAlg::read_matrix_market_file_as_sparse_matrix(
+        TESTING::get_support_file_path("test_matrices/poisson1d.mm").c_str(), comm_);
 
     {
       const int power = 0;
       std::shared_ptr<Core::LinAlg::Graph> graph_enriched =
-          Core::LinAlg::enrich_matrix_graph(A_sparse, power);
+          Core::LinAlg::enrich_matrix_graph(A, power);
 
       // Check for global entries
       EXPECT_EQ(graph_enriched->num_global_nonzeros(), 58);
@@ -137,7 +110,7 @@ namespace
     {
       const int power = -3;
       std::shared_ptr<Core::LinAlg::Graph> graph_enriched =
-          Core::LinAlg::enrich_matrix_graph(A_sparse, power);
+          Core::LinAlg::enrich_matrix_graph(A, power);
 
       // Check for global entries
       EXPECT_EQ(graph_enriched->num_global_nonzeros(), 58);
@@ -146,7 +119,7 @@ namespace
     {
       const int power = 1;
       std::shared_ptr<Core::LinAlg::Graph> graph_enriched =
-          Core::LinAlg::enrich_matrix_graph(A_sparse, power);
+          Core::LinAlg::enrich_matrix_graph(A, power);
 
       // Check for global entries
       EXPECT_EQ(graph_enriched->num_global_nonzeros(), 58);
@@ -155,7 +128,7 @@ namespace
     {
       const int power = 2;
       std::shared_ptr<Core::LinAlg::Graph> graph_enriched =
-          Core::LinAlg::enrich_matrix_graph(A_sparse, power);
+          Core::LinAlg::enrich_matrix_graph(A, power);
 
       // Check for global entries
       EXPECT_EQ(graph_enriched->num_global_nonzeros(), 94);
@@ -164,7 +137,7 @@ namespace
     {
       const int power = 3;
       std::shared_ptr<Core::LinAlg::Graph> graph_enriched =
-          Core::LinAlg::enrich_matrix_graph(A_sparse, power);
+          Core::LinAlg::enrich_matrix_graph(A, power);
 
       // Check for global entries
       EXPECT_EQ(graph_enriched->num_global_nonzeros(), 128);
@@ -173,7 +146,7 @@ namespace
     {
       const int power = 4;
       std::shared_ptr<Core::LinAlg::Graph> graph_enriched =
-          Core::LinAlg::enrich_matrix_graph(A_sparse, power);
+          Core::LinAlg::enrich_matrix_graph(A, power);
 
       // Check for global entries
       EXPECT_EQ(graph_enriched->num_global_nonzeros(), 160);
@@ -182,19 +155,13 @@ namespace
 
   TEST_F(SparseAlgebraManipulationTest, EnrichMatrixGraph2)
   {
-    Epetra_CrsMatrix* A;
-
-    int err = EpetraExt::MatrixMarketFileToCrsMatrix(
-        TESTING::get_support_file_path("test_matrices/beamI.mm").c_str(),
-        Core::Communication::as_epetra_comm(comm_), A);
-    if (err != 0) FOUR_C_THROW("Matrix read failed.");
-    std::shared_ptr<Epetra_CrsMatrix> A_crs = Core::Utils::shared_ptr_from_ref(*A);
-    Core::LinAlg::SparseMatrix A_sparse(A_crs, Core::LinAlg::DataAccess::Copy);
+    Core::LinAlg::SparseMatrix A = Core::LinAlg::read_matrix_market_file_as_sparse_matrix(
+        TESTING::get_support_file_path("test_matrices/beamI.mm").c_str(), comm_);
 
     {
       const int power = 3;
       std::shared_ptr<Core::LinAlg::Graph> graph_enriched =
-          Core::LinAlg::enrich_matrix_graph(A_sparse, power);
+          Core::LinAlg::enrich_matrix_graph(A, power);
 
       // Check for global entries
       EXPECT_EQ(graph_enriched->num_global_nonzeros(), 228400);


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
Encapsulate the matrix read-in from matrixmarket file and put it into the linear algebra io utils.

This also simplifies some code.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
Related to #1622 