### PR TITLE
Disallow non-optional to optional Validator assignment

### DIFF
--- a/src/core/io/src/4C_io_input_spec_validators.hpp
+++ b/src/core/io/src/4C_io_input_spec_validators.hpp
@@ -218,7 +218,7 @@ namespace Core::IO::InputSpecBuilders::Validators
     class ValidatorImpl<RangeLike<T>>
     {
      public:
-      ValidatorImpl(ValidatorImpl<T> inner) : inner_validator_(inner) {}
+      explicit ValidatorImpl(ValidatorImpl<T> inner) : inner_validator_(inner) {}
 
       template <std::ranges::range R>
       [[nodiscard]]
@@ -251,7 +251,7 @@ namespace Core::IO::InputSpecBuilders::Validators
     class ValidatorImpl<std::optional<T>>
     {
      public:
-      ValidatorImpl(ValidatorImpl<T> inner) : inner_validator_(inner) {}
+      explicit ValidatorImpl(ValidatorImpl<T> inner) : inner_validator_(inner) {}
 
       template <typename U>
       [[nodiscard]] bool operator()(const std::optional<U>& opt) const

--- a/src/core/io/tests/4C_io_input_spec_validators_test.cpp
+++ b/src/core/io/tests/4C_io_input_spec_validators_test.cpp
@@ -138,4 +138,7 @@ namespace
     EXPECT_FALSE(v2(0));
   }
 
+  // Ensure that optional and non-optional validators are not assignable to each other
+  static_assert(!std::assignable_from<Validator<std::optional<int>>, Validator<int>>);
+  static_assert(!std::assignable_from<Validator<int>, Validator<std::optional<int>>>);
 }  // namespace


### PR DESCRIPTION
A small quirk that @rjoussen uncovered with his example in #1708. Does not yet close the issue.

`Validator<std::optional<int>> = positive<int>();` should not be allowed and become `Validator<std::optional<int>> = null_or(positive<int>());`.