### PR TITLE
Refactor Airways in ReducedLung

### DIFF
--- a/src/reduced_lung/src/4C_reduced_lung_airways.cpp
+++ b/src/reduced_lung/src/4C_reduced_lung_airways.cpp
@@ -1,0 +1,373 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "4C_reduced_lung_airways.hpp"
+
+#include <cmath>
+#include <vector>
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace ReducedLung
+{
+  namespace Airways
+  {
+    void evaluate_negative_rigid_wall_residual(Core::LinAlg::Vector<double>& target,
+        const AirwayData& data, const Core::LinAlg::Vector<double>& locally_relevant_dofs,
+        const std::vector<double>& resistance, const std::vector<double>& inertia, double dt)
+    {
+      for (size_t i = 0; i < data.number_of_elements(); i++)
+      {
+        double negative_rigid_wall_residual =
+            -1 *
+            (locally_relevant_dofs.local_values_as_span()[data.lid_p1[i]] -
+                locally_relevant_dofs.local_values_as_span()[data.lid_p2[i]] -
+                resistance[i] * locally_relevant_dofs.local_values_as_span()[data.lid_q1[i]] -
+                inertia[i] / dt *
+                    (locally_relevant_dofs.local_values_as_span()[data.lid_q1[i]] - data.q1_n[i]));
+        target.replace_local_value(data.local_row_id[i], negative_rigid_wall_residual);
+      }
+    }
+
+    void evaluate_negative_kelvin_voigt_wall_residual(Core::LinAlg::Vector<double>& target,
+        const KelvinVoigtWall& kelvin_voigt_wall_model, const AirwayData& data,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs,
+        const std::vector<double>& resistance, const std::vector<double>& inertia, double dt)
+    {
+      for (size_t i = 0; i < data.number_of_elements(); i++)
+      {
+        double neg_res_momentum =
+            -1 * (locally_relevant_dofs.local_values_as_span()[data.lid_p1[i]] -
+                     locally_relevant_dofs.local_values_as_span()[data.lid_p2[i]] -
+                     (resistance[i] / 2 + inertia[i] / (2 * dt)) *
+                         (locally_relevant_dofs.local_values_as_span()[data.lid_q1[i]] +
+                             locally_relevant_dofs.local_values_as_span()[data.lid_q2[i]]) +
+                     inertia[i] / (2 * dt) * (data.q1_n[i] + data.q2_n[i]));
+        double neg_res_mass =
+            -1 * (locally_relevant_dofs.local_values_as_span()[data.lid_p1[i]] +
+                     locally_relevant_dofs.local_values_as_span()[data.lid_p2[i]] - data.p1_n[i] -
+                     data.p2_n[i] -
+                     2 *
+                         (kelvin_voigt_wall_model.viscous_resistance_Rvisc[i] +
+                             dt / kelvin_voigt_wall_model.compliance_C[i]) *
+                         (locally_relevant_dofs.local_values_as_span()[data.lid_q1[i]] -
+                             locally_relevant_dofs.local_values_as_span()[data.lid_q2[i]]) +
+                     2 * kelvin_voigt_wall_model.viscous_resistance_Rvisc[i] *
+                         (data.q1_n[i] - data.q2_n[i]));  // Pext component not implemented yet.
+        target.replace_local_value(data.local_row_id[i], neg_res_momentum);
+        target.replace_local_value(
+            static_cast<int>(data.local_row_id[i] + data.number_of_elements()), neg_res_mass);
+      }
+    }
+
+    void evaluate_jacobian_rigid_wall(Core::LinAlg::SparseMatrix& target, AirwayData const& data,
+        const std::vector<double>& resistance_derivative,
+        const std::vector<double>& inertia_derivative, double dt)
+    {
+      [[maybe_unused]] int err;  // Saves error code of trilinos functions.
+      std::array<int, 3> column_indices;
+      std::array<double, 3> values;
+      for (size_t i = 0; i < data.number_of_elements(); i++)
+      {
+        column_indices = {data.lid_p1[i], data.lid_p2[i], data.lid_q1[i]};
+        values = {1.0, -1.0, -resistance_derivative[i] - inertia_derivative[i]};
+        target.insert_my_values(data.local_row_id[i], 3, values.data(), column_indices.data());
+      }
+    }
+
+    std::vector<double> evaluate_nonlinear_flow_resistance_derivative_rigid(
+        const NonLinearResistive& model, const AirwayData& data,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt)
+    {
+      auto poiseuille_resistance = ComputePoiseuilleResistance{}(data, data.ref_area);
+      std::vector<double> resistance_derivative(data.number_of_elements());
+      for (size_t i = 0; i < data.number_of_elements(); i++)
+      {
+        double R = poiseuille_resistance[i] * model.k_turb[i];
+
+        double dk_dq1;
+        if (model.k_turb[i] > 1.0)
+        {
+          dk_dq1 =
+              model.turbulence_factor_gamma[i] *
+              std::sqrt(data.air_properties.density /
+                        (M_PI * data.air_properties.dynamic_viscosity * data.ref_length[i])) *
+              1 / std::sqrt(std::abs(locally_relevant_dofs.local_values_as_span()[data.lid_q1[i]]));
+        }
+        else
+        {
+          dk_dq1 = 0.0;
+        }
+        resistance_derivative[i] =
+            (poiseuille_resistance[i] * dk_dq1) *
+                locally_relevant_dofs.local_values_as_span()[data.lid_q1[i]] +
+            R;
+      }
+      return resistance_derivative;
+    }
+
+    void evaluate_jacobian_kelvin_voigt_wall(Core::LinAlg::SparseMatrix& target,
+        AirwayData const& data, const KelvinVoigtWall& kelvin_voigt_wall_model,
+        const std::pair<std::vector<double>, std::vector<double>>& resistance_derivative,
+        const std::pair<std::vector<double>, std::vector<double>>& inertia_derivative,
+        const std::pair<std::vector<double>, std::vector<double>>&
+            viscous_wall_resistance_derivative,
+        double dt)
+    {
+      [[maybe_unused]] int err;  // Saves error code of trilinos functions.
+      std::array<int, 4> column_indices;
+      std::array<double, 4> values;
+      for (size_t i = 0; i < data.number_of_elements(); i++)
+      {
+        column_indices = {data.lid_p1[i], data.lid_p2[i], data.lid_q1[i], data.lid_q2[i]};
+        values = {1.0, -1.0, resistance_derivative.first[i] + inertia_derivative.first[i],
+            resistance_derivative.second[i] + inertia_derivative.second[i]};
+        target.insert_my_values(data.local_row_id[i], 4, values.data(), column_indices.data());
+        values = {1.0, 1.0, viscous_wall_resistance_derivative.first[i],
+            viscous_wall_resistance_derivative.second[i]};
+        target.insert_my_values(static_cast<int>(data.local_row_id[i] + data.number_of_elements()),
+            4, values.data(), column_indices.data());
+      }
+    }
+
+    std::pair<std::vector<double>, std::vector<double>>
+    evaluate_linear_flow_resistance_derivative_kelvin_voigt(const LinearResistive& model,
+        const AirwayData& data, const Core::LinAlg::Vector<double>& dofs, std::vector<double>& area,
+        double dt)
+    {
+      auto poiseuille_resistance = ComputePoiseuilleResistance{}(data, area);
+      std::vector<double> resistance_derivative_q1(data.number_of_elements());
+      std::vector<double> resistance_derivative_q2(data.number_of_elements());
+      for (size_t i = 0; i < data.number_of_elements(); i++)
+      {
+        double dRp_da = -16 * M_PI * data.air_properties.dynamic_viscosity * data.ref_length[i] /
+                        (area[i] * area[i] * area[i]);
+        double da_dq1 = dt / data.ref_length[i];
+        double da_dq2 = -dt / data.ref_length[i];
+        resistance_derivative_q1[i] =
+            -0.5 * (dRp_da * da_dq1 *
+                           (dofs.local_values_as_span()[data.lid_q1[i]] +
+                               dofs.local_values_as_span()[data.lid_q2[i]]) +
+                       poiseuille_resistance[i]);
+        resistance_derivative_q2[i] =
+            -0.5 * (dRp_da * da_dq2 *
+                           (dofs.local_values_as_span()[data.lid_q1[i]] +
+                               dofs.local_values_as_span()[data.lid_q2[i]]) +
+                       poiseuille_resistance[i]);
+      }
+      return {resistance_derivative_q1, resistance_derivative_q2};
+    }
+
+    std::pair<std::vector<double>, std::vector<double>>
+    evaluate_nonlinear_flow_resistance_derivative_kelvin_voigt(const NonLinearResistive& model,
+        const AirwayData& data, const Core::LinAlg::Vector<double>& dofs, std::vector<double>& area,
+        double dt)
+    {
+      auto poiseuille_resistance = ComputePoiseuilleResistance{}(data, area);
+      std::vector<double> resistance_derivative_q1(data.number_of_elements());
+      std::vector<double> resistance_derivative_q2(data.number_of_elements());
+      for (size_t i = 0; i < data.number_of_elements(); i++)
+      {
+        double dRp_da = -16 * M_PI * data.air_properties.dynamic_viscosity * data.ref_length[i] /
+                        (area[i] * area[i] * area[i]);
+        double da_dq1 = dt / data.ref_length[i];
+        double da_dq2 = -dt / data.ref_length[i];
+        double dk_dq1;
+        if (model.k_turb[i] > 1.0)
+        {
+          dk_dq1 =
+              model.turbulence_factor_gamma[i] *
+              std::sqrt(data.air_properties.density /
+                        (2 * M_PI * data.air_properties.dynamic_viscosity * data.ref_length[i])) *
+              (dofs.local_values_as_span()[data.lid_q1[i]] +
+                  dofs.local_values_as_span()[data.lid_q2[i]]) /
+              (std::abs(dofs.local_values_as_span()[data.lid_q1[i]] +
+                        dofs.local_values_as_span()[data.lid_q2[i]]) *
+                  std::sqrt(std::abs(
+                      dofs.local_values_as_span()[data.lid_q1[i]] +
+                      dofs.local_values_as_span()[data.lid_q2[i]])));  // (|q1+q2|^1.5) not using
+                                                                       // std::pow for performance
+        }
+        else
+        {
+          dk_dq1 = 0.0;
+        }
+        double dk_dq2 = dk_dq1;
+        double dalpha_dk = -4.0 / ((4.0 * model.k_turb[i] - 1.0) * (4.0 * model.k_turb[i] - 1.0));
+        double alpha = 4.0 * model.k_turb[i] / (4.0 * model.k_turb[i] - 1.0);
+
+        double resistance = poiseuille_resistance[i] * model.k_turb[i] +
+                            2 * data.air_properties.density * alpha / (area[i] * area[i]) *
+                                (dofs.local_values_as_span()[data.lid_q2[i]] -
+                                    dofs.local_values_as_span()[data.lid_q1[i]]);
+        resistance_derivative_q1[i] =
+            -0.5 *
+            ((dRp_da * da_dq1 * model.k_turb[i] + poiseuille_resistance[i] * dk_dq1 +
+                 2 * data.air_properties.density *
+                     (dofs.local_values_as_span()[data.lid_q2[i]] -
+                         dofs.local_values_as_span()[data.lid_q1[i]]) /
+                     (area[i] * area[i]) * dalpha_dk * dk_dq1 -  // <-- careful with sign here
+                 2 * data.air_properties.density * alpha / (area[i] * area[i]) -
+                 4 * data.air_properties.density * alpha / (area[i] * area[i] * area[i]) * da_dq1 *
+                     (dofs.local_values_as_span()[data.lid_q2[i]] -
+                         dofs.local_values_as_span()[data.lid_q1[i]])) *
+                    (dofs.local_values_as_span()[data.lid_q1[i]] +
+                        dofs.local_values_as_span()[data.lid_q2[i]]) +
+                resistance);
+        resistance_derivative_q2[i] =
+            -0.5 *
+            ((dRp_da * da_dq2 * model.k_turb[i] + poiseuille_resistance[i] * dk_dq2 +
+                 2 * data.air_properties.density *
+                     (dofs.local_values_as_span()[data.lid_q2[i]] -
+                         dofs.local_values_as_span()[data.lid_q1[i]]) /
+                     (area[i] * area[i]) * dalpha_dk * dk_dq2 +  // <-- careful with sign here
+                 2 * data.air_properties.density * alpha / (area[i] * area[i]) -
+                 4 * data.air_properties.density * alpha / (area[i] * area[i] * area[i]) * da_dq2 *
+                     (dofs.local_values_as_span()[data.lid_q2[i]] -
+                         dofs.local_values_as_span()[data.lid_q1[i]])) *
+                    (dofs.local_values_as_span()[data.lid_q1[i]] +
+                        dofs.local_values_as_span()[data.lid_q2[i]]) +
+                resistance);
+      }
+      return {resistance_derivative_q1, resistance_derivative_q2};
+    }
+
+    std::pair<std::vector<double>, std::vector<double>>
+    evaluate_viscous_wall_resistance_derivative_kelvin_voigt(const KelvinVoigtWall& model,
+        const AirwayData& data, const Core::LinAlg::Vector<double>& dofs, double dt)
+    {
+      std::vector<double> viscous_resistance_derivative_q1(data.number_of_elements());
+      std::vector<double> viscous_resistance_derivative_q2(data.number_of_elements());
+
+      for (size_t i = 0; i < data.number_of_elements(); i++)
+      {
+        double dRvisc_da =
+            model.viscous_time_constant[i] * std::tan(model.viscous_phase_shift[i]) /
+            (8.0 * M_PI * model.area[i] * std::sqrt(model.area[i]) * data.ref_length[i]) *
+            model.beta_w[i];
+        double da_dq1 = dt / data.ref_length[i];
+        double da_dq2 = -dt / data.ref_length[i];
+        double dCinv_da = -model.beta_w[i] / (4.0 * data.ref_area[i] * std::sqrt(data.ref_area[i]) *
+                                                 data.ref_length[i]);
+        viscous_resistance_derivative_q1[i] =
+            -2 * ((dRvisc_da * da_dq1 + dt * dCinv_da * da_dq1) *
+                         (dofs.local_values_as_span()[data.lid_q1[i]] -
+                             dofs.local_values_as_span()[data.lid_q2[i]]) +  // <-- careful with
+                                                                             // sign here
+                     (model.viscous_resistance_Rvisc[i] + dt / model.compliance_C[i]) -
+                     dRvisc_da * da_dq1 * (data.q1_n[i] - data.q2_n[i]));
+        viscous_resistance_derivative_q2[i] =
+            -2 * ((dRvisc_da * da_dq2 + dt * dCinv_da * da_dq2) *
+                         (dofs.local_values_as_span()[data.lid_q1[i]] -
+                             dofs.local_values_as_span()[data.lid_q2[i]]) -  // <-- careful with
+                                                                             // sign here
+                     (model.viscous_resistance_Rvisc[i] + dt / model.compliance_C[i]) -
+                     dRvisc_da * da_dq2 * (data.q1_n[i] - data.q2_n[i]));
+      }
+      return {viscous_resistance_derivative_q1, viscous_resistance_derivative_q2};
+    }
+
+
+    std::pair<std::vector<double>, std::vector<double>> evaluate_inertia_derivative_kelvin_voigt(
+        const std::vector<bool>& has_inertia, const AirwayData& data,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs, const KelvinVoigtWall& wall,
+        double dt)
+    {
+      std::vector<double> inertia_q1(data.number_of_elements(), 0.0);
+      std::vector<double> inertia_q2(data.number_of_elements(), 0.0);
+      for (size_t i = 0; i < data.number_of_elements(); ++i)
+      {
+        if (i < has_inertia.size() && has_inertia[i])
+        {
+          double dI_da =
+              -data.air_properties.density * data.ref_length[i] / (wall.area[i] * wall.area[i]);
+          double da_dq1 = dt / data.ref_length[i];
+          double da_dq2 = -dt / data.ref_length[i];
+          inertia_q1[i] = -0.5 / dt *
+                          (data.air_properties.density * data.ref_length[i] / wall.area[i] +
+                              dI_da * da_dq1 *
+                                  (locally_relevant_dofs.local_values_as_span()[data.lid_q1[i]] +
+                                      locally_relevant_dofs.local_values_as_span()[data.lid_q2[i]] -
+                                      data.q1_n[i] - data.q2_n[i]));
+
+          inertia_q2[i] = -0.5 / dt *
+                          (data.air_properties.density * data.ref_length[i] / wall.area[i] +
+                              dI_da * da_dq2 *
+                                  (locally_relevant_dofs.local_values_as_span()[data.lid_q1[i]] +
+                                      locally_relevant_dofs.local_values_as_span()[data.lid_q2[i]] -
+                                      data.q1_n[i] - data.q2_n[i]));
+        }
+      }
+      return {inertia_q1, inertia_q2};
+    }
+    void update_jacobian(Core::LinAlg::SparseMatrix& jac, AirwayContainer& airways,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt)
+    {
+      for (auto& model : airways.models)
+      {
+        model.jacobian_evaluator(model.data, jac, locally_relevant_dofs, dt);
+      }
+    }
+
+    void update_negative_residual_vector(Core::LinAlg::Vector<double>& res_vector,
+        AirwayContainer& airways, const Core::LinAlg::Vector<double>& locally_relevant_dofs,
+        double dt)
+    {
+      for (auto& model : airways.models)
+      {
+        model.negative_residual_evaluator(model.data, res_vector, locally_relevant_dofs, dt);
+      }
+    }
+
+
+    void update_internal_state_vectors(AirwayContainer& airways,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt)
+    {
+      for (auto& model : airways.models)
+      {
+        // Model specific updates
+        model.internal_state_updater(model.data, locally_relevant_dofs, dt);
+      }
+    }
+
+    void end_of_timestep_routine(AirwayContainer& airways,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt)
+    {
+      for (auto& model : airways.models)
+      {
+        for (size_t i = 0; i < model.data.number_of_elements(); i++)
+        {
+          model.data.p1_n[i] = locally_relevant_dofs.local_values_as_span()[model.data.lid_p1[i]];
+          model.data.p2_n[i] = locally_relevant_dofs.local_values_as_span()[model.data.lid_p2[i]];
+          model.data.q1_n[i] = locally_relevant_dofs.local_values_as_span()[model.data.lid_q1[i]];
+          if (model.data.n_state_equations == 2)
+          {
+            model.data.q2_n[i] = locally_relevant_dofs.local_values_as_span()[model.data.lid_q2[i]];
+          }
+
+          model.end_of_timestep_routine(model.data, locally_relevant_dofs, dt);
+        }
+      }
+    }
+
+    void create_evaluators(AirwayContainer& airways)
+    {
+      for (auto& model : airways.models)
+      {
+        model.negative_residual_evaluator =
+            std::visit(MakeNegativeResidualEvaluator{model.flow_model}, model.wall_model);
+        model.jacobian_evaluator =
+            std::visit(MakeJacobianEvaluator{model.flow_model}, model.wall_model);
+        model.internal_state_updater =
+            std::visit(MakeInternalStateUpdater{model.flow_model}, model.wall_model);
+        model.end_of_timestep_routine = std::visit(MakeEndOfTimestepRoutine{}, model.wall_model);
+      }
+    }
+  }  // namespace Airways
+}  // namespace ReducedLung
+
+FOUR_C_NAMESPACE_CLOSE

