### PR TITLE
Add additional NOX status test for beaminteraction using Lagrange multipliers 

### DIFF
--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_aux.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_aux.cpp
@@ -497,6 +497,9 @@ NOX::Nln::SolutionType NOX::Nln::Aux::convert_quantity_type_to_solution_type(
     case NOX::Nln::StatusTest::quantity_cardiovascular0d:
       soltype = NOX::Nln::sol_cardiovascular0d;
       break;
+    case NOX::Nln::StatusTest::quantity_beaminteraction_lm:
+      soltype = NOX::Nln::sol_beaminteraction_lm;
+      break;
     case NOX::Nln::StatusTest::quantity_unknown:
     default:
       FOUR_C_THROW("Unknown conversion for the quantity type \"{}\".",

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_enum_lists.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_enum_lists.hpp
@@ -29,7 +29,8 @@ namespace NOX
       sol_meshtying,           ///< meshtying problem
       sol_cardiovascular0d,    ///< 0D cardiovascular problem
       sol_lag_pen_constraint,  ///< Lagrange or/and penalty enforced constraint problem
-      sol_scatra               ///< scalar transport problem
+      sol_scatra,              ///< scalar transport problem
+      sol_beaminteraction_lm   ///< beaminteraction with Lagrange multipliers problem
     };
 
     //! Map quantity enum to std::string
@@ -268,6 +269,7 @@ namespace NOX
         quantity_eas,                 ///< check eas dofs
         quantity_levelset_reinit,     ///< check levelset reinitialization
         quantity_constraints,         ///< check constraint framework quantities
+        quantity_beaminteraction_lm,  ///< check lagrange multiplier quantities for beaminteraction
       };
 
       /// Map quantity name to std::string
@@ -295,6 +297,8 @@ namespace NOX
             return "LevelSet-Reinit";
           case quantity_constraints:
             return "Constraints";
+          case quantity_beaminteraction_lm:
+            return "Beaminteraction-LM";
           case quantity_unknown:
           default:
             return "unknown quantity type";
@@ -326,6 +330,8 @@ namespace NOX
           type = quantity_levelset_reinit;
         else if (name == "Constraints")
           type = quantity_constraints;
