### PR TITLE
Provide standard column map to `extend_wall_element_ghosting()`

### DIFF
--- a/src/core/binstrategy/4C_binstrategy.cpp
+++ b/src/core/binstrategy/4C_binstrategy.cpp
@@ -1251,10 +1251,11 @@ Core::Binstrategy::BinningStrategy::weighted_distribution_of_bins_to_procs(
 }
 
 std::shared_ptr<Core::LinAlg::Map> Core::Binstrategy::BinningStrategy::extend_element_col_map(
-    std::map<int, std::set<int>> const& bin_to_row_ele_map,
-    std::map<int, std::set<int>>& bin_to_row_ele_map_to_lookup_requests,
-    std::map<int, std::set<int>>& ext_bin_to_ele_map, std::shared_ptr<Core::LinAlg::Map> bin_colmap,
-    std::shared_ptr<Core::LinAlg::Map> bin_rowmap,
+    const std::map<int, std::set<int>>& bin_to_row_ele_map,
+    const std::map<int, std::set<int>>& bin_to_row_ele_map_to_lookup_requests,
+    std::map<int, std::set<int>>& ext_bin_to_ele_map,
+    std::shared_ptr<const Core::LinAlg::Map> bin_colmap,
+    std::shared_ptr<const Core::LinAlg::Map> bin_rowmap,
     const Core::LinAlg::Map* ele_colmap_from_standardghosting) const
 {
   // do communication to gather all elements for extended ghosting
@@ -1308,10 +1309,9 @@ std::shared_ptr<Core::LinAlg::Map> Core::Binstrategy::BinningStrategy::extend_el
 
     for (int i = 0; i < numbin; ++i)
     {
-      if (bin_to_row_ele_map_to_lookup_requests.find(binids[i]) !=
-          bin_to_row_ele_map_to_lookup_requests.end())
-        sdata[binids[i]].insert(bin_to_row_ele_map_to_lookup_requests[binids[i]].begin(),
-            bin_to_row_ele_map_to_lookup_requests[binids[i]].end());
+      const auto it_bin_id = bin_to_row_ele_map_to_lookup_requests.find(binids[i]);
+      if (it_bin_id != bin_to_row_ele_map_to_lookup_requests.end())
+        sdata[binids[i]].insert(it_bin_id->second.begin(), it_bin_id->second.end());
     }
 
     Core::LinAlg::gather<int>(sdata, rdata, 1, &iproc, comm_);

--- a/src/core/binstrategy/4C_binstrategy.hpp
+++ b/src/core/binstrategy/4C_binstrategy.hpp
@@ -605,11 +605,11 @@ namespace Core::Binstrategy
      * \return extended element column map
      */
     std::shared_ptr<Core::LinAlg::Map> extend_element_col_map(
-        std::map<int, std::set<int>> const& bin_to_row_ele_map,
-        std::map<int, std::set<int>>& bin_to_row_ele_map_to_lookup_requests,
+        const std::map<int, std::set<int>>& bin_to_row_ele_map,
+        const std::map<int, std::set<int>>& bin_to_row_ele_map_to_lookup_requests,
         std::map<int, std::set<int>>& ext_bin_to_ele_map,
-        std::shared_ptr<Core::LinAlg::Map> bin_colmap = nullptr,
-        std::shared_ptr<Core::LinAlg::Map> bin_rowmap = nullptr,
+        std::shared_ptr<const Core::LinAlg::Map> bin_colmap = nullptr,
+        std::shared_ptr<const Core::LinAlg::Map> bin_rowmap = nullptr,
         const Core::LinAlg::Map* ele_colmap_from_standardghosting = nullptr) const;
 
     /*!

--- a/src/particle/src/wall/4C_particle_wall.cpp
+++ b/src/particle/src/wall/4C_particle_wall.cpp
@@ -486,7 +486,7 @@ void Particle::WallHandlerDiscretCondition::distribute_wall_elements_and_nodes()
       *walldiscretization_, walldiscretization_->my_row_element_range(), bintorowelemap, disn_col);
 
   // extend wall element ghosting
-  extend_wall_element_ghosting(bintorowelemap);
+  extend_wall_element_ghosting(bintorowelemap, stdelecolmap);
 
   // update maps of state vectors
   walldatastate_->update_maps_of_state_vectors();
@@ -510,18 +510,19 @@ void Particle::WallHandlerDiscretCondition::transfer_wall_elements_and_nodes()
       *walldiscretization_, walldatastate_->get_disp_col(), bintorowelemap);
 
   // extend wall element ghosting
-  extend_wall_element_ghosting(bintorowelemap);
+  extend_wall_element_ghosting(bintorowelemap, nullptr);
 
   // update maps of state vectors
   walldatastate_->update_maps_of_state_vectors();
 }
 
 void Particle::WallHandlerDiscretCondition::extend_wall_element_ghosting(
-    std::map<int, std::set<int>>& bintorowelemap)
+    const std::map<int, std::set<int>>& bintorowelemap,
+    std::shared_ptr<const Core::LinAlg::Map> stdelecolmap)
 {
   std::map<int, std::set<int>> colbintoelemap;
   std::shared_ptr<Core::LinAlg::Map> extendedelecolmap = binstrategy_->extend_element_col_map(
-      bintorowelemap, bintorowelemap, colbintoelemap, bincolmap_);
+      bintorowelemap, bintorowelemap, colbintoelemap, bincolmap_, nullptr, stdelecolmap.get());
 
   Core::Binstrategy::Utils::extend_discretization_ghosting(
       *walldiscretization_, *extendedelecolmap, true, false, false);

--- a/src/particle/src/wall/4C_particle_wall.hpp
+++ b/src/particle/src/wall/4C_particle_wall.hpp
@@ -322,8 +322,10 @@ namespace Particle
      *
      *
      * \param[in] bintorowelemap bin to row wall element distribution
+     * \param[in] stdelecolmap standard element column map
      */
-    void extend_wall_element_ghosting(std::map<int, std::set<int>>& bintorowelemap);
+    void extend_wall_element_ghosting(const std::map<int, std::set<int>>& bintorowelemap,
+        std::shared_ptr<const Core::LinAlg::Map> stdelecolmap);
 
     /*!
      * \brief init wall discretization


### PR DESCRIPTION
## Description and Context
It seems the lack of a standard column map caused the problem had been reported in #1677. It is though difficult to say why previously this error was not triggered. The issue was identified and fixed together with @georghammerl.

@ppraegla, @slfuchs 

## Related Issues and Pull Requests
#1677