--- a/src/reduced_lung/src/4C_reduced_lung_airways.hpp
+++ b/src/reduced_lung/src/4C_reduced_lung_airways.hpp
@@ -1,0 +1,1141 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+
+
+#ifndef FOUR_C_REDUCED_LUNG_AIRWAYS_HPP
+#define FOUR_C_REDUCED_LUNG_AIRWAYS_HPP
+
+#include "4C_config.hpp"
+
+#include "4C_fem_discretization.hpp"
+#include "4C_linalg_sparsematrix.hpp"
+#include "4C_linalg_vector.hpp"
+#include "4C_reduced_lung_input.hpp"
+#include "4C_utils_exceptions.hpp"
+
+#include <cstddef>
+#include <cstdlib>
+#include <functional>
+#include <type_traits>
+#include <variant>
+#include <vector>
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace ReducedLung
+{
+  namespace Airways
+  {
+    /**
+     * @brief Shared data container for all airway elements.
+     *
+     * Stores identifiers and physical parameters (length, area, etc.) for each
+     * airway, which are used across all flow and wall models.
+     *
+     * @note This data is independent of specific models and is shared across evaluators.
+     */
+    struct AirwayData
+    {
+      // Global element IDs.
+      std::vector<int> global_element_id;
+      // Local element IDs.
+      std::vector<int> local_element_id;
+      // IDs of the local rows in the row map. This defines the place for these airways in the
+      // system of equations.
+      std::vector<int> local_row_id;
+      // Global dof IDs
+      std::vector<int> gid_p1, gid_p2, gid_q1, gid_q2;
+      // Dof IDs from locally relevant / column map. Used for lookup in dof-vector during assembly.
+      std::vector<int> lid_p1, lid_p2, lid_q1, lid_q2;
+
+      // Physical quantities of each airway.
+      std::vector<double> ref_length;
+      std::vector<double> ref_area;
+      struct AirProperties
+      {
+        double dynamic_viscosity;
+        double density;
+      } air_properties;
+
+      // Dof values at previous time step
+      std::vector<double> q1_n;
+      std::vector<double> q2_n;
+      std::vector<double> p1_n;
+      std::vector<double> p2_n;
+
+      int n_state_equations;  // number of state equations per airway
+      // convenience
+      [[nodiscard]] size_t number_of_elements() const { return global_element_id.size(); }
+    };
+
+    // ----- Flow resistance models -----
+
+    /**
+     * @brief Linear resistive model for airway flow.
+     *
+     * Considers Poiseuille resistance \f$R_p= 8 \pi \mu L / A^2\f$ and optional inertial effects.
+     */
+    struct LinearResistive
+    {
+      std::vector<bool> has_inertia;
+    };
+
+    /**
+     * @brief Nonlinear resistive model considering turbulence effects and convective resistance
+     * from momentum flux.
+     *
+     * Airway resistance is defined as \f$R = R_p \, k_{turb} + \frac{2 \alpha
+     * \rho}{A^2}(Q_2-Q_1)\f$, where \f$_p\f$ is the Poiseuille resistance and \f$k_{turb}\f$ is a
+     * turbulence correction factor depending on the Reynolds number. The second term represents
+     * convective resistance due to momentum flux, with \f$\alpha\f$ being a correction factor
+     * \f$\alpha = \frac{4 k_{turb}}{4 k_{turb}-1}\f$.
+     */
+    struct NonLinearResistive
+    {
+      std::vector<double> turbulence_factor_gamma;
+      std::vector<bool> has_inertia;
+
+      // internal state variables
+      std::vector<double> k_turb;
+    };
+
+    // ----- Wall models -----
+
+    /**
+     * @brief Rigid wall model for airways.
+     */
+    struct RigidWall
+    {
+      // empty for now
+    };
+
+    /**
+     * @brief Kelvin-Voigt wall model for airways.
+     *
+     * Models airway wall mechanics of a Kelvin-Voigt type wall by the equation \f$ \frac{\dot{P}_1
+     * -
+     * \dot{P}_2}{2} - \dot{P}_{ext} = R_{visc} \cdot (Q_1 - Q_2) + \frac{1}{C} \cdot \frac{(Q_1 -
+     * Q_2)}{dt} \f$, where \f$R_{visc}\f$ is the viscous resistance and \f$C\f$ the compliance of
+     * the airway wall.
+     */
+    struct KelvinVoigtWall
+    {
+      std::vector<double> wall_poisson_ratio;
+      std::vector<double> wall_elasticity;
+      std::vector<double> wall_thickness;
+      std::vector<double> viscous_time_constant;
+      std::vector<double> viscous_phase_shift;
+      std::vector<double> area_n;
+
+      // internal state variables
+      std::vector<double> area;
+      std::vector<double> viscous_resistance_Rvisc;
+      std::vector<double> compliance_C;
+      std::vector<double> gamma_w;
+      std::vector<double> beta_w;
+    };
+
+    // ----- Evaluator function types -----
+
+    // Function handle for evaluating the negative model residuals.
+    using NegativeResidualEvaluator =
+        std::function<void(const AirwayData& data, Core::LinAlg::Vector<double>& target_vector,
+            const Core::LinAlg::Vector<double>& locally_relevant_dofs, double time_step_size_dt)>;
+
+    // Function handle for evaluating Jacobian (the model gradients w.r.t the primary variables).
+    using JacobianEvaluatorAW =
+        std::function<void(const AirwayData& data, Core::LinAlg::SparseMatrix& target_mat,
+            const Core::LinAlg::Vector<double>& locally_relevant_dofs, double time_step_size_dt)>;
+
+    // Function handle to update internal state vector.
+    using InternalStateUpdaterAW = std::function<void(AirwayData& data,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs, double time_step_size_dt)>;
+
+    // Function handle to run at the end of time step. Stores history variables
+    using EndOfTimestepRoutine = std::function<void(AirwayData& data,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs, double time_step_size_dt)>;
+
+    // Variant type to hold different flow and wall models.
+    using FlowModel = std::variant<LinearResistive, NonLinearResistive>;
+    using WallModel = std::variant<RigidWall, KelvinVoigtWall>;
+
+    /**
+     * @brief Holds all elements with a unique combination of flow and wall model.
+     *
+     * Stores the element-specific data and associated evaluation functions
+     * (residuals, Jacobians, internal state updates) for a given model combination. Every
+     * airway-specific information or action can be found here.
+     */
+    struct AirwayModel
+    {
+      AirwayData data;
+      FlowModel flow_model;
+      WallModel wall_model;
+      NegativeResidualEvaluator negative_residual_evaluator;
+      JacobianEvaluatorAW jacobian_evaluator;
+      InternalStateUpdaterAW internal_state_updater;
+      EndOfTimestepRoutine end_of_timestep_routine;
+    };
+
+    /**
+     * @brief All airway models together and interface for access.
+     *
+     * Stores all different airway models as distinct building blocks. Acts as interface for
+     * distributing airways to the correct models in the input phase and allows access to all
+     * airway model blocks for assembly, output, etc..
+     */
+    struct AirwayContainer
+    {
+      std::vector<AirwayModel> models;
+    };
+
+    // compile-time traits for number of state equations contributed by each model type
+    template <typename F>
+    struct FlowModelStateCount
+    {
+    };
+    template <>
+    struct FlowModelStateCount<LinearResistive>
+    {
+      static constexpr int value = 1;
+    };
+    template <>
+    struct FlowModelStateCount<NonLinearResistive>
+    {
+      static constexpr int value = 1;
+    };
+
+    template <typename W>
+    struct WallModelStateCount
+    {
+    };
+    template <>
+    struct WallModelStateCount<RigidWall>
+    {
+      static constexpr int value = 0;
+    };
+    template <>
+    struct WallModelStateCount<KelvinVoigtWall>
+    {
+      static constexpr int value = 1;
+    };
+
+    /**
+     * @brief Calculates the Poiseuille resistance for airway elements.
+     *
+     *
+     * @param data The airway data containing air properties and element reference lengths
+     * @param area Vector of cross-sectional areas for each airway element
+     *
+     * @return std::vector<double> Vector of Poiseuille resistance values for each element,
+     *         computed as: \f$ R_p = \frac{8 \pi \mu L}{A^2} \f$
+     */
+    struct ComputePoiseuilleResistance
+    {
+      std::vector<double> operator()(const AirwayData& data, const std::vector<double>& area) const
+      {
+        std::vector<double> poiseuille(data.number_of_elements());
+        for (size_t i = 0; i < data.number_of_elements(); ++i)
+        {
+          poiseuille[i] = 8 * std::numbers::pi * data.air_properties.dynamic_viscosity *
+                          data.ref_length[i] / (area[i] * area[i]);
+        }
+        return poiseuille;
+      }
+    };
+
+    /**
+    * @brief Assembles the negative residual vector of airways with rigid walls.
+    * Each airway is described by one state equation (momentum conservation).
+    *
+    * \f$ -f_1 = -(P_1 - P_2 - R\,Q_1 - \frac{I}{\Delta t} \, (Q_1 - Q_1^n)) = -(P_1 - P_2  +
+    f_{1,QR}
+    * + f_{1,QI})\f$ \n
+    * with \f$ f_{1,QR} = - R\,Q_1 \f$ and \f$ f_{1,QI} = - \frac{I}{\Delta t} \, (Q_1 - Q_1^n) \f$
+
+    * @param target The target RHS vector to store the negative residuals.
+    * @param data The airway data containing element information.
+    * @param locally_relevant_dofs The DOF vector containing current flows and pressures in column
+    map layout.
+    * @param resistance The flow resistance \f$ R \f$ for each airway element.
+    * @param inertia The inertia \f$ I \f$ for each airway element.
+    * @param dt The time step size.
+    */
+    void evaluate_negative_rigid_wall_residual(Core::LinAlg::Vector<double>& target,
+        const AirwayData& data, const Core::LinAlg::Vector<double>& locally_relevant_dofs,
+        const std::vector<double>& resistance, const std::vector<double>& inertia, double dt);
+
+    /**
+     * @brief Assembles the negative residual vector of airways with Kelvin-Voigt walls.
+     * Each airway is described by two state equations (momentum and mass conservation).
+     *
+     * \f$ -f_1 = -(P_1 - P_2 - ( \frac{R}{2} + \frac{I}{2 \Delta t}) (Q_1 + Q_2) + \frac{I}{2
+     * \Delta t} (Q_1^n + Q_2^n)) = -(P_1 -P_2 + f_{1,QR} + f_{1,QI}) \f$
+     *
+     * \f$ -f_2 = -(P_1 + P_2 - P_1^n - P_2^n - 2 (R_{visc} + \frac{\Delta t}{C}) (Q_1 - Q_2) + 2
+     * R_{visc} (Q_1^n - Q_2^n)) = -(P_1 + P_2 - P_1^n - P_2^n + f_{2,QR_{visc}})\f$
+     *
+     * with \f$ f_{1,QR} = - \frac{R}{2} (Q_1 + Q_2) \f$, \f$ f_{1,QI} = - \frac{I}{2 \Delta t} (Q_1
+     * + Q_2 - Q_1^n - Q_2^n) \f$
+     * and \f$ f_{2,QR_{visc}} = - 2 (R_{visc} + \frac{\Delta t}{C}) (Q_1 - Q_2) + 2 R_{visc} (Q_1^n
+     * - Q_2^n) \f$
+     *
+     * @param target The target RHS vector to store the negative residuals.
+     * @param kelvin_voigt_wall_model The Kelvin-Voigt wall model containing wall parameters and
+     * internal states.
+     * @param data The airway data containing element information.
+     * @param locally_relevant_dofs The DOF vector containing current flows and pressures in column
+     * map layout.
+     * @param resistance The flow resistance \f$ R \f$ for each airway element.
+     * @param inertia The inertia \f$ I \f$ for each airway element.
+     * @param dt The time step size.
+     */
+    void evaluate_negative_kelvin_voigt_wall_residual(Core::LinAlg::Vector<double>& target,
+        const KelvinVoigtWall& kelvin_voigt_wall_model, const AirwayData& data,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs,
+        const std::vector<double>& resistance, const std::vector<double>& inertia, double dt);
+
+    /**
+     * @brief Assembles the Jacobian matrix of airways with rigid walls.
+     *
+     * @param target The target sparse matrix to store the Jacobian entries.
+     * @param data The airway data containing element information.
+     * @param resistance_derivative The derivative of the flow resistance term w.r.t. \f$ Q_1 \f$
+     * for each airway element.
+     * @param inertia_derivative The derivative of the inertia term w.r.t. \f$ Q_1 \f$ for each
+     * airway element.
+     * @param dt The time step size.
+     */
+    void evaluate_jacobian_rigid_wall(Core::LinAlg::SparseMatrix& target, AirwayData const& data,
+        const std::vector<double>& resistance_derivative,
+        const std::vector<double>& inertia_derivative, double dt);
+
+    /**
+     * @brief Calculates the derivative of the nonlinear flow term for rigid walls.
+     *
+     * @param model The nonlinear resistive flow model containing turbulence parameters.
+     * @param data The airway data containing element information.
+     * @param locally_relevant_dofs The DOF vector containing current flows and pressures in column
+     * map layout.
+     * @param dt The time step size.
+     * @return std::vector<double> Vector of flow resistance derivatives for each airway element.
+     *
+     * The derivative is given by:
+     * \f$ \frac{\partial f_{1,QR}}{\partial Q_1} = R_p \frac{\partial k_{turb}}{\partial Q_1} \cdot
+     * Q_1 + R_p \, k_{turb} \f$
+     *
+     * with \f$ \frac{\partial k_{turb}}{\partial Q_1} = \gamma \cdot \sqrt{\frac{\rho}{\pi \mu L}}
+     * \, \frac{1}{\sqrt{Q_1}}\f$
+     */
+    std::vector<double> evaluate_nonlinear_flow_resistance_derivative_rigid(
+        const NonLinearResistive& model, const AirwayData& data,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt);
+
+    /**
+     * @brief Assembles the Jacobian matrix of airways with Kelvin-Voigt walls.
+     *
+     * @param target The target sparse matrix to store the Jacobian entries.
+     * @param data The airway data containing element information.
+     * @param resistance_derivative The derivative of the flow resistance term w.r.t. \f$ Q_1 \f$
+     * and
+     * \f$ Q_2 \f$ for each airway element.
+     * @param inertia_derivative The derivative of the inertia term w.r.t. \f$ Q_1 \f$ and \f$ Q_2
+     * \f$ for each airway element.
+     * @param viscous_wall_resistance_derivative The derivative of the viscous wall resistance term
+     * w.r.t. \f$ Q_1 \f$ and \f$ Q_2 \f$ for each airway element.
+     * @param dt The time step size.
+     */
+    void evaluate_jacobian_kelvin_voigt_wall(Core::LinAlg::SparseMatrix& target,
+        AirwayData const& data, const KelvinVoigtWall& kelvin_voigt_wall_model,
+        const std::pair<std::vector<double>, std::vector<double>>& resistance_derivative,
+        const std::pair<std::vector<double>, std::vector<double>>& inertia_derivative,
+        const std::pair<std::vector<double>, std::vector<double>>&
+            viscous_wall_resistance_derivative,
+        double dt);
+
+
+    /**
+     * @brief Derivatives of the linear flow term for Kelvin-Voigt walls.
+     *
+     * @param model The linear resistive flow model.
+     * @param data The airway data containing element information.
+     * @param locally_relevant_dofs The DOF vector containing current flows and pressures in column
+     * map layout.
+     * @param area The current cross-sectional areas of the airway elements.
+     * @param dt The time step size.
+     * @return std::pair<std::vector<double>, std::vector<double>> Pair of vectors containing the
+     * flow resistance term derivatives for each airway element w.r.t. \f$ Q_1 \f$ and \f$ Q_2 \f$.
+     *
+     * The derivatives are given by:
+     * \f$ \frac{\partial f_{1,QR}}{\partial Q_1} = -\frac{1}{2}\left(\frac{\partial R_p}{\partial
+     * A}\frac{\partial A}{\partial Q_1}(Q_1+Q_2) + R_p\right) \f$,
+     *
+     * \f$ \frac{\partial f_{1,QR}}{\partial Q_2} = -\frac{1}{2}\left(\frac{\partial R_p}{\partial
+     * A}\frac{\partial A}{\partial Q_2}(Q_1+Q_2) + R_p\right) \f$
+     *
+     * with \f$ \frac{\partial R_p}{\partial A} = -\frac{16 \pi \mu
+     * L}{A^3},\; \frac{\partial A}{\partial Q_1} = \frac{\Delta t}{L},\; \frac{\partial A}{\partial
+     * Q_2} = -\frac{\Delta t}{L} \f$.
+     * @note Unlike in rigid walls, the derivative of the linear flow resistance is not \f$ R_p \f$,
+     * because of the change in cross-sectional area.
+     */
+    std::pair<std::vector<double>, std::vector<double>>
+    evaluate_linear_flow_resistance_derivative_kelvin_voigt(const LinearResistive& model,
+        const AirwayData& data, const Core::LinAlg::Vector<double>& locally_relevant_dofs,
+        std::vector<double>& area, double dt);
+
+
+    /**
+     * @brief Calculates the derivative of the nonlinear flow term for Kelvin Voigt walls.
+     *
+     * @param data The airway data containing element information.
+     * @param locally_relevant_dofs The DOF vector containing current flows and pressures in column
+     * map layout.
+     * @param area The current cross-sectional areas of the airway elements.
+     * @param dt The time step size.
+     * @return std::pair<std::vector<double>, std::vector<double>> Pair of vectors containing the
+     * flow resistance term derivatives for each airway element w.r.t. \f$ Q_1 \f$ and \f$ Q_2 \f$.
+     *
+     * The derivatives are given by:
+     *
+     * \f$ \frac{\partial f_{1,QR}}{\partial Q_1} = -\frac{1}{2}\left[\left(\frac{\partial R_p}
+     * {\partial A}\frac{\partial A}{\partial Q_1} k_{turb} + R_p \frac{\partial k_{turb}}
+     * {\partial Q_1} + \frac{2\rho (Q_2-Q_1)}{A^2} \frac{\partial \alpha}{\partial k_{turb}}
+     * \frac{\partial k_{turb}}{\partial Q_1} - \frac{2\rho \alpha}{A^2} - \frac{4\rho \alpha}
+     * {A^3}\frac{\partial A}{\partial Q_1}(Q_2-Q_1)\right)(Q_1+Q_2) + R\right] \f$
+     *
+     * \f$ \frac{\partial f_{1,QR}}{\partial Q_2} = -\frac{1}{2}\left[\left(\frac{\partial
+     * R_p}{\partial A}\frac{\partial A}{\partial Q_2} k_{turb} + R_p \frac{\partial k_{turb}}
+     * {\partial Q_2} + \frac{2\rho (Q_2-Q_1)}{A^2} \frac{\partial \alpha}{\partial k_{turb}}
+     * \frac{\partial k_{turb}}{\partial Q_2} + \frac{2\rho \alpha}{A^2} - \frac{4\rho \alpha}{A^3}
+     * \frac{\partial A}{\partial Q_2}(Q_2-Q_1)\right)(Q_1+Q_2) + R\right] \f$
+     *
+     * where \f$ R = R_p k_{turb} + \frac{2 \alpha \rho}{A^2}(Q_2-Q_1) \f$,
+     *
+     * \f$ \frac{\partial R_p}{\partial A} = -\frac{16 \pi \mu L}{A^3}\f$,
+     *
+     * \f$\frac{\partial A}{\partial Q_1} = \frac{\Delta t}{L} = -\frac{\partial A}{\partial
+     * Q_1} \f$,
+     *
+     * \f$ \frac{\partial k_{turb}}{\partial Q_1} = \gamma \cdot \sqrt{\frac{\rho}{2\pi \mu L}} \,
+     * \frac{Q_1+Q_2}{|Q_1+Q_2|^{3/2}} =  \frac{\partial k_{turb}}{\partial Q_2} \f$,
+     *
+     * \f$ \alpha = \frac{4 k_{turb}}{4 k_{turb}-1} \f$,
+     *
+     * and \f$ \frac{\partial \alpha}{\partial k_{turb}} = -\frac{4}{(4k_{turb}-1)^2} \f$.
+     */
+    std::pair<std::vector<double>, std::vector<double>>
+    evaluate_nonlinear_flow_resistance_derivative_kelvin_voigt(const NonLinearResistive& model,
+        const AirwayData& data, const Core::LinAlg::Vector<double>& locally_relevant_dofs,
+        std::vector<double>& area, double dt);
+
+    /**
+     * @brief Calculates the derivative of the viscous wall resistance term for Kelvin-Voigt walls.
+     *
+     * @param kelvin_voigt_wall_model The Kelvin-Voigt wall model containing wall parameters and
+     * internal states.
+     * @param data The airway data containing element information.
+     * @param locally_relevant_dofs The DOF vector containing current flows and pressures in column
+     * map layout.
+     * @param dt The time step size.
+     * @return std::pair<std::vector<double>, std::vector<double>> Pair of vectors containing the
+     * viscous wall resistance term derivatives for each airway element w.r.t. \f$ Q_1 \f$ and \f$
+     * Q_2
+     * \f$.
+     *
+     * The derivatives are given by:
+     *
+     * \f$ \frac{\partial f_{2,QR_{visc}}}{\partial Q_1} = -2\left[\left(\frac{\partial
+     * R_{visc}}{\partial A}\frac{\partial A}{\partial Q_1} + \Delta t \,\frac{\partial}{\partial
+     * A}(\frac{1}{C})\frac{\partial A}{\partial Q_1}\right)(Q_1-Q_2) + \left(R_{visc} +
+     * \frac{\Delta t}{C}\right) - \frac{\partial R_{visc}}{\partial A}\frac{\partial A}{\partial
+     * Q_1}(Q_1^n-Q_2^n)\right] \f$
+     *
+     * \f$ \frac{\partial f_{2,QR_{visc}}}{\partial Q_2} = -2\left[\left(\frac{\partial
+     * R_{visc}}{\partial A}\frac{\partial A}{\partial Q_2} + \Delta t \,\frac{\partial}{\partial
+     * A}(\frac{1}{C})\frac{\partial A}{\partial Q_1}\right)(Q_1-Q_2) - \left(R_{visc} +
+     * \frac{\Delta t}{C}\right) - \frac{\partial R_{visc}}{\partial A}\frac{\partial A}{\partial
+     * Q_2}(Q_1^n-Q_2^n)\right] \f$
+     *
+     * where \f$ \frac{\partial R_{visc}}{\partial A} = \frac{\tau_w \tan(\phi_w)}{8\pi\sqrt{A^3}L}
+     * \beta_w \f$, \n
+     * \f$ \frac{\partial A}{\partial Q_1} = \frac{\Delta t}{L} = -\frac{\partial A}{\partial Q_2}
+     * \f$,
+     * \n and \f$\frac{\partial}{\partial A}(\frac{1}{C}) = -\frac{\beta_w}{4 L\, \sqrt{A^3}} \f$.
+     */
+    std::pair<std::vector<double>, std::vector<double>>
+    evaluate_viscous_wall_resistance_derivative_kelvin_voigt(
+        const KelvinVoigtWall& kelvin_voigt_wall_model, const AirwayData& data,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt);
+
+    /**
+     * @brief Calculates the derivative of the inertia term for Kelvin-Voigt walls.
+     *
+     * Computes the derivatives of the inertia contribution to the residual with respect to the
+     * flow rates Q1 and Q2. The inertia term accounts for the mass of air in the airway and its
+     * acceleration effects.
+     *
+     * @param has_inertia Vector of boolean flags indicating whether inertia is included for each
+     * element.
+     * @param data The airway data containing element information and properties.
+     * @param locally_relevant_dofs The DOF vector containing current flows and pressures in column
+     * map layout.
+     * @param wall The Kelvin-Voigt wall model containing area information.
+     * @param dt The time step size.
+     *
+     * @return std::pair<std::vector<double>, std::vector<double>> Pair of vectors containing the
+     * inertia term derivatives for each airway element with respect to Q1 and Q2, respectively.
+     * Elements where inertia is disabled (has_inertia[i] = false) will have zero derivatives.
+     *
+     * The derivatives are computed as:
+     *
+     * \f$ \frac{\partial f_{1,QI}}{\partial Q_1} = -\frac{1}{2\,\Delta t}\left[\frac{\rho L}{A} +
+     * \frac{\partial I}{\partial A}\frac{\partial A}{\partial Q_1}(Q_1+Q_2-Q_1^n-Q_2^n)\right] \f$
+     *
+     * \f$ \frac{\partial f_{1,QI}}{\partial Q_2} = -\frac{1}{2\,\Delta t}\left[\frac{\rho L}{A} +
+     * \frac{\partial I}{\partial A}\frac{\partial A}{\partial Q_2}(Q_1+Q_2-Q_1^n-Q_2^n)\right] \f$
+     *
+     * where \f$ I = \frac{\rho L}{A} \f$, \f$ \frac{\partial I}{\partial A} = -\frac{\rho L}{A^2}
+     * \f$, and \f$ \frac{\partial A}{\partial Q_1} = \frac{\Delta t}{L} \f$,
+     * \f$ \frac{\partial A}{\partial Q_2} = -\frac{\Delta t}{L} \f$.
+     */
+    std::pair<std::vector<double>, std::vector<double>> evaluate_inertia_derivative_kelvin_voigt(
+        const std::vector<bool>& has_inertia, const AirwayData& data,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs, const KelvinVoigtWall& wall,
+        double dt);
+
+    /**
+     * Creates the model-specific inertia evaluator function.
+     */
+    struct MakeInertiaEvaluator
+    {
+      using InertiaEvaluator =
+          std::function<std::vector<double>(const AirwayData&, const std::vector<double>& area)>;
+
+      template <typename M>
+      InertiaEvaluator operator()(const M& model) const
+      {
+        using HasInertiaT = decltype(std::declval<M>().has_inertia);
+        static_assert(std::is_same_v<std::remove_reference_t<HasInertiaT>, std::vector<bool>>,
+            "Model must have member 'has_inertia' of type std::vector<bool>");
+
+        return [&model](const AirwayData& data, const std::vector<double>& area)
+        {
+          std::vector<double> inertia(data.number_of_elements(), 0.0);
+          for (size_t i = 0; i < data.number_of_elements(); ++i)
+          {
+            if (i < model.has_inertia.size() && model.has_inertia[i])
+            {
+              inertia[i] = data.air_properties.density * data.ref_length[i] / area[i];
+            }
+          }
+          return inertia;
+        };
+      }
+    };
+
+    /**
+     * Creates the model-specific negative residual evaluator function for airways.
+     */
+    struct MakeNegativeResidualEvaluator
+    {
+      /**
+       * Creates the model-specific flow resistance evaluator.
+       */
+      struct MakeFlowResistanceEvaluator
+      {
+        struct RigidWallTag
+        {
+        };
+        struct KelvinVoigtWallTag
+        {
+        };
+
+        // Evaluator type for both wall models: (AirwayData, DOF vector, area) -> flow resistance
+        // vector
+        using FlowResistanceEvaluator = std::function<std::vector<double>(
+            const AirwayData&, const Core::LinAlg::Vector<double>&, const std::vector<double>&)>;
+
+        FlowResistanceEvaluator operator()(
+            RigidWallTag /*tag*/, const LinearResistive& /*model*/) const
+        {
+          return [](const AirwayData& data, const Core::LinAlg::Vector<double>& /*dofs*/,
+                     const std::vector<double>& area)
+          { return ComputePoiseuilleResistance{}(data, area); };
+        }
+
+        FlowResistanceEvaluator operator()(
+            RigidWallTag /*tag*/, const NonLinearResistive& model) const
+        {
+          return [&model](const AirwayData& data, const Core::LinAlg::Vector<double>& dofs,
+                     const std::vector<double>& area)
+          {
+            auto poiseuille = ComputePoiseuilleResistance{}(data, area);
+            std::vector<double> resistance(data.number_of_elements());
+            for (size_t i = 0; i < resistance.size(); ++i)
+            {
+              resistance[i] = poiseuille[i] * model.k_turb[i];
+            }
+            return resistance;
+          };
+        }
+
+        FlowResistanceEvaluator operator()(
+            KelvinVoigtWallTag /*tag*/, const LinearResistive& /*model*/) const
+        {
+          return [](const AirwayData& data, const Core::LinAlg::Vector<double>& /*dofs*/,
+                     const std::vector<double>& area)
+          { return ComputePoiseuilleResistance{}(data, area); };
+        }
+
+        FlowResistanceEvaluator operator()(
+            KelvinVoigtWallTag /*tag*/, const NonLinearResistive& model) const
+        {
+          return [&model](const AirwayData& data, const Core::LinAlg::Vector<double>& dofs,
+                     const std::vector<double>& area)
+          {
+            auto poiseuille = ComputePoiseuilleResistance{}(data, area);
+            std::vector<double> resistance(area.size());
+            for (size_t i = 0; i < resistance.size(); ++i)
+            {
+              double alpha = 4.0 * model.k_turb[i] / (4.0 * model.k_turb[i] - 1.0);
+              resistance[i] = poiseuille[i] * model.k_turb[i] +
+                              2 * data.air_properties.density * alpha / (area[i] * area[i]) *
+                                  (dofs.local_values_as_span()[data.lid_q2[i]] -
+                                      dofs.local_values_as_span()[data.lid_q1[i]]);
+            }
+            return resistance;
+          };
+        }
+      };
+
+      NegativeResidualEvaluator operator()(RigidWall& rigid_wall_model)
+      {
+        auto resistance_factory = MakeFlowResistanceEvaluator{};
+        auto resistance_evaluator = std::visit([&resistance_factory](const auto& flow_model)
+            { return resistance_factory(MakeFlowResistanceEvaluator::RigidWallTag{}, flow_model); },
+            flow_model);
+        auto inertia_evaluator = std::visit(MakeInertiaEvaluator{}, flow_model);
+        return [resistance_evaluator, inertia_evaluator](const AirwayData& airway_data,
+                   Core::LinAlg::Vector<double>& target_vector,
+                   const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt)
+        {
+          std::vector<double> resistance =
+              resistance_evaluator(airway_data, locally_relevant_dofs, airway_data.ref_area);
+
+          std::vector<double> inertia = inertia_evaluator(airway_data, airway_data.ref_area);
+
+          evaluate_negative_rigid_wall_residual(
+              target_vector, airway_data, locally_relevant_dofs, resistance, inertia, dt);
+        };
+      }
+
+      NegativeResidualEvaluator operator()(KelvinVoigtWall& kelvin_voigt_wall_model)
+      {
+        auto resistance_factory = MakeFlowResistanceEvaluator{};
+        auto resistance_evaluator = std::visit(
+            [&resistance_factory](const auto& flow_model)
+            {
+              return resistance_factory(
+                  MakeFlowResistanceEvaluator::KelvinVoigtWallTag{}, flow_model);
+            },
+            flow_model);
+        auto inertia_evaluator = std::visit(MakeInertiaEvaluator{}, flow_model);
+        return [resistance_evaluator, inertia_evaluator, &kelvin_voigt_wall_model](
+                   const AirwayData& airway_data, Core::LinAlg::Vector<double>& target_vector,
+                   const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt)
+        {
+          std::vector<double> resistance = resistance_evaluator(
+              airway_data, locally_relevant_dofs, kelvin_voigt_wall_model.area);
+
+          std::vector<double> inertia =
+              inertia_evaluator(airway_data, kelvin_voigt_wall_model.area);
+
+          evaluate_negative_kelvin_voigt_wall_residual(target_vector, kelvin_voigt_wall_model,
+              airway_data, locally_relevant_dofs, resistance, inertia, dt);
+        };
+      }
+      FlowModel& flow_model;
+    };
+
+    // Creates the model-specific Jacobian evaluator function for airways.
+    struct MakeJacobianEvaluator
+    {
+      /**
+       * Creates the model-specific derivative evaluator of the flow resistance term.
+       * The evaluators return the derivatives of the flow resistance term w.r.t. the flow DOFs.
+       * \f$ \frac{\partial f_{1,QR}}{\partial Q_1} \f$ for rigid walls
+       * and \f$ \frac{\partial f_{1,QR}}{\partial Q_1} \f$, \f$ \frac{\partial f_{1,QR}}{\partial
+       * Q_2}
+       * \f$ for Kelvin-Voigt walls.
+       */
+      struct MakeFlowResistanceDerivativeEvaluator
+      {
+        struct RigidWallTag
+        {
+        };
+        struct KelvinVoigtWallTag
+        {
+        };
+
+        KelvinVoigtWall* kv_wall_model = nullptr;
+
+        // Rigid wall evaluators return single vector for the derivatives w.r.t. Q1
+        using FlowResistanceDerivativeEvaluatorRigid = std::function<std::vector<double>(
+            const AirwayData&, const Core::LinAlg::Vector<double>&, double)>;
+
+        // Kelvin-Voigt wall evaluators return pair of vectors for the derivatives w.r.t. Q1 and Q2
+        using FlowResistanceDerivativeEvaluatorKelvinVoigt =
+            std::function<std::pair<std::vector<double>, std::vector<double>>(
+                const AirwayData&, const Core::LinAlg::Vector<double>&, double)>;
+
+        FlowResistanceDerivativeEvaluatorRigid operator()(
+            RigidWallTag /*tag*/, const LinearResistive& /*model*/) const
+        {
+          return [](const AirwayData& data, const Core::LinAlg::Vector<double>&, double)
+          { return ComputePoiseuilleResistance{}(data, data.ref_area); };
+        }
+
+        FlowResistanceDerivativeEvaluatorRigid operator()(
+            RigidWallTag /*tag*/, const NonLinearResistive& model) const
+        {
+          return
+              [&model](const AirwayData& data, const Core::LinAlg::Vector<double>& dofs, double dt)
+          { return evaluate_nonlinear_flow_resistance_derivative_rigid(model, data, dofs, dt); };
+        }
+
+        FlowResistanceDerivativeEvaluatorKelvinVoigt operator()(
+            KelvinVoigtWallTag /*tag*/, const LinearResistive& flow_resistance_model) const
+        {
+          KelvinVoigtWall* wall = kv_wall_model;
+          return [wall, &flow_resistance_model](
+                     const AirwayData& data, const Core::LinAlg::Vector<double>& dofs, double dt)
+          {
+            return evaluate_linear_flow_resistance_derivative_kelvin_voigt(
+                flow_resistance_model, data, dofs, wall->area, dt);
+          };
+        }
+
+        FlowResistanceDerivativeEvaluatorKelvinVoigt operator()(
+            KelvinVoigtWallTag /*tag*/, const NonLinearResistive& flow_resistance_model) const
+        {
+          KelvinVoigtWall* wall = kv_wall_model;
+          return [wall, &flow_resistance_model](
+                     const AirwayData& data, const Core::LinAlg::Vector<double>& dofs, double dt)
+          {
+            return evaluate_nonlinear_flow_resistance_derivative_kelvin_voigt(
+                flow_resistance_model, data, dofs, wall->area, dt);
+          };
+        }
+      };
+
+      // Creates the derivative evaluator for the interia term in Kelvin-Voigt walls.
+      struct MakeInertiaDerivativeEvaluatorKelvinVoigt
+      {
+        KelvinVoigtWall* kv_wall_model;
+        using InertiaDerivativeEvaluatorKelvinVoigt =
+            std::function<std::pair<std::vector<double>, std::vector<double>>(
+                const AirwayData&, const Core::LinAlg::Vector<double>&, double)>;
+        template <typename M>
+        InertiaDerivativeEvaluatorKelvinVoigt operator()(const M& model) const
+        {
+          using HasInertiaT = decltype(std::declval<M>().has_inertia);
+          static_assert(std::is_same_v<std::remove_reference_t<HasInertiaT>, std::vector<bool>>,
+              "Model must have member 'has_inertia' of type std::vector<bool>");
+
+          KelvinVoigtWall* wall = kv_wall_model;
+          return [&model, wall](
+                     const AirwayData& data, const Core::LinAlg::Vector<double>& dofs, double dt)
+          {
+            return evaluate_inertia_derivative_kelvin_voigt(
+                model.has_inertia, data, dofs, *wall, dt);
+          };
+        }
+      };
+
+      FlowModel& flow_model;
+
+      JacobianEvaluatorAW operator()(RigidWall& rigid_wall_model)
+      {
+        auto resistance_derivative_factory = MakeFlowResistanceDerivativeEvaluator{};
+        auto resistance_derivative_evaluator = std::visit(
+            [&resistance_derivative_factory](const auto& flow_model)
+            {
+              return resistance_derivative_factory(
+                  MakeFlowResistanceDerivativeEvaluator::RigidWallTag{}, flow_model);
+            },
+            flow_model);
+        auto inertia_evaluator = std::visit(MakeInertiaEvaluator{}, flow_model);
+        return [resistance_derivative_evaluator, inertia_evaluator](const AirwayData& airway_data,
+                   Core::LinAlg::SparseMatrix& target,
+                   const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt)
+        {
+          std::vector<double> resistance_derivative =
+              resistance_derivative_evaluator(airway_data, locally_relevant_dofs, dt);
+          std::vector<double> inertia_derivative =
+              [dt, &evaluator = inertia_evaluator, &data = airway_data]()
+          {
+            auto vals = evaluator(data, data.ref_area);
+            for (auto& v : vals) v /= dt;
+            return vals;
+          }();
+          evaluate_jacobian_rigid_wall(
+              target, airway_data, resistance_derivative, inertia_derivative, dt);
+        };
+      }
+
+      JacobianEvaluatorAW operator()(KelvinVoigtWall& kelvin_voigt_wall_model)
+      {
+        auto resistance_derivative_factory =
+            MakeFlowResistanceDerivativeEvaluator{&kelvin_voigt_wall_model};
+        auto resistance_derivative_evaluator = std::visit(
+            [&resistance_derivative_factory](const auto& flow_model)
+            {
+              return resistance_derivative_factory(
+                  MakeFlowResistanceDerivativeEvaluator::KelvinVoigtWallTag{}, flow_model);
+            },
+            flow_model);
+        auto inertia_derivative_evaluator = std::visit(
+            MakeInertiaDerivativeEvaluatorKelvinVoigt{&kelvin_voigt_wall_model}, flow_model);
+        return [resistance_derivative_evaluator, inertia_derivative_evaluator,
+                   &kelvin_voigt_wall_model](const AirwayData& airway_data,
+                   Core::LinAlg::SparseMatrix& target,
+                   const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt)
+        {
+          auto resistance_derivative =
+              resistance_derivative_evaluator(airway_data, locally_relevant_dofs, dt);
+          auto inertia_derivative =
+              inertia_derivative_evaluator(airway_data, locally_relevant_dofs, dt);
+          auto viscous_wall_resistance_derivative =
+              evaluate_viscous_wall_resistance_derivative_kelvin_voigt(
+                  kelvin_voigt_wall_model, airway_data, locally_relevant_dofs, dt);
+
+          evaluate_jacobian_kelvin_voigt_wall(target, airway_data, kelvin_voigt_wall_model,
+              resistance_derivative, inertia_derivative, viscous_wall_resistance_derivative, dt);
+        };
+      }
+    };
+
+    // Creates the model-specific internal state updater function for airways.
+    struct MakeInternalStateUpdater
+    {
+      struct MakeInternalStateUpdaterFlowModel
+      {
+        using InternalStateUpdaterFlowModel =
+            std::function<void(AirwayData&, const Core::LinAlg::Vector<double>&)>;
+        InternalStateUpdaterFlowModel operator()(LinearResistive& /*model*/)
+        {
+          return [](AirwayData& /*data*/,
+                     const Core::LinAlg::Vector<double>& /*locally_relevant_dofs*/)
+          {
+            // No internal state to update for linear resistive model
+          };
+        }
+        InternalStateUpdaterFlowModel operator()(NonLinearResistive& model)
+        {
+          return [&model](AirwayData& data, const Core::LinAlg::Vector<double>& dofs)
+          {
+            // Update internal state variable 'resistance' based on current flow rates
+            for (size_t i = 0; i < data.number_of_elements(); i++)
+            {
+              double q_characteristic;
+              if (data.n_state_equations == 1)
+              {
+                q_characteristic = std::abs(dofs.local_values_as_span()[data.lid_q1[i]]);
+              }
+              else if (data.n_state_equations == 2)
+              {
+                q_characteristic = 0.5 * std::abs(dofs.local_values_as_span()[data.lid_q1[i]] +
+                                                  dofs.local_values_as_span()[data.lid_q2[i]]);
+              }
+              else
+              {
+                FOUR_C_THROW("Number of state equations not supported.");
+              }
+              model.k_turb[i] =
+                  model.turbulence_factor_gamma[i] *
+                  std::sqrt((4 * data.air_properties.density) /
+                            (M_PI * data.air_properties.dynamic_viscosity * data.ref_length[i]) *
+                            q_characteristic);
+              if (model.k_turb[i] < 1.0) model.k_turb[i] = 1.0;
+            }
+          };
+        };
+      };
+      InternalStateUpdaterAW operator()(RigidWall& /*rigid_wall_model*/)
+      {
+        auto internal_state_updater_flow_model =
+            std::visit(MakeInternalStateUpdaterFlowModel{}, flow_model);
+        return [internal_state_updater_flow_model](AirwayData& data,
+                   const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt)
+        { internal_state_updater_flow_model(data, locally_relevant_dofs); };
+      }
+      InternalStateUpdaterAW operator()(KelvinVoigtWall& kv_model)
+      {
+        auto internal_state_updater_flow_model =
+            std::visit(MakeInternalStateUpdaterFlowModel{}, flow_model);
+        return [internal_state_updater_flow_model, &kv_model](AirwayData& data,
+                   const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt)
+        {
+          internal_state_updater_flow_model(data, locally_relevant_dofs);
+          for (size_t i = 0; i < data.number_of_elements(); i++)
+          {
+            kv_model.beta_w[i] =
+                std::sqrt(M_PI) * kv_model.wall_thickness[i] * kv_model.wall_elasticity[i] /
+                ((1 - kv_model.wall_poisson_ratio[i] * kv_model.wall_poisson_ratio[i]) *
+                    data.ref_area[i]);
+            kv_model.gamma_w[i] = kv_model.beta_w[i] * kv_model.viscous_time_constant[i] *
+                                  std::tan(kv_model.viscous_phase_shift[i]) / (4.0 * M_PI);
+            kv_model.compliance_C[i] =
+                2 * std::sqrt(data.ref_area[i]) * data.ref_length[i] / kv_model.beta_w[i];
+            kv_model.viscous_resistance_Rvisc[i] =
+                kv_model.gamma_w[i] / (std::sqrt(data.ref_area[i]) * data.ref_length[i]);
+            kv_model.area[i] =
+                kv_model.area_n[i] +
+                dt / data.ref_length[i] *
+                    (locally_relevant_dofs.local_values_as_span()[data.lid_q1[i]] -
+                        locally_relevant_dofs.local_values_as_span()[data.lid_q2[i]]);
+          }
+        };
+      }
+      FlowModel& flow_model;
+    };
+
+    /**
+     * Creates the model-specific routine at the end of the timestep that updates history variables
+     * that need to be tracked over time for model evaluation
+     */
+    struct MakeEndOfTimestepRoutine
+    {
+      EndOfTimestepRoutine operator()(RigidWall& rigid_wall_model)
+      {
+        return [&](AirwayData& data, const Core::LinAlg::Vector<double>& locally_relevant_dofs,
+                   double dt) {};
+      }
+      EndOfTimestepRoutine operator()(KelvinVoigtWall& kelvin_voigt_wall_model)
+      {
+        return [&](AirwayData& data, const Core::LinAlg::Vector<double>& locally_relevant_dofs,
+                   double dt)
+        {
+          for (size_t i = 0; i < data.number_of_elements(); i++)
+          {
+            // only in Kelvin-Voigt walls q2_n is stored as history variable
+            data.q2_n[i] = locally_relevant_dofs.local_values_as_span()[data.lid_q2[i]];
+
+            kelvin_voigt_wall_model.area_n[i] =
+                kelvin_voigt_wall_model.area_n[i] +
+                dt / data.ref_length[i] *
+                    (locally_relevant_dofs.local_values_as_span()[data.lid_q1[i]] -
+                        locally_relevant_dofs.local_values_as_span()[data.lid_q2[i]]);
+          }
+        };
+      }
+    };
+
+    /**
+     * @brief Returns an existing AirwayModel with specified flow and wall models
+     *
+     * @tparam F The flow model type.
+     * @tparam W The wall model type.
+     * @param airways Global container for all airway models.
+     * @return Reference to the matching AirwayModel.
+     */
+    template <typename F, typename W>
+    AirwayModel& register_or_access_airway_model(AirwayContainer& airways)
+    {
+      for (auto& model : airways.models)
+      {
+        if (std::holds_alternative<F>(model.flow_model) &&
+            std::holds_alternative<W>(model.wall_model))
+        {
+          return model;
+        }
+      }
+
+      // Create instance of the AirwayModel
+      airways.models.emplace_back();
+      AirwayModel& new_model = airways.models.back();
+
+      // Create models
+      new_model.flow_model = F{};
+      new_model.wall_model = W{};
+
+      // replace the previous if/constexpr chain with a compile-time sum
+      int n_state_eq = FlowModelStateCount<F>::value + WallModelStateCount<W>::value;
+      new_model.data.n_state_equations = n_state_eq;
+
+      return new_model;
+    }
+
+
+    struct AddFlowModelParameter
+    {
+      void operator()(LinearResistive& model)
+      {
+        model.has_inertia.push_back(
+            params.lung_tree.airways.flow_model.include_inertia.at(ele->id(), "include_inertia"));
+      }
+      void operator()(NonLinearResistive& model)
+      {
+        model.turbulence_factor_gamma.push_back(params.lung_tree.airways.flow_model.resistance_model
+                .non_linear.turbulence_factor_gamma.at(ele->id(), "turbulence_factor_gamma"));
+        model.has_inertia.push_back(
+            params.lung_tree.airways.flow_model.include_inertia.at(ele->id(), "include_inertia"));
+      }
+      Core::Elements::Element* ele;
+      ReducedLungParameters params;
+    };
+
+
+    struct AddWallModelParameter
+    {
+      void operator()(RigidWall& model)
+      {
+        // nothing to do here
+      }
+      void operator()(KelvinVoigtWall& model)
+      {
+        model.wall_poisson_ratio.push_back(
+            params.kelvin_voigt.elasticity.wall_poisson_ratio.at(ele->id(), "wall_poisson_ratio"));
+        model.wall_elasticity.push_back(
+            params.kelvin_voigt.elasticity.wall_elasticity.at(ele->id(), "wall_elasticity"));
+        model.wall_thickness.push_back(
+            params.kelvin_voigt.elasticity.wall_thickness.at(ele->id(), "wall_thickness"));
+        model.viscous_time_constant.push_back(
+            params.kelvin_voigt.viscosity.viscous_time_constant.at(
+                ele->id(), "viscous_time_constant"));
+        model.viscous_phase_shift.push_back(
+            params.kelvin_voigt.viscosity.viscous_phase_shift.at(ele->id(), "viscous_phase_shift"));
+        model.area_n.push_back(ref_area);
+      }
+      Core::Elements::Element* ele;
+      ReducedLungParameters::LungTree::Airways::WallModel params;
+      double ref_area;
+    };
+
+
+    /**
+     * @brief Adds a new element to the appropriate AirwayModel group.
+     *
+     * Computes length and area, assigns material parameters, and initializes internal state.
+     *
+     * @tparam F Flow model.
+     * @tparam W Wall model.
+     * @param airways Global container for all airway models.
+     * @param ele Pointer to element to be added.
+     * @param local_element_id Local identifier in 4C discretization.
+     */
+    template <typename F, typename W>
+    void add_airway_ele(AirwayContainer& airways, Core::Elements::Element* ele,
+        int local_element_id, ReducedLungParameters params)
+    {
+      AirwayModel& model = register_or_access_airway_model<F, W>(airways);
+
+      model.data.global_element_id.push_back(ele->id());
+      model.data.local_element_id.push_back(local_element_id);
+      const auto& coords_node_1 = ele->nodes()[0]->x();
+      const auto& coords_node_2 = ele->nodes()[1]->x();
+      const double length =
+          std::sqrt((coords_node_1[0] - coords_node_2[0]) * (coords_node_1[0] - coords_node_2[0]) +
+                    (coords_node_1[1] - coords_node_2[1]) * (coords_node_1[1] - coords_node_2[1]) +
+                    (coords_node_1[2] - coords_node_2[2]) * (coords_node_1[2] - coords_node_2[2]));
+      model.data.ref_length.push_back(length);
+      const double radius = params.lung_tree.airways.radius.at(ele->id(), "radius");
+      const double area = radius * radius * M_PI;
+      model.data.air_properties.dynamic_viscosity = params.air_properties.dynamic_viscosity;
+      model.data.air_properties.density = params.air_properties.density;
+      model.data.ref_area.push_back(area);
+
+      // Initialize history vectors to zero
+      model.data.q1_n.push_back(0.0);
+      model.data.q2_n.push_back(0.0);
+      model.data.p1_n.push_back(0.0);
+      model.data.p2_n.push_back(0.0);
+
+      std::visit(AddFlowModelParameter{.ele = ele, .params = params}, model.flow_model);
+      std::visit(
+          AddWallModelParameter{
+              .ele = ele, .params = params.lung_tree.airways.wall_model, .ref_area = area},
+          model.wall_model);
+    }
+
+    /**
+     * @brief Assembles the negative residual vector of all airways.
+     *
+     * Applies model-specific logic and calculates the residuals of each airway element and stores
+     * them.
+     *
+     * @param res_vector Residual vector in row map layout
+     * @param airways Global container for all airway models.
+     * @param locally_relevant_dofs DOF vector containing current inflow and pressure values in
+     * column map layout.
+     * @param dt Current time step size.
+     */
+    void update_negative_residual_vector(Core::LinAlg::Vector<double>& res_vector,
+        AirwayContainer& airways, const Core::LinAlg::Vector<double>& locally_relevant_dofs,
+        double dt);
+
+
+    /**
+     * @brief Assembles the Jacobian matrix contributions of all airways.
+     *
+     * Derivatives w.r.t. pressure and flow variables are computed using model-specific logic. They
+     * are directly stored in the given Jacobian.
+     *
+     * @param jac Jacobian matrix in (row, column) map layout.
+     * @param airways Global container for all airway models.
+     * @param locally_relevant_dofs DOF vector containing current inflow and pressure values in
+     * column map layout.
+     * @param dt Current time step size.
+     */
+    void update_jacobian(Core::LinAlg::SparseMatrix& jac, AirwayContainer& airways,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt);
+
+    /**
+     * @brief Creates evaluator functions for all airway models.
+     *
+     * This function must be called after all airway elements have been added.
+     * It initializes the evaluator function objects for each model, ensuring that references
+     * captured by these evaluators remain valid.
+     */
+    void create_evaluators(AirwayContainer& airways);
+
+    /**
+     * @brief Updates the internal state memory of each airway model.
+     *
+     * To be executed inside the nonlinear loop.
+     *
+     * @param airways All grouped airway models.
+     * @param locally_relevant_dofs DOF vector containing inflow and pressure values in
+     * column map layout.
+     * @param dt Time step size.
+     */
+    void update_internal_state_vectors(AirwayContainer& airways,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt);
+
+    /**
+     * @brief Routine to be executed at the end of each time step.
+     *
+     * Used to store history variables (e.g. flow, pressure, area) from previous time steps.
+     *
+     * @param airways All grouped airway models.
+     * @param locally_relevant_dofs DOF vector containing inflow and pressure values in
+     * column map layout. The DOFs have to be in a converged state.
+     * @param dt Time step size.
+     *
+     * @note Needs to be executed once between time steps to update the internal state with the
+     * converged DOFs.
+     */
+    void end_of_timestep_routine(AirwayContainer& airways,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt);
+  }  // namespace Airways
+}  // namespace ReducedLung
+
+FOUR_C_NAMESPACE_CLOSE
+
+#endif

