### PR TITLE
Add default status and type

### DIFF
--- a/src/particle/src/engine/4C_particle_engine_enums.hpp
+++ b/src/particle/src/engine/4C_particle_engine_enums.hpp
@@ -157,11 +157,12 @@ namespace Particle
     Phase2,  //!< particle type for particles of second phase
     /*---------------------------------------------------------------------------*/
     // particle types for SPH interaction
-    BoundaryPhase,   //!< particle type for boundary phase particles
-    RigidPhase,      //!< particle type for rigid phase particles
-    DirichletPhase,  //!< particle type for dirichlet phase particles (open boundary)
-    NeumannPhase,    //!< particle type for neumann phase particles (open boundary)
-    PDPhase          //!< particle tpe for peridynamic phase particles
+    BoundaryPhase,     //!< particle type for boundary phase particles
+    RigidPhase,        //!< particle type for rigid phase particles
+    DirichletPhase,    //!< particle type for dirichlet phase particles (open boundary)
+    NeumannPhase,      //!< particle type for neumann phase particles (open boundary)
+    PDPhase,           //!< particle type for peridynamic phase particles
+    UninitializedType  //!< not yet defined particle type
     /*---------------------------------------------------------------------------*/
   };
 
@@ -204,8 +205,9 @@ namespace Particle
    */
   enum ParticleStatus
   {
-    Owned,   //!< particle status for particles being owned on processors
-    Ghosted  //!< particle status for particles being ghosted on processors
+    Owned,               //!< particle status for particles being owned on processors
+    Ghosted,             //!< particle status for particles being ghosted on processors
+    UninitializedStatus  //!< not yet defined particle status
   };
 
   /*!

--- a/src/particle/src/interaction/4C_particle_interaction_pd_neighbor_pairs.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_pd_neighbor_pairs.cpp
@@ -504,20 +504,16 @@ void Particle::PDNeighborPairs::unpack_peridynamic_bond_list_data(const std::vec
   Core::Communication::UnpackBuffer data(buffer);
   while (!data.at_end())
   {
-    Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
-
-    Particle::TypeEnum type_j;
-    Particle::StatusEnum status_j;
-
     int globalid_i;
     extract_from_pack(data, globalid_i);
     int globalid_j;
     extract_from_pack(data, globalid_j);
 
     // setup default tuples with proper global ids
-    Particle::LocalGlobalIndexTuple tuple_i = std::make_tuple(type_i, status_i, -1, globalid_i);
-    Particle::LocalGlobalIndexTuple tuple_j = std::make_tuple(type_j, status_j, -1, globalid_j);
+    Particle::LocalGlobalIndexTuple tuple_i = std::make_tuple(
+        ParticleType::UninitializedType, ParticleStatus::UninitializedStatus, -1, globalid_i);
+    Particle::LocalGlobalIndexTuple tuple_j = std::make_tuple(
+        ParticleType::UninitializedType, ParticleStatus::UninitializedStatus, -1, globalid_j);
 
     // add bond pair
     bondlist_->push_back(std::make_pair(tuple_i, tuple_j));


### PR DESCRIPTION
## Description and Context
During communication in Peridynamics: `ParticleType` and `ParticleStatus` are unknown while sending data and will be filled on the receiving processor properly. Hence, a default/not yet initialized value is necessary.

## Interested parties
@ppraegla @slfuchs 