### PR TITLE
Cleanup TSI Algorithms

### DIFF
--- a/src/tsi/4C_tsi_algorithm.hpp
+++ b/src/tsi/4C_tsi_algorithm.hpp
@@ -76,8 +76,8 @@ namespace TSI
     explicit Algorithm(MPI_Comm comm);
 
 
-    //! outer level time loop (to be implemented by deriving classes)
-    virtual void time_loop() = 0;
+    //! outer level time loop
+    void time_loop();
 
     /// initialise TSI system
     virtual void setup_system() = 0;
@@ -112,10 +112,10 @@ namespace TSI
     virtual void prepare_output() = 0;
 
     //! take current results for converged and save for next time step
-    void update() override;
+    void update() override = 0;
 
     //! write output
-    virtual void output(bool forced_writerestart = false);
+    void output(bool forced_writerestart = false);
 
     //! communicate displacement vector to thermal field to enable their
     //! visualisation on the deformed body
@@ -127,18 +127,16 @@ namespace TSI
     //! @name Transfer methods
 
     //! apply temperature state on structure discretization
-    virtual void apply_thermo_coupling_state(
-        std::shared_ptr<const Core::LinAlg::Vector<double>> temp,
+    void apply_thermo_coupling_state(std::shared_ptr<const Core::LinAlg::Vector<double>> temp,
         std::shared_ptr<const Core::LinAlg::Vector<double>> temp_res = nullptr);
 
     //! apply structural displacements and velocities on thermo discretization
-    virtual void apply_struct_coupling_state(
-        std::shared_ptr<const Core::LinAlg::Vector<double>> disp,
+    void apply_struct_coupling_state(std::shared_ptr<const Core::LinAlg::Vector<double>> disp,
         std::shared_ptr<const Core::LinAlg::Vector<double>> vel);
 
     //! Prepare a ptr to the contact strategy from the structural field,
     //! store it in tsi and hand it to the thermal field
-    virtual void prepare_contact_strategy();
+    void prepare_contact_strategy();
 
     //! Access to the dof coupling for matching grid TSI
     Coupling::Adapter::Coupling& structure_thermo_coupling() { return *coupST_; }

--- a/src/tsi/4C_tsi_dyn.cpp
+++ b/src/tsi/4C_tsi_dyn.cpp
@@ -17,7 +17,6 @@
 #include "4C_tsi_monolithic.hpp"
 #include "4C_tsi_partitioned.hpp"
 #include "4C_tsi_utils.hpp"
-#include "4C_utils_enum.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>
 

--- a/src/tsi/4C_tsi_input.hpp
+++ b/src/tsi/4C_tsi_input.hpp
@@ -11,7 +11,6 @@
 #include "4C_config.hpp"
 
 #include "4C_io_input_spec.hpp"
-#include "4C_utils_exceptions.hpp"
 
 #include <vector>
 

--- a/src/tsi/4C_tsi_partitioned.cpp
+++ b/src/tsi/4C_tsi_partitioned.cpp
@@ -8,17 +8,15 @@
 #include "4C_tsi_partitioned.hpp"
 
 #include "4C_adapter_str_structure.hpp"
-#include "4C_contact_abstract_strategy.hpp"
 #include "4C_contact_lagrange_strategy_tsi.hpp"
-#include "4C_contact_meshtying_contact_bridge.hpp"
 #include "4C_fem_discretization.hpp"
 #include "4C_global_data.hpp"
 #include "4C_inpar_structure.hpp"
-#include "4C_linalg_utils_sparse_algebra_create.hpp"
-#include "4C_structure_new_model_evaluator_data.hpp"
 #include "4C_thermo_adapter.hpp"
 #include "4C_tsi_input.hpp"
 #include "4C_tsi_utils.hpp"
+
+#include <Teuchos_StandardParameterEntryValidators.hpp>
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -157,43 +155,6 @@ void TSI::Partitioned::solve()
 
   return;
 }  // Solve()
-
-
-/*----------------------------------------------------------------------*
- | time loop                                                 dano 12/09 |
- *----------------------------------------------------------------------*/
-void TSI::Partitioned::time_loop()
-{
-  // tsi with or without contact
-  // only tsi
-  // time loop
-  while (not_finished())
-  {
-    // counter and print header
-    prepare_time_step();
-
-    // normally prepare_time_step() should be called outside the nonlinear loop,
-    // but at this point the coupling variables are not known, yet!
-    // call prepare_time_step() after ApplyCouplingState()/ApplyStructVariables()
-
-    // integrate time step
-    solve();
-
-    // calculate stresses, strains, energies
-    prepare_output();
-
-    // update all single field solvers
-    update();
-
-    // write output to screen and files
-    output();
-
-  }  // time loop
-
-  // ==================================================================
-
-}  // TSI::Partitioned::TimeLoop()
-
 
 /*----------------------------------------------------------------------*
  | One-way coupling (only one field knows its counterpart)   dano 06/10 |
@@ -1279,15 +1240,6 @@ void TSI::Partitioned::prepare_output()
   structure_field()->discretization()->clear_state(true);
 
 }  // prepare_output()
-
-
-/*----------------------------------------------------------------------*
- |                                                                      |
- *----------------------------------------------------------------------*/
-void TSI::Partitioned::prepare_contact_strategy()
-{
-  TSI::Algorithm::prepare_contact_strategy();
-}  // prepare_contact_strategy()
 
 
 /*----------------------------------------------------------------------*

--- a/src/tsi/4C_tsi_partitioned.hpp
+++ b/src/tsi/4C_tsi_partitioned.hpp
@@ -38,14 +38,10 @@ namespace TSI
   //!  the order in which the filters handle the Discretizations, which in turn
   //!  defines the dof number ordering of the Discretizations... Don't get
   //!  confused. Just always list structure, thermo. In that order.
-  class Partitioned : public Algorithm
+  class Partitioned final : public Algorithm
   {
    public:
     explicit Partitioned(MPI_Comm comm);
-
-
-    //! outer level time loop (to be implemented by deriving classes)
-    void time_loop() override;
 
     //! non-linear solve, i.e. (multiple) corrector
     void solve() override;
@@ -78,11 +74,6 @@ namespace TSI
 
     //! take current results for converged and save for next time step
     void update() override;
-    //@}
-
-    void prepare_contact_strategy() override;
-
-    //! @name Solve
 
     //! solve temperature equations for current time step
     void do_thermo_step();

--- a/src/tsi/4C_tsi_utils.cpp
+++ b/src/tsi/4C_tsi_utils.cpp
@@ -93,7 +93,6 @@ void TSI::Utils::ThermoStructureCloneStrategy::set_element_data(
   {
     FOUR_C_THROW("unsupported element type '{}'", Core::Utils::get_dynamic_type_name(*newele));
   }
-  return;
 }  // set_element_data()
 
 
@@ -104,7 +103,7 @@ bool TSI::Utils::ThermoStructureCloneStrategy::determine_ele_type(
     Core::Elements::Element* actele, const bool ismyele, std::vector<std::string>& eletype)
 {
   // we only support thermo elements here
-  eletype.push_back("THERMO");
+  eletype.emplace_back("THERMO");
 
   return true;  // yes, we copy EVERY element (no submeshes)
 }  // determine_ele_type()
@@ -144,9 +143,11 @@ void TSI::Utils::setup_tsi(MPI_Comm comm)
   if (thermdis->num_global_nodes() == 0)
   {
     if (!matchinggrid)
+    {
       FOUR_C_THROW(
           "MATCHINGGRID is set to 'no' in TSI DYNAMIC section, but thermo discretization is "
           "empty!");
+    }
 
     Core::FE::clone_discretization<TSI::Utils::ThermoStructureCloneStrategy>(
         *structdis, *thermdis, Global::Problem::instance()->cloning_material_map());
@@ -192,9 +193,11 @@ void TSI::Utils::setup_tsi(MPI_Comm comm)
   else
   {
     if (matchinggrid)
+    {
       FOUR_C_THROW(
           "MATCHINGGRID is set to 'yes' in TSI DYNAMIC section, but thermo discretization is not "
           "empty!");
+    }
 
     // first call fill_complete for single discretizations.
     // This way the physical dofs are numbered successively
@@ -268,9 +271,6 @@ void TSI::Utils::TSIMaterialStrategy::assign_material2_to1(
   // call default assignment
   Coupling::VolMortar::Utils::DefaultMaterialStrategy::assign_material2_to1(
       volmortar, ele1, ids_2, dis1, dis2);
-
-  // done
-  return;
 };
 
 
@@ -331,9 +331,6 @@ void TSI::Utils::TSIMaterialStrategy::assign_material1_to2(
   {
     therm->set_kinematic_type(kintype);  // set kintype in cloned thermal element
   }
-
-  // done
-  return;
 }
 
 
@@ -344,7 +341,7 @@ void TSI::Utils::TSIMaterialStrategy::assign_material1_to2(
 void TSI::printlogo()
 {
   // more at http://www.ascii-art.de under entry "rockets"
-  std::cout << "Welcome to Thermo-Structure-Interaction " << std::endl;
+  std::cout << "Welcome to Thermo-Structure-Interaction \n";
   std::cout << "         !\n"
             << "         !\n"
             << "         ^\n"
@@ -373,8 +370,7 @@ void TSI::printlogo()
             << "         .\n"
             << "         .\n"
             << "         .\n"
-            << "\n"
-            << std::endl;
+            << "\n\n";
 }  // printlogo()
 
 


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?



Keep the description of the PR always up-to-date and concise.
-->

This PR attempts to cleanup the TSI Algorithms a little:

Remove some methods:
- `Monolithic::print_newton_conv (used, but was empty)`
- `Monolithic::combined_dbc_map` (unused)
- `Monolithic::apply_struct_coupling_state` (implemented identically in the Base Algorithm already)

Move between Base Algorithm and Monolithic/Partitioned:
- `prepare_contact_strategy` is moved to base, as it was implemented identically in both algorithms (and they just called the base method internally anyway)
- `update` is removed from base. It was implemented there before, but then overwritten only for Partitioned. Now its purely virtual in base and gets overwritten for Monolithic as well.
- `timeloop` was identical in both algorithms, hence moved to base.

Both specialised TSI Algorithms are declared `final`.

The last commit is just to make clangd a little happier. 

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
