### PR TITLE
Adapt the level of fill for `xff_kimmoin_15x15_stat_nitx_edgeb_gp_dens_5`

### DIFF
--- a/tests/input_files/xff_kimmoin_15x15_stat_nitx_edgeb_gp_dens_5.4C.yaml
+++ b/tests/input_files/xff_kimmoin_15x15_stat_nitx_edgeb_gp_dens_5.4C.yaml
@@ -43,7 +43,7 @@ XFLUID DYNAMIC/STABILIZATION:
   IS_PSEUDO_2D: true
 SOLVER 1:
   SOLVER: "Belos"
-  IFPACK_XML_FILE: "xml/preconditioner/ifpack.xml"
+  IFPACK_XML_FILE: "xml/preconditioner/ifpack_level-of-fill_3.xml"
   AZOUTPUT: 50
   AZREUSE: 1
   AZSUB: 1000

--- a/tests/input_files/xml/preconditioner/ifpack_level-of-fill_3.xml
+++ b/tests/input_files/xml/preconditioner/ifpack_level-of-fill_3.xml
@@ -1,0 +1,9 @@
+<ParameterList name="Ifpack">
+  <Parameter name="Prec Type" type="string" value="ILU"/>
+  <Parameter name="Overlap" type="int" value="0"/>
+  <ParameterList name="Ifpack Settings">
+    <Parameter name="fact: level-of-fill" type="int" value="3"/>
+    <Parameter name="schwarz: combine mode" type="string" value="Add"/>
+    <Parameter name="schwarz: reordering type" type="string" value="rcm"/>
+  </ParameterList>
+</ParameterList>


### PR DESCRIPTION


<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

As discussed in #1733, this increases the level of fill of the preconditioner used for `xff_kimmoin_15x15_stat_nitx_edgeb_gp_dens_5` to `3`. This hopefully yields higher success rates of that test. 

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
Closes #1733 