--- a/src/reduced_lung/src/4C_reduced_lung_input.cpp
+++ b/src/reduced_lung/src/4C_reduced_lung_input.cpp
@@ -80,7 +80,7 @@ Core::IO::InputSpec ReducedLung::valid_parameters()
                            {
                                .description = "Poisson's ratio of the airway wall.",
                                .store = in_struct(&ReducedLungParameters::LungTree::Airways::
-                                       WallModel::KelvinVoigt::Elasticity::wall_poisson_radio),
+                                       WallModel::KelvinVoigt::Elasticity::wall_poisson_ratio),
                            }),
                        input_field<double>("wall_elasticity",
                            {
@@ -88,12 +88,11 @@ Core::IO::InputSpec ReducedLung::valid_parameters()
                                .store = in_struct(&ReducedLungParameters::LungTree::Airways::
                                        WallModel::KelvinVoigt::Elasticity::wall_elasticity),
                            }),
-                       input_field<double>("diameter_over_wall_thickness",
+                       input_field<double>("wall_thickness",
                            {
-                               .description = "Ratio of diameter over wall thickness.",
-                               .store =
-                                   in_struct(&ReducedLungParameters::LungTree::Airways::WallModel::
-                                           KelvinVoigt::Elasticity::diameter_over_wall_thickness),
+                               .description = "Airway wall thickness.",
+                               .store = in_struct(&ReducedLungParameters::LungTree::Airways::
+                                       WallModel::KelvinVoigt::Elasticity::wall_thickness),
                            }),
                    },
                    {
@@ -346,7 +345,8 @@ Core::IO::InputSpec ReducedLung::valid_parameters()
                       {
                           .description = "Dynamic viscosity of air in the reduced dimensional lung "
                                          "simulation.",
-                          .store = in_struct(&ReducedLungParameters::AirProperties::viscosity),
+                          .store =
+                              in_struct(&ReducedLungParameters::AirProperties::dynamic_viscosity),
                       }),
 
                   parameter<double>("density",

--- a/src/reduced_lung/src/4C_reduced_lung_input.hpp
+++ b/src/reduced_lung/src/4C_reduced_lung_input.hpp
@@ -86,9 +86,9 @@ namespace ReducedLung
           {
             struct Elasticity
             {
-              Core::IO::InputField<double> wall_poisson_radio;
+              Core::IO::InputField<double> wall_poisson_ratio;
               Core::IO::InputField<double> wall_elasticity;
-              Core::IO::InputField<double> diameter_over_wall_thickness;
+              Core::IO::InputField<double> wall_thickness;
             } elasticity;
             struct Viscosity
             {
@@ -158,7 +158,7 @@ namespace ReducedLung
     struct AirProperties
     {
       double density;
-      double viscosity;
+      double dynamic_viscosity;
     } air_properties;
   };
   /// reduced airways parameters

--- a/src/reduced_lung/src/4C_reduced_lung_terminal_unit.cpp
+++ b/src/reduced_lung/src/4C_reduced_lung_terminal_unit.cpp
@@ -13,222 +13,236 @@ FOUR_C_NAMESPACE_OPEN
 
 namespace ReducedLung
 {
-
-  std::vector<double>& evaluate_linear_elastic_pressure(LinearElasticity& linear_elastic_model,
-      TerminalUnitData& data, const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt)
+  namespace TerminalUnits
   {
-    for (size_t i = 0; i < data.number_of_elements(); i++)
-    {
-      linear_elastic_model.elastic_pressure_p_el[i] =
-          linear_elastic_model.elasticity_E[i] *
-          ((data.volume_v[i] + dt * locally_relevant_dofs.local_values_as_span()[data.lid_q[i]]) /
-                  data.reference_volume_v0[i] -
-              1);
-    }
-    return linear_elastic_model.elastic_pressure_p_el;
-  }
-
-  std::vector<double>& evaluate_ogden_hyperelastic_pressure(
-      OgdenHyperelasticity& ogden_hyperelastic_model, TerminalUnitData& data,
-      const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt)
-  {
-    for (size_t i = 0; i < data.number_of_elements(); i++)
-    {
-      double v0_over_vi =
-          data.reference_volume_v0[i] /
-          (data.volume_v[i] + dt * locally_relevant_dofs.local_values_as_span()[data.lid_q[i]]);
-      ogden_hyperelastic_model.elastic_pressure_p_el[i] =
-          ogden_hyperelastic_model.bulk_modulus_kappa[i] /
-          ogden_hyperelastic_model.nonlinear_stiffening_beta[i] * v0_over_vi *
-          (1 - std::pow(v0_over_vi, ogden_hyperelastic_model.nonlinear_stiffening_beta[i]));
-    }
-    return ogden_hyperelastic_model.elastic_pressure_p_el;
-  }
-
-  void evaluate_negative_kelvin_voigt_residual(Core::LinAlg::Vector<double>& target,
-      const KelvinVoigt& kelvin_voigt_model, const TerminalUnitData& data,
-      const Core::LinAlg::Vector<double>& locally_relevant_dofs,
-      const std::vector<double>& elastic_pressure_p_el)
-  {
-    for (size_t i = 0; i < data.number_of_elements(); i++)
-    {
-      double negative_kelvin_voigt_residual =
-          -1 * (locally_relevant_dofs.local_values_as_span()[data.lid_p1[i]] -
-                   locally_relevant_dofs.local_values_as_span()[data.lid_p2[i]] -
-                   elastic_pressure_p_el[i] -
-                   kelvin_voigt_model.viscosity_eta[i] *
-                       locally_relevant_dofs.local_values_as_span()[data.lid_q[i]] /
-                       data.reference_volume_v0[i]);
-      target.replace_local_value(data.local_row_id[i], negative_kelvin_voigt_residual);
-    }
-  }
-
-  void evaluate_negative_four_element_maxwell_residual(Core::LinAlg::Vector<double>& target,
-      const FourElementMaxwell& four_element_maxwell_model, const TerminalUnitData& data,
-      const Core::LinAlg::Vector<double>& locally_relevant_dofs,
-      const std::vector<double>& elastic_pressure_p_el, double dt)
-  {
-    for (size_t i = 0; i < data.number_of_elements(); i++)
-    {
-      double negative_four_element_maxwell_residual =
-          -1 * (locally_relevant_dofs.local_values_as_span()[data.lid_p1[i]] -
-                   locally_relevant_dofs.local_values_as_span()[data.lid_p2[i]] -
-                   elastic_pressure_p_el[i] -
-                   (four_element_maxwell_model.viscosity_eta[i] +
-                       (four_element_maxwell_model.elasticity_E_m[i] * dt *
-                           four_element_maxwell_model.viscosity_eta_m[i]) /
-                           (four_element_maxwell_model.elasticity_E_m[i] * dt +
-                               four_element_maxwell_model.viscosity_eta_m[i])) /
-                       data.reference_volume_v0[i] *
-                       locally_relevant_dofs.local_values_as_span()[data.lid_q[i]] -
-                   four_element_maxwell_model.viscosity_eta_m[i] /
-                       (four_element_maxwell_model.elasticity_E_m[i] * dt +
-                           four_element_maxwell_model.viscosity_eta_m[i]) *
-                       four_element_maxwell_model.maxwell_pressure_p_m[i]);
-      target.replace_local_value(data.local_row_id[i], negative_four_element_maxwell_residual);
-    }
-  }
-
-  std::vector<double>& linear_elastic_pressure_gradient(
-      LinearElasticity& linear_elastic_model, TerminalUnitData& data, double dt)
-  {
-    for (size_t i = 0; i < data.number_of_elements(); i++)
-    {
-      linear_elastic_model.elastic_pressure_grad_dp_el[i] =
-          linear_elastic_model.elasticity_E[i] * dt / data.reference_volume_v0[i];
-    }
-    return linear_elastic_model.elastic_pressure_grad_dp_el;
-  }
-
-  std::vector<double>& ogden_hyperelastic_pressure_gradient(
-      OgdenHyperelasticity& ogden_hyperelastic_model, TerminalUnitData& data,
-      const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt)
-  {
-    for (size_t i = 0; i < data.number_of_elements(); i++)
-    {
-      double v0_over_vi =
-          data.reference_volume_v0[i] /
-          (data.volume_v[i] + dt * locally_relevant_dofs.local_values_as_span()[data.lid_q[i]]);
-      ogden_hyperelastic_model.elastic_pressure_grad_dp_el[i] =
-          ogden_hyperelastic_model.bulk_modulus_kappa[i] * dt /
-          (ogden_hyperelastic_model.nonlinear_stiffening_beta[i] * data.reference_volume_v0[i]) *
-          v0_over_vi * v0_over_vi *
-          ((ogden_hyperelastic_model.nonlinear_stiffening_beta[i] + 1) *
-                  std::pow(v0_over_vi, ogden_hyperelastic_model.nonlinear_stiffening_beta[i]) -
-              1);
-    }
-    return ogden_hyperelastic_model.elastic_pressure_grad_dp_el;
-  }
-
-  void evaluate_kelvin_voigt_jacobian(Core::LinAlg::SparseMatrix& target,
-      const KelvinVoigt& kelvin_voigt_model, TerminalUnitData& data,
-      const std::vector<double>& elastic_pressure_grad_dp_el)
-  {
-    if (!target.filled())
+    std::vector<double>& evaluate_linear_elastic_pressure(LinearElasticity& linear_elastic_model,
+        TerminalUnitData& data, const Core::LinAlg::Vector<double>& locally_relevant_dofs,
+        double dt)
     {
       for (size_t i = 0; i < data.number_of_elements(); i++)
       {
-        std::array<int, 3> column_indices{data.lid_p1[i], data.lid_p2[i], data.lid_q[i]};
-        std::array<double, 3> values{1.0, -1.0,
-            -elastic_pressure_grad_dp_el[i] -
-                kelvin_voigt_model.viscosity_eta[i] / data.reference_volume_v0[i]};
-        target.insert_my_values(data.local_row_id[i], 3, values.data(), column_indices.data());
+        linear_elastic_model.elastic_pressure_p_el[i] =
+            linear_elastic_model.elasticity_E[i] *
+            ((data.volume_v[i] + dt * locally_relevant_dofs.local_values_as_span()[data.lid_q[i]]) /
+                    data.reference_volume_v0[i] -
+                1);
       }
+      return linear_elastic_model.elastic_pressure_p_el;
     }
-    else
+
+    std::vector<double>& evaluate_ogden_hyperelastic_pressure(
+        OgdenHyperelasticity& ogden_hyperelastic_model, TerminalUnitData& data,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt)
     {
       for (size_t i = 0; i < data.number_of_elements(); i++)
       {
-        double grad_q = -elastic_pressure_grad_dp_el[i] -
-                        kelvin_voigt_model.viscosity_eta[i] / data.reference_volume_v0[i];
-        target.replace_my_values(data.local_row_id[i], 1, &grad_q, &data.lid_q[i]);
+        double v0_over_vi =
+            data.reference_volume_v0[i] /
+            (data.volume_v[i] + dt * locally_relevant_dofs.local_values_as_span()[data.lid_q[i]]);
+        ogden_hyperelastic_model.elastic_pressure_p_el[i] =
+            ogden_hyperelastic_model.bulk_modulus_kappa[i] /
+            ogden_hyperelastic_model.nonlinear_stiffening_beta[i] * v0_over_vi *
+            (1 - std::pow(v0_over_vi, ogden_hyperelastic_model.nonlinear_stiffening_beta[i]));
       }
+      return ogden_hyperelastic_model.elastic_pressure_p_el;
     }
-  }
 
-  void evaluate_four_element_maxwell_jacobian(Core::LinAlg::SparseMatrix& target,
-      const FourElementMaxwell& four_element_maxwell_model, TerminalUnitData& data,
-      const std::vector<double>& elastic_pressure_grad_dp_el, double dt)
-  {
-    if (!target.filled())
+    void evaluate_negative_kelvin_voigt_residual(Core::LinAlg::Vector<double>& target,
+        const KelvinVoigt& kelvin_voigt_model, const TerminalUnitData& data,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs,
+        const std::vector<double>& elastic_pressure_p_el)
     {
       for (size_t i = 0; i < data.number_of_elements(); i++)
       {
-        std::array<int, 3> column_indices{data.lid_p1[i], data.lid_p2[i], data.lid_q[i]};
-        std::array<double, 3> values{1.0, -1.0,
-            -elastic_pressure_grad_dp_el[i] -
-                (four_element_maxwell_model.viscosity_eta[i] +
-                    four_element_maxwell_model.elasticity_E_m[i] * dt *
-                        four_element_maxwell_model.viscosity_eta_m[i] /
-                        (four_element_maxwell_model.elasticity_E_m[i] * dt +
-                            four_element_maxwell_model.viscosity_eta_m[i])) /
-                    data.reference_volume_v0[i]};
-        target.insert_my_values(data.local_row_id[i], 3, values.data(), column_indices.data());
+        double negative_kelvin_voigt_residual =
+            -1 * (locally_relevant_dofs.local_values_as_span()[data.lid_p1[i]] -
+                     locally_relevant_dofs.local_values_as_span()[data.lid_p2[i]] -
+                     elastic_pressure_p_el[i] -
+                     kelvin_voigt_model.viscosity_eta[i] *
+                         locally_relevant_dofs.local_values_as_span()[data.lid_q[i]] /
+                         data.reference_volume_v0[i]);
+        target.replace_local_value(data.local_row_id[i], negative_kelvin_voigt_residual);
       }
     }
-    else
+
+    void evaluate_negative_four_element_maxwell_residual(Core::LinAlg::Vector<double>& target,
+        const FourElementMaxwell& four_element_maxwell_model, const TerminalUnitData& data,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs,
+        const std::vector<double>& elastic_pressure_p_el, double dt)
     {
       for (size_t i = 0; i < data.number_of_elements(); i++)
       {
-        double grad_q = -elastic_pressure_grad_dp_el[i] -
-                        (four_element_maxwell_model.viscosity_eta[i] +
-                            four_element_maxwell_model.elasticity_E_m[i] * dt *
-                                four_element_maxwell_model.viscosity_eta_m[i] /
-                                (four_element_maxwell_model.elasticity_E_m[i] * dt +
-                                    four_element_maxwell_model.viscosity_eta_m[i])) /
-                            data.reference_volume_v0[i];
-        target.replace_my_values(data.local_row_id[i], 1, &grad_q, &data.lid_q[i]);
+        double negative_four_element_maxwell_residual =
+            -1 * (locally_relevant_dofs.local_values_as_span()[data.lid_p1[i]] -
+                     locally_relevant_dofs.local_values_as_span()[data.lid_p2[i]] -
+                     elastic_pressure_p_el[i] -
+                     (four_element_maxwell_model.viscosity_eta[i] +
+                         (four_element_maxwell_model.elasticity_E_m[i] * dt *
+                             four_element_maxwell_model.viscosity_eta_m[i]) /
+                             (four_element_maxwell_model.elasticity_E_m[i] * dt +
+                                 four_element_maxwell_model.viscosity_eta_m[i])) /
+                         data.reference_volume_v0[i] *
+                         locally_relevant_dofs.local_values_as_span()[data.lid_q[i]] -
+                     four_element_maxwell_model.viscosity_eta_m[i] /
+                         (four_element_maxwell_model.elasticity_E_m[i] * dt +
+                             four_element_maxwell_model.viscosity_eta_m[i]) *
+                         four_element_maxwell_model.maxwell_pressure_p_m[i]);
+        target.replace_local_value(data.local_row_id[i], negative_four_element_maxwell_residual);
       }
     }
-  }
 
-  void update_terminal_unit_negative_residual_vector(Core::LinAlg::Vector<double>& res_vector,
-      TerminalUnits& terminal_units, const Core::LinAlg::Vector<double>& locally_relevant_dofs,
-      double dt)
-  {
-    for (auto& model : terminal_units.models)
+    std::vector<double>& linear_elastic_pressure_gradient(
+        LinearElasticity& linear_elastic_model, TerminalUnitData& data, double dt)
     {
-      model.negative_residual_evaluator(model.data, res_vector, locally_relevant_dofs, dt);
-    }
-  }
-
-  void update_terminal_unit_jacobian(Core::LinAlg::SparseMatrix& jac, TerminalUnits& terminal_units,
-      const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt)
-  {
-    for (auto& model : terminal_units.models)
-    {
-      model.jacobian_evaluator(model.data, jac, locally_relevant_dofs, dt);
-    }
-  }
-
-  void update_terminal_unit_internal_state_vectors(TerminalUnits& terminal_units,
-      const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt)
-  {
-    for (auto& model : terminal_units.models)
-    {
-      // Update volume
-      for (size_t i = 0; i < model.data.number_of_elements(); i++)
+      for (size_t i = 0; i < data.number_of_elements(); i++)
       {
-        model.data.volume_v[i] +=
-            locally_relevant_dofs.local_values_as_span()[model.data.lid_q[i]] * dt;
+        linear_elastic_model.elastic_pressure_grad_dp_el[i] =
+            linear_elastic_model.elasticity_E[i] * dt / data.reference_volume_v0[i];
       }
-      // Model specific updates
-      model.internal_state_updater(model.data, locally_relevant_dofs, dt);
+      return linear_elastic_model.elastic_pressure_grad_dp_el;
     }
-  }
 
-  void create_terminal_unit_evaluators(TerminalUnits& terminal_units)
-  {
-    for (auto& model : terminal_units.models)
+    std::vector<double>& ogden_hyperelastic_pressure_gradient(
+        OgdenHyperelasticity& ogden_hyperelastic_model, TerminalUnitData& data,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt)
     {
-      model.negative_residual_evaluator = std::visit(
-          MakeNegativeResidualEvaluator{model.elasticity_model}, model.rheological_model);
-      model.jacobian_evaluator =
-          std::visit(MakeJacobianEvaluator{model.elasticity_model}, model.rheological_model);
-      model.internal_state_updater =
-          std::visit(MakeInternalStateUpdater{}, model.rheological_model);
+      for (size_t i = 0; i < data.number_of_elements(); i++)
+      {
+        double v0_over_vi =
+            data.reference_volume_v0[i] /
+            (data.volume_v[i] + dt * locally_relevant_dofs.local_values_as_span()[data.lid_q[i]]);
+        ogden_hyperelastic_model.elastic_pressure_grad_dp_el[i] =
+            ogden_hyperelastic_model.bulk_modulus_kappa[i] * dt /
+            (ogden_hyperelastic_model.nonlinear_stiffening_beta[i] * data.reference_volume_v0[i]) *
+            v0_over_vi * v0_over_vi *
+            ((ogden_hyperelastic_model.nonlinear_stiffening_beta[i] + 1) *
+                    std::pow(v0_over_vi, ogden_hyperelastic_model.nonlinear_stiffening_beta[i]) -
+                1);
+      }
+      return ogden_hyperelastic_model.elastic_pressure_grad_dp_el;
     }
-  }
+
+    void evaluate_kelvin_voigt_jacobian(Core::LinAlg::SparseMatrix& target,
+        const KelvinVoigt& kelvin_voigt_model, TerminalUnitData& data,
+        const std::vector<double>& elastic_pressure_grad_dp_el)
+    {
+      if (!target.filled())
+      {
+        for (size_t i = 0; i < data.number_of_elements(); i++)
+        {
+          std::array<int, 3> column_indices{data.lid_p1[i], data.lid_p2[i], data.lid_q[i]};
+          std::array<double, 3> values{1.0, -1.0,
+              -elastic_pressure_grad_dp_el[i] -
+                  kelvin_voigt_model.viscosity_eta[i] / data.reference_volume_v0[i]};
+          target.insert_my_values(data.local_row_id[i], 3, values.data(), column_indices.data());
+        }
+      }
+      else
+      {
+        for (size_t i = 0; i < data.number_of_elements(); i++)
+        {
+          double grad_q = -elastic_pressure_grad_dp_el[i] -
+                          kelvin_voigt_model.viscosity_eta[i] / data.reference_volume_v0[i];
+          target.replace_my_values(data.local_row_id[i], 1, &grad_q, &data.lid_q[i]);
+        }
+      }
+    }
+
+    void evaluate_four_element_maxwell_jacobian(Core::LinAlg::SparseMatrix& target,
+        const FourElementMaxwell& four_element_maxwell_model, TerminalUnitData& data,
+        const std::vector<double>& elastic_pressure_grad_dp_el, double dt)
+    {
+      if (!target.filled())
+      {
+        for (size_t i = 0; i < data.number_of_elements(); i++)
+        {
+          std::array<int, 3> column_indices{data.lid_p1[i], data.lid_p2[i], data.lid_q[i]};
+          std::array<double, 3> values{1.0, -1.0,
+              -elastic_pressure_grad_dp_el[i] -
+                  (four_element_maxwell_model.viscosity_eta[i] +
+                      four_element_maxwell_model.elasticity_E_m[i] * dt *
+                          four_element_maxwell_model.viscosity_eta_m[i] /
+                          (four_element_maxwell_model.elasticity_E_m[i] * dt +
+                              four_element_maxwell_model.viscosity_eta_m[i])) /
+                      data.reference_volume_v0[i]};
+          target.insert_my_values(data.local_row_id[i], 3, values.data(), column_indices.data());
+        }
+      }
+      else
+      {
+        for (size_t i = 0; i < data.number_of_elements(); i++)
+        {
+          double grad_q = -elastic_pressure_grad_dp_el[i] -
+                          (four_element_maxwell_model.viscosity_eta[i] +
+                              four_element_maxwell_model.elasticity_E_m[i] * dt *
+                                  four_element_maxwell_model.viscosity_eta_m[i] /
+                                  (four_element_maxwell_model.elasticity_E_m[i] * dt +
+                                      four_element_maxwell_model.viscosity_eta_m[i])) /
+                              data.reference_volume_v0[i];
+          target.replace_my_values(data.local_row_id[i], 1, &grad_q, &data.lid_q[i]);
+        }
+      }
+    }
+
+    void update_negative_residual_vector(Core::LinAlg::Vector<double>& res_vector,
+        TerminalUnitContainer& terminal_units,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt)
+    {
+      for (auto& model : terminal_units.models)
+      {
+        model.negative_residual_evaluator(model.data, res_vector, locally_relevant_dofs, dt);
+      }
+    }
+
+    void update_jacobian(Core::LinAlg::SparseMatrix& jac, TerminalUnitContainer& terminal_units,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt)
+    {
+      for (auto& model : terminal_units.models)
+      {
+        model.jacobian_evaluator(model.data, jac, locally_relevant_dofs, dt);
+      }
+    }
+
+    void update_internal_state_vectors(TerminalUnitContainer& terminal_units,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt)
+    {
+      for (auto& model : terminal_units.models)
+      {
+        model.internal_state_updater(model.data, locally_relevant_dofs, dt);
+      }
+    }
+
+    void end_of_timestep_routine(TerminalUnitContainer& terminal_units,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt)
+    {
+      for (auto& model : terminal_units.models)
+      {
+        // Update volume
+        for (size_t i = 0; i < model.data.number_of_elements(); i++)
+        {
+          model.data.volume_v[i] +=
+              locally_relevant_dofs.local_values_as_span()[model.data.lid_q[i]] * dt;
+        }
+        // Model specific updates
+        model.end_of_timestep_routine(model.data, locally_relevant_dofs, dt);
+      }
+    }
+
+    void create_evaluators(TerminalUnitContainer& terminal_units)
+    {
+      for (auto& model : terminal_units.models)
+      {
+        model.negative_residual_evaluator = std::visit(
+            MakeNegativeResidualEvaluator{model.elasticity_model}, model.rheological_model);
+        model.jacobian_evaluator =
+            std::visit(MakeJacobianEvaluator{model.elasticity_model}, model.rheological_model);
+        model.internal_state_updater =
+            std::visit(MakeInternalStateUpdater{}, model.rheological_model);
+        model.end_of_timestep_routine =
+            std::visit(MakeEndOfTimestepRoutine{}, model.rheological_model);
+      }
+    }
+  }  // namespace TerminalUnits
 }  // namespace ReducedLung
 
 

--- a/src/reduced_lung/src/4C_reduced_lung_terminal_unit.hpp
+++ b/src/reduced_lung/src/4C_reduced_lung_terminal_unit.hpp
@@ -29,604 +29,652 @@ FOUR_C_NAMESPACE_OPEN
 
 namespace ReducedLung
 {
-
-  /**
-   * @brief Shared data container for all terminal unit elements.
-   *
-   * Stores identifiers and physical parameters (volume, pressure, etc.) for each terminal unit,
-   * which are used across all rheological and elasticity models.
-   *
-   * @note This data is independent of specific models and is shared across evaluators.
-   */
-  struct TerminalUnitData
-  {
-    // Global element IDs.
-    std::vector<int> global_element_id;
-    // Local element IDs in row map of the old discretization. May become obsolete with new input.
-    std::vector<int> local_element_id;
-    // IDs of the local rows in the row map. This defines the place for these terminal units in the
-    // system of equations.
-    std::vector<int> local_row_id;
-    // Global dof IDs
-    std::vector<int> gid_p1;
-    std::vector<int> gid_p2;
-    std::vector<int> gid_q;
-    // Dof IDs from locally relevant / column map. Used for lookup in dof-vector during assembly.
-    std::vector<int> lid_p1;
-    std::vector<int> lid_p2;
-    std::vector<int> lid_q;
-    // Physical quantities of each terminal unit.
-    std::vector<double> volume_v;
-    std::vector<double> reference_volume_v0;
-
-    /**
-     * Access this function when looping over elements.
-     */
-    [[nodiscard]] size_t number_of_elements() const { return global_element_id.size(); }
-  };
-
-  // ----- Rheological models of viscoelasticity -----
-
-  /**
-   * @brief Rheological Kelvin-Voigt model (spring and dashpot in parallel).
-   *
-   * @note The stress component from the spring is calculated with a given elasticity model
-   * (potentially nonlinear).
-   */
-  struct KelvinVoigt
-  {
-    std::vector<double> viscosity_eta;
-  };
-
-  /**
-   * @brief Rheological four-element Maxwell model (Kelvin-Voigt body and Maxwell body in parallel).
-   *
-   * The Maxwell body introduces an additional internal pressure state p_m, which is stored in this
-   * model and updated after every time step.
-   *
-   * @note The stress component from the spring in the Kelvin-Voigt body is calculated with a given
-   * elasticity model (potentially nonlinear).
-   */
-  struct FourElementMaxwell
-  {
-    std::vector<double> viscosity_eta;
-    std::vector<double> elasticity_E_m;
-    std::vector<double> viscosity_eta_m;
-    // Internal pressure state of the maxwell body
-    std::vector<double> maxwell_pressure_p_m;
-  };
-
-  // ----- Specialized Elasticity models -----
-
-  /**
-   * @brief Linear elasticity model. Substitutes a spring in a rheological model.
-   *
-   * Computes elastic pressure as linear function of volume.
-   * Includes internal variables for pressure and its gradient.
-   */
-  struct LinearElasticity
-  {
-    std::vector<double> elasticity_E;
-    // Internal elastic pressure state
-    std::vector<double> elastic_pressure_p_el;
-    std::vector<double> elastic_pressure_grad_dp_el;
-  };
-
-  /**
-   * @brief Ogden-type hyperelastic model. Substitutes a spring in a rheological model.
-   *
-   * Nonlinear stiffening behavior based on a bulk modulus kappa and shape parameter beta.
-   * Includes internal variables for pressure and pressure gradient.
-   *
-   * @note Ill-posed for beta = 0!
-   */
-  struct OgdenHyperelasticity
-  {
-    std::vector<double> bulk_modulus_kappa;
-    std::vector<double> nonlinear_stiffening_beta;
-    // Internal elastic pressure state
-    std::vector<double> elastic_pressure_p_el;
-    std::vector<double> elastic_pressure_grad_dp_el;
-  };
-
-  // Function handle for evaluating the negative model residuals.
-  using NegativeResidualEvaluator = std::function<void(TerminalUnitData& model_data,
-      Core::LinAlg::Vector<double>& target_vector,
-      const Core::LinAlg::Vector<double>& locally_relevant_dof_vector, double time_step_size_dt)>;
-
-  // Function handle for evaluating the model gradients w.r.t. the primary variables.
-  using JacobianEvaluator = std::function<void(TerminalUnitData& model_data,
-      Core::LinAlg::SparseMatrix& target_matrix,
-      const Core::LinAlg::Vector<double>& locally_relevant_dof_vector, double time_step_size_dt)>;
-
-  // Function handle for updating the internal state vectors storing information from the previous
-  // time step.
-  using InternalStateUpdater = std::function<void(TerminalUnitData& model_data,
-      const Core::LinAlg::Vector<double>& locally_relevant_dof_vector, double time_step_size_dt)>;
-
-  // Model types
-  using RheologicalModel = std::variant<KelvinVoigt, FourElementMaxwell>;
-  using ElasticityModel = std::variant<LinearElasticity, OgdenHyperelasticity>;
-
-  /**
-   * @brief Encapsulates a unique combination of rheological and elasticity models.
-   *
-   * Stores the element-specific data and associated evaluation functions
-   * (residuals, Jacobians, internal state updates) for a given model combination. Every
-   * terminal-unit specific information or action can be found here.
-   */
-  struct TerminalUnitModel
-  {
-    TerminalUnitData data;
-    RheologicalModel rheological_model;
-    ElasticityModel elasticity_model;
-    NegativeResidualEvaluator negative_residual_evaluator;
-    JacobianEvaluator jacobian_evaluator;
-    InternalStateUpdater internal_state_updater;
-  };
-
-  /**
-   * @brief All terminal unit models together and interface for access.
-   *
-   * Stores all different terminal unit models as distinct building blocks. Acts as interface for
-   * distributing terminal units to the correct models in the input phase and allows access to all
-   * terminal unit model blocks for assembly, output, etc..
-   */
-  struct TerminalUnits
-  {
-    std::vector<TerminalUnitModel> models;
-  };
-
-  /**
-   * @brief Evaluates the linear elastic pressure for all terminal units in one model.
-   *
-   * @param[in,out] linear_elastic_model Elastic model containing parameters and internal pressure
-   * state vector. Must belong to the same TerminalUnitModel as data.
-   * @param[in] data Terminal unit metadata (IDs, volume, etc.).
-   * @param[in] locally_relevant_dofs DOF vector containing current inflow and pressure values in
-   * column map layout.
-   * @param[in] dt Current time step size.
-   * @return Reference to internal elastic pressure vector, updated in-place with current values.
-   *
-   * @note This function updates and returns the internal vector `elastic_pressure_p_el` stored
-   * in the linear_elastic_model. It must not be used concurrently across models.
-   */
-  std::vector<double>& evaluate_linear_elastic_pressure(LinearElasticity& linear_elastic_model,
-      TerminalUnitData& data, const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt);
-
-  /**
-   * @brief Evaluates the nonlinear Ogden hyperelastic pressure for each terminal unit in one model.
-   *
-   * @param[in,out] ogden_hyperelastic_model Model parameters and internal pressure state vector.
-   * Must belong to the same TerminalUnitModel as data.
-   * @param[in] data Metadata and volume of each terminal unit.
-   * @param[in] locally_relevant_dofs DOF vector containing current inflow and pressure values in
-   * column map layout.
-   * @param[in] dt Time step size.
-   * @return Reference to internal elastic pressure vector, updated in-place with current values.
-   *
-   * @note This function updates and returns the internal vector `elastic_pressure_p_el` stored
-   * in the ogden_hyperelastic_model. It must not be used concurrently across models.
-   */
-  std::vector<double>& evaluate_ogden_hyperelastic_pressure(
-      OgdenHyperelasticity& ogden_hyperelastic_model, TerminalUnitData& data,
-      const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt);
-
-  /**
-   * @brief Assembles the negative residual for a Kelvin-Voigt viscoelastic model.
-   *
-   * @param[out] target Target vector to which the residual is written.
-   * @param[in] kelvin_voigt_model Model containing viscosity parameters. Must belong to the same
-   * TerminalUnitModel as data.
-   * @param[in] data Terminal unit metadata.
-   * @param[in] locally_relevant_dofs DOF vector containing current inflow and pressure values in
-   * column map layout.
-   * @param[in] elastic_pressure_p_el Current elastic pressure values from the spring model.
-   *
-   * @note The function writes directly into the `target` vector using the row IDs from `data`.
-   */
-  void evaluate_negative_kelvin_voigt_residual(Core::LinAlg::Vector<double>& target,
-      const KelvinVoigt& kelvin_voigt_model, const TerminalUnitData& data,
-      const Core::LinAlg::Vector<double>& locally_relevant_dofs,
-      const std::vector<double>& elastic_pressure_p_el);
-
-  /**
-   * @brief Assembles the negative residual for a four-element Maxwell viscoelastic model.
-   *
-   * @param[out] target Target vector to which the residual is written.
-   * @param[in] four_element_maxwell_model Model parameters and internal Maxwell body pressure
-   * state. Must belong to the same TerminalUnitModel as data.
-   * @param[in] data Terminal unit metadata.
-   * @param[in] locally_relevant_dofs DOF vector containing current inflow and pressure values in
-   * column map layout.
-   * @param[in] elastic_pressure_p_el Current elastic pressure values from the spring model in the
-   * Kelvin-Voigt body.
-   * @param[in] dt Current time step size.
-   *
-   * @note The function writes directly into the `target` vector using the row IDs from `data`. It
-   * relies on an up-to-date internal Maxwell pressure state (p_m updated with DOFs from the last
-   * time step).
-   */
-  void evaluate_negative_four_element_maxwell_residual(Core::LinAlg::Vector<double>& target,
-      const FourElementMaxwell& four_element_maxwell_model, const TerminalUnitData& data,
-      const Core::LinAlg::Vector<double>& locally_relevant_dofs,
-      const std::vector<double>& elastic_pressure_p_el, double dt);
-
-  /**
-   * @brief Computes the gradient of the linear elastic pressure  model w.r.t. the inflow q.
-   *
-   * The elastic pressure is independent of the pressure state (p1 and p2).
-   *
-   * @param[in,out] linear_elastic_model Model with stiffness parameters and gradient vector. Must
-   * belong to the same TerminalUnitModel as data.
-   * @param[in] data Terminal unit metadata.
-   * @param[in] dt Current time step size.
-   * @return Reference to the internal gradient vector dp_el, updated in-place.
-   */
-  std::vector<double>& linear_elastic_pressure_gradient(
-      LinearElasticity& linear_elastic_model, TerminalUnitData& data, double dt);
-
-  /**
-   * @brief Computes the gradient of the nonlinear Ogden hyperelastic pressure w.r.t. inflow q.
-   *
-   * The elastic pressure is independent of the pressure state (p1 and p2). The elastic pressure
-   * gradient depends on the current volume state and inflow.
-   *
-   * @param[in,out] ogden_hyperelastic_model Ogden parameters and gradient vector. Must belong
-   * to the same TerminalUnitModel as data.
-   * @param[in] data Terminal unit metadata.
-   * @param[in] locally_relevant_dofs DOF vector containing current inflow and pressure values in
-   * column map layout.
-   * @param[in] dt Current time step size.
-   * @return Reference to the internal gradient vector dp_el, updated in-place.
-   */
-  std::vector<double>& ogden_hyperelastic_pressure_gradient(
-      OgdenHyperelasticity& ogden_hyperelastic_model, TerminalUnitData& data,
-      const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt);
-
-  /**
-   * @brief Assembles the Jacobian matrix entries for the Kelvin-Voigt viscoelastic model.
-   *
-   * @param[out] target Sparse matrix to which the Jacobian entries are written.
-   * @param[in] kelvin_voigt_model Rheological model with viscosity parameters. Must belong
-   * to the same TerminalUnitModel as data.
-   * @param[in] data Terminal unit metadata.
-   * @param[in] elastic_pressure_grad_dp_el Gradient of the elastic pressure from the spring model
-   * w.r.t. inflow.
-   *
-   * @note The function writes directly into the `target` matrix using the row IDs and column (DOF)
-   * IDs from `data`.
-   */
-  void evaluate_kelvin_voigt_jacobian(Core::LinAlg::SparseMatrix& target,
-      const KelvinVoigt& kelvin_voigt_model, TerminalUnitData& data,
-      const std::vector<double>& elastic_pressure_grad_dp_el);
-
-  /**
-   * @brief Assembles the Jacobian matrix for the four-element Maxwell viscoelastic model.
-   *
-   * @param[out] target Sparse matrix to which the Jacobian entries are written.
-   * @param[in] four_element_maxwell_model Four-element Maxwell parameters and internal Maxwell
-   * pressure state. Must belong to the same TerminalUnitModel as data.
-   * @param[in] data Terminal unit metadata.
-   * @param[in] elastic_pressure_grad_dp_el Gradient of the elastic pressure from the spring model
-   * w.r.t. inflow.
-   * @param[in] dt Current time step size.
-   *
-   * @note The function writes directly into the `target` matrix using the row IDs and column (DOF)
-   * IDs from `data`.
-   */
-  void evaluate_four_element_maxwell_jacobian(Core::LinAlg::SparseMatrix& target,
-      const FourElementMaxwell& four_element_maxwell_model, TerminalUnitData& data,
-      const std::vector<double>& elastic_pressure_grad_dp_el, double dt);
-
-
-  /**
-   * Creates the model-specific evaluator function for assembling the negative model residual.
-   */
-  struct MakeNegativeResidualEvaluator
+  namespace TerminalUnits
   {
     /**
-     * Creates a function for evaluating the elastic pressure given a specific elasticity model. The
-     * elastic pressure is one additive component of the rheological model's residual function.
+     * @brief Shared data container for all terminal unit elements.
+     *
+     * Stores identifiers and physical parameters (volume, pressure, etc.) for each terminal unit,
+     * which are used across all rheological and elasticity models.
+     *
+     * @note This data is independent of specific models and is shared across evaluators.
      */
-    struct MakeElasticPressureEvaluator
+    struct TerminalUnitData
     {
-      using ElasticPressureEvaluator = std::function<std::vector<double>&(
-          TerminalUnitData&, const Core::LinAlg::Vector<double>&, double)>;
+      // Global element IDs.
+      std::vector<int> global_element_id;
+      // Local element IDs in row map of the old discretization. May become obsolete with new input.
+      std::vector<int> local_element_id;
+      // IDs of the local rows in the row map. This defines the place for these terminal units in
+      // the system of equations.
+      std::vector<int> local_row_id;
+      // Global dof IDs
+      std::vector<int> gid_p1;
+      std::vector<int> gid_p2;
+      std::vector<int> gid_q;
+      // Dof IDs from locally relevant / column map. Used for lookup in dof-vector during assembly.
+      std::vector<int> lid_p1;
+      std::vector<int> lid_p2;
+      std::vector<int> lid_q;
+      // Physical quantities of each terminal unit.
+      std::vector<double> volume_v;
+      std::vector<double> reference_volume_v0;
 
-      ElasticPressureEvaluator operator()(LinearElasticity& linear_elasticity_model)
-      {
-        return std::bind_front(evaluate_linear_elastic_pressure, std::ref(linear_elasticity_model));
-      }
-      ElasticPressureEvaluator operator()(OgdenHyperelasticity& ogden_model)
-      {
-        return std::bind_front(evaluate_ogden_hyperelastic_pressure, std::ref(ogden_model));
-      }
+      /**
+       * Access this function when looping over elements.
+       */
+      [[nodiscard]] size_t number_of_elements() const { return global_element_id.size(); }
     };
 
-    NegativeResidualEvaluator operator()(KelvinVoigt& kelvin_voigt_model)
-    {
-      auto elastic_pressure_evaluator =
-          std::visit(MakeElasticPressureEvaluator{}, elasticity_model);
-      return [elastic_pressure_evaluator, &kelvin_voigt_model](TerminalUnitData& data,
-                 Core::LinAlg::Vector<double>& target, const Core::LinAlg::Vector<double>& dofs,
-                 double dt)
-      {
-        auto& p_el = elastic_pressure_evaluator(data, dofs, dt);
-        evaluate_negative_kelvin_voigt_residual(target, kelvin_voigt_model, data, dofs, p_el);
-      };
-    }
-    NegativeResidualEvaluator operator()(FourElementMaxwell& four_element_maxwell_model)
-    {
-      auto elastic_pressure_evaluator =
-          std::visit(MakeElasticPressureEvaluator{}, elasticity_model);
-      return [elastic_pressure_evaluator, &four_element_maxwell_model](TerminalUnitData& data,
-                 Core::LinAlg::Vector<double>& target, const Core::LinAlg::Vector<double>& dofs,
-                 double dt)
-      {
-        auto& p_el = elastic_pressure_evaluator(data, dofs, dt);
-        evaluate_negative_four_element_maxwell_residual(
-            target, four_element_maxwell_model, data, dofs, p_el, dt);
-      };
-    }
+    // ----- Rheological models of viscoelasticity -----
 
-    ElasticityModel& elasticity_model;
-  };
-
-  /**
-   * Creates the model-specific evaluator function for assembling the Jacobian.
-   */
-  struct MakeJacobianEvaluator
-  {
     /**
-     * Creates a function for evaluating the elastic pressure gradient w.r.t. inflow q given a
-     * specific elasticity model. The elastic pressure gradient is one additive component of the
-     * rheological model's derivative w.r.t. inflow q.
+     * @brief Rheological Kelvin-Voigt model (spring and dashpot in parallel).
+     *
+     * @note The stress component from the spring is calculated with a given elasticity model
+     * (potentially nonlinear).
      */
-    struct MakeElasticPressureGradientEvaluator
+    struct KelvinVoigt
     {
-      using ElasticPressureGradientEvaluator = std::function<std::vector<double>&(
-          TerminalUnitData&, const Core::LinAlg::Vector<double>&, double)>;
-
-      ElasticPressureGradientEvaluator operator()(LinearElasticity& linear_elasticity_model)
-      {
-        return [&linear_elasticity_model](TerminalUnitData& data,
-                   const Core::LinAlg::Vector<double>& dofs, double dt) -> std::vector<double>&
-        { return linear_elastic_pressure_gradient(linear_elasticity_model, data, dt); };
-      }
-      ElasticPressureGradientEvaluator operator()(OgdenHyperelasticity& ogden_model)
-      {
-        return std::bind_front(ogden_hyperelastic_pressure_gradient, std::ref(ogden_model));
-      }
+      std::vector<double> viscosity_eta;
     };
 
-    JacobianEvaluator operator()(KelvinVoigt& kelvin_voigt_model)
+    /**
+     * @brief Rheological four-element Maxwell model (Kelvin-Voigt body and Maxwell body in
+     * parallel).
+     *
+     * The Maxwell body introduces an additional internal pressure state p_m, which is stored in
+     * this model and updated after every time step.
+     *
+     * @note The stress component from the spring in the Kelvin-Voigt body is calculated with a
+     * given elasticity model (potentially nonlinear).
+     */
+    struct FourElementMaxwell
     {
-      auto elastic_pressure_gradient_evaluator =
-          std::visit(MakeElasticPressureGradientEvaluator{}, elasticity_model);
-      return [elastic_pressure_gradient_evaluator, &kelvin_voigt_model](TerminalUnitData& data,
-                 Core::LinAlg::SparseMatrix& target, const Core::LinAlg::Vector<double>& dofs,
-                 double dt)
-      {
-        auto& dp_el = elastic_pressure_gradient_evaluator(data, dofs, dt);
-        evaluate_kelvin_voigt_jacobian(target, kelvin_voigt_model, data, dp_el);
-      };
-    }
-    JacobianEvaluator operator()(FourElementMaxwell& four_element_maxwell_model)
-    {
-      auto elastic_pressure_gradient_evaluator =
-          std::visit(MakeElasticPressureGradientEvaluator{}, elasticity_model);
-      return [elastic_pressure_gradient_evaluator, &four_element_maxwell_model](
-                 TerminalUnitData& data, Core::LinAlg::SparseMatrix& target,
-                 const Core::LinAlg::Vector<double>& dofs, double dt)
-      {
-        auto& dp_el = elastic_pressure_gradient_evaluator(data, dofs, dt);
-        evaluate_four_element_maxwell_jacobian(target, four_element_maxwell_model, data, dp_el, dt);
-      };
-    }
+      std::vector<double> viscosity_eta;
+      std::vector<double> elasticity_E_m;
+      std::vector<double> viscosity_eta_m;
+      // Internal pressure state of the maxwell body
+      std::vector<double> maxwell_pressure_p_m;
+    };
 
-    ElasticityModel& elasticity_model;
-  };
+    // ----- Specialized Elasticity models -----
 
-  /**
-   * Creates the model-specific updater that updates internal states (variables that need to be
-   * tracked over time for model evaluation).
-   */
-  struct MakeInternalStateUpdater
-  {
-    InternalStateUpdater operator()(KelvinVoigt& kelvin_voigt_model)
+    /**
+     * @brief Linear elasticity model. Substitutes a spring in a rheological model.
+     *
+     * Computes elastic pressure as linear function of volume.
+     * Includes internal variables for pressure and its gradient.
+     */
+    struct LinearElasticity
     {
-      return [&](TerminalUnitData& data, const Core::LinAlg::Vector<double>& locally_relevant_dofs,
-                 double dt) {};
-    }
-    InternalStateUpdater operator()(FourElementMaxwell& four_element_maxwell)
+      std::vector<double> elasticity_E;
+      // Internal elastic pressure state
+      std::vector<double> elastic_pressure_p_el;
+      std::vector<double> elastic_pressure_grad_dp_el;
+    };
+
+    /**
+     * @brief Ogden-type hyperelastic model. Substitutes a spring in a rheological model.
+     *
+     * Nonlinear stiffening behavior based on a bulk modulus kappa and shape parameter beta.
+     * Includes internal variables for pressure and pressure gradient.
+     *
+     * @note Ill-posed for beta = 0!
+     */
+    struct OgdenHyperelasticity
     {
-      return [&](TerminalUnitData& data, const Core::LinAlg::Vector<double>& locally_relevant_dofs,
-                 double dt)
+      std::vector<double> bulk_modulus_kappa;
+      std::vector<double> nonlinear_stiffening_beta;
+      // Internal elastic pressure state
+      std::vector<double> elastic_pressure_p_el;
+      std::vector<double> elastic_pressure_grad_dp_el;
+    };
+
+    // Function handle for evaluating the negative model residuals.
+    using NegativeResidualEvaluator = std::function<void(TerminalUnitData& model_data,
+        Core::LinAlg::Vector<double>& target_vector,
+        const Core::LinAlg::Vector<double>& locally_relevant_dof_vector, double time_step_size_dt)>;
+
+    // Function handle for evaluating the model gradients w.r.t. the primary variables.
+    using JacobianEvaluator = std::function<void(TerminalUnitData& model_data,
+        Core::LinAlg::SparseMatrix& target_matrix,
+        const Core::LinAlg::Vector<double>& locally_relevant_dof_vector, double time_step_size_dt)>;
+
+    // Function handle for updating the internal state vectors
+    using InternalStateUpdater = std::function<void(TerminalUnitData& model_data,
+        const Core::LinAlg::Vector<double>& locally_relevant_dof_vector, double time_step_size_dt)>;
+
+    // Function handle to run at the end of time step. Stores history variables
+    using EndOfTimestepRoutine = std::function<void(TerminalUnitData& model_data,
+        const Core::LinAlg::Vector<double>& locally_relevant_dof_vector, double time_step_size_dt)>;
+
+    // Model types
+    using RheologicalModel = std::variant<KelvinVoigt, FourElementMaxwell>;
+    using ElasticityModel = std::variant<LinearElasticity, OgdenHyperelasticity>;
+
+    /**
+     * @brief Encapsulates a unique combination of rheological and elasticity models.
+     *
+     * Stores the element-specific data and associated evaluation functions
+     * (residuals, Jacobians, internal state updates, end-of-timestep routines) for a given model
+     * combination. Every terminal-unit specific information or action can be found here.
+     */
+    struct TerminalUnitModel
+    {
+      TerminalUnitData data;
+      RheologicalModel rheological_model;
+      ElasticityModel elasticity_model;
+      NegativeResidualEvaluator negative_residual_evaluator;
+      JacobianEvaluator jacobian_evaluator;
+      InternalStateUpdater internal_state_updater;
+      EndOfTimestepRoutine end_of_timestep_routine;
+    };
+
+    /**
+     * @brief All terminal unit models together and interface for access.
+     *
+     * Stores all different terminal unit models as distinct building blocks. Acts as interface for
+     * distributing terminal units to the correct models in the input phase and allows access to all
+     * terminal unit model blocks for assembly, output, etc..
+     */
+    struct TerminalUnitContainer
+    {
+      std::vector<TerminalUnitModel> models;
+    };
+
+    /**
+     * @brief Evaluates the linear elastic pressure for all terminal units in one model.
+     *
+     * @param[in,out] linear_elastic_model Elastic model containing parameters and internal pressure
+     * state vector. Must belong to the same TerminalUnitModel as data.
+     * @param[in] data Terminal unit metadata (IDs, volume, etc.).
+     * @param[in] locally_relevant_dofs DOF vector containing current inflow and pressure values in
+     * column map layout.
+     * @param[in] dt Current time step size.
+     * @return Reference to internal elastic pressure vector, updated in-place with current values.
+     *
+     * @note This function updates and returns the internal vector `elastic_pressure_p_el` stored
+     * in the linear_elastic_model. It must not be used concurrently across models.
+     */
+    std::vector<double>& evaluate_linear_elastic_pressure(LinearElasticity& linear_elastic_model,
+        TerminalUnitData& data, const Core::LinAlg::Vector<double>& locally_relevant_dofs,
+        double dt);
+
+    /**
+     * @brief Evaluates the nonlinear Ogden hyperelastic pressure for each terminal unit in one
+     * model.
+     *
+     * @param[in,out] ogden_hyperelastic_model Model parameters and internal pressure state vector.
+     * Must belong to the same TerminalUnitModel as data.
+     * @param[in] data Metadata and volume of each terminal unit.
+     * @param[in] locally_relevant_dofs DOF vector containing current inflow and pressure values in
+     * column map layout.
+     * @param[in] dt Time step size.
+     * @return Reference to internal elastic pressure vector, updated in-place with current values.
+     *
+     * @note This function updates and returns the internal vector `elastic_pressure_p_el` stored
+     * in the ogden_hyperelastic_model. It must not be used concurrently across models.
+     */
+    std::vector<double>& evaluate_ogden_hyperelastic_pressure(
+        OgdenHyperelasticity& ogden_hyperelastic_model, TerminalUnitData& data,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt);
+
+    /**
+     * @brief Assembles the negative residual for a Kelvin-Voigt viscoelastic model.
+     *
+     * @param[out] target Target vector to which the residual is written.
+     * @param[in] kelvin_voigt_model Model containing viscosity parameters. Must belong to the same
+     * TerminalUnitModel as data.
+     * @param[in] data Terminal unit metadata.
+     * @param[in] locally_relevant_dofs DOF vector containing current inflow and pressure values in
+     * column map layout.
+     * @param[in] elastic_pressure_p_el Current elastic pressure values from the spring model.
+     *
+     * @note The function writes directly into the `target` vector using the row IDs from `data`.
+     */
+    void evaluate_negative_kelvin_voigt_residual(Core::LinAlg::Vector<double>& target,
+        const KelvinVoigt& kelvin_voigt_model, const TerminalUnitData& data,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs,
+        const std::vector<double>& elastic_pressure_p_el);
+
+    /**
+     * @brief Assembles the negative residual for a four-element Maxwell viscoelastic model.
+     *
+     * @param[out] target Target vector to which the residual is written.
+     * @param[in] four_element_maxwell_model Model parameters and internal Maxwell body pressure
+     * state. Must belong to the same TerminalUnitModel as data.
+     * @param[in] data Terminal unit metadata.
+     * @param[in] locally_relevant_dofs DOF vector containing current inflow and pressure values in
+     * column map layout.
+     * @param[in] elastic_pressure_p_el Current elastic pressure values from the spring model in the
+     * Kelvin-Voigt body.
+     * @param[in] dt Current time step size.
+     *
+     * @note The function writes directly into the `target` vector using the row IDs from `data`. It
+     * relies on an up-to-date internal Maxwell pressure state (p_m updated with DOFs from the last
+     * time step).
+     */
+    void evaluate_negative_four_element_maxwell_residual(Core::LinAlg::Vector<double>& target,
+        const FourElementMaxwell& four_element_maxwell_model, const TerminalUnitData& data,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs,
+        const std::vector<double>& elastic_pressure_p_el, double dt);
+
+    /**
+     * @brief Computes the gradient of the linear elastic pressure  model w.r.t. the inflow q.
+     *
+     * The elastic pressure is independent of the pressure state (p1 and p2).
+     *
+     * @param[in,out] linear_elastic_model Model with stiffness parameters and gradient vector. Must
+     * belong to the same TerminalUnitModel as data.
+     * @param[in] data Terminal unit metadata.
+     * @param[in] dt Current time step size.
+     * @return Reference to the internal gradient vector dp_el, updated in-place.
+     */
+    std::vector<double>& linear_elastic_pressure_gradient(
+        LinearElasticity& linear_elastic_model, TerminalUnitData& data, double dt);
+
+    /**
+     * @brief Computes the gradient of the nonlinear Ogden hyperelastic pressure w.r.t. inflow q.
+     *
+     * The elastic pressure is independent of the pressure state (p1 and p2). The elastic pressure
+     * gradient depends on the current volume state and inflow.
+     *
+     * @param[in,out] ogden_hyperelastic_model Ogden parameters and gradient vector. Must belong
+     * to the same TerminalUnitModel as data.
+     * @param[in] data Terminal unit metadata.
+     * @param[in] locally_relevant_dofs DOF vector containing current inflow and pressure values in
+     * column map layout.
+     * @param[in] dt Current time step size.
+     * @return Reference to the internal gradient vector dp_el, updated in-place.
+     */
+    std::vector<double>& ogden_hyperelastic_pressure_gradient(
+        OgdenHyperelasticity& ogden_hyperelastic_model, TerminalUnitData& data,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt);
+
+    /**
+     * @brief Assembles the Jacobian matrix entries for the Kelvin-Voigt viscoelastic model.
+     *
+     * @param[out] target Sparse matrix to which the Jacobian entries are written.
+     * @param[in] kelvin_voigt_model Rheological model with viscosity parameters. Must belong
+     * to the same TerminalUnitModel as data.
+     * @param[in] data Terminal unit metadata.
+     * @param[in] elastic_pressure_grad_dp_el Gradient of the elastic pressure from the spring model
+     * w.r.t. inflow.
+     *
+     * @note The function writes directly into the `target` matrix using the row IDs and column
+     * (DOF) IDs from `data`.
+     */
+    void evaluate_kelvin_voigt_jacobian(Core::LinAlg::SparseMatrix& target,
+        const KelvinVoigt& kelvin_voigt_model, TerminalUnitData& data,
+        const std::vector<double>& elastic_pressure_grad_dp_el);
+
+    /**
+     * @brief Assembles the Jacobian matrix for the four-element Maxwell viscoelastic model.
+     *
+     * @param[out] target Sparse matrix to which the Jacobian entries are written.
+     * @param[in] four_element_maxwell_model Four-element Maxwell parameters and internal Maxwell
+     * pressure state. Must belong to the same TerminalUnitModel as data.
+     * @param[in] data Terminal unit metadata.
+     * @param[in] elastic_pressure_grad_dp_el Gradient of the elastic pressure from the spring model
+     * w.r.t. inflow.
+     * @param[in] dt Current time step size.
+     *
+     * @note The function writes directly into the `target` matrix using the row IDs and column
+     * (DOF) IDs from `data`.
+     */
+    void evaluate_four_element_maxwell_jacobian(Core::LinAlg::SparseMatrix& target,
+        const FourElementMaxwell& four_element_maxwell_model, TerminalUnitData& data,
+        const std::vector<double>& elastic_pressure_grad_dp_el, double dt);
+
+
+    /**
+     * Creates the model-specific evaluator function for assembling the negative model residual.
+     */
+    struct MakeNegativeResidualEvaluator
+    {
+      /**
+       * Creates a function for evaluating the elastic pressure given a specific elasticity model.
+       * The elastic pressure is one additive component of the rheological model's residual
+       * function.
+       */
+      struct MakeElasticPressureEvaluator
       {
-        for (size_t i = 0; i < data.number_of_elements(); i++)
+        using ElasticPressureEvaluator = std::function<std::vector<double>&(
+            TerminalUnitData&, const Core::LinAlg::Vector<double>&, double)>;
+
+        ElasticPressureEvaluator operator()(LinearElasticity& linear_elasticity_model)
         {
-          four_element_maxwell.maxwell_pressure_p_m[i] *=
-              four_element_maxwell.viscosity_eta_m[i] /
-              (four_element_maxwell.elasticity_E_m[i] * dt +
-                  four_element_maxwell.viscosity_eta_m[i]);
-          four_element_maxwell.maxwell_pressure_p_m[i] +=
-              four_element_maxwell.elasticity_E_m[i] * dt *
-              four_element_maxwell.viscosity_eta_m[i] /
-              (four_element_maxwell.elasticity_E_m[i] * dt +
-                  four_element_maxwell.viscosity_eta_m[i]) /
-              data.reference_volume_v0[i] *
-              locally_relevant_dofs.local_values_as_span()[data.lid_q[i]];
+          return std::bind_front(
+              evaluate_linear_elastic_pressure, std::ref(linear_elasticity_model));
+        }
+        ElasticPressureEvaluator operator()(OgdenHyperelasticity& ogden_model)
+        {
+          return std::bind_front(evaluate_ogden_hyperelastic_pressure, std::ref(ogden_model));
         }
       };
-    }
-  };
 
