### PR TITLE
[Particles] Simplifications/nullifications for 2D problems

### DIFF
--- a/src/particle/src/4C_particle_input.cpp
+++ b/src/particle/src/4C_particle_input.cpp
@@ -243,6 +243,13 @@ std::vector<Core::IO::InputSpec> Particle::valid_parameters()
               {.description = "type of transport velocity formulation",
                   .default_value = Particle::NoTransportVelocity}),
 
+          // reduced dimension scale factor for computing SPH forces
+          parameter<double>("REDUCED_DIMENSION_SCALE_FACTOR",
+              {.description =
+                      "scaling factor for the wall contact force to consider reduced "
+                      "dimensional modeling from 1D or 2D particle field to 3D structural field",
+                  .default_value = 1.0}),
+
           // type of temperature evaluation scheme
           parameter<TemperatureEvaluationScheme>(
               "TEMPERATUREEVALUATION", {.description = "type of temperature evaluation scheme",

--- a/src/particle/src/interaction/4C_particle_interaction_sph_momentum.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_momentum.cpp
@@ -46,6 +46,7 @@ Particle::SPHMomentum::SPHMomentum(const Teuchos::ParameterList& params)
           Teuchos::getIntegralValue<Particle::TransportVelocityFormulation>(
               params_sph_, "TRANSPORTVELOCITYFORMULATION")),
       writeparticlewallinteraction_(params_sph_.get<bool>("WRITE_PARTICLE_WALL_INTERACTION")),
+      reduced_dimension_scale_factor_(params_sph_.get<double>("REDUCED_DIMENSION_SCALE_FACTOR")),
       allfluidtypes_(
           {Particle::Phase1, Particle::Phase2, Particle::DirichletPhase, Particle::NeumannPhase}),
       intfluidtypes_({Particle::Phase1, Particle::Phase2, Particle::NeumannPhase}),
@@ -852,7 +853,8 @@ void Particle::SPHMomentum::momentum_equation_particle_wall_contribution() const
       std::vector<double> nodal_force(numnodes * 3);
       for (int node = 0; node < numnodes; ++node)
         for (int dim = 0; dim < 3; ++dim)
-          nodal_force[node * 3 + dim] = funct[node] * wallcontactforce[dim];
+          nodal_force[node * 3 + dim] =
+              funct[node] * wallcontactforce[dim] * reduced_dimension_scale_factor_;
 
       // assemble nodal forces
       walldatastate->get_force_col()->sum_into_global_values(

--- a/src/particle/src/interaction/4C_particle_interaction_sph_momentum.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_momentum.hpp
@@ -147,6 +147,9 @@ namespace Particle
     //! write particle-wall interaction output
     const bool writeparticlewallinteraction_;
 
+    //! reduced dimension scale factor
+    const double reduced_dimension_scale_factor_;
+
     //! set of all fluid particle types
     std::set<Particle::TypeEnum> allfluidtypes_;
 

--- a/src/particle/src/interaction/4C_particle_interaction_sph_virtual_wall_particle.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_virtual_wall_particle.cpp
@@ -88,12 +88,22 @@ void Particle::SPHVirtualWallParticle::init_relative_positions_of_virtual_partic
   // number of particles per direction
   const int numparticleperdir = std::round(maxinteractiondistance / initialparticlespacing);
 
+  // get the kernel dimensionality
+  int kernel_dim = 0;
+  kernel_->kernel_space_dimension(kernel_dim);
+
+  const int s_start = (kernel_dim > 1) ? (-numparticleperdir + 1) : 0;
+  const int s_end = (kernel_dim > 1) ? numparticleperdir : 1;
+
+  const int t_start = (kernel_dim > 2) ? (-numparticleperdir + 1) : 0;
+  const int t_end = (kernel_dim > 2) ? numparticleperdir : 1;
+
   // iterate over virtual particles
   for (int r = 0; r < numparticleperdir; ++r)
   {
-    for (int s = (-numparticleperdir + 1); s < numparticleperdir; ++s)
+    for (int s = s_start; s < s_end; ++s)
     {
-      for (int t = (-numparticleperdir + 1); t < numparticleperdir; ++t)
+      for (int t = t_start; t < t_end; ++t)
       {
         // relative position of current virtual particle
         std::vector<double> currvirtualparticle(3);


### PR DESCRIPTION
Some of the 2D benchmarks, especially those operating with virtual walls, require some simplifications in the code. Eventually, this PR introduces 3 operations:

1. Nullify z-coordinate of the closest point returned by `Core::Geo::nearest_3d_object_on_element()` for the 2D case. The implementation additionally nullifies y-component for the 1D scenario.
2. The virtual wall particles are not generated along the z-axis for 2D and z- and y-axes for 1D.
3. A new parameter `ELEMENT_THICKNESS_FACTOR` is introduced to account for that the interaction force from the SPH field in the case of the 2D scenario needs to be scaled to 3D space with the element thickness in order to get the correct forces on the 3D structure.

There is one more component required, but it will be in a separate PR since it requires a bit more work.

Of course, the best way would be to write things in more rigorous way, e.g. templatizing certain parts of the particle code from the dimension (like deal.II does) such that unnecessary dummy degrees of freedom would not appear in the first place. But these modifications is the bare minimum required to handle 2D problems with the existing infrastructure.

@slfuchs, @ppraegla