+        else if (name == "Beaminteraction-LM")
+          type = quantity_beaminteraction_lm;
 
         return type;
       };

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_group.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_group.cpp
@@ -240,7 +240,14 @@ Teuchos::RCP<const std::vector<double>> NOX::Nln::Group::get_rhs_norms(
     if (rval >= 0.0)
     {
       norms->push_back(rval);
+      continue;
     }
+
+    rval = get_nln_req_interface_ptr()->get_primary_rhs_norms(RHSVector.get_linalg_vector(), chQ[i],
+        type[i], (*scale)[i] == ::NOX::StatusTest::NormF::Scaled);
+
+    if (rval >= 0.0)
+      norms->push_back(rval);
     else
     {
       std::ostringstream msg;
@@ -343,7 +350,15 @@ Teuchos::RCP<std::vector<double>> NOX::Nln::Group::get_solution_update_norms(
     if (rval >= 0.0)
     {
       norms->push_back(rval);
+      continue;
     }
+
+    rval = get_nln_req_interface_ptr()->get_primary_solution_update_norms(
+        xVector.get_linalg_vector(), xOldNox.get_linalg_vector(), chQ[i], type[i],
+        (*scale)[i] == StatusTest::NormUpdate::Scaled);
+
+    if (rval >= 0.0)
+      norms->push_back(rval);
     else
     {
       std::ostringstream msg;
@@ -381,7 +396,14 @@ Teuchos::RCP<std::vector<double>> NOX::Nln::Group::get_previous_solution_norms(
     if (rval >= 0.0)
     {
       norms->push_back(rval);
+      continue;
     }
+    rval = get_nln_req_interface_ptr()->get_previous_primary_solution_norms(
+        xOldNox.get_linalg_vector(), chQ[i], type[i],
+        (*scale)[i] == StatusTest::NormUpdate::Scaled);
+
+    if (rval >= 0.0)
+      norms->push_back(rval);
     else
     {
       std::ostringstream msg;

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_interface_required.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_interface_required.hpp
@@ -41,8 +41,7 @@ namespace NOX
        public:
         //! Constructor
         Required() {};
-
-        //! returns the right-hand-side norms of the primary DoF fields
+        //! Return the desired norm of the residual of the primary DoF fields
         virtual double get_primary_rhs_norms(const Core::LinAlg::Vector<double>& F,
             const NOX::Nln::StatusTest::QuantityType& checkQuantity,
             const ::NOX::Abstract::Vector::NormType& type = ::NOX::Abstract::Vector::TwoNorm,
@@ -54,14 +53,14 @@ namespace NOX
             const NOX::Nln::StatusTest::QuantityType& checkQuantity,
             const bool& disable_implicit_weighting = false) const = 0;
 
-        //! Returns the increment norm of the primary DoF fields
+        //! Return the desired norm of the increment of the primary DoF fields
         virtual double get_primary_solution_update_norms(const Core::LinAlg::Vector<double>& xNew,
             const Core::LinAlg::Vector<double>& xOld,
             const NOX::Nln::StatusTest::QuantityType& checkQuantity,
             const ::NOX::Abstract::Vector::NormType& type = ::NOX::Abstract::Vector::TwoNorm,
             const bool& isScaled = false) const = 0;
 
-        //! Returns the previous solution norm of primary DoF fields
+        //! Return the desired norm of the solution of primary DoF fields from previous iteration
         virtual double get_previous_primary_solution_norms(const Core::LinAlg::Vector<double>& xOld,
             const NOX::Nln::StatusTest::QuantityType& checkQuantity,
             const ::NOX::Abstract::Vector::NormType& type = ::NOX::Abstract::Vector::TwoNorm,

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_timint_noxinterface.cpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_timint_noxinterface.cpp
@@ -162,6 +162,7 @@ double Solid::TimeInt::NoxInterface::get_primary_rhs_norms(const Core::LinAlg::V
       break;
     }
     case NOX::Nln::StatusTest::quantity_pressure:
+    case NOX::Nln::StatusTest::quantity_beaminteraction_lm:
     {
       // export the model specific solution if necessary
       auto rhs_ptr = gstate_ptr_->extract_model_entries(mt, F);
@@ -244,6 +245,7 @@ double Solid::TimeInt::NoxInterface::get_primary_solution_update_norms(
     case NOX::Nln::StatusTest::quantity_structure:
     case NOX::Nln::StatusTest::quantity_cardiovascular0d:
     case NOX::Nln::StatusTest::quantity_pressure:
+    case NOX::Nln::StatusTest::quantity_beaminteraction_lm:
     {
       // export the displacement solution if necessary
       auto model_incr_ptr = gstate_ptr_->extract_model_entries(mt, xold);
@@ -295,6 +297,7 @@ double Solid::TimeInt::NoxInterface::get_previous_primary_solution_norms(
     case NOX::Nln::StatusTest::quantity_structure:
     case NOX::Nln::StatusTest::quantity_cardiovascular0d:
     case NOX::Nln::StatusTest::quantity_pressure:
+    case NOX::Nln::StatusTest::quantity_beaminteraction_lm:
     {
       // export the displacement solution if necessary
       auto model_xold_ptr = gstate_ptr_->extract_model_entries(mt, xold);

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_timint_noxinterface.hpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_timint_noxinterface.hpp
@@ -75,7 +75,7 @@ namespace Solid
       bool compute_f_and_jacobian(const Core::LinAlg::Vector<double>& x,
           Core::LinAlg::Vector<double>& rhs, Core::LinAlg::SparseOperator& jac) override;
 
-      /*! Get the norm of right hand side rows/entries related to
+      /*! Get the norm of residual rows/entries related to
        *  primary DoFs (derived from NOX::Nln::Interface::Required) */
       double get_primary_rhs_norms(const Core::LinAlg::Vector<double>& F,
           const NOX::Nln::StatusTest::QuantityType& checkquantity,
@@ -97,7 +97,7 @@ namespace Solid
           const ::NOX::Abstract::Vector::NormType& type = ::NOX::Abstract::Vector::TwoNorm,
           const bool& isscaled = false) const override;
 
-      /*! Returns the previous solution norm of primary DoF fields
+      /*! Return the desired norm of solution of the primary DoF fields from previous iteration
        *  (derived from NOX::Nln::Interface::Required) */
       double get_previous_primary_solution_norms(const Core::LinAlg::Vector<double>& xold,
           const NOX::Nln::StatusTest::QuantityType& checkquantity,

--- a/src/structure_new/src/utils/4C_structure_new_utils.cpp
+++ b/src/structure_new/src/utils/4C_structure_new_utils.cpp
@@ -177,6 +177,9 @@ Inpar::Solid::ModelType Solid::Nln::convert_sol_type2_model_type(
     case NOX::Nln::sol_lag_pen_constraint:
       modeltype = Inpar::Solid::model_lag_pen_constraint;
       break;
+    case NOX::Nln::sol_beaminteraction_lm:
+      modeltype = Inpar::Solid::model_beaminteraction;
+      break;
     default:
       // check if the corresponding enum could be found.
       if (do_check)

--- a/tests/input_files/beam3eb_static_beam_to_solid_volume_meshtying_mortar_lagrange_regularized_line3.4C.yaml
+++ b/tests/input_files/beam3eb_static_beam_to_solid_volume_meshtying_mortar_lagrange_regularized_line3.4C.yaml
@@ -25,16 +25,9 @@ STRUCTURAL DYNAMIC:
   RESULTSEVERY: 1
   NLNSOL: fullnewton
   LOADLIN: true
-  PREDICT: TangDis
   TIMESTEP: 0.5
   NUMSTEP: 2
   MAXTIME: 1.0
-  TOLRES: 1e-10
-  TOLDISP: 1e-10
-  NORM_RESF: Abs
-  NORM_DISP: Abs
-  NORMCOMBI_RESFDISP: And
-  MAXITER: 20
 SOLVER 1:
   NAME: Structure_Solver
   SOLVER: Superlu
@@ -118,6 +111,8 @@ DESIGN SURF DIRICH CONDITIONS:
 BEAM INTERACTION/BEAM TO SOLID VOLUME MESHTYING VOLUME:
   - E: 1
     COUPLING_ID: 1
+STRUCT NOX/Status Test:
+  XML File: "beam3r_herm2line3_static_beam_to_solid_volume_meshtying_mortar_lagrange.xml"
 MATERIALS:
   - MAT: 1
     MAT_Struct_StVenantKirchhoff:

--- a/tests/input_files/beam3eb_static_beam_to_solid_volume_meshtying_mortar_lagrange_saddlepoint_line3.4C.yaml
+++ b/tests/input_files/beam3eb_static_beam_to_solid_volume_meshtying_mortar_lagrange_saddlepoint_line3.4C.yaml
@@ -25,16 +25,9 @@ STRUCTURAL DYNAMIC:
   RESULTSEVERY: 1
   NLNSOL: fullnewton
   LOADLIN: true
-  PREDICT: TangDis
   TIMESTEP: 0.5
   NUMSTEP: 2
   MAXTIME: 1.0
-  TOLRES: 1e-10
-  TOLDISP: 1e-10
-  NORM_RESF: Abs
-  NORM_DISP: Abs
-  NORMCOMBI_RESFDISP: And
-  MAXITER: 20
 SOLVER 1:
   NAME: Structure_Solver
   SOLVER: Superlu
@@ -118,6 +111,8 @@ DESIGN SURF DIRICH CONDITIONS:
 BEAM INTERACTION/BEAM TO SOLID VOLUME MESHTYING VOLUME:
   - E: 1
     COUPLING_ID: 1
+STRUCT NOX/Status Test:
+  XML File: "beam3r_herm2line3_static_beam_to_solid_volume_meshtying_mortar_lagrange.xml"
 MATERIALS:
   - MAT: 1
     MAT_Struct_StVenantKirchhoff:

--- a/tests/input_files/beam3r_herm2line3_static_beam_to_solid_volume_meshtying_mortar_lagrange.xml
+++ b/tests/input_files/beam3r_herm2line3_static_beam_to_solid_volume_meshtying_mortar_lagrange.xml
@@ -1,0 +1,69 @@
+<ParameterList name="Status Test">
+  <!-- Outer Status Test: This test is an OR combination of the structural convergence and the maximum number of iterations -->
+  <ParameterList name="Outer Status Test">
+    <Parameter name="Test Type" type="string" value="Combo"/>
+    <Parameter name="Combo Type" type="string" value="OR"/>
+    <!-- Structural convergence is an AND combination of the residuum and step update -->
+    <ParameterList name="Test 0">
+      <Parameter name="Test Type" type="string" value="Combo"/>
+      <Parameter name="Combo Type" type="string" value="AND"/>
+      <!-- BEGIN: Combo AND - Test 0: "NormF" -->
+      <ParameterList name="Test 0">
+        <Parameter name="Test Type" type="string" value="Combo"/>
+        <Parameter name="Combo Type" type="string" value="AND"/>
+        <ParameterList name="Test 0">
+          <Parameter name="Test Type" type="string" value="NormF"/>
+          <!-- NormF - Quantity 0: Check the residual norm of the structural quantities -->
+          <ParameterList name="Quantity 0">
+            <Parameter name="Quantity Type" type="string" value="Structure"/>
+            <Parameter name="Tolerance Type" type="string" value="Absolute"/>
+            <Parameter name="Tolerance" type="double" value="1e-12"/>
+            <Parameter name="Norm Type" type="string" value="Two Norm"/>
+            <Parameter name="Scale Type" type="string" value="Scaled"/>
+          </ParameterList>
+          <!-- NormF - Quantity 1: Check the residual norm of the Lagrange Multiplier quantities -->
+          <ParameterList name="Quantity 1">
+            <Parameter name="Quantity Type" type="string" value="Beaminteraction-LM"/>
+            <Parameter name="Tolerance Type" type="string" value="Absolute"/>
+            <Parameter name="Tolerance" type="double" value="1.0e-12"/>
+            <Parameter name="Norm Type" type="string" value="Two Norm"/>
+            <Parameter name="Scale Type" type="string" value="Scaled"/>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+      <!-- END: Combo AND - Test 0: "NormF" -->
+      <!-- BEGIN: Combo AND - Test 1: "UpdateNorm" -->
+      <ParameterList name="Test 1">
+        <Parameter name="Test Type" type="string" value="Combo"/>
+        <Parameter name="Combo Type" type="string" value="AND"/>
+        <ParameterList name="Test 0">
+          <Parameter name="Test Type" type="string" value="NormUpdate"/>
+          <!-- UpdateNorm - Quantity 0: Check the increment of the structural displacements -->
+          <ParameterList name="Quantity 0">
+            <Parameter name="Quantity Type" type="string" value="Structure"/>
+            <Parameter name="Tolerance Type" type="string" value="Absolute"/>
+            <Parameter name="Tolerance" type="double" value="1e-12"/>
+            <Parameter name="Norm Type" type="string" value="Two Norm"/>
+            <Parameter name="Scale Type" type="string" value="Scaled"/>
+          </ParameterList>
+          <!-- UpdateNorm - Quantity 1: Check the increment of the Lagrange Multiplier quantities -->
+          <ParameterList name="Quantity 1">
+            <Parameter name="Quantity Type" type="string" value="Beaminteraction-LM"/>
+            <Parameter name="Tolerance Type" type="string" value="Absolute"/>
+            <Parameter name="Tolerance" type="double" value="1.0e-12"/>
+            <Parameter name="Norm Type" type="string" value="Two Norm"/>
+            <Parameter name="Scale Type" type="string" value="Scaled"/>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+      <!-- END: Combo AND - Test 1: "UpdateNorm" -->
+    </ParameterList>
+    <!-- END: Combo 0 - Test 0: "Combo" -->
+    <!-- BEGIN: Combo OR - Test 1: "MaxIters" -->
+    <ParameterList name="Test 1">
+      <Parameter name="Test Type" type="string" value="MaxIters"/>
+      <Parameter name="Maximum Iterations" type="int" value="10"/>
+    </ParameterList>
+    <!--END: "MaxIters" -->
+  </ParameterList>
+</ParameterList>

--- a/tests/input_files/beam3r_herm2line3_static_beam_to_solid_volume_meshtying_mortar_lagrange_regularized_line3.4C.yaml
+++ b/tests/input_files/beam3r_herm2line3_static_beam_to_solid_volume_meshtying_mortar_lagrange_regularized_line3.4C.yaml
@@ -21,10 +21,6 @@ STRUCTURAL DYNAMIC:
   TIMESTEP: 0.5
   NUMSTEP: 2
   MAXTIME: 1
-  TOLDISP: 1e-12
-  TOLRES: 1e-12
-  MAXITER: 20
-  PREDICT: "TangDis"
   LINEAR_SOLVER: 1
 SOLVER 1:
   SOLVER: "Superlu"
@@ -90,6 +86,8 @@ RESULT DESCRIPTION:
       QUANTITY: "dispz"
       VALUE: 1.899650306824355
       TOLERANCE: 1e-10
+STRUCT NOX/Status Test:
+  XML File: "beam3r_herm2line3_static_beam_to_solid_volume_meshtying_mortar_lagrange.xml"
 MATERIALS:
   - MAT: 1
     MAT_Struct_StVenantKirchhoff:

--- a/tests/input_files/beam3r_herm2line3_static_beam_to_solid_volume_meshtying_mortar_lagrange_saddlepoint_line3.4C.yaml
+++ b/tests/input_files/beam3r_herm2line3_static_beam_to_solid_volume_meshtying_mortar_lagrange_saddlepoint_line3.4C.yaml
@@ -22,10 +22,6 @@ STRUCTURAL DYNAMIC:
   TIMESTEP: 0.5
   NUMSTEP: 2
   MAXTIME: 1
-  TOLDISP: 1e-12
-  TOLRES: 1e-12
-  MAXITER: 20
-  PREDICT: "TangDis"
   LINEAR_SOLVER: 1
 SOLVER 1:
   SOLVER: "Superlu"
@@ -91,6 +87,8 @@ RESULT DESCRIPTION:
       QUANTITY: "dispz"
       VALUE: 1.89956091210363054e+00
       TOLERANCE: 1e-10
+STRUCT NOX/Status Test:
+  XML File: "beam3r_herm2line3_static_beam_to_solid_volume_meshtying_mortar_lagrange.xml"
 MATERIALS:
   - MAT: 1
     MAT_Struct_StVenantKirchhoff:


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

Following #1540, this PR adds two more additional convergence checks, by checking the update norm and the rhs norm specifically for the Lagrange multipliers  in beaminteraction. This results in improved convergence behavior of the NL solver when dealing with beaminteraction problems using Lagrange multipliers. 

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
#1162 