### PR TITLE
Emit optional enum choices to metadata

### DIFF
--- a/src/core/io/src/4C_io_input_spec_builders.hpp
+++ b/src/core/io/src/4C_io_input_spec_builders.hpp
@@ -1975,7 +1975,7 @@ void Core::IO::Internal::ParameterSpec<T>::emit_metadata(
   }
 
   // Enums are special: their validation is built in
-  if constexpr (std::is_enum_v<T>)
+  if constexpr (std::is_enum_v<RemoveOptional<T>>)
   {
     if (data.validator)
     {
@@ -1987,7 +1987,7 @@ void Core::IO::Internal::ParameterSpec<T>::emit_metadata(
       // If no validator is set, we emit all enum values as valid values.
       auto choices_node = node.node["choices"];
       choices_node |= ryml::SEQ;
-      for (const auto& choice : EnumTools::enum_values<T>())
+      for (const auto& choice : EnumTools::enum_values<RemoveOptional<T>>())
       {
         auto choice_node = choices_node.append_child();
         choice_node |= ryml::MAP;

--- a/src/core/io/tests/4C_io_input_spec_test.cpp
+++ b/src/core/io/tests/4C_io_input_spec_test.cpp
@@ -880,6 +880,10 @@ specs:
             type: enum
             required: false
             default: null
+            choices:
+              - name: A
+              - name: B
+              - name: C
           - name: group2
             type: group
             required: false
@@ -963,6 +967,10 @@ specs:
             type: enum
             required: false
             default: null
+            choices:
+              - name: A
+              - name: B
+              - name: C
           - name: group2
             type: group
             required: false
@@ -1050,6 +1058,10 @@ specs:
             type: enum
             required: false
             default: null
+            choices:
+              - name: A
+              - name: B
+              - name: C
           - name: group2
             type: group
             required: false
@@ -2554,6 +2566,27 @@ parameters:
       InputParameterContainer container;
       FOUR_C_EXPECT_THROW_WITH_MESSAGE(spec.match(node, container), Core::Exception,
           "Candidate parameter 'a' does not pass validation: null_or{in_range[0,10]}");
+    }
+  }
+
+  TEST(InputSpecTest, OptionalEnum)
+  {
+    enum class EnumClass
+    {
+      A,
+      B,
+    };
+
+    auto spec = parameter<std::optional<EnumClass>>("e", {});
+    {
+      ryml::Tree tree = init_yaml_tree_with_exceptions();
+      ryml::NodeRef root = tree.rootref();
+      ryml::parse_in_arena(R"(e: A)", root);
+
+      ConstYamlNodeRef node(root, "");
+      InputParameterContainer container;
+      spec.match(node, container);
+      EXPECT_EQ(container.get<std::optional<EnumClass>>("e"), EnumClass::A);
     }
   }
 


### PR DESCRIPTION
Part of #1708 

Not the prettiest fix, as it further circumvents inconsistencies rather than fixing them, but it should at least help with the immediate problem regarding optional enums. I made a checklist of possible improvements in #1708 so that enums integrate more smoothly with the rest of the types.