### PR TITLE
Fix input field interpolation for 1d and 2d elements

### DIFF
--- a/tests/input_files/shell7p_mixture_vtu_input_field.4C.yaml
+++ b/tests/input_files/shell7p_mixture_vtu_input_field.4C.yaml
@@ -1,0 +1,192 @@
+TITLE:
+  - Test shell7p elements with mixture material and vtu input fields
+  - Rotationally symmetric cylinder (2 axial, 1 circumferential elements) with two fiber families (axial/circumferential),
+    isotropic growth strategy, and spatially varying pressure load.
+PROBLEM TYPE:
+  PROBLEMTYPE: "Structure"
+STRUCT NOX/Printing:
+  Warning: false
+  Inner Iteration: false
+  Outer Iteration StatusTest: false
+STRUCTURAL DYNAMIC:
+  DYNAMICTYPE: "Statics"
+  RESULTSEVERY: 5
+  RESTARTEVERY: 5
+  TIMESTEP: 1.0
+  NUMSTEP: 10
+  MAXTIME: 10
+  LOADLIN: true
+  LINEAR_SOLVER: 1
+SOLVER 1:
+  SOLVER: "UMFPACK"
+  NAME: "Structure_Solver"
+MATERIALS:
+  - MAT: 1
+    MAT_Mixture:
+      MATIDMIXTURERULE: 11
+      MATIDSCONST: [2, 3, 4]
+  - MAT: 11
+    MIX_GrowthRemodelMixtureRule:
+      GROWTH_STRATEGY: 100
+      DENS: 1
+      MASSFRAC: [0.35, 0.35, 0.3]
+  - MAT: 100
+    MIX_GrowthStrategy_Isotropic: {}
+  - MAT: 2
+    MIX_Constituent_ExplicitRemodelFiber:
+      ORIENTATION:
+        from_mesh: fiber2
+      FIBER_MATERIAL_ID: 22
+      DECAY_TIME: 10
+      GROWTH_CONSTANT: 0.01
+      DEPOSITION_STRETCH: 1.1783669297169928
+      INELASTIC_GROWTH: true
+  - MAT: 22
+    MIX_Constituent_RemodelFiber_Material_Exponential:
+      K1: 8
+      K2: 16
+      COMPRESSION: false
+  - MAT: 3
+    MIX_Constituent_ExplicitRemodelFiber:
+      ORIENTATION:
+        from_mesh: fiber1
+      FIBER_MATERIAL_ID: 33
+      ENABLE_GROWTH: true
+      DECAY_TIME: 10
+      GROWTH_CONSTANT: 0.05
+      DEPOSITION_STRETCH: 1.1783669297169928
+      INELASTIC_GROWTH: true
+  - MAT: 33
+    MIX_Constituent_RemodelFiber_Material_Exponential:
+      K1: 15
+      K2: 30
+      COMPRESSION: false
+  - MAT: 4
+    MIX_Constituent_ElastHyper:
+      NUMMAT: 2
+      MATIDS: [44, 45]
+      PRESTRESS_STRATEGY: 129
+  - MAT: 44
+    ELAST_IsoNeoHooke:
+      MUE:
+        constant: 70
+  - MAT: 45
+    ELAST_VolSussmanBathe:
+      KAPPA: 150
+  - MAT: 129
+    MIX_Prestress_Strategy_Iterative:
+      ACTIVE: false
+      ISOCHORIC: true
+FUNCT1:
+  - COMPONENT: 0
+    SYMBOLIC_FUNCTION_OF_SPACE_TIME: "1+0.2*x+0.8*z"
+FUNCT2:
+  - COMPONENT: 0
+    SYMBOLIC_FUNCTION_OF_SPACE_TIME: "atan(z/y)"
+STRUCTURE GEOMETRY:
+  ELEMENT_BLOCKS:
+    - ID: 1
+      SHELL7PSCATRA:
+        QUAD4:
+          MAT: 1
+          SDC: 1.0
+          EAS: ["N_3", "N_4", "N_3", "N_2", "N_2"]
+          USE_ANS: true
+          THICK: 3.5
+          TYPE: Undefined
+  FILE: vtu/rot_sym_cyl_quad4.vtu
+fields:
+  - name: fiber1
+    discretization: "structure"
+    source:
+      from_mesh:
+        basis: points
+  - name: fiber2
+    discretization: "structure"
+    source:
+      from_mesh:
+        basis: points
+DESIGN SURF NEUMANN CONDITIONS:
+  - E: 5
+    ENTITY_TYPE: node_set_id
+    NUMDOF: 6
+    ONOFF: [0, 0, 1, 0, 0, 0]
+    VAL: [0, 0, 3.0, 0, 0, 0]
+    FUNCT: [0, 0, 1, 0, 0, 0]
+    TYPE: "orthopressure"
+DESIGN POINT DIRICH CONDITIONS:
+  - E: 1
+    NUMDOF: 6
+    ENTITY_TYPE: node_set_id
+    ONOFF: [1, 0, 1, 0, 0, 0]
+    VAL: [0, 0, 0, 0, 0, 0]
+    FUNCT: [0, 0, 0, 0, 0, 0]
+  - E: 2
+    ENTITY_TYPE: node_set_id
+    NUMDOF: 6
+    ONOFF: [1, 0, 1, 0, 0, 0]
+    VAL: [0, 0, 0, 0, 0, 0]
+    FUNCT: [0, 0, 0, 0, 0, 0]
+DESIGN LINE DIRICH CONDITIONS:
+  - E: 4
+    ENTITY_TYPE: node_set_id
+    NUMDOF: 6
+    ONOFF: [0, 0, 1, 0, 0, 0]
+    VAL: [0, 0, 0, 0, 0, 0]
+    FUNCT: [0, 0, 0, 0, 0, 0]
+  - E: 3
+    ENTITY_TYPE: node_set_id
+    NUMDOF: 6
+    ONOFF: [0, 0, 1, 0, 0, 0]
+    VAL: [0, 0, 0, 0, 0, 0]
+    FUNCT: [0, 0, 0, 0, 0, 0]
+DESIGN POINT LOCSYS CONDITIONS:
+  - E: 2
+    ENTITY_TYPE: node_set_id
+    ROTANGLE: [1, 0, 0]
+    FUNCT: [2, 0, 0]
+    USEUPDATEDNODEPOS: 0
+DESIGN LINE LOCSYS CONDITIONS:
+  - E: 3
+    ENTITY_TYPE: node_set_id
+    ROTANGLE: [1, 0, 0]
+    FUNCT: [2, 0, 0]
+    USEUPDATEDNODEPOS: 0
+    USECONSISTENTNODENORMAL: 0
+RESULT DESCRIPTION:
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 1
+      QUANTITY: "dispx"
+      VALUE: 0
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 1
+      QUANTITY: "dispy"
+      VALUE: -6.98087730857424149e-01
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 1
+      QUANTITY: "dispz"
+      VALUE: -6.85370799129139500e-03
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 6
+      QUANTITY: "dispx"
+      VALUE: 0
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 6
+      QUANTITY: "dispy"
+      VALUE: -6.98487488998592254e-01
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 6
+      QUANTITY: "dispz"
+      VALUE: 0.00000000000000000e+00
+      TOLERANCE: 1e-08