-  /**
-   * @brief Returns an existing or newly created model for a given rheological/elasticity pair.
-   *
-   * May become obsolete with the new input
-   *
-   * @tparam R Rheological model type.
-   * @tparam E Elasticity model type.
-   * @param terminal_units Global container for all terminal unit models.
-   * @return Reference to the matching TerminalUnitModel.
-   *
-   * @note Ensures reuse of model instances for shared material parameter sets.
-   */
-  template <typename R, typename E>
-  TerminalUnitModel& register_or_access_terminal_unit_model(TerminalUnits& terminal_units)
-  {
-    for (auto& model : terminal_units.models)
-    {
-      if (std::holds_alternative<R>(model.rheological_model) &&
-          std::holds_alternative<E>(model.elasticity_model))
+      NegativeResidualEvaluator operator()(KelvinVoigt& kelvin_voigt_model)
       {
-        return model;
+        auto elastic_pressure_evaluator =
+            std::visit(MakeElasticPressureEvaluator{}, elasticity_model);
+        return [elastic_pressure_evaluator, &kelvin_voigt_model](TerminalUnitData& data,
+                   Core::LinAlg::Vector<double>& target, const Core::LinAlg::Vector<double>& dofs,
+                   double dt)
+        {
+          auto& p_el = elastic_pressure_evaluator(data, dofs, dt);
+          evaluate_negative_kelvin_voigt_residual(target, kelvin_voigt_model, data, dofs, p_el);
+        };
       }
-    }
+      NegativeResidualEvaluator operator()(FourElementMaxwell& four_element_maxwell_model)
+      {
+        auto elastic_pressure_evaluator =
+            std::visit(MakeElasticPressureEvaluator{}, elasticity_model);
+        return [elastic_pressure_evaluator, &four_element_maxwell_model](TerminalUnitData& data,
+                   Core::LinAlg::Vector<double>& target, const Core::LinAlg::Vector<double>& dofs,
+                   double dt)
+        {
+          auto& p_el = elastic_pressure_evaluator(data, dofs, dt);
+          evaluate_negative_four_element_maxwell_residual(
+              target, four_element_maxwell_model, data, dofs, p_el, dt);
+        };
+      }
 
-    // Create instance of the TerminalUnitModel
-    terminal_units.models.emplace_back();
-    TerminalUnitModel& new_model = terminal_units.models.back();
+      ElasticityModel& elasticity_model;
+    };
 
