### PR TITLE
Resolve redundancy of add_other functions

### DIFF
--- a/src/core/linalg/src/sparse/4C_linalg_blocksparsematrix.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_blocksparsematrix.cpp
@@ -253,41 +253,26 @@ int Core::LinAlg::BlockSparseMatrixBase::ApplyInverse(
 void Core::LinAlg::BlockSparseMatrixBase::add(const Core::LinAlg::SparseOperator& A,
     const bool transposeA, const double scalarA, const double scalarB)
 {
-  A.add_other(*this, transposeA, scalarA, scalarB);
-}
+  auto* blocksparse_matrix = dynamic_cast<const Core::LinAlg::BlockSparseMatrixBase*>(&A);
+  FOUR_C_ASSERT(blocksparse_matrix != nullptr,
+      "Matrix A cannot be added to this block sparse matrix as it is not a block sparse matrix!");
+  FOUR_C_ASSERT(blocksparse_matrix->rows() == rows(),
+      "The number of rows of the block matrix does not match: {} vs {}.",
+      blocksparse_matrix->rows(), rows());
+  FOUR_C_ASSERT(blocksparse_matrix->cols() == cols(),
+      "The number of columns of the block matrix does not match: {} vs {}.",
+      blocksparse_matrix->cols(), cols());
 
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-void Core::LinAlg::BlockSparseMatrixBase::add_other(Core::LinAlg::BlockSparseMatrixBase& A,
-    const bool transposeA, const double scalarA, const double scalarB) const
-{
-  A.add(*this, transposeA, scalarA, scalarB);
-}
-
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-void Core::LinAlg::BlockSparseMatrixBase::add_other(Core::LinAlg::SparseMatrix& A,
-    const bool transposeA, const double scalarA, const double scalarB) const
-{
-  FOUR_C_THROW("BlockSparseMatrix and SparseMatrix cannot be added");
-}
-
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-void Core::LinAlg::BlockSparseMatrixBase::add(const Core::LinAlg::BlockSparseMatrixBase& A,
-    const bool transposeA, const double scalarA, const double scalarB)
-{
   for (int i = 0; i < rows(); i++)
   {
     for (int j = 0; j < cols(); j++)
     {
       if (transposeA)
-        Core::LinAlg::matrix_add(A.matrix(j, i), transposeA, scalarA, matrix(i, j), scalarB);
+        Core::LinAlg::matrix_add(
+            blocksparse_matrix->matrix(j, i), transposeA, scalarA, matrix(i, j), scalarB);
       else
-        Core::LinAlg::matrix_add(A.matrix(i, j), transposeA, scalarA, matrix(i, j), scalarB);
+        Core::LinAlg::matrix_add(
+            blocksparse_matrix->matrix(i, j), transposeA, scalarA, matrix(i, j), scalarB);
     }
   }
 }

--- a/src/core/linalg/src/sparse/4C_linalg_blocksparsematrix.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_blocksparsematrix.hpp
@@ -166,21 +166,9 @@ namespace Core::LinAlg
     void multiply(bool TransA, const Core::LinAlg::MultiVector<double>& X,
         Core::LinAlg::MultiVector<double>& Y) const override;
 
-    /// Add a (transposed) BlockSparseMatrix: (*this) = (*this)*scalarB + A(^T)*scalarA
-    virtual void add(const BlockSparseMatrixBase& A, const bool transposeA, const double scalarA,
-        const double scalarB);
-
-    /// Resolve virtual function of parent class
+    /// Add a sparse operator to the block sparse matrix: (*this) = (*this)*scalarB + A(^T)*scalarA
     void add(const SparseOperator& A, const bool transposeA, const double scalarA,
         const double scalarB) override;
-
-    /// Resolve virtual function of parent class
-    void add_other(SparseMatrix& A, const bool transposeA, const double scalarA,
-        const double scalarB) const override;
-
-    /// Resolve virtual function of parent class
-    void add_other(BlockSparseMatrixBase& A, const bool transposeA, const double scalarA,
-        const double scalarB) const override;
 
     /// Multiply all values in the matrix by a constant value (in place: A <- ScalarConstant * A).
     void scale(double ScalarConstant) override;

--- a/src/core/linalg/src/sparse/4C_linalg_sparsematrix.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_sparsematrix.cpp
@@ -1491,25 +1491,12 @@ void Core::LinAlg::SparseMatrix::replace_or_insert_global_values(
 void Core::LinAlg::SparseMatrix::add(const Core::LinAlg::SparseOperator& A, const bool transposeA,
     const double scalarA, const double scalarB)
 {
-  A.add_other(*this, transposeA, scalarA, scalarB);
-}
+  const auto* sparse_matrix = dynamic_cast<const Core::LinAlg::SparseMatrix*>(&A);
+  FOUR_C_ASSERT(sparse_matrix != nullptr,
+      "Matrix A cannot be added to this sparse matrix as it is not a sparse matrix!");
 
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-void Core::LinAlg::SparseMatrix::add_other(Core::LinAlg::SparseMatrix& B, const bool transposeA,
-    const double scalarA, const double scalarB) const
-{
-  Core::LinAlg::matrix_add(*this, transposeA, scalarA, B, scalarB);
+  Core::LinAlg::matrix_add(*sparse_matrix, transposeA, scalarA, *this, scalarB);
 }
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-void Core::LinAlg::SparseMatrix::add_other(Core::LinAlg::BlockSparseMatrixBase& B,
-    const bool transposeA, const double scalarA, const double scalarB) const
-{
-  FOUR_C_THROW("BlockSparseMatrix and SparseMatrix cannot be added");
-}
-
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/

--- a/src/core/linalg/src/sparse/4C_linalg_sparsematrix.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_sparsematrix.hpp
@@ -334,27 +334,6 @@ namespace Core::LinAlg
 
     /** \name Utility functions */
     //@{
-
-    /// Add a (transposed) Epetra_CrsMatrix to another: (*this) = (*this)*scalarB + A(^T)*scalarA
-    /*!
-
-    Add one matrix to another. the matrix (*this) to be added to must not be
-    completed. Sparsity patterns of A and (*this) need not match and A and (*this) can be
-    nonsymmetric in value and pattern.  Row map of A has to be a
-    processor-local subset of the row map of (*this).
-
-    \note This is a true parallel add, even in the transposed case!
-
-    \param A          (in)     : Matrix to add to B (must have Filled()==true)
-    \param transposeA (in)     : flag indicating whether transposed of A should be used
-    \param scalarA    (in)     : scaling factor for A
-    \param scalarB    (in)     : scaling factor for B
-    */
-    // void add(const SparseMatrix& A, const bool transposeA, const double scalarA,
-    //     const double scalarB);
-
-    //@}
-
     /*! \brief return the internal Epetra_Operator
 
     The internal Epetra_Operator here is the internal Epetra_CrsMatrix or Epetra_FECrsMatrix. This
@@ -375,6 +354,8 @@ namespace Core::LinAlg
     /// return the internal Epetra_CrsMatrix or Epetra_FECrsMatrix
     /// (down-cast from Epetra_CrsMatrix !) (you should not need this!)
     const Epetra_CrsMatrix& epetra_matrix() const { return *sysmat_; }
+
+    //@}
 
     /** \name Matrix Properties Query Methods */
     //@{
@@ -578,17 +559,9 @@ namespace Core::LinAlg
 
     //@}
 
-    /// Add one operator to another
+    /// Add a sparse operator to the sparse matrix: (*this) = (*this)*scalarB + A(^T)*scalarA
     void add(const Core::LinAlg::SparseOperator& A, const bool transposeA, const double scalarA,
         const double scalarB) override;
-
-    /// Add one SparseMatrixBase to another
-    void add_other(Core::LinAlg::SparseMatrix& B, const bool transposeA, const double scalarA,
-        const double scalarB) const override;
-
-    /// Add one BlockSparseMatrix to another
-    void add_other(Core::LinAlg::BlockSparseMatrixBase& B, const bool transposeA,
-        const double scalarA, const double scalarB) const override;
 
     //! Print to user-provided output stream
     void print(std::ostream& os) const { sysmat_->Print(os); }

--- a/src/core/linalg/src/sparse/4C_linalg_sparseoperator.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_sparseoperator.hpp
@@ -201,14 +201,6 @@ namespace Core::LinAlg
     virtual void add(const Core::LinAlg::SparseOperator& A, const bool transposeA,
         const double scalarA, const double scalarB) = 0;
 
-    /// Add one SparseMatrixBase to another
-    virtual void add_other(Core::LinAlg::SparseMatrix& A, const bool transposeA,
-        const double scalarA, const double scalarB) const = 0;
-
-    /// Add one BlockSparseMatrix to another
-    virtual void add_other(Core::LinAlg::BlockSparseMatrixBase& A, const bool transposeA,
-        const double scalarA, const double scalarB) const = 0;
-
     /// Multiply all values by a constant value (in place: A <- ScalarConstant * A).
     virtual void scale(double ScalarConstant) = 0;
 

--- a/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_jacobian.cpp
+++ b/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_jacobian.cpp
@@ -110,18 +110,6 @@ void NOX::FSI::FSIMatrixFree::add(const Core::LinAlg::SparseOperator& A, const b
   FOUR_C_THROW("Not implemented");
 }
 
-void NOX::FSI::FSIMatrixFree::add_other(Core::LinAlg::SparseMatrix& A, const bool transposeA,
-    const double scalarA, const double scalarB) const
-{
-  FOUR_C_THROW("Not implemented");
-}
-
-void NOX::FSI::FSIMatrixFree::add_other(Core::LinAlg::BlockSparseMatrixBase& A,
-    const bool transposeA, const double scalarA, const double scalarB) const
-{
-  FOUR_C_THROW("Not implemented");
-}
-
 void NOX::FSI::FSIMatrixFree::scale(double ScalarConstant) { FOUR_C_THROW("Not implemented"); }
 
 void NOX::FSI::FSIMatrixFree::multiply(bool TransA, const Core::LinAlg::MultiVector<double>& X,

--- a/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_jacobian.hpp
+++ b/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_jacobian.hpp
@@ -78,12 +78,6 @@ namespace NOX
       void add(const Core::LinAlg::SparseOperator& A, const bool transposeA, const double scalarA,
           const double scalarB) override;
 
-      void add_other(Core::LinAlg::SparseMatrix& A, const bool transposeA, const double scalarA,
-          const double scalarB) const override;
-
-      void add_other(Core::LinAlg::BlockSparseMatrixBase& A, const bool transposeA,
-          const double scalarA, const double scalarB) const override;
-
       void scale(double ScalarConstant) override;
 
       void multiply(bool TransA, const Core::LinAlg::MultiVector<double>& X,

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_matrixfree.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_matrixfree.cpp
@@ -162,18 +162,6 @@ void NOX::Nln::MatrixFree::SparseOperatorWrapper::add(const Core::LinAlg::Sparse
   FOUR_C_THROW("Not implemented");
 }
 
-void NOX::Nln::MatrixFree::SparseOperatorWrapper::add_other(Core::LinAlg::SparseMatrix& A,
-    const bool transposeA, const double scalarA, const double scalarB) const
-{
-  FOUR_C_THROW("Not implemented");
-}
-
-void NOX::Nln::MatrixFree::SparseOperatorWrapper::add_other(Core::LinAlg::BlockSparseMatrixBase& A,
-    const bool transposeA, const double scalarA, const double scalarB) const
-{
-  FOUR_C_THROW("Not implemented");
-}
-
 void NOX::Nln::MatrixFree::SparseOperatorWrapper::scale(double ScalarConstant)
 {
   FOUR_C_THROW("Not implemented");

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_matrixfree.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_matrixfree.hpp
@@ -102,12 +102,6 @@ namespace NOX
         void add(const Core::LinAlg::SparseOperator& A, const bool transposeA, const double scalarA,
             const double scalarB) override;
 
-        void add_other(Core::LinAlg::SparseMatrix& A, const bool transposeA, const double scalarA,
-            const double scalarB) const override;
-
-        void add_other(Core::LinAlg::BlockSparseMatrixBase& A, const bool transposeA,
-            const double scalarA, const double scalarB) const override;
-
         void scale(double ScalarConstant) override;
 
         void multiply(bool TransA, const Core::LinAlg::MultiVector<double>& X,


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
In this PR, the `add_other()` methods are deleted from `SparseOperator` and its sub-classes. In the current implementation, these methods where used to call the overloaded add() functions from the `SparseOperator` for the sub-classes `SparseMatrix` and `BlockSparseMatrixBase`, which results in confusing code. I think this is done to be sure that only a  `SparseMatrix` is added to a `SparseMatrix` instance and a `BlockSparseMatrixBase` added to a `BlockSparseMatrixBase` instance. 

In this PR, a `dynamic_cast` is added to be sure that the correct matrix types are added. 

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
Related to #136 