--- a/tests/input_files/vtu/rot_sym_cyl_quad4.vtu
+++ b/tests/input_files/vtu/rot_sym_cyl_quad4.vtu
@@ -1,0 +1,150 @@
+<?xml version="1.0"?>
+<VTKFile type="UnstructuredGrid" version="0.1" byte_order="LittleEndian">
+<!--This file was created by meshio v5.3.5-->
+<UnstructuredGrid>
+<Piece NumberOfPoints="6" NumberOfCells="2">
+<Points>
+<DataArray type="Float64" Name="Points" NumberOfComponents="3" format="ascii">
+0.00000000000e+00
+5.09271274201e+01
+4.99993976035e-01
+0.00000000000e+00
+5.09295817894e+01
+0.00000000000e+00
+5.00000000000e-01
+5.09271274201e+01
+4.99993976035e-01
+5.00000000000e-01
+5.09295817894e+01
+0.00000000000e+00
+1.00000000000e+00
+5.09271274201e+01
+4.99993976035e-01
+1.00000000000e+00
+5.09295817894e+01
+0.00000000000e+00
+
+</DataArray>
+</Points>
+<Cells>
+<DataArray type="Int64" Name="connectivity" format="ascii">
+0
+2
+3
+1
+2
+4
+5
+3
+
+</DataArray>
+<DataArray type="Int64" Name="offsets" format="ascii">
+4
+8
+
+</DataArray>
+<DataArray type="Int64" Name="types" format="ascii">
+9
+9
+
+</DataArray>
+</Cells>
+<PointData>
+<DataArray type="Int64" Name="point_set_2" format="ascii">
+1
+0
+0
+0
+1
+0
+
+</DataArray>
+<DataArray type="Int64" Name="point_set_3" format="ascii">
+1
+0
+1
+0
+1
+0
+
+</DataArray>
+<DataArray type="Int64" Name="point_set_5" format="ascii">
+1
+1
+1
+1
+0
+0
+
+</DataArray>
+<DataArray type="Int64" Name="point_set_1" format="ascii">
+0
+1
+0
+0
+0
+1
+
+</DataArray>
+<DataArray type="Int64" Name="point_set_4" format="ascii">
+0
+1
+0
+1
+0
+1
+
+</DataArray>
+<DataArray type="Float64" Name="fiber1" NumberOfComponents="3" format="ascii">
+-1.00000000000e+00
+0.00000000000e+00
+0.00000000000e+00
+-1.00000000000e+00
+0.00000000000e+00
+0.00000000000e+00
+-1.00000000000e+00
+0.00000000000e+00
+0.00000000000e+00
+-1.00000000000e+00
+0.00000000000e+00
+0.00000000000e+00
+-1.00000000000e+00
+0.00000000000e+00
+0.00000000000e+00
+-1.00000000000e+00
+0.00000000000e+00
+0.00000000000e+00
+
+</DataArray>
+<DataArray type="Float64" Name="fiber2" NumberOfComponents="3" format="ascii">
+0.00000000000e+00
+-9.81735876220e-03
+9.99951808572e-01
+0.00000000000e+00 
+0.00000000000e+00 
+1.00000000000e+00
+0.00000000000e+00 
+-9.81735876220e-03
+9.99951808572e-01
+0.00000000000e+00
+0.00000000000e+00 
+1.00000000000e+00
+0.00000000000e+00
+-9.81735876220e-03
+9.99951808572e-01
+0.00000000000e+00 
+0.00000000000e+00 
+1.00000000000e+00
+
+</DataArray>
+</PointData>
+<CellData>
+<DataArray type="Int64" Name="block_id" format="ascii">
+1
+1
+
+</DataArray>
+</CellData>
+</Piece>
+</UnstructuredGrid>
+</VTKFile>