-    // Create models
-    new_model.rheological_model = R{};
-    new_model.elasticity_model = E{};
-
-    // Evaluators are assigned later to avoid capturing references into `terminal_units.models`
-    // while the vector may still reallocate during element registration.
-
-    return new_model;
-  }
-
-  struct AddRheologicalModelParameter
-  {
-    void operator()(KelvinVoigt& kelvin_voigt_model) const
+    /**
+     * Creates the model-specific evaluator function for assembling the Jacobian.
+     */
+    struct MakeJacobianEvaluator
     {
-      kelvin_voigt_model.viscosity_eta.push_back(params.kelvin_voigt.viscosity_kelvin_voigt_eta.at(
-          ele->id(), "viscosity_kelvin_voigt_eta"));
-    }
-    void operator()(FourElementMaxwell& model) const
+      /**
+       * Creates a function for evaluating the elastic pressure gradient w.r.t. inflow q given a
+       * specific elasticity model. The elastic pressure gradient is one additive component of the
+       * rheological model's derivative w.r.t. inflow q.
+       */
+      struct MakeElasticPressureGradientEvaluator
+      {
+        using ElasticPressureGradientEvaluator = std::function<std::vector<double>&(
+            TerminalUnitData&, const Core::LinAlg::Vector<double>&, double)>;
+
+        ElasticPressureGradientEvaluator operator()(LinearElasticity& linear_elasticity_model)
+        {
+          return [&linear_elasticity_model](TerminalUnitData& data,
+                     const Core::LinAlg::Vector<double>& dofs, double dt) -> std::vector<double>&
+          { return linear_elastic_pressure_gradient(linear_elasticity_model, data, dt); };
+        }
+        ElasticPressureGradientEvaluator operator()(OgdenHyperelasticity& ogden_model)
+        {
+          return std::bind_front(ogden_hyperelastic_pressure_gradient, std::ref(ogden_model));
+        }
+      };
+
+      JacobianEvaluator operator()(KelvinVoigt& kelvin_voigt_model)
+      {
+        auto elastic_pressure_gradient_evaluator =
+            std::visit(MakeElasticPressureGradientEvaluator{}, elasticity_model);
+        return [elastic_pressure_gradient_evaluator, &kelvin_voigt_model](TerminalUnitData& data,
+                   Core::LinAlg::SparseMatrix& target, const Core::LinAlg::Vector<double>& dofs,
+                   double dt)
+        {
+          auto& dp_el = elastic_pressure_gradient_evaluator(data, dofs, dt);
+          evaluate_kelvin_voigt_jacobian(target, kelvin_voigt_model, data, dp_el);
+        };
+      }
+      JacobianEvaluator operator()(FourElementMaxwell& four_element_maxwell_model)
+      {
+        auto elastic_pressure_gradient_evaluator =
+            std::visit(MakeElasticPressureGradientEvaluator{}, elasticity_model);
+        return [elastic_pressure_gradient_evaluator, &four_element_maxwell_model](
+                   TerminalUnitData& data, Core::LinAlg::SparseMatrix& target,
+                   const Core::LinAlg::Vector<double>& dofs, double dt)
+        {
+          auto& dp_el = elastic_pressure_gradient_evaluator(data, dofs, dt);
+          evaluate_four_element_maxwell_jacobian(
+              target, four_element_maxwell_model, data, dp_el, dt);
+        };
+      }
+
+      ElasticityModel& elasticity_model;
+    };
+
+    /**
+     * Creates the model-specific routine that updates internal state variables during the nonlinear
+     * loop
+     */
+    struct MakeInternalStateUpdater
     {
-      model.elasticity_E_m.push_back(params.four_element_maxwell.elasticity_maxwell_e_m.at(
-          ele->id(), "elasticity_maxwell_e_m"));
-      model.viscosity_eta.push_back(params.four_element_maxwell.viscosity_kelvin_voigt_eta.at(
-          ele->id(), "viscosity_kelvin_voigt_eta"));
-      model.viscosity_eta_m.push_back(params.four_element_maxwell.viscosity_maxwell_eta_m.at(
-          ele->id(), "viscosity_maxwell_eta_m"));
-      model.maxwell_pressure_p_m.push_back(0.0);
-    }
+      InternalStateUpdater operator()(KelvinVoigt& kelvin_voigt_model)
+      {
+        return [&](TerminalUnitData& data,
+                   const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt) {};
+      }
+      InternalStateUpdater operator()(FourElementMaxwell& four_element_maxwell)
+      {
+        return [&](TerminalUnitData& data,
+                   const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt) {};
+      }
+    };
 
