### PR TITLE
Improve documentation of mat.4C.yaml files

### DIFF
--- a/tests/input_files/elch_1D_line2_multiscale_butlervolmer_anode.mat.4C.yaml
+++ b/tests/input_files/elch_1D_line2_multiscale_butlervolmer_anode.mat.4C.yaml
@@ -7,6 +7,9 @@ TITLE:
   - "- initial and boundary conditions on macro and micro scales as given by the reference"
   - "- coupling between macro and micro scales based on Butler-Volmer charge transfer kinetics"
   - "- discharge from fully charged state at C rate of 1"
+  - "NOTE: This file only defines the material definition for a multiscale simulation scenario. It is
+    thus NOT a self-contained 4C input file. The corresponding 4C input file is the file that references
+    this file with a MICROFILE attribute."
 PROBLEM SIZE:
   DIM: 1
 PROBLEM TYPE:

--- a/tests/input_files/elch_1D_line2_multiscale_butlervolmer_cathode.mat.4C.yaml
+++ b/tests/input_files/elch_1D_line2_multiscale_butlervolmer_cathode.mat.4C.yaml
@@ -7,6 +7,9 @@ TITLE:
   - "- initial and boundary conditions on macro and micro scales as given by the reference"
   - "- coupling between macro and micro scales based on Butler-Volmer charge transfer kinetics"
   - "- discharge from fully charged state at C rate of 1"
+  - "NOTE: This file only defines the material definition for a multiscale simulation scenario. It is
+    thus NOT a self-contained 4C input file. The corresponding 4C input file is the file that references
+    this file with a MICROFILE attribute."
 PROBLEM SIZE:
   DIM: 1
 PROBLEM TYPE:

--- a/tests/input_files/scatra_1D_line2_multiscale_constperm_micro1.mat.4C.yaml
+++ b/tests/input_files/scatra_1D_line2_multiscale_constperm_micro1.mat.4C.yaml
@@ -9,6 +9,9 @@ TITLE:
   - "- diffusion on macro scale from micro scale 2 region towards micro scale 1 region"
   - "- symmetry boundary conditions, i.e., homogeneous Neumann boundary conditions, at both ends of macro
     scale"
+  - "NOTE: This file only defines the material definition for a multiscale simulation scenario. It is
+    thus NOT a self-contained 4C input file. The corresponding 4C input file is the file that references
+    this file with a MICROFILE attribute."
 PROBLEM SIZE:
   DIM: 1
 PROBLEM TYPE:

--- a/tests/input_files/scatra_1D_line2_multiscale_constperm_micro2.mat.4C.yaml
+++ b/tests/input_files/scatra_1D_line2_multiscale_constperm_micro2.mat.4C.yaml
@@ -9,6 +9,9 @@ TITLE:
   - "- diffusion on macro scale from micro scale 2 region towards micro scale 1 region"
   - "- symmetry boundary conditions, i.e., homogeneous Neumann boundary conditions, at both ends of macro
     scale"
+  - "NOTE: This file only defines the material definition for a multiscale simulation scenario. It is
+    thus NOT a self-contained 4C input file. The corresponding 4C input file is the file that references
+    this file with a MICROFILE attribute."
 PROBLEM SIZE:
   DIM: 1
 PROBLEM TYPE:

--- a/tests/input_files/sohex8_multiscale_micro.mat.4C.yaml
+++ b/tests/input_files/sohex8_multiscale_micro.mat.4C.yaml
@@ -1,7 +1,7 @@
 TITLE:
-  - This is an input file for the micro scale of a multi scale
-  - simulation. It is referenced in the material of the
-  - corresponding macro file. This file cannot be run standalone.
+  - "NOTE: This file only defines the material definition for a multiscale simulation scenario. It is
+    thus NOT a self-contained 4C input file. The corresponding 4C input file is the file that references
+    this file with a MICROFILE attribute."
 PROBLEM SIZE:
   ELEMENTS: 27
   NODES: 64

