### PR TITLE
Let ParameterList survive lin-solver builder

### DIFF
--- a/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_ifpack.cpp
+++ b/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_ifpack.cpp
@@ -55,14 +55,15 @@ void Core::LinearSolver::IFPACKPreconditioner::setup(
     ifpack_params.set("Prec Type", "ILU");
   }
 
-  // setup preconditioner builder and enable relevant packages
-  Stratimikos::LinearSolverBuilder<double> builder;
 
   // get preconditioner parameter list
   Teuchos::ParameterList stratimikos_params;
   Teuchos::ParameterList& ifpack_list =
       stratimikos_params.sublist("Preconditioner Types").sublist("Ifpack");
   ifpack_list.setParameters(ifpack_params);
+
+  // setup preconditioner builder and enable relevant packages
+  Stratimikos::LinearSolverBuilder<double> builder;
   builder.setParameterList(Teuchos::rcpFromRef(stratimikos_params));
 
   // construct preconditioning operator


### PR DESCRIPTION
Cherry-pick from #1600

Avoids a segmentation fault when compiling with Trilinos in debug mode. The `ParameterList` needs to outlive the `LinearSolverBuilder`.