### PR TITLE
[NOX] Remove `Epetra_Map` from `FSIMatrixFree`

### DIFF
--- a/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_jacobian.cpp
+++ b/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_jacobian.cpp
@@ -32,24 +32,6 @@ NOX::FSI::FSIMatrixFree::FSIMatrixFree(Teuchos::ParameterList& printParams,
 {
   perturbX.init(0.0);
   perturbY.init(0.0);
-
-  // Epetra_Operators require Epetra_Maps, so anyone using block maps
-  // (Core::LinAlg::Map) won't be able to directly use the iterative solver.
-  // We get around this by creating an Epetra_Map from the Core::LinAlg::Map.
-  try
-  {
-    epetraMap =
-        std::make_shared<Epetra_Map>(currentX.get_linalg_vector().get_map().get_epetra_map());
-  }
-  catch (const Core::Exception&)
-  {
-    int size = currentX.get_linalg_vector().get_map().num_global_points();
-    int mySize = currentX.get_linalg_vector().get_map().num_my_points();
-    int indexBase = currentX.get_linalg_vector().get_map().index_base();
-    const auto& comm = currentX.get_linalg_vector().get_map().get_comm();
-    epetraMap = std::make_shared<Epetra_Map>(
-        size, mySize, indexBase, Core::Communication::as_epetra_comm(comm));
-  }
 }
 
 Epetra_Operator& NOX::FSI::FSIMatrixFree::epetra_operator() { FOUR_C_THROW("Not implemented"); }

--- a/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_jacobian.hpp
+++ b/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_jacobian.hpp
@@ -109,13 +109,6 @@ namespace NOX
       //! Perturbed solution vector
       mutable NOX::Nln::Vector perturbY;
 
-      //! Core::LinAlg::Map object used in the returns of the Epetra_Operator derived methods.
-      /*! If the user is using Core::LinAlg::Maps, then ::NOX::Epetra::MatrixFree must create an
-       * equivalent Core::LinAlg::Map from the Core::LinAlg::Map that can be used as the return
-       * object of the OperatorDomainMap() and OperatorRangeMap() methods.
-       */
-      std::shared_ptr<const Epetra_Map> epetraMap;
-
       //! Flag to enables the use of a group instead of the interface for the computeF() calls in
       //! the directional difference calculation.
       bool useGroupForComputeF;


### PR DESCRIPTION
## Description and Context
A minor clean up. This object is no longer needed inside `FSIMatrixFree`.