--- a/tests/input_files/sohex8_multiscale_micro1.mat.4C.yaml
+++ b/tests/input_files/sohex8_multiscale_micro1.mat.4C.yaml
@@ -1,7 +1,7 @@
 TITLE:
-  - This is an input file for the micro scale of a multi scale
-  - simulation. It is referenced in the material of the
-  - corresponding macro file. This file cannot be run standalone.
+  - "NOTE: This file only defines the material definition for a multiscale simulation scenario. It is
+    thus NOT a self-contained 4C input file. The corresponding 4C input file is the file that references
+    this file with a MICROFILE attribute."
 PROBLEM SIZE:
   ELEMENTS: 27
   NODES: 64

--- a/tests/input_files/sohex8_multiscale_micro_eas.mat.4C.yaml
+++ b/tests/input_files/sohex8_multiscale_micro_eas.mat.4C.yaml
@@ -1,7 +1,7 @@
 TITLE:
-  - This is an input file for the micro scale of a multi scale
-  - simulation. It is referenced in the material of the
-  - corresponding macro file. This file cannot be run standalone.
+  - "NOTE: This file only defines the material definition for a multiscale simulation scenario. It is
+    thus NOT a self-contained 4C input file. The corresponding 4C input file is the file that references
+    this file with a MICROFILE attribute."
 PROBLEM SIZE:
   ELEMENTS: 27
   NODES: 64

--- a/tests/input_files/sohex8_multiscale_micro_plastic.mat.4C.yaml
+++ b/tests/input_files/sohex8_multiscale_micro_plastic.mat.4C.yaml
@@ -1,7 +1,7 @@
 TITLE:
-  - This is an input file for the micro scale of a multi scale
-  - simulation. It is referenced in the material of the
-  - corresponding macro file. This file cannot be run standalone.
+  - "NOTE: This file only defines the material definition for a multiscale simulation scenario. It is
+    thus NOT a self-contained 4C input file. The corresponding 4C input file is the file that references
+    this file with a MICROFILE attribute."
 PROBLEM SIZE:
   ELEMENTS: 27
   NODES: 64

--- a/tests/input_files/ssi_oneway_scatra_to_solid_3D_line2_elch_s2i_butlervolmer_multiscale_cathode.mat.4C.yaml
+++ b/tests/input_files/ssi_oneway_scatra_to_solid_3D_line2_elch_s2i_butlervolmer_multiscale_cathode.mat.4C.yaml
@@ -1,3 +1,7 @@
+TITLE:
+  - "NOTE: This file only defines the material definition for a multiscale simulation scenario. It is
+    thus NOT a self-contained 4C input file. The corresponding 4C input file is the file that references
+    this file with a MICROFILE attribute."
 PROBLEM SIZE:
   DIM: 1
 PROBLEM TYPE:

--- a/tests/input_files/ssi_twoway_3D_line2_elch_s2i_butlervolmer_multiscale_cathode.mat.4C.yaml
+++ b/tests/input_files/ssi_twoway_3D_line2_elch_s2i_butlervolmer_multiscale_cathode.mat.4C.yaml
@@ -7,6 +7,9 @@ TITLE:
   - "- initial and boundary conditions on macro and micro scales as given by the reference"
   - "- coupling between macro and micro scales based on Butler-Volmer charge transfer kinetics"
   - "- discharge from fully charged state at C rate of 1"
+  - "NOTE: This file only defines the material definition for a multiscale simulation scenario. It is
+    thus NOT a self-contained 4C input file. The corresponding 4C input file is the file that references
+    this file with a MICROFILE attribute."
 PROBLEM SIZE:
   DIM: 1
 PROBLEM TYPE:


### PR DESCRIPTION
## Description and Context
As discussed in #1721 there should be an info in the *.mat.4C.yaml files clarifying that these are not self-contained 4C input files, but only material definitions for a multiscale simulation

## Related Issues and Pull Requests
part of #1721 
