### PR TITLE
Correct comments on poroelastic preconditioner

### DIFF
--- a/tests/input_files/xml/block_preconditioner/porofluid_pressure_based_elast_scatra_BGS-AMG_3x3.xml
+++ b/tests/input_files/xml/block_preconditioner/porofluid_pressure_based_elast_scatra_BGS-AMG_3x3.xml
@@ -1,0 +1,69 @@
+<ParameterList name="Teko">
+  <!--
+                  For poro interaction, these are the recommended settings for the block preconditioner
+                  containing a block Gauss-Seidel from Teko, using MueLu as multigrid preconditioner for the single
+                  field inverses.
+                  -->
+  <!-- ===========  BLOCK PRECONDITIONER ================ -->
+  <!-- Definition of the block preconditioner, which has to be defined under sub-list "Preconditioner",
+                       which is used by Teko. The single field inverse approximation methods have to be given under
+                       sub-lists "Inverse<1..n>". -->
+  <Parameter name="Inverse Type" type="string" value="Preconditioner"/>
+  <ParameterList name="Inverse Factory Library">
+    <ParameterList name="Preconditioner">
+      <Parameter name="Type" type="string" value="Block Gauss-Seidel"/>
+      <Parameter name="Use Upper Triangle" type="bool" value="false"/>
+      <Parameter name="Inverse Type 1" type="string" value="Inverse1"/>
+      <Parameter name="Inverse Type 2" type="string" value="Inverse2"/>
+      <Parameter name="Inverse Type 3" type="string" value="Inverse3"/>
+    </ParameterList>
+    <!-- ===========  SINGLE FIELD PRECONDITIONER FOR STRUCTURE ================ -->
+    <ParameterList name="Inverse1">
+      <Parameter name="Type" type="string" value="MueLu"/>
+      <Parameter name="multigrid algorithm" type="string" value="sa"/>
+      <Parameter name="max levels" type="int" value="3"/>
+      <Parameter name="problem: symmetric" type="bool" value="false"/>
+      <Parameter name="verbosity" type="string" value="none"/>
+      <Parameter name="coarse: max size" type="int" value="7"/>
+      <Parameter name="smoother: type" type="string" value="RILUK"/>
+      <ParameterList name="smoother: params">
+        <Parameter name="fact: iluk level-of-fill" type="int" value="0"/>
+        <Parameter name="fact: absolute threshold" type="double" value="0.0"/>
+        <Parameter name="fact: relative threshold" type="double" value="1.0"/>
+        <Parameter name="fact: relax value" type="double" value="0.0"/>
+      </ParameterList>
+    </ParameterList>
+    <!-- ===========  SINGLE FIELD PRECONDITIONER FOR FLUID ================ -->
+    <ParameterList name="Inverse2">
+      <Parameter name="Type" type="string" value="MueLu"/>
+      <Parameter name="multigrid algorithm" type="string" value="pg"/>
+      <Parameter name="max levels" type="int" value="3"/>
+      <Parameter name="problem: symmetric" type="bool" value="false"/>
+      <Parameter name="verbosity" type="string" value="none"/>
+      <Parameter name="coarse: max size" type="int" value="7"/>
+      <Parameter name="smoother: type" type="string" value="RILUK"/>
+      <ParameterList name="smoother: params">
+        <Parameter name="fact: iluk level-of-fill" type="int" value="0"/>
+        <Parameter name="fact: absolute threshold" type="double" value="0.0"/>
+        <Parameter name="fact: relative threshold" type="double" value="1.0"/>
+        <Parameter name="fact: relax value" type="double" value="0.0"/>
+      </ParameterList>
+    </ParameterList>
+    <!-- ===========  SINGLE FIELD PRECONDITIONER FOR SCATRA ================ -->
+    <ParameterList name="Inverse3">
+      <Parameter name="Type" type="string" value="MueLu"/>
+      <Parameter name="multigrid algorithm" type="string" value="pg"/>
+      <Parameter name="max levels" type="int" value="3"/>
+      <Parameter name="problem: symmetric" type="bool" value="false"/>
+      <Parameter name="verbosity" type="string" value="none"/>
+      <Parameter name="coarse: max size" type="int" value="7"/>
+      <Parameter name="smoother: type" type="string" value="RILUK"/>
+      <ParameterList name="smoother: params">
+        <Parameter name="fact: iluk level-of-fill" type="int" value="0"/>
+        <Parameter name="fact: absolute threshold" type="double" value="0.0"/>
+        <Parameter name="fact: relative threshold" type="double" value="1.0"/>
+        <Parameter name="fact: relax value" type="double" value="0.0"/>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+</ParameterList>


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->
Correct names of the field preconditioners for the poroelastic approach.

## Description and Context

The block preconditioners in porofluid_pressure_based can be categorised according to the number of fields being solved for in the problem. In elast_scatra_BSG-AMG_3x3, three fields are solved in the following order: structure, fluid, and scalar transport (scatra).
In this case, artery pressure is not solved. There was a lapse in the comments, but the settings are correct. 

<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