-    Core::Elements::Element* ele;
-    ReducedLungParameters::LungTree::TerminalUnits::RheologicalModel params;
-  };
-
-  struct AddElasticityModelParameter
-  {
-    void operator()(LinearElasticity& linear_elasticity_model) const
+    /**
+     * Creates the model-specific routine at the end of the timestep that updates history variables
+     * that need to be tracked over time for model evaluation
+     */
+    struct MakeEndOfTimestepRoutine
     {
-      linear_elasticity_model.elasticity_E.push_back(
-          params.linear.elasticity_e.at(ele->id(), "elasticity_e"));
-      // Vector initialization for internal pressure state.
-      linear_elasticity_model.elastic_pressure_p_el.push_back(0.0);
-      linear_elasticity_model.elastic_pressure_grad_dp_el.push_back(0.0);
+      EndOfTimestepRoutine operator()(KelvinVoigt& kelvin_voigt_model)
+      {
+        return [&](TerminalUnitData& data,
+                   const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt) {};
+      }
+      EndOfTimestepRoutine operator()(FourElementMaxwell& four_element_maxwell)
+      {
+        return [&](TerminalUnitData& data,
+                   const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt)
+        {
+          for (size_t i = 0; i < data.number_of_elements(); i++)
+          {
+            four_element_maxwell.maxwell_pressure_p_m[i] *=
+                four_element_maxwell.viscosity_eta_m[i] /
+                (four_element_maxwell.elasticity_E_m[i] * dt +
+                    four_element_maxwell.viscosity_eta_m[i]);
+            four_element_maxwell.maxwell_pressure_p_m[i] +=
+                four_element_maxwell.elasticity_E_m[i] * dt *
+                four_element_maxwell.viscosity_eta_m[i] /
+                (four_element_maxwell.elasticity_E_m[i] * dt +
+                    four_element_maxwell.viscosity_eta_m[i]) /
+                data.reference_volume_v0[i] *
+                locally_relevant_dofs.local_values_as_span()[data.lid_q[i]];
+          }
+        };
+      }
+    };
+
+    /**
+     * @brief Returns an existing or newly created model for a given rheological/elasticity pair.
+     *
+     * May become obsolete with the new input
+     *
+     * @tparam R Rheological model type.
+     * @tparam E Elasticity model type.
+     * @param terminal_units Global container for all terminal unit models.
+     * @return Reference to the matching TerminalUnitModel.
+     *
+     * @note Ensures reuse of model instances for shared material parameter sets.
+     */
+    template <typename R, typename E>
+    TerminalUnitModel& register_or_access_terminal_unit_model(TerminalUnitContainer& terminal_units)
+    {
+      for (auto& model : terminal_units.models)
+      {
+        if (std::holds_alternative<R>(model.rheological_model) &&
+            std::holds_alternative<E>(model.elasticity_model))
+        {
+          return model;
+        }
+      }
+
+      // Create instance of the TerminalUnitModel
+      terminal_units.models.emplace_back();
+      TerminalUnitModel& new_model = terminal_units.models.back();
+
+      // Create models
+      new_model.rheological_model = R{};
+      new_model.elasticity_model = E{};
+
+      // Evaluators are assigned later to avoid capturing references into `terminal_units.models`
+      // while the vector may still reallocate during element registration.
+
+      return new_model;
     }
-    void operator()(OgdenHyperelasticity& ogden_model) const {}
 
-    Core::Elements::Element* ele;
-    ReducedLungParameters::LungTree::TerminalUnits::ElasticityModel params;
-  };
+    struct AddRheologicalModelParameter
+    {
+      void operator()(KelvinVoigt& kelvin_voigt_model) const
+      {
+        kelvin_voigt_model.viscosity_eta.push_back(
+            params.kelvin_voigt.viscosity_kelvin_voigt_eta.at(
+                ele->id(), "viscosity_kelvin_voigt_eta"));
+      }
+      void operator()(FourElementMaxwell& model) const
+      {
+        model.elasticity_E_m.push_back(params.four_element_maxwell.elasticity_maxwell_e_m.at(
+            ele->id(), "elasticity_maxwell_e_m"));
+        model.viscosity_eta.push_back(params.four_element_maxwell.viscosity_kelvin_voigt_eta.at(
+            ele->id(), "viscosity_kelvin_voigt_eta"));
+        model.viscosity_eta_m.push_back(params.four_element_maxwell.viscosity_maxwell_eta_m.at(
+            ele->id(), "viscosity_maxwell_eta_m"));
+        model.maxwell_pressure_p_m.push_back(0.0);
+      }
 
-  /**
-   * @brief Adds a new element to the appropriate TerminalUnitModel group.
-   *
-   * Computes volume, assigns material parameters, and initializes internal state.
-   *
-   * @tparam R Rheological model.
-   * @tparam E Elasticity model.
-   * @param terminal_units Global container for all terminal unit models.
-   * @param ele Pointer to element to be added.
-   * @param local_element_id Local identifier in 4C discretization.
-   */
-  template <typename R, typename E>
-  void add_terminal_unit_ele(TerminalUnits& terminal_units, Core::Elements::Element* ele,
-      int local_element_id, ReducedLungParameters::LungTree::TerminalUnits tu_params)
-  {
-    TerminalUnitModel& model = register_or_access_terminal_unit_model<R, E>(terminal_units);
+      Core::Elements::Element* ele;
+      ReducedLungParameters::LungTree::TerminalUnits::RheologicalModel params;
+    };
 
-    model.data.global_element_id.push_back(ele->id());
-    model.data.local_element_id.push_back(local_element_id);
-    const auto& coords_node_1 = ele->nodes()[0]->x();
-    const auto& coords_node_2 = ele->nodes()[1]->x();
-    const double radius =
-        std::sqrt((coords_node_1[0] - coords_node_2[0]) * (coords_node_1[0] - coords_node_2[0]) +
-                  (coords_node_1[1] - coords_node_2[1]) * (coords_node_1[1] - coords_node_2[1]) +
-                  (coords_node_1[2] - coords_node_2[2]) * (coords_node_1[2] - coords_node_2[2]));
-    const double volume = (4.0 / 3.0) * std::numbers::pi * radius * radius * radius;
-    model.data.volume_v.push_back(volume);
-    model.data.reference_volume_v0.push_back(volume);
-    std::visit(AddRheologicalModelParameter{.ele = ele, .params = tu_params.rheological_model},
-        model.rheological_model);
-    std::visit(AddElasticityModelParameter{.ele = ele, .params = tu_params.elasticity_model},
-        model.elasticity_model);
-  }
+    struct AddElasticityModelParameter
+    {
+      void operator()(LinearElasticity& linear_elasticity_model) const
+      {
+        linear_elasticity_model.elasticity_E.push_back(
+            params.linear.elasticity_e.at(ele->id(), "elasticity_e"));
+        // Vector initialization for internal pressure state.
+        linear_elasticity_model.elastic_pressure_p_el.push_back(0.0);
+        linear_elasticity_model.elastic_pressure_grad_dp_el.push_back(0.0);
+      }
+      void operator()(OgdenHyperelasticity& ogden_model) const {}
 
-  /**
-   * @brief Assembles the negative residual vector of all terminal units.
-   *
-   * Applies model-specific logic to compute viscoelastic responses of all terminal units and store
-   * them in the residual.
-   *
-   * @param res_vector Residual vector in row map layout
-   * @param terminal_units All grouped terminal unit models.
-   * @param locally_relevant_dofs DOF vector containing current inflow and pressure values in
-   * column map layout.
-   * @param dt Current time step size.
-   */
-  void update_terminal_unit_negative_residual_vector(Core::LinAlg::Vector<double>& res_vector,
-      TerminalUnits& terminal_units, const Core::LinAlg::Vector<double>& locally_relevant_dofs,
-      double dt);
+      Core::Elements::Element* ele;
+      ReducedLungParameters::LungTree::TerminalUnits::ElasticityModel params;
+    };
 
