### PR TITLE
Remove unnecessary member of enum class MatrixType

### DIFF
--- a/src/adapter/4C_adapter_scatra_base_algorithm.cpp
+++ b/src/adapter/4C_adapter_scatra_base_algorithm.cpp
@@ -210,7 +210,8 @@ Adapter::ScaTraBaseAlgorithm::ScaTraBaseAlgorithm(const Teuchos::ParameterList& 
     {
       case Inpar::ScaTra::timeint_one_step_theta:
       {
-        if (elchparams->sublist("SCL").get<bool>("ADD_MICRO_MACRO_COUPLING"))
+        if (elchparams->isSublist("SCL") and
+            elchparams->sublist("SCL").get<bool>("ADD_MICRO_MACRO_COUPLING"))
         {
           if (disname == "scatra")
           {

--- a/src/core/linalg/src/sparse/4C_linalg_equilibrate.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_equilibrate.cpp
@@ -476,7 +476,7 @@ std::shared_ptr<Core::LinAlg::Equilibration> Core::LinAlg::build_equilibration(M
               std::make_shared<Core::LinAlg::EquilibrationSparse>(method_global, dofrowmap);
           break;
         }
-        case Core::LinAlg::MatrixType::block_field:
+        case Core::LinAlg::MatrixType::block:
         case Core::LinAlg::MatrixType::block_condition:
         case Core::LinAlg::MatrixType::block_condition_dof:
         {

--- a/src/core/linalg/src/sparse/4C_linalg_sparseoperator.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_sparseoperator.hpp
@@ -31,9 +31,8 @@ namespace Core::LinAlg
   //! type of global system matrix in global system of equations
   enum class MatrixType
   {
-    undefined,           /*!< Type of system matrix is undefined. */
     sparse,              /*!< System matrix is a sparse matrix. */
-    block_field,         /*!< System matrix is a block matrix that consists of NxN matrices.
+    block,               /*!< System matrix is a block matrix that consists of NxN matrices.
                             In the simplest case, where each (physical) field is represented by just one
                             sparse matrix, N equals the number of (physical) fields of your problem.
                             However, it is also possible that the matrix of each (physical) field itself is

--- a/src/elch/4C_elch_input.cpp
+++ b/src/elch/4C_elch_input.cpp
@@ -164,10 +164,8 @@ std::vector<Core::IO::InputSpec> ElCh::valid_parameters()
   /*----------------------------------------------------------------------*/
   // sublist for space-charge layers
   specs.push_back(group("ELCH CONTROL/SCL",
-      {
-
-          parameter<bool>("ADD_MICRO_MACRO_COUPLING",
-              {.description = "flag for micro macro coupling with scls", .default_value = false}),
+      {parameter<bool>("ADD_MICRO_MACRO_COUPLING",
+           {.description = "flag for micro macro coupling with scls", .default_value = false}),
           parameter<bool>("COUPLING_OUTPUT",
               {.description = "write coupled node gids and node coordinates to csv file",
                   .default_value = false}),
@@ -175,14 +173,8 @@ std::vector<Core::IO::InputSpec> ElCh::valid_parameters()
               {.description = "calculate initial potential field?", .default_value = false}),
           parameter<int>(
               "SOLVER", {.description = "solver for coupled SCL problem", .default_value = -1}),
-          deprecated_selection<Core::LinAlg::MatrixType>("MATRIXTYPE",
-              {
-                  {"undefined", Core::LinAlg::MatrixType::undefined},
-                  {"block", Core::LinAlg::MatrixType::block_field},
-                  {"sparse", Core::LinAlg::MatrixType::sparse},
-              },
-              {.description = "type of global system matrix in global system of equations",
-                  .default_value = Core::LinAlg::MatrixType::undefined}),
+          parameter<Core::LinAlg::MatrixType>("MATRIXTYPE",
+              {.description = "type of global system matrix in global system of equations"}),
           parameter<int>(
               "ADAPT_TIME_STEP", {.description = "time step when time step size should be updated "
                                                  "to 'ADAPTED_TIME_STEP_SIZE'.",

--- a/src/poroelast/4C_poroelast_monolithic.cpp
+++ b/src/poroelast/4C_poroelast_monolithic.cpp
@@ -479,7 +479,7 @@ void PoroElast::Monolithic::setup_equilibration()
   auto equilibration_method =
       std::vector<Core::LinAlg::EquilibrationMethod>(1, equilibration_method_);
   equilibration_ = Core::LinAlg::build_equilibration(
-      Core::LinAlg::MatrixType::block_field, equilibration_method, fullmap_);
+      Core::LinAlg::MatrixType::block, equilibration_method, fullmap_);
 }
 
 void PoroElast::Monolithic::setup_system_matrix(Core::LinAlg::BlockSparseMatrixBase& mat)

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_monolithic.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_monolithic.cpp
@@ -152,7 +152,7 @@ void PoroPressureBased::PorofluidElastMonolithicAlgorithm::setup_system()
   auto equilibration_method =
       std::vector<Core::LinAlg::EquilibrationMethod>(1, equilibration_method_);
   equilibration_ = Core::LinAlg::build_equilibration(
-      Core::LinAlg::MatrixType::block_field, equilibration_method, fullmap_);
+      Core::LinAlg::MatrixType::block, equilibration_method, fullmap_);
 
   // structure_field: check whether we have locsys BCs, i.e. inclined structural
   //  Dirichlet BC

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_monolithic.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_monolithic.cpp
@@ -166,12 +166,8 @@ void PoroPressureBased::PorofluidElastScatraMonolithicAlgorithm::setup_system()
       81, true, true);
 
   // instantiate appropriate equilibration class
-  auto equilibration_method =
-      std::vector<Core::LinAlg::EquilibrationMethod>(1, equilibration_method_);
   equilibration_ = Core::LinAlg::build_equilibration(
-      Core::LinAlg::MatrixType::block_field, equilibration_method, fullmap_);
-
-  return;
+      Core::LinAlg::MatrixType::block, {equilibration_method_}, fullmap_);
 }
 
 /*----------------------------------------------------------------------*

--- a/src/scatra/4C_scatra_timint_elch_scl.cpp
+++ b/src/scatra/4C_scatra_timint_elch_scl.cpp
@@ -45,7 +45,7 @@ ScaTra::ScaTraTimIntElchSCL::ScaTraTimIntElchSCL(std::shared_ptr<Core::FE::Discr
           Teuchos::getIntegralValue<Core::LinAlg::MatrixType>(params->sublist("SCL"), "MATRIXTYPE"))
 {
   if (matrixtype_elch_scl_ != Core::LinAlg::MatrixType::sparse and
-      matrixtype_elch_scl_ != Core::LinAlg::MatrixType::block_field)
+      matrixtype_elch_scl_ != Core::LinAlg::MatrixType::block)
     FOUR_C_THROW("Only sparse and block field matrices supported in SCL computations");
 
   if (elchparams_->get<bool>("INITPOTCALC"))
@@ -114,12 +114,11 @@ void ScaTra::ScaTraTimIntElchSCL::setup()
     case Core::LinAlg::MatrixType::sparse:
       block_map_vec_scl = {full_map_elch_scl_};
       break;
-    case Core::LinAlg::MatrixType::block_field:
+    case Core::LinAlg::MatrixType::block:
       block_map_vec_scl = {dof_row_map(), micro_scatra_field()->dof_row_map()};
       break;
     default:
       FOUR_C_THROW("Matrix type not supported.");
-      break;
   }
   full_block_map_elch_scl_ =
       std::make_shared<Core::LinAlg::MultiMapExtractor>(*full_map_elch_scl_, block_map_vec_scl);
@@ -140,7 +139,7 @@ void ScaTra::ScaTraTimIntElchSCL::setup()
           *full_map_elch_scl_, expected_entries_per_row, explicitdirichlet, savegraph);
       break;
     }
-    case Core::LinAlg::MatrixType::block_field:
+    case Core::LinAlg::MatrixType::block:
     {
       const int expected_entries_per_row = 81;
       const bool explicitdirichlet = false;
@@ -154,7 +153,6 @@ void ScaTra::ScaTraTimIntElchSCL::setup()
     }
     default:
       FOUR_C_THROW("Matrix type not supported.");
-      break;
   }
 
   // extractor to get micro or macro dofs from global vector
@@ -175,7 +173,7 @@ void ScaTra::ScaTraTimIntElchSCL::setup()
   {
     case Core::LinAlg::MatrixType::sparse:
       break;
-    case Core::LinAlg::MatrixType::block_field:
+    case Core::LinAlg::MatrixType::block:
     {
       std::ostringstream scatrablockstr;
       scatrablockstr << 1;
@@ -960,7 +958,7 @@ void ScaTra::ScaTraTimIntElchSCL::assemble_and_apply_mesh_tying()
           &(micro_side_converter), &(micro_side_converter), *sparse_systemmatrix, true, true);
       break;
     }
-    case Core::LinAlg::MatrixType::block_field:
+    case Core::LinAlg::MatrixType::block:
     {
       auto block_systemmatrix =
           Core::LinAlg::cast_to_block_sparse_matrix_base_and_check_success(system_matrix_elch_scl_);

--- a/src/ssi/4C_ssi_input.cpp
+++ b/src/ssi/4C_ssi_input.cpp
@@ -147,14 +147,8 @@ std::vector<Core::IO::InputSpec> SSI::valid_parameters()
                                    .default_value = -1}),
 
           // type of global system matrix in global system of equations
-          deprecated_selection<Core::LinAlg::MatrixType>("MATRIXTYPE",
-              {
-                  {"undefined", Core::LinAlg::MatrixType::undefined},
-                  {"block", Core::LinAlg::MatrixType::block_field},
-                  {"sparse", Core::LinAlg::MatrixType::sparse},
-              },
-              {.description = "type of global system matrix in global system of equations",
-                  .default_value = Core::LinAlg::MatrixType::undefined}),
+          parameter<Core::LinAlg::MatrixType>("MATRIXTYPE",
+              {.description = "type of global system matrix in global system of equations"}),
 
           parameter<Core::LinAlg::EquilibrationMethod>("EQUILIBRATION",
               {.description = "flag for equilibration of global system of equations",

--- a/src/ssi/4C_ssi_monolithic.cpp
+++ b/src/ssi/4C_ssi_monolithic.cpp
@@ -716,7 +716,7 @@ void SSI::SsiMono::setup_system()
   // perform initializations associated with global system matrix
   switch (matrixtype_)
   {
-    case Core::LinAlg::MatrixType::block_field:
+    case Core::LinAlg::MatrixType::block:
     {
       // feed block preconditioner with null space information for each block of global block system
       // matrix
@@ -1019,7 +1019,7 @@ std::vector<Core::LinAlg::EquilibrationMethod> SSI::SsiMono::get_block_equilibra
       equilibration_method_vector = std::vector(1, equilibration_method_.global);
       break;
     }
-    case Core::LinAlg::MatrixType::block_field:
+    case Core::LinAlg::MatrixType::block:
     {
       if (equilibration_method_.global != Core::LinAlg::EquilibrationMethod::local)
       {
@@ -1388,7 +1388,7 @@ void SSI::SsiMono::calc_initial_time_derivative()
   // assemble global mass matrix from
   switch (matrix_type())
   {
-    case Core::LinAlg::MatrixType::block_field:
+    case Core::LinAlg::MatrixType::block:
     {
       switch (scatra_field()->matrix_type())
       {
@@ -1596,7 +1596,7 @@ void SSI::SsiMono::print_system_matrix_rhs_to_mat_lab_format() const
   // print system matrix
   switch (matrixtype_)
   {
-    case Core::LinAlg::MatrixType::block_field:
+    case Core::LinAlg::MatrixType::block:
     {
       auto block_matrix =
           cast_to_const_block_sparse_matrix_base_and_check_success(ssi_matrices_->system_matrix());

--- a/src/ssi/4C_ssi_monolithic_assemble_strategy.cpp
+++ b/src/ssi/4C_ssi_monolithic_assemble_strategy.cpp
@@ -527,7 +527,7 @@ std::shared_ptr<SSI::AssembleStrategyBase> SSI::build_assemble_strategy(
 
   switch (matrixtype_ssi)
   {
-    case Core::LinAlg::MatrixType::block_field:
+    case Core::LinAlg::MatrixType::block:
     {
       switch (matrixtype_scatra)
       {

--- a/src/ssi/4C_ssi_monolithic_dbc_handler.cpp
+++ b/src/ssi/4C_ssi_monolithic_dbc_handler.cpp
@@ -195,7 +195,7 @@ std::shared_ptr<SSI::DBCHandlerBase> SSI::build_dbc_handler(const bool is_scatra
 
   switch (matrixtype_ssi)
   {
-    case Core::LinAlg::MatrixType::block_field:
+    case Core::LinAlg::MatrixType::block:
     {
       dbc_handler = std::make_shared<SSI::DBCHandlerBlock>(
           is_scatra_manifold, scatra, scatra_manifold, ssi_maps, structure);

--- a/src/ssi/4C_ssi_utils.hpp
+++ b/src/ssi/4C_ssi_utils.hpp
@@ -372,7 +372,7 @@ namespace SSI
       const Core::LinAlg::MatrixType scatra_matrixtype_;
 
       //! matrix type of scatra manifold matrix
-      const Core::LinAlg::MatrixType scatra_manifold_matrixtype_;
+      std::optional<Core::LinAlg::MatrixType> scatra_manifold_matrixtype_{std::nullopt};
 
       //! matrix type of ssi matrix
       const Core::LinAlg::MatrixType ssi_matrixtype_;

--- a/src/ssti/4C_ssti_input.cpp
+++ b/src/ssti/4C_ssti_input.cpp
@@ -86,14 +86,8 @@ std::vector<Core::IO::InputSpec> SSTI::valid_parameters()
           parameter<int>(
               "LINEAR_SOLVER", {.description = "ID of linear solver for global system of equations",
                                    .default_value = -1}),
-          deprecated_selection<Core::LinAlg::MatrixType>("MATRIXTYPE",
-              {
-                  {"undefined", Core::LinAlg::MatrixType::undefined},
-                  {"block", Core::LinAlg::MatrixType::block_field},
-                  {"sparse", Core::LinAlg::MatrixType::sparse},
-              },
-              {.description = "type of global system matrix in global system of equations",
-                  .default_value = Core::LinAlg::MatrixType::undefined}),
+          parameter<Core::LinAlg::MatrixType>("MATRIXTYPE",
+              {.description = "type of global system matrix in global system of equations"}),
           parameter<Core::LinAlg::EquilibrationMethod>("EQUILIBRATION",
               {.description = "flag for equilibration of global system of equations",
                   .default_value = Core::LinAlg::EquilibrationMethod::none}),

--- a/src/ssti/4C_ssti_monolithic.cpp
+++ b/src/ssti/4C_ssti_monolithic.cpp
@@ -331,7 +331,7 @@ void SSTI::SSTIMono::setup_system()
   residual_ = std::make_shared<Core::LinAlg::Vector<double>>(
       *ssti_maps_mono_->maps_sub_problems()->full_map(), true);
 
-  if (matrixtype_ == Core::LinAlg::MatrixType::block_field)
+  if (matrixtype_ == Core::LinAlg::MatrixType::block)
   {
     // safety check
     const bool allowed_block_system_solvers = solver_->params().isSublist("Teko Parameters") or
@@ -701,7 +701,7 @@ std::vector<Core::LinAlg::EquilibrationMethod> SSTI::SSTIMono::get_block_equilib
           std::vector<Core::LinAlg::EquilibrationMethod>(1, equilibration_method_.global);
       break;
     }
-    case Core::LinAlg::MatrixType::block_field:
+    case Core::LinAlg::MatrixType::block:
     {
       if (equilibration_method_.global != Core::LinAlg::EquilibrationMethod::local)
       {

--- a/src/ssti/4C_ssti_monolithic_assemble_strategy.cpp
+++ b/src/ssti/4C_ssti_monolithic_assemble_strategy.cpp
@@ -1348,7 +1348,7 @@ std::shared_ptr<SSTI::AssembleStrategyBase> SSTI::build_assemble_strategy(
 
   switch (matrixtype_ssti)
   {
-    case Core::LinAlg::MatrixType::block_field:
+    case Core::LinAlg::MatrixType::block:
     {
       switch (matrixtype_scatra)
       {

--- a/src/ssti/4C_ssti_utils.cpp
+++ b/src/ssti/4C_ssti_utils.cpp
@@ -250,7 +250,7 @@ SSTI::SSTIMatrices::SSTIMatrices(std::shared_ptr<SSTI::SSTIMapsMono> ssti_maps_m
   // perform initializations associated with global system matrix
   switch (matrixtype_global)
   {
-    case Core::LinAlg::MatrixType::block_field:
+    case Core::LinAlg::MatrixType::block:
     {
       systemmatrix_ = setup_block_matrix(
           *ssti_maps_mono->block_map_system_matrix(), *ssti_maps_mono->block_map_system_matrix());

--- a/src/sti/4C_sti_monolithic.cpp
+++ b/src/sti/4C_sti_monolithic.cpp
@@ -1043,8 +1043,7 @@ void STI::Monolithic::assemble_mat_and_rhs()
           FOUR_C_THROW("Invalid matrix type associated with scalar transport field!");
           break;
         }
-        case Core::LinAlg::MatrixType::undefined:
-        case Core::LinAlg::MatrixType::block_field:
+        case Core::LinAlg::MatrixType::block:
         case Core::LinAlg::MatrixType::block_condition_dof:
           break;
       }


### PR DESCRIPTION
## Description and Context
Minor cleanup, as the title states. Alongside, I changed:
- switch from deprecated_selection to parameter
- make one class member optional, as an undefined enum class value is removed
