### PR TITLE
Be more precise on available discretization methods in doxygen main page

### DIFF
--- a/doc/doxygen/index.doc
+++ b/doc/doxygen/index.doc
@@ -7,7 +7,7 @@
 4C (Comprehensive Computational Community Code) is a powerful research code for multiphysics computer simulations.
 Building on more than 20 years of research and development, 4C can model a plethora of physical systems, including solid mechanics, fluid dynamics, scalar transport, and chemical reaction among others.
 
-4C mainly implements finite element methods (FEM) but also offers alternative discretization methods such as discontinuous Galerkin methods (DG), particle methods, and mesh-free methods. 4C is written in C++ using modern software design and uses MPI for distributed memory hardware architectures.
+4C mainly implements finite element methods (FEM) but also offers alternative discretization methods such as discontinuous Galerkin methods or particle methods. 4C is written in C++ using modern software design and uses MPI for distributed memory hardware architectures.
 
 \section mainpagepurpose Purpose of this document
 


### PR DESCRIPTION
## Description and Context

There are various meshless methods out there, though we only implement particle methods. Hence, make the description more accurate by mentioning particle methods only.