### PR TITLE
DiscretizationBuilder creates elements on-the-fly

### DIFF
--- a/src/core/fem/benchmark_tests/discretization/4C_fem_discretization_benchmark.cpp
+++ b/src/core/fem/benchmark_tests/discretization/4C_fem_discretization_benchmark.cpp
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include "4C_fem_discretization.hpp"
+#include "4C_fem_general_element.hpp"
 #include "4C_unittest_utils_create_discretization_helper_test.hpp"
 
 #include <benchmark/benchmark.h>

--- a/src/core/fem/src/discretization/4C_fem_discretization_builder.hpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_builder.hpp
@@ -33,16 +33,38 @@ namespace Core::FE
     using IndexType = int;
 
     /**
+     * DofInfo with necessary information to create elements on-the-fly.
+     */
+    struct DofInfo
+    {
+      int num_dof_per_node;
+      int num_dof_per_element;
+    };
+
+    /**
+     * Create a DiscretizationBuilder. This is a collective call and all processes in the
+     * communicator must call it even if you do not intend to add any data on some ranks.
+     */
+    explicit DiscretizationBuilder(MPI_Comm communicator);
+
+    /**
      * @brief Add a node to the builder
      */
     void add_node(std::span<const double, dim> x, IndexType global_id,
         std::shared_ptr<Core::Nodes::Node> user_node = nullptr);
 
     /**
-     * @brief Add an element to the builder
+     * @brief Add an element to the builder with a user-provided Element object.
      */
     void add_element(Core::FE::CellType cell_type, std::span<const IndexType> node_ids,
-        IndexType global_id, std::shared_ptr<Core::Elements::Element> user_element = nullptr);
+        IndexType global_id, std::shared_ptr<Core::Elements::Element> user_element);
+
+    /**
+     * @brief Add an element to the builder and generate an appropriate Element object on-the-fly
+     * based on the provided DofInfo.
+     */
+    void add_element(Core::FE::CellType cell_type, std::span<const IndexType> node_ids,
+        IndexType global_id, DofInfo dof_info);
 
     /**
      * @brief Build a Discretization from the data added to the builder
@@ -79,6 +101,8 @@ namespace Core::FE
     std::map<IndexType, ElementData> elements_;
 
     std::unordered_set<IndexType> used_node_ids_;
+
+    int my_rank_;
   };
 }  // namespace Core::FE
 

--- a/src/core/io/tests/4C_io_input_field_test.np2.cpp
+++ b/src/core/io/tests/4C_io_input_field_test.np2.cpp
@@ -105,9 +105,6 @@ namespace
     GTEST_SKIP() << "Skipping test: Reading point based input fields requires VTK support";
 #endif
     Core::Utils::SingletonOwnerRegistry::ScopeGuard guard;
-    // Dummy call to ensure the element type is registered
-    TESTING::PureGeometryElementType::instance();
-
     // Read mesh from vtu file (only on rank 0)
     auto mesh = MeshInput::Mesh<3>(Core::Communication::my_mpi_rank(MPI_COMM_WORLD) == 0
                                        ? VTU::read_vtu_file(TESTING::get_support_file_path(
@@ -180,8 +177,6 @@ namespace
     GTEST_SKIP() << "Skipping test: Reading point based input fields requires VTK support";
 #endif
     Core::Utils::SingletonOwnerRegistry::ScopeGuard guard;
-    // Dummy call to ensure the element type is registered
-    TESTING::PureGeometryElementType::instance();
 
     // Read mesh from vtu file (only on rank 0)
     auto mesh = MeshInput::Mesh<3>(Core::Communication::my_mpi_rank(MPI_COMM_WORLD) == 0


### PR DESCRIPTION
Came up during a discussion about #1757 

DiscretizationBuilder can now create elements for you if you do not need the virtual `evaluate` function. IMHO, new code modules should never use the inflexible `evaluate` method, see e.g. the developments in reduced lung models, so it is important to make things a bit easier for them. All the functionality was already there, it just needed some shuffling around.

@bgoderbauer would be very nice if you could try this out for #1757. 

Part of #1228 