-  /**
-   * @brief Assembles the Jacobian matrix contributions from all terminal units.
-   *
-   * Derivatives w.r.t. pressure and flow variables are computed using model-specific logic. They
-   * are directly stored in the given Jacobian.
-   *
-   * @param jac Jacobian matrix in (row, column) map layout.
-   * @param terminal_units All grouped terminal unit models.
-   * @param locally_relevant_dofs DOF vector containing current inflow and pressure values in
-   * column map layout.
-   * @param dt Current time step size.
-   */
-  void update_terminal_unit_jacobian(Core::LinAlg::SparseMatrix& jac, TerminalUnits& terminal_units,
-      const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt);
+    /**
+     * @brief Adds a new element to the appropriate TerminalUnitModel group.
+     *
+     * Computes volume, assigns material parameters, and initializes internal state.
+     *
+     * @tparam R Rheological model.
+     * @tparam E Elasticity model.
+     * @param terminal_units Global container for all terminal unit models.
+     * @param ele Pointer to element to be added.
+     * @param local_element_id Local identifier in 4C discretization.
+     */
+    template <typename R, typename E>
+    void add_terminal_unit_ele(TerminalUnitContainer& terminal_units, Core::Elements::Element* ele,
+        int local_element_id, ReducedLungParameters::LungTree::TerminalUnits tu_params)
+    {
+      TerminalUnitModel& model = register_or_access_terminal_unit_model<R, E>(terminal_units);
 
-  /**
-   * @brief Creates evaluator functions for all terminal unit models.
-   *
-   * This function must be called after all terminal unit elements have been added.
-   * It initializes the evaluator function objects (residual, Jacobian, internal state updater)
-   * for each model, ensuring that references captured by these evaluators remain valid.
-   */
-  void create_terminal_unit_evaluators(TerminalUnits& terminal_units);
+      model.data.global_element_id.push_back(ele->id());
+      model.data.local_element_id.push_back(local_element_id);
+      const auto& coords_node_1 = ele->nodes()[0]->x();
+      const auto& coords_node_2 = ele->nodes()[1]->x();
+      const double radius =
+          std::sqrt((coords_node_1[0] - coords_node_2[0]) * (coords_node_1[0] - coords_node_2[0]) +
+                    (coords_node_1[1] - coords_node_2[1]) * (coords_node_1[1] - coords_node_2[1]) +
+                    (coords_node_1[2] - coords_node_2[2]) * (coords_node_1[2] - coords_node_2[2]));
+      const double volume = (4.0 / 3.0) * std::numbers::pi * radius * radius * radius;
+      model.data.volume_v.push_back(volume);
+      model.data.reference_volume_v0.push_back(volume);
+      std::visit(AddRheologicalModelParameter{.ele = ele, .params = tu_params.rheological_model},
+          model.rheological_model);
+      std::visit(AddElasticityModelParameter{.ele = ele, .params = tu_params.elasticity_model},
+          model.elasticity_model);
+    }
 
