### PR TITLE
Remove `Epetra_Vector` and `Epetra_Operator` from `NOX::Nln::Interface::Jacobian` and `NOX::Nln::Interface::Required`

### DIFF
--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_interface_jacobian.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_interface_jacobian.hpp
@@ -10,6 +10,7 @@
 
 #include "4C_config.hpp"
 
+#include "4C_linalg_vector.hpp"
 #include "4C_solver_nonlin_nox_enum_lists.hpp"
 #include "4C_solver_nonlin_nox_forward_decl.hpp"
 #include "4C_solver_nonlin_nox_interface_jacobian_base.hpp"
@@ -22,7 +23,8 @@ FOUR_C_NAMESPACE_OPEN
 namespace Core::LinAlg
 {
   class SparseMatrix;
-}
+  class SparseOperator;
+}  // namespace Core::LinAlg
 
 namespace NOX
 {
@@ -39,15 +41,15 @@ namespace NOX
         /*! \brief Compute RHS and Jacobian at once.
          *
          *  \return TRUE if computation was successful. */
-        virtual bool compute_f_and_jacobian(
-            const Epetra_Vector& x, Epetra_Vector& rhs, Epetra_Operator& jac) = 0;
+        virtual bool compute_f_and_jacobian(const Core::LinAlg::Vector<double>& x,
+            Core::LinAlg::Vector<double>& rhs, Core::LinAlg::SparseOperator& jac) = 0;
 
         /*! \brief Compute the correction system of given type.
          *
          *  \return TRUE if computation was successful. */
         virtual bool compute_correction_system(const CorrectionType type,
-            const ::NOX::Abstract::Group& grp, const Epetra_Vector& x, Epetra_Vector& rhs,
-            Epetra_Operator& jac)
+            const ::NOX::Abstract::Group& grp, const Core::LinAlg::Vector<double>& x,
+            Core::LinAlg::Vector<double>& rhs, Core::LinAlg::SparseOperator& jac)
         {
           return false;
         };

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_interface_required.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_interface_required.hpp
@@ -10,6 +10,7 @@
 
 #include "4C_config.hpp"
 
+#include "4C_linalg_vector.hpp"
 #include "4C_solver_nonlin_nox_enum_lists.hpp"
 #include "4C_solver_nonlin_nox_interface_required_base.hpp"
 #include "4C_utils_exceptions.hpp"
@@ -42,36 +43,39 @@ namespace NOX
         Required() {};
 
         //! returns the right-hand-side norms of the primary DoF fields
