### PR TITLE
Remove redundant thermo vtk input parameters

### DIFF
--- a/src/thermo/src/implicit/4C_thermo_timint.cpp
+++ b/src/thermo/src/implicit/4C_thermo_timint.cpp
@@ -130,8 +130,6 @@ Thermo::TimInt::TimInt(const Teuchos::ParameterList& ioparams,
       bool output_temperature_rate_state =
           thermo_vtk_runtime_output_list.get<bool>("TEMPERATURE_RATE");
       bool output_conductivity_state = thermo_vtk_runtime_output_list.get<bool>("CONDUCTIVITY");
-      bool output_heatflux_state = thermo_vtk_runtime_output_list.get<bool>("HEATFLUX");
-      bool output_tempgrad_state = thermo_vtk_runtime_output_list.get<bool>("TEMPGRAD");
       bool output_element_owner = thermo_vtk_runtime_output_list.get<bool>("ELEMENT_OWNER");
       bool output_element_gid = thermo_vtk_runtime_output_list.get<bool>("ELEMENT_GID");
       bool output_node_gid = thermo_vtk_runtime_output_list.get<bool>("NODE_GID");
@@ -139,8 +137,6 @@ Thermo::TimInt::TimInt(const Teuchos::ParameterList& ioparams,
       runtime_vtk_params_ = {.output_temperature_state = output_temperature_state,
           .output_temperature_rate_state = output_temperature_rate_state,
           .output_conductivity_state = output_conductivity_state,
-          .output_heatflux_state = output_heatflux_state,
-          .output_tempgrad_state = output_tempgrad_state,
           .output_element_owner = output_element_owner,
           .output_element_gid = output_element_gid,
           .output_node_gid = output_node_gid};
@@ -397,16 +393,6 @@ void Thermo::TimInt::write_runtime_output()
       std::vector<std::optional<std::string>> context(conductivity_->num_vectors(), "conductivity");
       runtime_vtk_writer_->append_result_data_vector_with_context(
           *conductivity_, Core::IO::OutputEntity::node, context);
-    }
-
-    if (runtime_vtk_params_.output_heatflux_state)
-    {
-      FOUR_C_THROW("VTK runtime output is not yet implemented for the heatflux state.");
-    }
-
-    if (runtime_vtk_params_.output_tempgrad_state)
-    {
-      FOUR_C_THROW("VTK runtime output is not yet implemented for the temperature gradient state.");
     }
 
     if (runtime_vtk_params_.output_element_owner)

--- a/src/thermo/src/utils/4C_thermo_input.cpp
+++ b/src/thermo/src/utils/4C_thermo_input.cpp
@@ -225,14 +225,6 @@ std::vector<Core::IO::InputSpec> Thermo::valid_parameters()
             parameter<bool>("CONDUCTIVITY",
                 {.description = "write conductivity output", .default_value = false}),
 
-            // whether to write heatflux state
-            parameter<bool>(
-                "HEATFLUX", {.description = "write heatflux output", .default_value = false}),
-
-            // whether to write temperature gradient state
-            parameter<bool>("TEMPGRAD",
-                {.description = "write temperature gradient output", .default_value = false}),
-
             // whether to write element owner
             parameter<bool>(
                 "ELEMENT_OWNER", {.description = "write element owner", .default_value = false}),


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

This removes the `THERMAL DYNAMIC/RUNTIME VTK OUTPUT`'s `HEATFLUX` and `TEMPGRAD` options. Neither of them can be used anyway, and postrpocessing them is rather easy.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