--- a/tests/list_of_tests.cmake
+++ b/tests/list_of_tests.cmake
@@ -2677,6 +2677,8 @@ four_c_test(TEST_FILE solid_vtu_input.4C.yaml NP 2 REQUIRED_DEPENDENCIES VTK RET
 four_c_test_restart(BASED_ON ${current} SAME_FILE NP 2 RESTART_STEP 5 REQUIRED_DEPENDENCIES VTK)
 four_c_test(TEST_FILE solid_vtu_field_input.4C.yaml NP 2 REQUIRED_DEPENDENCIES VTK RETURN_AS current)
 four_c_test_restart(BASED_ON ${current} SAME_FILE NP 2 RESTART_STEP 5 REQUIRED_DEPENDENCIES VTK)
+four_c_test(TEST_FILE shell7p_mixture_vtu_input_field.4C.yaml NP 2 RETURN_AS current REQUIRED_DEPENDENCIES VTK)
+four_c_test_restart(BASED_ON ${current} SAME_FILE NP 2 RESTART_STEP 5 REQUIRED_DEPENDENCIES VTK)
 
 # Tests requiring Gmsh
 four_c_test(TEST_FILE solid_gmsh_input.4C.yaml NP 2 REQUIRED_DEPENDENCIES GMSH RETURN_AS current)


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
Currently, the input field interpolation does not work for 1d and 2d elements because the shape functions are selected based on the number of Gauss point coordinates.. However, in `Mat::EvaluationContext`, the coordinates xi are always stored as `Tensor<double, 3>`, and the unused components are zero-padded for 1d and 2d elements.

As a result, the interpolation always selects 3d shape functions, even for 1d and 2d elements that use EvaluationContext.

This PR fixes the issue by determining the dimensionality based on the element cell type instead of the size of xi.

Additionally, I added a small test using vtu input fields with shell7p elements.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
