### PR TITLE
Deactivate gmsh in published docker images

### DIFF
--- a/docker/prebuilt_4C/Dockerfile
+++ b/docker/prebuilt_4C/Dockerfile
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 FROM ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:main
-LABEL org.opencontainers.image.description="Image containing the built 4C code"
+LABEL org.opencontainers.image.description="Image containing the built 4C code. All optional dependencies compatible with 4C's license are enabled."
 LABEL org.4c-multiphysics.project=4C
 
 RUN git clone https://github.com/4C-multiphysics/4C.git

--- a/docker/prebuilt_4C/README.md
+++ b/docker/prebuilt_4C/README.md
@@ -1,6 +1,7 @@
 >**Disclaimer:** this docker image is new. So, the usability might still be suboptimal.
 
-This `Dockerfile` creates an docker image with a ready to use 4C executable.
+This `Dockerfile` creates an docker image with a ready to use 4C executable containing all optional
+dependencies that are compatible with 4C's license.
 
 You can just start the docker image with
 ```

--- a/docker/prebuilt_4C_minimal/Dockerfile
+++ b/docker/prebuilt_4C_minimal/Dockerfile
@@ -35,7 +35,7 @@ RUN rm -r /home/user/4C-source
 # Copy everything to a new image to get rid of the intermediate layers
 FROM scratch
 COPY --from=0 / /
-LABEL org.opencontainers.image.description="Image containing the 4C executable"
+LABEL org.opencontainers.image.description="Image containing the 4C executable. All optional dependencies compatible with 4C's license are enabled."
 LABEL org.4c-multiphysics.project=4C
 
 USER user

--- a/docker/prebuilt_4C_minimal/README.md
+++ b/docker/prebuilt_4C_minimal/README.md
@@ -2,7 +2,8 @@
 
 This `Dockerfile` creates an docker image with a ready to use 4C executable. Compared to
 `prebuilt_4C`, this image only contains the bare minimum to run 4C, so, no source, build folder,
-tests, or other testing infrastructure.
+tests, or other testing infrastructure. All optional dependencies that are compatible with 4C's
+license are enabled.
 
 This image is for you if you just want a 4C executable or want to use it as image in GitHub Actions.
 

--- a/presets/docker/CMakePresets.json
+++ b/presets/docker/CMakePresets.json
@@ -36,10 +36,13 @@
     {
       "name": "docker",
       "displayName": "Release build for Docker image",
-      "description": "Build release version on a Docker image",
+      "description": "Build release version on a Docker image. All optional dependencies compatible with 4C's license are enabled.",
       "inherits": [
         ".docker_base"
-      ]
+      ],
+      "cacheVariables": {
+        "FOUR_C_WITH_GMSH": "OFF"
+      }
     },
     {
       "name": "docker_assertions",
@@ -110,7 +113,7 @@
     {
       "name": "docker_minimal",
       "displayName": "Minimal build for Docker image",
-      "description": "Build minimal Docker image without source, build folder, and tests",
+      "description": "Build minimal Docker image without source, build folder, and tests. All optional dependencies compatible with 4C's license are enabled.",
       "inherits": [
         ".docker_base"
       ],
@@ -119,7 +122,8 @@
         "FOUR_C_WITH_GOOGLE_BENCHMARK": "OFF",
         "FOUR_C_ENABLE_DOXYGEN": "OFF",
         "FOUR_C_ENABLE_DOCUMENTATION": "OFF",
-        "FOUR_C_DOXYGEN_USE_LOCAL_MATHJAX": "OFF"
+        "FOUR_C_DOXYGEN_USE_LOCAL_MATHJAX": "OFF",
+        "FOUR_C_WITH_GMSH": "OFF"
       }
     },
     {


### PR DESCRIPTION
This PR deactivates the usage of Gmsh in our docker images.

@4C-multiphysics/maintainer @rjoussen 