-        virtual double get_primary_rhs_norms(const Epetra_Vector& F,
+        virtual double get_primary_rhs_norms(const Core::LinAlg::Vector<double>& F,
             const NOX::Nln::StatusTest::QuantityType& checkQuantity,
             const ::NOX::Abstract::Vector::NormType& type = ::NOX::Abstract::Vector::TwoNorm,
             const bool& isScaled = false) const = 0;
 
         //! Returns the Root Mean Squares (abbr.: RMS) of the primary solution updates
-        virtual double get_primary_solution_update_rms(const Epetra_Vector& xNew,
-            const Epetra_Vector& xOld, const double& aTol, const double& rTol,
+        virtual double get_primary_solution_update_rms(const Core::LinAlg::Vector<double>& xNew,
+            const Core::LinAlg::Vector<double>& xOld, const double& aTol, const double& rTol,
             const NOX::Nln::StatusTest::QuantityType& checkQuantity,
             const bool& disable_implicit_weighting = false) const = 0;
 
         //! Returns the increment norm of the primary DoF fields
-        virtual double get_primary_solution_update_norms(const Epetra_Vector& xNew,
-            const Epetra_Vector& xOld, const NOX::Nln::StatusTest::QuantityType& checkQuantity,
+        virtual double get_primary_solution_update_norms(const Core::LinAlg::Vector<double>& xNew,
+            const Core::LinAlg::Vector<double>& xOld,
+            const NOX::Nln::StatusTest::QuantityType& checkQuantity,
             const ::NOX::Abstract::Vector::NormType& type = ::NOX::Abstract::Vector::TwoNorm,
             const bool& isScaled = false) const = 0;
 
         //! Returns the previous solution norm of primary DoF fields
-        virtual double get_previous_primary_solution_norms(const Epetra_Vector& xOld,
+        virtual double get_previous_primary_solution_norms(const Core::LinAlg::Vector<double>& xOld,
             const NOX::Nln::StatusTest::QuantityType& checkQuantity,
             const ::NOX::Abstract::Vector::NormType& type = ::NOX::Abstract::Vector::TwoNorm,
             const bool& isScaled = false) const = 0;
 
         //! compute and return some energy representative
-        virtual double get_model_value(const Epetra_Vector& x, const Epetra_Vector& F,
+        virtual double get_model_value(const Core::LinAlg::Vector<double>& x,
+            const Core::LinAlg::Vector<double>& F,
             const MeritFunction::MeritFctName merit_func_type) const = 0;
 
         //! return model terms of a linear model (optional)
         virtual double get_linearized_model_terms(const ::NOX::Abstract::Group* group,
-            const Epetra_Vector& dir, const NOX::Nln::MeritFunction::MeritFctName mf_type,
+            const Core::LinAlg::Vector<double>& dir,
+            const NOX::Nln::MeritFunction::MeritFctName mf_type,
             const NOX::Nln::MeritFunction::LinOrder linorder,
             const NOX::Nln::MeritFunction::LinType lintype) const
         {
@@ -81,15 +85,8 @@ namespace NOX
         //! calculate characteristic/reference norms for forces
         virtual double calc_ref_norm_force() = 0;
 
-        //! access the lumped mass matrix
-        virtual Teuchos::RCP<const Epetra_Vector> get_lumped_mass_matrix_ptr() const
-        {
-          FOUR_C_THROW("The evaluation of the lumped mass matrix is not implemented!");
-          return Teuchos::null;
-        }
-
         //! create a backup state (optional)
-        virtual void create_backup_state(const Epetra_Vector& dir)
+        virtual void create_backup_state(const Core::LinAlg::Vector<double>& dir)
         {
           FOUR_C_THROW("There is no meaningful implementation for this method!");
         }

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_timint_noxinterface.hpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_timint_noxinterface.hpp
@@ -70,37 +70,38 @@ namespace Solid
 
       /*! compute right hand side and jacobian
        *  (derived from NOX::Nln::Interface::Jacobian) */
-      bool compute_f_and_jacobian(
-          const Epetra_Vector& x, Epetra_Vector& rhs, Epetra_Operator& jac) override;
+      bool compute_f_and_jacobian(const Core::LinAlg::Vector<double>& x,
+          Core::LinAlg::Vector<double>& rhs, Core::LinAlg::SparseOperator& jac) override;
 
       bool compute_correction_system(const NOX::Nln::CorrectionType type,
-          const ::NOX::Abstract::Group& grp, const Epetra_Vector& x, Epetra_Vector& rhs,
-          Epetra_Operator& jac) override;
+          const ::NOX::Abstract::Group& grp, const Core::LinAlg::Vector<double>& x,
+          Core::LinAlg::Vector<double>& rhs, Core::LinAlg::SparseOperator& jac) override;
 
       /*! Get the norm of right hand side rows/entries related to
        *  primary DoFs (derived from NOX::Nln::Interface::Required) */
-      double get_primary_rhs_norms(const Epetra_Vector& F,
+      double get_primary_rhs_norms(const Core::LinAlg::Vector<double>& F,
           const NOX::Nln::StatusTest::QuantityType& checkquantity,
           const ::NOX::Abstract::Vector::NormType& type = ::NOX::Abstract::Vector::TwoNorm,
           const bool& isscaled = false) const override;
 
       /*! Get the root mean square of the solution update (vector) entries
        *  (derived from NOX::Nln::Interface::Required) */
-      double get_primary_solution_update_rms(const Epetra_Vector& xnew, const Epetra_Vector& xold,
-          const double& aTol, const double& rTol,
+      double get_primary_solution_update_rms(const Core::LinAlg::Vector<double>& xnew,
+          const Core::LinAlg::Vector<double>& xold, const double& aTol, const double& rTol,
           const NOX::Nln::StatusTest::QuantityType& checkQuantity,
           const bool& disable_implicit_weighting = false) const override;
 
       /*! Returns the desired norm of the solution update (vector) entries
        *  (derived from NOX::Nln::Interface::Required) */
-      double get_primary_solution_update_norms(const Epetra_Vector& xnew, const Epetra_Vector& xold,
+      double get_primary_solution_update_norms(const Core::LinAlg::Vector<double>& xnew,
+          const Core::LinAlg::Vector<double>& xold,
           const NOX::Nln::StatusTest::QuantityType& checkquantity,
           const ::NOX::Abstract::Vector::NormType& type = ::NOX::Abstract::Vector::TwoNorm,
           const bool& isscaled = false) const override;
 
       /*! Returns the previous solution norm of primary DoF fields
        *  (derived from NOX::Nln::Interface::Required) */
-      double get_previous_primary_solution_norms(const Epetra_Vector& xold,
+      double get_previous_primary_solution_norms(const Core::LinAlg::Vector<double>& xold,
           const NOX::Nln::StatusTest::QuantityType& checkquantity,
           const ::NOX::Abstract::Vector::NormType& type = ::NOX::Abstract::Vector::TwoNorm,
           const bool& isscaled = false) const override;
@@ -108,11 +109,13 @@ namespace Solid
       /*! Compute and return some energy representative or any other scalar value
        *  which is capable to describe the solution path progress
        *  (derived from NOX::Nln::Interface::Required) */
-      double get_model_value(const Epetra_Vector& x, const Epetra_Vector& F,
+      double get_model_value(const Core::LinAlg::Vector<double>& x,
+          const Core::LinAlg::Vector<double>& F,
           const NOX::Nln::MeritFunction::MeritFctName merit_func_type) const override;
 
       double get_linearized_model_terms(const ::NOX::Abstract::Group* group,
-          const Epetra_Vector& dir, const NOX::Nln::MeritFunction::MeritFctName mf_type,
+          const Core::LinAlg::Vector<double>& dir,
+          const NOX::Nln::MeritFunction::MeritFctName mf_type,
           const NOX::Nln::MeritFunction::LinOrder linorder,
           const NOX::Nln::MeritFunction::LinType lintype) const override;
 
@@ -123,7 +126,7 @@ namespace Solid
       double calc_ref_norm_force() override;
 
       /// create back-up state of condensed solution variables (e.g. EAS)
-      void create_backup_state(const Epetra_Vector& dir) override;
+      void create_backup_state(const Core::LinAlg::Vector<double>& dir) override;
 
       /// recover from back-up
       void recover_from_backup_state() override;


### PR DESCRIPTION
## Description and Context
The replaces more `Epetra_Vector`s `Epetra_Operator`s with `Core::LinAlg::Vector`s and `Core::LinAlg::SparseOperator`s, respectively.  Required to proceed with #1524.

## Related Issues and Pull Requests
#1524, #1535, #1486, #1557
