### PR TITLE
Code clean up

### DIFF
--- a/src/particle/src/algorithm/4C_particle_algorithm.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm.cpp
@@ -545,7 +545,7 @@ void Particle::ParticleAlgorithm::determine_particle_types()
 
   // safety check
   for (auto& particle : particlestodistribute_)
-    if (not particlestatestotypes_.count(particle->return_particle_type()))
+    if (not particlestatestotypes_.contains(particle->return_particle_type()))
       FOUR_C_THROW("particle type '{}' of initial particle not defined!",
           Particle::enum_to_type_name(particle->return_particle_type()));
 }

--- a/src/particle/src/algorithm/4C_particle_algorithm_timint.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_timint.cpp
@@ -76,7 +76,7 @@ void Particle::TimInt::setup(
 
   // determine set of particle types to be integrated in time
   for (auto& typeEnum : particlecontainerbundle->get_particle_types())
-    if (not typesexludedfromtimeintegration.count(typeEnum)) typestointegrate_.insert(typeEnum);
+    if (not typesexludedfromtimeintegration.contains(typeEnum)) typestointegrate_.insert(typeEnum);
 }
 
 void Particle::TimInt::insert_particle_states_of_particle_types(

--- a/src/particle/src/engine/4C_particle_engine.cpp
+++ b/src/particle/src/engine/4C_particle_engine.cpp
@@ -883,7 +883,7 @@ int Particle::ParticleEngine::get_number_of_particles() const
 int Particle::ParticleEngine::get_number_of_particles_of_specific_type(
     const ParticleType type) const
 {
-  if (not particlecontainerbundle_->get_particle_types().count(type)) return 0;
+  if (not particlecontainerbundle_->get_particle_types().contains(type)) return 0;
 
   // get container of owned particles of specific particle type
   ParticleContainer* container = particlecontainerbundle_->get_specific_container(type, Owned);
@@ -1486,7 +1486,7 @@ void Particle::ParticleEngine::determine_particles_to_be_transferred(
       if (gidofbin == -1)
       {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-        if (not particlestoremove[type].count(ownedindex))
+        if (not particlestoremove[type].contains(ownedindex))
           FOUR_C_THROW(
               "on processor {} a particle left the computational domain without being detected!",
               myrank_);

--- a/src/particle/src/engine/4C_particle_engine_container.cpp
+++ b/src/particle/src/engine/4C_particle_engine_container.cpp
@@ -218,7 +218,7 @@ void Particle::ParticleContainer::remove_particle(int index)
 double Particle::ParticleContainer::get_min_value_of_state(ParticleState state) const
 {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-  if (not storedstates_.count(state))
+  if (not storedstates_.contains(state))
     FOUR_C_THROW("particle state '{}' not stored in container!", enum_to_state_name(state));
 #endif
 
@@ -235,7 +235,7 @@ double Particle::ParticleContainer::get_min_value_of_state(ParticleState state) 
 double Particle::ParticleContainer::get_max_value_of_state(ParticleState state) const
 {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-  if (not storedstates_.count(state))
+  if (not storedstates_.contains(state))
     FOUR_C_THROW("particle state '{}' not stored in container!", enum_to_state_name(state));
 #endif
 

--- a/src/particle/src/engine/4C_particle_engine_container.hpp
+++ b/src/particle/src/engine/4C_particle_engine_container.hpp
@@ -160,7 +160,7 @@ namespace Particle
     inline int get_state_dim(ParticleState state)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (not storedstates_.count(state))
+      if (not storedstates_.contains(state))
         FOUR_C_THROW("particle state '{}' not stored in container!", enum_to_state_name(state));
 #endif
 
@@ -188,7 +188,7 @@ namespace Particle
     inline double* get_ptr_to_state(ParticleState state, int index)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (not storedstates_.count(state))
+      if (not storedstates_.contains(state))
         FOUR_C_THROW("particle state '{}' not stored in container!", enum_to_state_name(state));
 
       if (index < 0 or index > (particlestored_ - 1))
@@ -223,7 +223,7 @@ namespace Particle
             "can not return pointer to state of particle as index {} out of bounds!", index);
 #endif
 
-      if (storedstates_.count(state)) return &((states_[state])[index * statedim_[state]]);
+      if (storedstates_.contains(state)) return &((states_[state])[index * statedim_[state]]);
 
       return nullptr;
     };
@@ -262,7 +262,7 @@ namespace Particle
     inline void scale_state(double fac, ParticleState state)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (not storedstates_.count(state))
+      if (not storedstates_.contains(state))
         FOUR_C_THROW("particle state '{}' not stored in container!", enum_to_state_name(state));
 #endif
 
@@ -281,10 +281,10 @@ namespace Particle
     inline void update_state(double facA, ParticleState stateA, double facB, ParticleState stateB)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (not storedstates_.count(stateA))
+      if (not storedstates_.contains(stateA))
         FOUR_C_THROW("particle state '{}' not stored in container!", enum_to_state_name(stateA));
 
-      if (not storedstates_.count(stateB))
+      if (not storedstates_.contains(stateB))
         FOUR_C_THROW("particle state '{}' not stored in container!", enum_to_state_name(stateB));
 
       if (statedim_[stateA] != statedim_[stateB])
@@ -305,7 +305,7 @@ namespace Particle
     inline void set_state(std::vector<double> val, ParticleState state)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (not storedstates_.count(state))
+      if (not storedstates_.contains(state))
         FOUR_C_THROW("particle state '{}' not stored in container!", enum_to_state_name(state));
 
       if (statedim_[state] != static_cast<int>(val.size()))
@@ -326,7 +326,7 @@ namespace Particle
     inline void clear_state(ParticleState state)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (not storedstates_.count(state))
+      if (not storedstates_.contains(state))
         FOUR_C_THROW("particle state '{}' not stored in container!", enum_to_state_name(state));
 #endif
 
@@ -353,7 +353,10 @@ namespace Particle
      *
      * \return flag indicating stored state
      */
-    inline bool have_stored_state(ParticleState state) const { return storedstates_.count(state); };
+    inline bool have_stored_state(ParticleState state) const
+    {
+      return storedstates_.contains(state);
+    };
 
     /*!
      * \brief get size of particle container

--- a/src/particle/src/engine/4C_particle_engine_container_bundle.hpp
+++ b/src/particle/src/engine/4C_particle_engine_container_bundle.hpp
@@ -74,7 +74,7 @@ namespace Particle
     inline ParticleContainer* get_specific_container(ParticleType type, ParticleStatus status) const
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (not storedtypes_.count(type))
+      if (not storedtypes_.contains(type))
         FOUR_C_THROW("container for particle type '{}' not stored!", enum_to_type_name(type));
 #endif
 
@@ -96,7 +96,7 @@ namespace Particle
         double fac, ParticleState state, ParticleType type) const
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (not storedtypes_.count(type))
+      if (not storedtypes_.contains(type))
         FOUR_C_THROW("container for particle type '{}' not stored!", enum_to_type_name(type));
 #endif
 
@@ -118,7 +118,7 @@ namespace Particle
         ParticleState stateB, ParticleType type) const
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (not storedtypes_.count(type))
+      if (not storedtypes_.contains(type))
         FOUR_C_THROW("container for particle type '{}' not stored!", enum_to_type_name(type));
 #endif
 
@@ -137,7 +137,7 @@ namespace Particle
         std::vector<double> val, ParticleState state, ParticleType type) const
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (not storedtypes_.count(type))
+      if (not storedtypes_.contains(type))
         FOUR_C_THROW("container for particle type '{}' not stored!", enum_to_type_name(type));
 #endif
 
@@ -154,7 +154,7 @@ namespace Particle
     inline void clear_state_specific_container(ParticleState state, ParticleType type) const
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (not storedtypes_.count(type))
+      if (not storedtypes_.contains(type))
         FOUR_C_THROW("container for particle type '{}' not stored!", enum_to_type_name(type));
 #endif
 

--- a/src/particle/src/engine/4C_particle_engine_interface.hpp
+++ b/src/particle/src/engine/4C_particle_engine_interface.hpp
@@ -19,7 +19,6 @@
 #include <Teuchos_RCPStdSharedPtrConversions.hpp>
 
 #include <memory>
-#include <unordered_map>
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/particle/src/engine/4C_particle_engine_runtime_vtp_writer.cpp
+++ b/src/particle/src/engine/4C_particle_engine_runtime_vtp_writer.cpp
@@ -140,7 +140,7 @@ void Particle::ParticleRuntimeVtpWriter::set_particle_positions_and_states()
                 statedim * particlestored, positiondata.size());
 #endif
         }
-        else if (not blackliststates_.count(state))
+        else if (not blackliststates_.contains(state))
         {
           // prepare particle state data
           std::vector<double> statedata;

--- a/src/particle/src/engine/4C_particle_engine_unique_global_id.cpp
+++ b/src/particle/src/engine/4C_particle_engine_unique_global_id.cpp
@@ -247,7 +247,7 @@ void Particle::UniqueGlobalIdHandler::extract_requested_global_ids_on_master_pro
 {
   if (myrank_ == masterrank_)
   {
-    if (not preparedglobalids.count(masterrank_)) return;
+    if (not preparedglobalids.contains(masterrank_)) return;
 
     requesteduniqueglobalids.insert(requesteduniqueglobalids.begin(),
         preparedglobalids[masterrank_].begin(), preparedglobalids[masterrank_].end());

--- a/src/particle/src/interaction/4C_particle_interaction_dem.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_dem.cpp
@@ -21,7 +21,6 @@
 #include "4C_particle_interaction_dem_neighbor_pairs.hpp"
 #include "4C_particle_interaction_material_handler.hpp"
 #include "4C_particle_interaction_runtime_writer.hpp"
-#include "4C_particle_interaction_sph.hpp"
 #include "4C_particle_interaction_utils.hpp"
 #include "4C_particle_wall_interface.hpp"
 

--- a/src/particle/src/interaction/4C_particle_interaction_dem_history_pairs.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_dem_history_pairs.cpp
@@ -258,7 +258,7 @@ void Particle::DEMHistoryPairs::communicate_specific_history_pairs(
     for (int globalid : particletargets[torank])
     {
       // no history pairs for current global id
-      if (not historydata.count(globalid)) continue;
+      if (not historydata.contains(globalid)) continue;
 
       for (auto& it_j : historydata[globalid])
       {

--- a/src/particle/src/interaction/4C_particle_interaction_dem_neighbor_pairs.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_dem_neighbor_pairs.hpp
@@ -26,12 +26,8 @@ namespace Particle
 {
   class ParticleEngineInterface;
   class ParticleContainerBundle;
-}  // namespace Particle
-
-namespace Particle
-{
   class WallHandlerInterface;
-}
+}  // namespace Particle
 
 /*---------------------------------------------------------------------------*
  | type definitions                                                          |

--- a/src/particle/src/interaction/4C_particle_interaction_runtime_writer.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_runtime_writer.cpp
@@ -37,7 +37,7 @@ void Particle::InteractionWriter::register_specific_runtime_output_writer(
     const std::string& fieldname)
 {
   // safety check
-  if (runtime_visualization_managers_.count(fieldname))
+  if (runtime_visualization_managers_.contains(fieldname))
     FOUR_C_THROW("a runtime output writer for field '{}' is already stored!", fieldname);
 
   // construct and init the output writer object
@@ -55,7 +55,7 @@ void Particle::InteractionWriter::register_specific_runtime_output_writer(
 void Particle::InteractionWriter::register_specific_runtime_csv_writer(const std::string& fieldname)
 {
   // safety check
-  if (runtime_csvwriters_.count(fieldname))
+  if (runtime_csvwriters_.contains(fieldname))
     FOUR_C_THROW("a runtime csv writer for field '{}' is already stored!", fieldname);
 
   // set the csv writer object

--- a/src/particle/src/interaction/4C_particle_interaction_runtime_writer.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_runtime_writer.hpp
@@ -65,7 +65,7 @@ namespace Particle
         const std::string& fieldname)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (not runtime_visualization_managers_.count(fieldname))
+      if (not runtime_visualization_managers_.contains(fieldname))
         FOUR_C_THROW("no runtime output writer for field '{}' stored!", fieldname);
 #endif
 
@@ -76,7 +76,7 @@ namespace Particle
     inline Core::IO::RuntimeCsvWriter* get_specific_runtime_csv_writer(const std::string& fieldname)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (not runtime_csvwriters_.count(fieldname))
+      if (not runtime_csvwriters_.contains(fieldname))
         FOUR_C_THROW("no runtime csv writer for field '{}' stored!", fieldname);
 #endif
 

--- a/src/particle/src/interaction/4C_particle_interaction_sph_boundary_particle.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_boundary_particle.cpp
@@ -42,12 +42,13 @@ void Particle::SPHBoundaryParticleBase::setup(
   // update with actual fluid particle types
   const auto fluidtypes = fluidtypes_;
   for (const auto& type_i : fluidtypes)
-    if (not particlecontainerbundle_->get_particle_types().count(type_i)) fluidtypes_.erase(type_i);
+    if (not particlecontainerbundle_->get_particle_types().contains(type_i))
+      fluidtypes_.erase(type_i);
 
   // update with actual boundary particle types
   const auto boundarytypes = boundarytypes_;
   for (const auto& type_i : boundarytypes)
-    if (not particlecontainerbundle_->get_particle_types().count(type_i))
+    if (not particlecontainerbundle_->get_particle_types().contains(type_i))
       boundarytypes_.erase(type_i);
 
   // safety check
@@ -131,7 +132,7 @@ void Particle::SPHBoundaryParticleAdami::init_boundary_particle_states(std::vect
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
 
     // evaluate contribution of neighboring fluid particle j
-    if (boundarytypes_.count(type_i))
+    if (boundarytypes_.contains(type_i))
     {
       // get container of owned particles
       Particle::ParticleContainer* container_j =
@@ -155,7 +156,7 @@ void Particle::SPHBoundaryParticleAdami::init_boundary_particle_states(std::vect
     }
 
     // evaluate contribution of neighboring fluid particle i
-    if (boundarytypes_.count(type_j) and status_j == Particle::Owned)
+    if (boundarytypes_.contains(type_j) and status_j == Particle::Owned)
     {
       // get container of owned particles
       Particle::ParticleContainer* container_i =

--- a/src/particle/src/interaction/4C_particle_interaction_sph_density.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_density.cpp
@@ -75,7 +75,8 @@ void Particle::SPHDensityBase::setup(
   // update with actual fluid particle types
   const auto fluidtypes = fluidtypes_;
   for (const auto& type_i : fluidtypes)
-    if (not particlecontainerbundle_->get_particle_types().count(type_i)) fluidtypes_.erase(type_i);
+    if (not particlecontainerbundle_->get_particle_types().contains(type_i))
+      fluidtypes_.erase(type_i);
 
   // setup density of ghosted particles to refresh
   {
@@ -726,7 +727,7 @@ void Particle::SPHDensitySummation::insert_particle_states_of_particle_types(
     std::set<Particle::StateEnum>& particlestates = typeIt.second;
 
     // current particle type is not a fluid particle type
-    if (not fluidtypes_.count(type_i)) continue;
+    if (not fluidtypes_.contains(type_i)) continue;
 
     // states for density evaluation scheme
     particlestates.insert(Particle::DensitySum);
@@ -766,7 +767,7 @@ void Particle::SPHDensityIntegration::insert_particle_states_of_particle_types(
     std::set<Particle::StateEnum>& particlestates = typeIt.second;
 
     // current particle type is not a fluid particle type
-    if (not fluidtypes_.count(type_i)) continue;
+    if (not fluidtypes_.contains(type_i)) continue;
 
     // states for density evaluation scheme
     particlestates.insert(Particle::DensityDot);
@@ -822,7 +823,7 @@ void Particle::SPHDensityPredictCorrect::insert_particle_states_of_particle_type
     std::set<Particle::StateEnum>& particlestates = typeIt.second;
 
     // current particle type is not a fluid particle type
-    if (not fluidtypes_.count(type_i)) continue;
+    if (not fluidtypes_.contains(type_i)) continue;
 
     // states for density evaluation scheme
     particlestates.insert({Particle::DensityDot, Particle::DensitySum, Particle::Colorfield});

--- a/src/particle/src/interaction/4C_particle_interaction_sph_heatsource.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_heatsource.cpp
@@ -69,14 +69,14 @@ void Particle::SPHHeatSourceBase::setup(
     if (thermomaterial_[type_i]->thermalAbsorptivity_ > 0.0)
     {
       // safety check
-      if (not potentialabsorbingtypes.count(type_i))
+      if (not potentialabsorbingtypes.contains(type_i))
         FOUR_C_THROW("thermal absorptivity for particles of type '{}' not possible!",
             Particle::enum_to_type_name(type_i));
 
       absorbingtypes_.insert(type_i);
     }
     // determine non-absorbing particle types
-    else if (potentialabsorbingtypes.count(type_i))
+    else if (potentialabsorbingtypes.contains(type_i))
     {
       nonabsorbingtypes_.insert(type_i);
     }
@@ -249,7 +249,7 @@ void Particle::SPHHeatSourceSurface::evaluate_heat_source(const double& evaltime
         (ParticleUtils::pow<2>(V_i) + ParticleUtils::pow<2>(V_j)) / (dens_i[0] + dens_j[0]);
 
     // evaluate contribution of neighboring particle j
-    if (absorbingtypes_.count(type_i))
+    if (absorbingtypes_.contains(type_i))
     {
       // sum contribution of neighboring particle j
       ParticleUtils::vec_add_scale(cfg_i[type_i][particle_i].data(),
@@ -257,7 +257,7 @@ void Particle::SPHHeatSourceSurface::evaluate_heat_source(const double& evaltime
     }
 
     // evaluate contribution of neighboring particle i
-    if (absorbingtypes_.count(type_j) and status_j == Particle::Owned)
+    if (absorbingtypes_.contains(type_j) and status_j == Particle::Owned)
     {
       // sum contribution of neighboring particle i
       ParticleUtils::vec_add_scale(cfg_i[type_j][particle_j].data(),

--- a/src/particle/src/interaction/4C_particle_interaction_sph_momentum.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_momentum.cpp
@@ -102,23 +102,23 @@ void Particle::SPHMomentum::setup(
   // update with actual fluid particle types
   const auto allfluidtypes = allfluidtypes_;
   for (const auto& type_i : allfluidtypes)
-    if (not particlecontainerbundle_->get_particle_types().count(type_i))
+    if (not particlecontainerbundle_->get_particle_types().contains(type_i))
       allfluidtypes_.erase(type_i);
 
   const auto intfluidtypes = intfluidtypes_;
   for (const auto& type_i : intfluidtypes)
-    if (not particlecontainerbundle_->get_particle_types().count(type_i))
+    if (not particlecontainerbundle_->get_particle_types().contains(type_i))
       intfluidtypes_.erase(type_i);
 
   const auto purefluidtypes = purefluidtypes_;
   for (const auto& type_i : purefluidtypes)
-    if (not particlecontainerbundle_->get_particle_types().count(type_i))
+    if (not particlecontainerbundle_->get_particle_types().contains(type_i))
       purefluidtypes_.erase(type_i);
 
   // update with actual boundary particle types
   const auto boundarytypes = boundarytypes_;
   for (const auto& type_i : boundarytypes)
-    if (not particlecontainerbundle_->get_particle_types().count(type_i))
+    if (not particlecontainerbundle_->get_particle_types().contains(type_i))
       boundarytypes_.erase(type_i);
 
   // determine size of vectors indexed by particle types
@@ -148,7 +148,7 @@ void Particle::SPHMomentum::insert_particle_states_of_particle_types(
     std::set<Particle::StateEnum>& particlestates = typeIt.second;
 
     // current particle type is not a pure fluid particle type
-    if (not purefluidtypes_.count(type_i)) continue;
+    if (not purefluidtypes_.contains(type_i)) continue;
 
     // additional states for transport velocity formulation
     if (transportvelocityformulation_ !=
@@ -252,7 +252,7 @@ void Particle::SPHMomentum::momentum_equation_particle_contribution() const
     const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
 
     double* acc_i = nullptr;
-    if (intfluidtypes_.count(type_i))
+    if (intfluidtypes_.contains(type_i))
       acc_i = container_i->get_ptr_to_state(Particle::Acceleration, particle_i);
 
     const double* mod_vel_i =
@@ -268,7 +268,7 @@ void Particle::SPHMomentum::momentum_equation_particle_contribution() const
     const double* vel_j = container_j->get_ptr_to_state(Particle::Velocity, particle_j);
 
     double* acc_j = nullptr;
-    if (intfluidtypes_.count(type_j) and status_j == Particle::Owned)
+    if (intfluidtypes_.contains(type_j) and status_j == Particle::Owned)
       acc_j = container_j->get_ptr_to_state(Particle::Acceleration, particle_j);
 
     const double* mod_vel_j =
@@ -398,7 +398,7 @@ void Particle::SPHMomentum::momentum_equation_particle_boundary_contribution() c
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
 
     // swap fluid particle and boundary particle
-    const bool swapparticles = boundarytypes_.count(type_i);
+    const bool swapparticles = boundarytypes_.contains(type_i);
     if (swapparticles)
     {
       std::tie(type_i, status_i, particle_i) = particlepair.tuple_j_;

--- a/src/particle/src/interaction/4C_particle_interaction_sph_neighbor_pairs.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_neighbor_pairs.cpp
@@ -63,7 +63,7 @@ void Particle::SPHNeighborPairs::get_relevant_particle_pair_indices_for_disjoint
   if (relindices.size() != 0) FOUR_C_THROW("vector of relevant particle pair indices not cleared!");
 
   for (const auto& type_i : types_a)
-    if (types_b.count(type_i)) FOUR_C_THROW("no disjoint combination of particle types!");
+    if (types_b.contains(type_i)) FOUR_C_THROW("no disjoint combination of particle types!");
 #endif
 
   for (const auto& type_i : types_a)

--- a/src/particle/src/interaction/4C_particle_interaction_sph_neighbor_pairs.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_neighbor_pairs.hpp
@@ -26,12 +26,8 @@ namespace Particle
 {
   class ParticleEngineInterface;
   class ParticleContainerBundle;
-}  // namespace Particle
-
-namespace Particle
-{
   class WallHandlerInterface;
-}
+}  // namespace Particle
 
 namespace Particle
 {

--- a/src/particle/src/interaction/4C_particle_interaction_sph_open_boundary.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_open_boundary.cpp
@@ -63,7 +63,7 @@ void Particle::SPHOpenBoundaryBase::setup(
 
   // safety check
   for (const auto& type_i : {fluidphase_, openboundaryphase_})
-    if (not particlecontainerbundle_->get_particle_types().count(type_i))
+    if (not particlecontainerbundle_->get_particle_types().contains(type_i))
       FOUR_C_THROW("no particle container for particle type '{}' found!",
           Particle::enum_to_type_name(type_i));
 }

--- a/src/particle/src/interaction/4C_particle_interaction_sph_phase_change.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_phase_change.cpp
@@ -123,7 +123,7 @@ void Particle::SPHPhaseChangeBase::setup(
 
   // safety check
   for (const auto& type_i : {belowphase_, abovephase_})
-    if (not particlecontainerbundle_->get_particle_types().count(type_i))
+    if (not particlecontainerbundle_->get_particle_types().contains(type_i))
       FOUR_C_THROW("no particle container for particle type '{}' found!",
           Particle::enum_to_type_name(type_i));
 }

--- a/src/particle/src/interaction/4C_particle_interaction_sph_pressure.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_pressure.cpp
@@ -43,7 +43,8 @@ void Particle::SPHPressure::setup(
   // update with actual fluid particle types
   const auto fluidtypes = fluidtypes_;
   for (const auto& type_i : fluidtypes)
-    if (not particlecontainerbundle_->get_particle_types().count(type_i)) fluidtypes_.erase(type_i);
+    if (not particlecontainerbundle_->get_particle_types().contains(type_i))
+      fluidtypes_.erase(type_i);
 
   // setup pressure of ghosted particles to refresh
   {

--- a/src/particle/src/interaction/4C_particle_interaction_sph_rigid_particle_contact.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_rigid_particle_contact.cpp
@@ -64,11 +64,11 @@ void Particle::SPHRigidParticleContactBase::setup(
   // update with actual boundary particle types
   const auto boundarytypes = boundarytypes_;
   for (const auto& type_i : boundarytypes)
-    if (not particlecontainerbundle_->get_particle_types().count(type_i))
+    if (not particlecontainerbundle_->get_particle_types().contains(type_i))
       boundarytypes_.erase(type_i);
 
   // safety check
-  if (not boundarytypes_.count(Particle::RigidPhase))
+  if (not boundarytypes_.contains(Particle::RigidPhase))
     FOUR_C_THROW("no rigid particles defined but a rigid particle contact formulation is set!");
 }
 

--- a/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension.cpp
@@ -127,14 +127,14 @@ void Particle::SPHSurfaceTension::setup(
 
   // safety check
   for (const auto& type_i : fluidtypes_)
-    if (not particlecontainerbundle_->get_particle_types().count(type_i))
+    if (not particlecontainerbundle_->get_particle_types().contains(type_i))
       FOUR_C_THROW("no particle container for particle type '{}' found!",
           Particle::enum_to_type_name(type_i));
 
   // update with actual boundary particle types
   const auto boundarytypes = boundarytypes_;
   for (const auto& type_i : boundarytypes)
-    if (not particlecontainerbundle_->get_particle_types().count(type_i))
+    if (not particlecontainerbundle_->get_particle_types().contains(type_i))
       boundarytypes_.erase(type_i);
 
   // setup interface normal of ghosted particles to refresh
@@ -163,7 +163,7 @@ void Particle::SPHSurfaceTension::insert_particle_states_of_particle_types(
     // get type of particles
     Particle::TypeEnum type = typeIt.first;
 
-    if (boundarytypes_.count(type)) haveboundarytypes = true;
+    if (boundarytypes_.contains(type)) haveboundarytypes = true;
   }
 
   // iterate over particle types
@@ -176,7 +176,7 @@ void Particle::SPHSurfaceTension::insert_particle_states_of_particle_types(
     std::set<Particle::StateEnum>& particlestates = typeIt.second;
 
     // current particle type is not a fluid particle type
-    if (not fluidtypes_.count(type)) continue;
+    if (not fluidtypes_.contains(type)) continue;
 
     // states for surface tension evaluation scheme
     particlestates.insert(
@@ -403,7 +403,7 @@ void Particle::SPHSurfaceTension::compute_wall_colorfield_and_wall_interface_nor
         particlecontainerbundle_->get_specific_container(type_j, status_j);
 
     // evaluate contribution of neighboring boundary particle j
-    if (fluidtypes_.count(type_i))
+    if (fluidtypes_.contains(type_i))
     {
       // get material for current particle type
       const Mat::PAR::ParticleMaterialBase* material_j =
@@ -441,7 +441,7 @@ void Particle::SPHSurfaceTension::compute_wall_colorfield_and_wall_interface_nor
     }
 
     // evaluate contribution of neighboring boundary particle i
-    if (fluidtypes_.count(type_j) and status_j == Particle::Owned)
+    if (fluidtypes_.contains(type_j) and status_j == Particle::Owned)
     {
       // get material for current particle type
       const Mat::PAR::ParticleMaterialBase* material_i =

--- a/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_barrier_force.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_barrier_force.cpp
@@ -66,14 +66,14 @@ void Particle::SPHBarrierForce::setup(
 
   // safety check
   for (const auto& type_i : fluidtypes_)
-    if (not particlecontainerbundle_->get_particle_types().count(type_i))
+    if (not particlecontainerbundle_->get_particle_types().contains(type_i))
       FOUR_C_THROW("no particle container for particle type '{}' found!",
           Particle::enum_to_type_name(type_i));
 
   // update with actual boundary particle types
   const auto boundarytypes = boundarytypes_;
   for (const auto& type_i : boundarytypes)
-    if (not particlecontainerbundle_->get_particle_types().count(type_i))
+    if (not particlecontainerbundle_->get_particle_types().contains(type_i))
       boundarytypes_.erase(type_i);
 }
 
@@ -189,7 +189,7 @@ void Particle::SPHBarrierForce::compute_barrier_force_particle_boundary_contribu
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
 
     // swap fluid particle and boundary particle
-    const bool swapparticles = boundarytypes_.count(type_i);
+    const bool swapparticles = boundarytypes_.contains(type_i);
     if (swapparticles)
     {
       std::tie(type_i, status_i, particle_i) = particlepair.tuple_j_;

--- a/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_interface_viscosity.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_interface_viscosity.cpp
@@ -75,14 +75,14 @@ void Particle::SPHInterfaceViscosity::setup(
 
   // safety check
   for (const auto& type_i : fluidtypes_)
-    if (not particlecontainerbundle_->get_particle_types().count(type_i))
+    if (not particlecontainerbundle_->get_particle_types().contains(type_i))
       FOUR_C_THROW("no particle container for particle type '{}' found!",
           Particle::enum_to_type_name(type_i));
 
   // update with actual boundary particle types
   const auto boundarytypes = boundarytypes_;
   for (const auto& type_i : boundarytypes)
-    if (not particlecontainerbundle_->get_particle_types().count(type_i))
+    if (not particlecontainerbundle_->get_particle_types().contains(type_i))
       boundarytypes_.erase(type_i);
 
   // determine size of vectors indexed by particle types
@@ -236,7 +236,7 @@ void Particle::SPHInterfaceViscosity::compute_interface_viscosity_particle_bound
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
 
     // swap fluid particle and boundary particle
-    const bool swapparticles = boundarytypes_.count(type_i);
+    const bool swapparticles = boundarytypes_.contains(type_i);
     if (swapparticles)
     {
       std::tie(type_i, status_i, particle_i) = particlepair.tuple_j_;

--- a/src/particle/src/interaction/4C_particle_interaction_sph_temperature.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_temperature.cpp
@@ -62,7 +62,7 @@ void Particle::SPHTemperature::setup(
   // update with actual integrated thermo particle types
   const auto intthermotypes = intthermotypes_;
   for (const auto& type_i : intthermotypes)
-    if (not particlecontainerbundle_->get_particle_types().count(type_i))
+    if (not particlecontainerbundle_->get_particle_types().contains(type_i))
       intthermotypes_.erase(type_i);
 
   // setup temperature of ghosted particles to refresh
@@ -121,7 +121,7 @@ void Particle::SPHTemperature::insert_particle_states_of_particle_types(
     particlestates.insert(Particle::Temperature);
 
     // current particle type is not an integrated thermo particle type
-    if (not intthermotypes_.count(type)) continue;
+    if (not intthermotypes_.contains(type)) continue;
 
     // state for temperature evaluation scheme
     particlestates.insert(Particle::TemperatureDot);

--- a/src/particle/src/interaction/4C_particle_interaction_sph_virtual_wall_particle.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_virtual_wall_particle.cpp
@@ -64,12 +64,12 @@ void Particle::SPHVirtualWallParticle::setup(
   // update with actual fluid particle types
   const auto allfluidtypes = allfluidtypes_;
   for (const auto& type_i : allfluidtypes)
-    if (not particlecontainerbundle_->get_particle_types().count(type_i))
+    if (not particlecontainerbundle_->get_particle_types().contains(type_i))
       allfluidtypes_.erase(type_i);
 
   const auto intfluidtypes = intfluidtypes_;
   for (const auto& type_i : intfluidtypes)
-    if (not particlecontainerbundle_->get_particle_types().count(type_i))
+    if (not particlecontainerbundle_->get_particle_types().contains(type_i))
       intfluidtypes_.erase(type_i);
 }
 
@@ -232,7 +232,7 @@ void Particle::SPHVirtualWallParticle::init_states_at_wall_contact_points(
       std::tie(type_k, status_k, particle_k) = neighboringparticle;
 
       // evaluation only for fluid particles
-      if (not allfluidtypes_.count(type_k)) continue;
+      if (not allfluidtypes_.contains(type_k)) continue;
 
       // get container of particles of current particle type
       Particle::ParticleContainer* container_k =

--- a/src/particle/src/rigidbody/4C_particle_rigidbody.cpp
+++ b/src/particle/src/rigidbody/4C_particle_rigidbody.cpp
@@ -59,7 +59,7 @@ void Particle::RigidBodyHandler::setup(
     Particle::ParticleContainerBundleShrdPtr particlecontainerbundle =
         particleengineinterface_->get_particle_container_bundle();
 
-    if (not particlecontainerbundle->get_particle_types().count(Particle::RigidPhase))
+    if (not particlecontainerbundle->get_particle_types().contains(Particle::RigidPhase))
       FOUR_C_THROW("no particle container for particle type '{}' found!",
           Particle::enum_to_type_name(Particle::RigidPhase));
   }

--- a/src/particle/src/rigidbody/4C_particle_rigidbody_initial_field.cpp
+++ b/src/particle/src/rigidbody/4C_particle_rigidbody_initial_field.cpp
@@ -33,7 +33,7 @@ void Particle::set_initial_fields(const Teuchos::ParameterList& params,
 
   for (auto& stateIt : statetotypetofunctidmap)
   {
-    if (not stateIt.second.count(Particle::RigidPhase)) continue;
+    if (not stateIt.second.contains(Particle::RigidPhase)) continue;
 
     // state vector
     Particle::StateEnum particleState = stateIt.first;

--- a/src/particle/src/wall/4C_particle_wall.cpp
+++ b/src/particle/src/wall/4C_particle_wall.cpp
@@ -110,19 +110,19 @@ void Particle::WallHandlerBase::insert_particle_states_of_particle_types(
         Particle::LastIterAcceleration,
     });
 
-    if (particlestates.count(Particle::AngularVelocity))
+    if (particlestates.contains(Particle::AngularVelocity))
       particlestates.insert(Particle::LastIterAngularVelocity);
 
-    if (particlestates.count(Particle::AngularAcceleration))
+    if (particlestates.contains(Particle::AngularAcceleration))
       particlestates.insert(Particle::LastIterAngularAcceleration);
 
-    if (particlestates.count(Particle::ModifiedAcceleration))
+    if (particlestates.contains(Particle::ModifiedAcceleration))
       particlestates.insert(Particle::LastIterModifiedAcceleration);
 
-    if (particlestates.count(Particle::DensityDot))
+    if (particlestates.contains(Particle::DensityDot))
       particlestates.insert(Particle::LastIterDensity);
 
-    if (particlestates.count(Particle::TemperatureDot))
+    if (particlestates.contains(Particle::TemperatureDot))
       particlestates.insert(Particle::LastIterTemperature);
   }
 }


### PR DESCRIPTION
Just some minor code clean up in the particle code
- calls to `std::set.count()` replaced with `std::set.contains()`
- removed unnecessary header inclusions
- due to renaming and unification of `Particle` namespaces, forward declarations can be unified, too