-  /**
-   * @brief Updates the internal state memory of each terminal unit model.
-   *
-   * Used to store history variables (e.g. volume, Maxwell pressure) from previous time steps.
-   *
-   * @param terminal_units All grouped terminal unit models.
-   * @param locally_relevant_dofs DOF vector containing inflow and pressure values in
-   * column map layout. The DOFs have to be in a converged state.
-   * @param dt Time step size.
-   *
-   * @note Needs to be executed once between time steps to update the internal state with the
-   * converged DOFs.
-   */
-  void update_terminal_unit_internal_state_vectors(TerminalUnits& terminal_units,
-      const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt);
+    /**
+     * @brief Assembles the negative residual vector of all terminal units.
+     *
+     * Applies model-specific logic to compute viscoelastic responses of all terminal units and
+     * store them in the residual.
+     *
+     * @param res_vector Residual vector in row map layout
+     * @param terminal_units All grouped terminal unit models.
+     * @param locally_relevant_dofs DOF vector containing current inflow and pressure values in
+     * column map layout.
+     * @param dt Current time step size.
+     */
+    void update_negative_residual_vector(Core::LinAlg::Vector<double>& res_vector,
+        TerminalUnitContainer& terminal_units,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt);
+
+    /**
+     * @brief Assembles the Jacobian matrix contributions from all terminal units.
+     *
+     * Derivatives w.r.t. pressure and flow variables are computed using model-specific logic. They
+     * are directly stored in the given Jacobian.
+     *
+     * @param jac Jacobian matrix in (row, column) map layout.
+     * @param terminal_units All grouped terminal unit models.
+     * @param locally_relevant_dofs DOF vector containing current inflow and pressure values in
+     * column map layout.
+     * @param dt Current time step size.
+     */
+    void update_jacobian(Core::LinAlg::SparseMatrix& jac, TerminalUnitContainer& terminal_units,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt);
+
+    /**
+     * @brief Creates evaluator functions for all terminal unit models.
+     *
+     * This function must be called after all terminal unit elements have been added.
+     * It initializes the evaluator function objects (residual, Jacobian, internal state updater,
+     * end-of-timestep routine) for each model, ensuring that references captured by these
+     * evaluators remain valid.
+     */
+    void create_evaluators(TerminalUnitContainer& terminal_units);
+
+    /**
+     * @brief Updates the internal state memory of each terminal unit model.
+     *
+     * Used to store history variables (e.g. volume, Maxwell pressure) from previous time steps.
+     *
+     * @param terminal_units All grouped terminal unit models.
+     * @param locally_relevant_dofs DOF vector containing inflow and pressure values in
+     * column map layout. The DOFs have to be in a converged state.
+     * @param dt Time step size.
+     *
+     * @note Needs to be executed once between time steps to update the internal state with the
+     * converged DOFs.
+     */
+    void update_internal_state_vectors(TerminalUnitContainer& terminal_units,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt);
+
+    /**
+     * @brief Routine to be executed at the end of each time step.
+     *
+     * Used to store history variables from previous time steps.
+     *
+     * @param terminal_units All grouped terminal unit models.
+     * @param locally_relevant_dofs DOF vector containing inflow and pressure values in
+     * column map layout. The DOFs have to be in a converged state.
+     * @param dt Time step size.
+     *
+     * @note Needs to be executed once between time steps to update the internal state with the
+     * converged DOFs.
+     */
+    void end_of_timestep_routine(TerminalUnitContainer& terminal_units,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt);
+  }  // namespace TerminalUnits
 }  // namespace ReducedLung
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/reduced_lung/tests/4C_reduced_lung_airways_test.cpp
+++ b/src/reduced_lung/tests/4C_reduced_lung_airways_test.cpp
@@ -1,0 +1,339 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+// Reimplemented airway tests to match the style of the terminal unit tests.
+// Tests only linear and nonlinear resistive flow without inertia.
+#include <gtest/gtest.h>
+
+#include "4C_reduced_lung_airways.hpp"
+
+#include "4C_linalg_sparsematrix.hpp"
+#include "4C_reduced_lung_helpers.hpp"
+#include "4C_reduced_lung_terminal_unit.hpp"
+#include "4C_reduced_lung_test_utils_test.hpp"
+// needed for export_to
+#include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
+
+
+namespace
+{
+  using namespace FourC::ReducedLung;
+  using namespace FourC::Core::LinAlg;
+  using namespace FourC::ReducedLung::Airways;
+
+
+  TEST(AirwayTests, JacobianVsFiniteDifferenceRigidWall)
+  {
+    AirwayContainer airways;
+    AirwayModel model;
+
+    // Create small airway data for testing (3 elements)
+    model.data.global_element_id = {0, 1, 2};
+    model.data.local_element_id = {0, 1, 2};
+    model.data.local_row_id = {0, 1, 2};
+    model.data.gid_p1 = {0, 1, 2};
+    model.data.gid_p2 = {3, 4, 5};
+    model.data.gid_q1 = {6, 7, 8};
+    model.data.gid_q2 = {6, 7, 8};
+    model.data.lid_p1 = {0, 1, 2};
+    model.data.lid_p2 = {3, 4, 5};
+    model.data.lid_q1 = {6, 7, 8};
+    model.data.lid_q2 = {6, 7, 8};
+    model.data.ref_length = {1.0, 1.0, 1.0};
+    model.data.ref_area = {0.5, 0.5, 0.5};
+    model.data.n_state_equations = 1;
+    model.data.air_properties.dynamic_viscosity = 1.79105e-05;
+    model.data.air_properties.density = 1.176e-06;
+    model.data.q1_n = {1.0, 1.0, 1.0};
+    model.data.q2_n = {0.0, 0.0, 0.0};
+    airways.models.push_back(model);
+
+    // We'll reuse the same model structure and swap evaluators per case below.
+    // Prepare maps used by both cases
+    const auto dof_map =
+        create_domain_map(MPI_COMM_WORLD, airways, TerminalUnits::TerminalUnitContainer{});
+    const auto row_map =
+        create_row_map(MPI_COMM_WORLD, airways, TerminalUnits::TerminalUnitContainer{}, {}, {}, {});
+    const auto col_map =
+        create_column_map(MPI_COMM_WORLD, airways, TerminalUnits::TerminalUnitContainer{},
+            {{0, 3}, {1, 3}, {2, 3}}, {{0, 0}, {1, 3}, {2, 6}}, {}, {}, {});
+
+    Vector<double> dofs(dof_map, true);
+    Vector<double> locally_relevant_dofs(col_map, true);
+    dofs.replace_local_values(9, std::array<double, 9>{1, 1, 1, 1, 1, 1, 100, 50, 10}.data(),
+        std::array<int, 9>{0, 1, 2, 3, 4, 5, 6, 7, 8}.data());
+    export_to(dofs, locally_relevant_dofs);
+
+    double dt = 1e-1;
+    const double eps = 1e-6;
+    {
+      SCOPED_TRACE("Linear resistive (no inertia)");
+
+      SparseMatrix jac(row_map, col_map, 3);
+      model.flow_model = LinearResistive{.has_inertia = std::vector<bool>{false, false, false}};
+      model.wall_model = RigidWall{};
+
+      model.internal_state_updater =
+          std::visit(Airways::MakeInternalStateUpdater{model.flow_model}, model.wall_model);
+      model.negative_residual_evaluator =
+          std::visit(Airways::MakeNegativeResidualEvaluator{model.flow_model}, model.wall_model);
+      model.jacobian_evaluator =
+          std::visit(Airways::MakeJacobianEvaluator{model.flow_model}, model.wall_model);
+
+      model.jacobian_evaluator(model.data, jac, locally_relevant_dofs, dt);
+
+      TestUtils::check_jacobian_column_against_fd(
+          model.data.lid_p1, 0, model, jac, locally_relevant_dofs, dt, eps, row_map);
+      TestUtils::check_jacobian_column_against_fd(
+          model.data.lid_p2, 1, model, jac, locally_relevant_dofs, dt, eps, row_map);
+      TestUtils::check_jacobian_column_against_fd(
+          model.data.lid_q1, 2, model, jac, locally_relevant_dofs, dt, eps, row_map);
+    }
+    {
+      SCOPED_TRACE("Linear resistive (with inertia)");
+      SparseMatrix jac(row_map, col_map, 3);
+
+      model.flow_model = LinearResistive{.has_inertia = std::vector<bool>{true, true, true}};
+      // Wall model: rigid
+      model.wall_model = RigidWall{};
+
+      model.internal_state_updater =
+          std::visit(Airways::MakeInternalStateUpdater{model.flow_model}, model.wall_model);
+      model.negative_residual_evaluator =
+          std::visit(Airways::MakeNegativeResidualEvaluator{model.flow_model}, model.wall_model);
+      model.jacobian_evaluator =
+          std::visit(Airways::MakeJacobianEvaluator{model.flow_model}, model.wall_model);
+
+      model.jacobian_evaluator(model.data, jac, locally_relevant_dofs, dt);
+      TestUtils::check_jacobian_column_against_fd(
+          model.data.lid_p1, 0, model, jac, locally_relevant_dofs, dt, eps, row_map);
+      TestUtils::check_jacobian_column_against_fd(
+          model.data.lid_p2, 1, model, jac, locally_relevant_dofs, dt, eps, row_map);
+      TestUtils::check_jacobian_column_against_fd(
+          model.data.lid_q1, 2, model, jac, locally_relevant_dofs, dt, eps, row_map);
+    }
+    {
+      SCOPED_TRACE("Nonlinear resistive (no inertia)");
+
+      SparseMatrix jac(row_map, col_map, 3);
+
+      model.flow_model =
+          NonLinearResistive{.turbulence_factor_gamma = std::vector<double>{0.6, 0.4, 0.2},
+              .has_inertia = std::vector<bool>{false, false, false},
+              .k_turb = std::vector<double>{2.0, 1.0, 1.0}};
+      // Wall model: rigid
+      model.wall_model = RigidWall{};
+
+      model.internal_state_updater =
+          std::visit(Airways::MakeInternalStateUpdater{model.flow_model}, model.wall_model);
+      model.negative_residual_evaluator =
+          std::visit(Airways::MakeNegativeResidualEvaluator{model.flow_model}, model.wall_model);
+      model.jacobian_evaluator =
+          std::visit(Airways::MakeJacobianEvaluator{model.flow_model}, model.wall_model);
+
+      model.internal_state_updater(model.data, locally_relevant_dofs, dt);
+      model.jacobian_evaluator(model.data, jac, locally_relevant_dofs, dt);
+
+      TestUtils::check_jacobian_column_against_fd(
+          model.data.lid_p1, 0, model, jac, locally_relevant_dofs, dt, eps, row_map);
+      TestUtils::check_jacobian_column_against_fd(
+          model.data.lid_p2, 1, model, jac, locally_relevant_dofs, dt, eps, row_map);
+      TestUtils::check_jacobian_column_against_fd(
+          model.data.lid_q1, 2, model, jac, locally_relevant_dofs, dt, eps, row_map);
+    }
+    {
+      SCOPED_TRACE("Nonlinear resistive (with inertia)");
+      SparseMatrix jac(row_map, col_map, 3);
+
+      model.flow_model =
+          NonLinearResistive{.turbulence_factor_gamma = std::vector<double>{0.6, 0.4, 0.2},
+              .has_inertia = std::vector<bool>{true, true, true},
+              .k_turb = std::vector<double>{2.0, 1.0, 1.0}};
+      // Wall model: rigid
+      model.wall_model = RigidWall{};
+
+      model.internal_state_updater =
+          std::visit(Airways::MakeInternalStateUpdater{model.flow_model}, model.wall_model);
+      model.negative_residual_evaluator =
+          std::visit(Airways::MakeNegativeResidualEvaluator{model.flow_model}, model.wall_model);
+      model.jacobian_evaluator =
+          std::visit(Airways::MakeJacobianEvaluator{model.flow_model}, model.wall_model);
+
+      model.internal_state_updater(model.data, locally_relevant_dofs, dt);
+      model.jacobian_evaluator(model.data, jac, locally_relevant_dofs, dt);
+      TestUtils::check_jacobian_column_against_fd(
+          model.data.lid_p1, 0, model, jac, locally_relevant_dofs, dt, eps, row_map);
+      TestUtils::check_jacobian_column_against_fd(
+          model.data.lid_p2, 1, model, jac, locally_relevant_dofs, dt, eps, row_map);
+      TestUtils::check_jacobian_column_against_fd(
+          model.data.lid_q1, 2, model, jac, locally_relevant_dofs, dt, eps, row_map);
+    }
+  }
+
+  TEST(AirwayTests, JacobianVsFiniteDifferenceKelvinVoigtWall)
+  {
+    AirwayContainer airways;
+    AirwayModel model;
+
+    // Create small airway data for testing (3 elements)
+    model.data.global_element_id = {0, 1, 2};
+    model.data.local_element_id = {0, 1, 2};
+    model.data.local_row_id = {0, 1, 2};
+    model.data.gid_p1 = {0, 1, 2};
+    model.data.gid_p2 = {3, 4, 5};
+    model.data.gid_q1 = {6, 7, 8};
+    model.data.gid_q2 = {9, 10, 11};
+    model.data.lid_p1 = {0, 1, 2};
+    model.data.lid_p2 = {3, 4, 5};
+    model.data.lid_q1 = {6, 7, 8};
+    model.data.lid_q2 = {9, 10, 11};
+    model.data.ref_length = {1.0, 1.0, 1.0};
+    model.data.ref_area = {0.5, 0.5, 0.5};
+    model.data.n_state_equations = 2;
+    model.data.air_properties.dynamic_viscosity = 1.79105e-05;
+    model.data.air_properties.density = 1.176e-06;
+    model.data.q1_n = {1.0, 1.0, 1.0};
+    model.data.q2_n = {0.9, 0.9, 0.9};
+    model.data.p1_n = {1.0, 1.0, 1.0};
+    model.data.p2_n = {1.0, 1.0, 1.0};
+    airways.models.push_back(model);
+
+    // We'll reuse the same model structure and swap evaluators per case below.
+    // Prepare maps used by both cases
+    const auto dof_map =
+        create_domain_map(MPI_COMM_WORLD, airways, TerminalUnits::TerminalUnitContainer{});
+    const auto row_map =
+        create_row_map(MPI_COMM_WORLD, airways, TerminalUnits::TerminalUnitContainer{}, {}, {}, {});
+    const auto col_map =
+        create_column_map(MPI_COMM_WORLD, airways, TerminalUnits::TerminalUnitContainer{},
+            {{0, 4}, {1, 4}, {2, 4}}, {{0, 0}, {1, 4}, {2, 8}}, {}, {}, {});
+
+    Vector<double> dofs(dof_map, true);
+    Vector<double> locally_relevant_dofs(col_map, true);
+    dofs.replace_local_values(12,
+        std::array<double, 12>{1, 1, 1, 1, 1, 1, 100, 50, 10, 101, 52, 9}.data(),
+        std::array<int, 12>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}.data());
+    export_to(dofs, locally_relevant_dofs);
+
+    double dt = 1e-1;
+    const double eps = 1e-6;
+    model.wall_model = KelvinVoigtWall{.wall_poisson_ratio = std::vector<double>{0.3, 0.3, 0.3},
+        .wall_elasticity = std::vector<double>{50000.0, 50000.0, 50000.0},
+        .wall_thickness = std::vector<double>{0.001, 0.001, 0.001},
+        .viscous_time_constant = std::vector<double>{0.01, 0.01, 0.01},
+        .viscous_phase_shift = std::vector<double>{0.0, 0.0, 0.0},
+        .area_n = std::vector<double>{0.5, 0.5, 0.5},
+        .area = std::vector<double>(3, 1.0),
+        .viscous_resistance_Rvisc = std::vector<double>(3, 1.0),
+        .compliance_C = std::vector<double>(3, 1.0),
+        .gamma_w = std::vector<double>(3, 1.0),
+        .beta_w = std::vector<double>(3, 1.0)};
+
+    {
+      SCOPED_TRACE("Linear resistive (no inertia) - KV wall model");
+      SparseMatrix jac(row_map, col_map, 4);
+
+      model.flow_model = LinearResistive{
+          .has_inertia = std::vector<bool>{false, false, false},
+      };
+
+      model.internal_state_updater =
+          std::visit(Airways::MakeInternalStateUpdater{model.flow_model}, model.wall_model);
+      model.negative_residual_evaluator =
+          std::visit(Airways::MakeNegativeResidualEvaluator{model.flow_model}, model.wall_model);
+      model.jacobian_evaluator =
+          std::visit(Airways::MakeJacobianEvaluator{model.flow_model}, model.wall_model);
+      model.internal_state_updater(model.data, locally_relevant_dofs, dt);
+      model.jacobian_evaluator(model.data, jac, locally_relevant_dofs, dt);
+      TestUtils::check_jacobian_column_against_fd(
+          model.data.lid_p1, 0, model, jac, locally_relevant_dofs, dt, eps, row_map);
+      TestUtils::check_jacobian_column_against_fd(
+          model.data.lid_p2, 1, model, jac, locally_relevant_dofs, dt, eps, row_map);
+      TestUtils::check_jacobian_column_against_fd(
+          model.data.lid_q1, 2, model, jac, locally_relevant_dofs, dt, eps, row_map);
+      TestUtils::check_jacobian_column_against_fd(
+          model.data.lid_q2, 3, model, jac, locally_relevant_dofs, dt, eps, row_map);
+    }
+    {
+      SCOPED_TRACE("Linear resistive (with inertia) - KV wall model");
+      SparseMatrix jac(row_map, col_map, 4);
+
+      model.flow_model = LinearResistive{
+          .has_inertia = std::vector<bool>{true, true, true},
+      };
+
+      model.internal_state_updater =
+          std::visit(Airways::MakeInternalStateUpdater{model.flow_model}, model.wall_model);
+      model.negative_residual_evaluator =
+          std::visit(Airways::MakeNegativeResidualEvaluator{model.flow_model}, model.wall_model);
+      model.jacobian_evaluator =
+          std::visit(Airways::MakeJacobianEvaluator{model.flow_model}, model.wall_model);
+      model.internal_state_updater(model.data, locally_relevant_dofs, dt);
+      model.jacobian_evaluator(model.data, jac, locally_relevant_dofs, dt);
+      TestUtils::check_jacobian_column_against_fd(
+          model.data.lid_p1, 0, model, jac, locally_relevant_dofs, dt, eps, row_map);
+      TestUtils::check_jacobian_column_against_fd(
+          model.data.lid_p2, 1, model, jac, locally_relevant_dofs, dt, eps, row_map);
+      TestUtils::check_jacobian_column_against_fd(
+          model.data.lid_q1, 2, model, jac, locally_relevant_dofs, dt, eps, row_map);
+      TestUtils::check_jacobian_column_against_fd(
+          model.data.lid_q2, 3, model, jac, locally_relevant_dofs, dt, eps, row_map);
+    }
+    {
+      SCOPED_TRACE("Nonlinear resistive (no inertia) - KV wall model");
+      SparseMatrix jac(row_map, col_map, 4);
+
+      model.flow_model =
+          NonLinearResistive{.turbulence_factor_gamma = std::vector<double>{0.6, 0.4, 0.2},
+              .has_inertia = std::vector<bool>{false, false, false},
+              .k_turb = std::vector<double>{2.0, 1.0, 1.0}};
+
+      model.internal_state_updater =
+          std::visit(Airways::MakeInternalStateUpdater{model.flow_model}, model.wall_model);
+      model.negative_residual_evaluator =
+          std::visit(Airways::MakeNegativeResidualEvaluator{model.flow_model}, model.wall_model);
+      model.jacobian_evaluator =
+          std::visit(Airways::MakeJacobianEvaluator{model.flow_model}, model.wall_model);
+      model.internal_state_updater(model.data, locally_relevant_dofs, dt);
+      model.jacobian_evaluator(model.data, jac, locally_relevant_dofs, dt);
+      TestUtils::check_jacobian_column_against_fd(
+          model.data.lid_p1, 0, model, jac, locally_relevant_dofs, dt, eps, row_map);
+      TestUtils::check_jacobian_column_against_fd(
+          model.data.lid_p2, 1, model, jac, locally_relevant_dofs, dt, eps, row_map);
+      TestUtils::check_jacobian_column_against_fd(
+          model.data.lid_q1, 2, model, jac, locally_relevant_dofs, dt, eps, row_map);
+      TestUtils::check_jacobian_column_against_fd(
+          model.data.lid_q2, 3, model, jac, locally_relevant_dofs, dt, eps, row_map);
+    }
+    {
+      SCOPED_TRACE("Nonlinear resistive (with inertia) - KV wall model");
+      SparseMatrix jac(row_map, col_map, 4);
+
+      model.flow_model =
+          NonLinearResistive{.turbulence_factor_gamma = std::vector<double>{0.6, 0.4, 0.2},
+              .has_inertia = std::vector<bool>{true, true, true},
+              .k_turb = std::vector<double>{2.0, 1.0, 1.0}};
+
+      model.internal_state_updater =
+          std::visit(Airways::MakeInternalStateUpdater{model.flow_model}, model.wall_model);
+      model.negative_residual_evaluator =
+          std::visit(Airways::MakeNegativeResidualEvaluator{model.flow_model}, model.wall_model);
+      model.jacobian_evaluator =
+          std::visit(Airways::MakeJacobianEvaluator{model.flow_model}, model.wall_model);
+      model.internal_state_updater(model.data, locally_relevant_dofs, dt);
+      model.jacobian_evaluator(model.data, jac, locally_relevant_dofs, dt);
+      TestUtils::check_jacobian_column_against_fd(
+          model.data.lid_p1, 0, model, jac, locally_relevant_dofs, dt, eps, row_map);
+      TestUtils::check_jacobian_column_against_fd(
+          model.data.lid_p2, 1, model, jac, locally_relevant_dofs, dt, eps, row_map);
+      TestUtils::check_jacobian_column_against_fd(
+          model.data.lid_q1, 2, model, jac, locally_relevant_dofs, dt, eps, row_map);
+      TestUtils::check_jacobian_column_against_fd(
+          model.data.lid_q2, 3, model, jac, locally_relevant_dofs, dt, eps, row_map);
+    }
+  }
+}  // namespace

--- a/src/reduced_lung/tests/4C_reduced_lung_test_utils_test.hpp
+++ b/src/reduced_lung/tests/4C_reduced_lung_test_utils_test.hpp
@@ -1,0 +1,77 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+// Shared test utilities for reduced_lung tests
+#ifndef FOUR_C_REDUCED_LUNG_TEST_UTILS_TEST_HPP
+#define FOUR_C_REDUCED_LUNG_TEST_UTILS_TEST_HPP
+
+#include <gtest/gtest.h>
+
+#include "4C_config.hpp"
+
+#include "4C_linalg_map.hpp"
+#include "4C_linalg_sparsematrix.hpp"
+#include "4C_linalg_vector.hpp"
+#include "4C_reduced_lung_airways.hpp"
+#include "4C_reduced_lung_terminal_unit.hpp"
+
+#include <string>
+#include <vector>
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace ReducedLung::TestUtils
+{
+  // Generalized helper to check a Jacobian column against a central finite-difference
+  // approximation of the residual. Works for both TerminalUnitModel and AirwayModel as long
+  // as the model exposes `data`, `negative_residual_evaluator` and the data structure
+  // provides `number_of_elements()` and per-element lid vectors passed in `dof_lids`.
+  template <typename Model>
+  void check_jacobian_column_against_fd(const std::vector<int>& dof_lids, int jac_col, Model& model,
+      Core::LinAlg::SparseMatrix& jac, Core::LinAlg::Vector<double>& locally_relevant_dofs,
+      double dt, double eps, const Core::LinAlg::Map& row_map)
+  {
+    SCOPED_TRACE(
+        std::string("Comparing FD approximation with Jacobian column ") + std::to_string(jac_col));
+
+    // Perturb in +epsilon direction
+    for (int lid : dof_lids) locally_relevant_dofs.get_values()[lid] += eps;
+    Core::LinAlg::Vector<double> res_plus(row_map, true);
+    model.internal_state_updater(model.data, locally_relevant_dofs, dt);
+    model.negative_residual_evaluator(model.data, res_plus, locally_relevant_dofs, dt);
+
+    // Perturb in -epsilon direction
+    for (int lid : dof_lids) locally_relevant_dofs.get_values()[lid] -= 2 * eps;
+    Core::LinAlg::Vector<double> res_minus(row_map, true);
+    model.internal_state_updater(model.data, locally_relevant_dofs, dt);
+    model.negative_residual_evaluator(model.data, res_minus, locally_relevant_dofs, dt);
+
+    // Restore original state
+    for (int lid : dof_lids) locally_relevant_dofs.get_values()[lid] += eps;
+
+    // Compute FD approximation
+    Core::LinAlg::Vector<double> fd_derivative(row_map, true);
+    fd_derivative.update(-1.0 / (2 * eps), res_plus, 1.0 / (2 * eps), res_minus, 0.0);
+
+    // Compare with Jacobian column
+    for (size_t i = 0; i < model.data.number_of_elements(); ++i)
+    {
+      int n_entries = 0;
+      double* jac_vals = nullptr;
+      int* col_indices = nullptr;
+      jac.extract_my_row_view(i, n_entries, jac_vals, col_indices);
+
+      ASSERT_EQ(col_indices[jac_col], dof_lids[i]);
+      EXPECT_NEAR(jac_vals[jac_col], fd_derivative.local_values_as_span()[i], eps)
+          << "Mismatch at row " << i << ", col " << jac_col;
+    }
+  }
+}  // namespace ReducedLung::TestUtils
+
+FOUR_C_NAMESPACE_CLOSE
+
+#endif


### PR DESCRIPTION
# Description and Context
This PR refactors the Airway logic in `ReducedLung`. The layout is oriented according to the one of the `TerminalUnits`.
 The most significant changes are the addition compliant airway evaluation routines and the refactoring of several helper functions to operate on the new model containers.

### Airway model evaluation routines

Added `4C_reduced_lung_airways.cpp`, which implements functions for evaluating residuals, Jacobians, and derivatives for different model combinations. The `Airway consists of a flow model (linear, nonlinear) and a wall model (rigid, Kelvin-Voigt). Inertia terms can be switched on and off. 


