### PR TITLE
Fix uninitialized CommConfig in solid 3D benchmark

### DIFF
--- a/src/core/comm/src/4C_comm_utils.hpp
+++ b/src/core/comm/src/4C_comm_utils.hpp
@@ -47,8 +47,8 @@ namespace Core::Communication
    */
   struct CommConfig
   {
-    std::vector<int> group_layout;
-    NestedParallelismType np_type;
+    std::vector<int> group_layout = {};
+    NestedParallelismType np_type = NestedParallelismType::no_nested_parallelism;
     int diffgroup = -1;
   };
 


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
The benchmark test was creating a default-constructed CommConfig without initializing the np_type field, leading to undefined behavior and a segmentation fault in create_comm().

Initialize CommConfig by default with: 
- empty group_layout
- no_nested_parallelism for np_type
- default diffgroup value (-1)

Fixes the benchmarktests_solid_3D_ele test failure.

## Related Issues and Pull Requests
#1666 #1490
