### PR TITLE
Reduced Lung refactor boundary condition handling

### DIFF
--- a/src/reduced_lung/src/4C_reduced_lung_boundary_conditions.cpp
+++ b/src/reduced_lung/src/4C_reduced_lung_boundary_conditions.cpp
@@ -1,0 +1,413 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "4C_reduced_lung_boundary_conditions.hpp"
+
+#include "4C_fem_discretization.hpp"
+#include "4C_fem_general_element.hpp"
+#include "4C_global_data.hpp"
+#include "4C_linalg_map.hpp"
+#include "4C_linalg_sparsematrix.hpp"
+#include "4C_linalg_vector.hpp"
+#include "4C_utils_exceptions.hpp"
+#include "4C_utils_function_of_time.hpp"
+
+#include <tuple>
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace ReducedLung
+{
+  namespace BoundaryConditions
+  {
+    namespace
+    {
+      struct ModelKey
+      {
+        Type type;
+        ValueSource value_source;
+        int function_id;
+
+        bool operator<(const ModelKey& other) const
+        {
+          return std::tie(type, value_source, function_id) <
+                 std::tie(other.type, other.value_source, other.function_id);
+        }
+      };
+
+      Type map_bc_type(ReducedLungParameters::BoundaryConditions::Type bc_type)
+      {
+        switch (bc_type)
+        {
+          case ReducedLungParameters::BoundaryConditions::Type::Pressure:
+            return Type::Pressure;
+          case ReducedLungParameters::BoundaryConditions::Type::Flow:
+            return Type::Flow;
+        }
+        FOUR_C_THROW("Boundary condition type not implemented.");
+      }
+
+      const char* bc_type_label(Type type)
+      {
+        switch (type)
+        {
+          case Type::Pressure:
+            return "pressure";
+          case Type::Flow:
+            return "flow";
+        }
+        return "unknown";
+      }
+
+      void evaluate_constant_value(const BoundaryConditionModel& model,
+          Core::LinAlg::Vector<double>& rhs, const Core::LinAlg::Vector<double>& dofs,
+          double /*time*/)
+      {
+        for (size_t i = 0; i < model.data.size(); ++i)
+        {
+          const int local_dof_id = model.data.local_dof_id[i];
+          const double res = -dofs.local_values_as_span()[local_dof_id] + model.values[i];
+          rhs.replace_local_value(model.data.local_equation_id[i], res);
+        }
+      }
+
+      void evaluate_function_value(const BoundaryConditionModel& model,
+          Core::LinAlg::Vector<double>& rhs, const Core::LinAlg::Vector<double>& dofs, double time)
+      {
+        if (model.function == nullptr)
+        {
+          FOUR_C_THROW(
+              "Boundary condition function not set for bc_function_id {}.", model.function_id);
+        }
+        const double bc_value = model.function->evaluate(time);
+        for (size_t i = 0; i < model.data.size(); ++i)
+        {
+          const int local_dof_id = model.data.local_dof_id[i];
+          const double res = -dofs.local_values_as_span()[local_dof_id] + bc_value;
+          rhs.replace_local_value(model.data.local_equation_id[i], res);
+        }
+      }
+
+      void assemble_diagonal_jacobian(
+          const BoundaryConditionModel& model, Core::LinAlg::SparseMatrix& sysmat)
+      {
+        const double val = 1.0;
+        for (size_t i = 0; i < model.data.size(); ++i)
+        {
+          const int local_dof_id = model.data.local_dof_id[i];
+          sysmat.insert_my_values(model.data.local_equation_id[i], 1, &val, &local_dof_id);
+        }
+      }
+    }  // namespace
+
+    void BoundaryConditionData::clear()
+    {
+      node_id.clear();
+      global_element_id.clear();
+      input_bc_id.clear();
+      local_bc_id.clear();
+      local_equation_id.clear();
+      global_equation_id.clear();
+      global_dof_id.clear();
+      local_dof_id.clear();
+    }
+
+    void BoundaryConditionData::reserve(size_t count)
+    {
+      node_id.reserve(count);
+      global_element_id.reserve(count);
+      input_bc_id.reserve(count);
+      local_bc_id.reserve(count);
+      local_equation_id.reserve(count);
+      global_equation_id.reserve(count);
+      global_dof_id.reserve(count);
+      local_dof_id.reserve(count);
+    }
+
+    void BoundaryConditionData::add_entry(int node_id_value, int element_id_value,
+        int local_bc_id_value, int global_dof_id_value, int input_bc_id_value)
+    {
+      node_id.push_back(node_id_value);
+      global_element_id.push_back(element_id_value);
+      input_bc_id.push_back(input_bc_id_value);
+      local_bc_id.push_back(local_bc_id_value);
+      local_equation_id.push_back(0);
+      global_equation_id.push_back(0);
+      global_dof_id.push_back(global_dof_id_value);
+      local_dof_id.push_back(0);
+    }
+
+    void BoundaryConditionModel::add_condition(int node_id_value, int element_id_value,
+        int local_bc_id_value, int global_dof_id_value, int input_bc_id_value, double value)
+    {
+      data.add_entry(node_id_value, element_id_value, local_bc_id_value, global_dof_id_value,
+          input_bc_id_value);
+      if (value_source == ValueSource::constant_value)
+      {
+        values.push_back(value);
+      }
+    }
+
+    void create_boundary_conditions(const Core::FE::Discretization& discretization,
+        const ReducedLungParameters& parameters,
+        const std::map<int, std::vector<int>>& global_ele_ids_per_node,
+        const std::map<int, int>& global_dof_per_ele,
+        const std::map<int, int>& first_global_dof_of_ele,
+        BoundaryConditionContainer& boundary_conditions)
+    {
+      boundary_conditions.models.clear();
+
+      const auto& bc_parameters = parameters.boundary_conditions;
+      if (bc_parameters.num_conditions < 0)
+      {
+        FOUR_C_THROW("Number of boundary conditions must be non-negative, got {}.",
+            bc_parameters.num_conditions);
+      }
+
+      std::map<ModelKey, size_t> model_indices;
+      std::map<std::pair<int, Type>, int> bc_per_node_and_type;
+      int local_bc_id = 0;
+
+      for (int bc_id = 0; bc_id < bc_parameters.num_conditions; ++bc_id)
+      {
+        const int node_id_one_based = bc_parameters.node_id.at(bc_id, "bc_node_id");
+        if (node_id_one_based < 1 || node_id_one_based > parameters.lung_tree.topology.num_nodes)
+        {
+          FOUR_C_THROW("Boundary condition bc_node_id {} is outside the valid range [1, {}].",
+              node_id_one_based, parameters.lung_tree.topology.num_nodes);
+        }
+        const int node_id = node_id_one_based - 1;
+        auto node_it = global_ele_ids_per_node.find(node_id);
+        if (node_it == global_ele_ids_per_node.end())
+        {
+          FOUR_C_THROW(
+              "Boundary condition bc_node_id {} is not part of the topology.", node_id_one_based);
+        }
+        const auto& adjacent_elements = node_it->second;
+        if (adjacent_elements.size() != 1u)
+        {
+          FOUR_C_THROW(
+              "Boundary condition bc_node_id {} must connect to exactly one element, but connects "
+              "to {} elements.",
+              node_id_one_based, adjacent_elements.size());
+        }
+
+        const int element_id = adjacent_elements.front();
+        const int local_element_id = discretization.element_row_map()->lid(element_id);
+        if (local_element_id == -1)
+        {
+          // Only own boundary conditions when the attached element is owned by this rank.
+          continue;
+        }
+        auto* ele = discretization.l_row_element(local_element_id);
+        const auto node_ids = ele->node_ids();
+        const bool is_inlet = node_ids[0] == node_id;
+        const bool is_outlet = node_ids[1] == node_id;
+        if (!is_inlet && !is_outlet)
+        {
+          FOUR_C_THROW(
+              "Boundary condition bc_node_id {} is not attached to element {} as inlet or outlet.",
+              node_id_one_based, element_id + 1);
+        }
+
+        const auto bc_type_input = bc_parameters.bc_type.at(bc_id, "bc_type");
+        const Type bc_type = map_bc_type(bc_type_input);
+        const auto duplicate_key = std::make_pair(node_id, bc_type);
+        auto duplicate_it = bc_per_node_and_type.find(duplicate_key);
+        if (duplicate_it != bc_per_node_and_type.end())
+        {
+          FOUR_C_THROW(
+              "Multiple {} boundary conditions assigned to node {} (input BC ids {} and {}).",
+              bc_type_label(bc_type), node_id_one_based, duplicate_it->second + 1, bc_id + 1);
+        }
+        // Enforce at most one boundary condition per (node, type).
+        bc_per_node_and_type.emplace(duplicate_key, bc_id);
+        int dof_offset = 0;
+        if (bc_type == Type::Pressure)
+        {
+          // Pressure uses inlet/outlet pressure dofs on the attached element.
+          dof_offset = is_inlet ? 0 : 1;
+        }
+        else if (bc_type == Type::Flow)
+        {
+          if (is_inlet)
+          {
+            // Inlet flow dof is stored at the fixed offset 2.
+            dof_offset = 2;
+          }
+          else
+          {
+            // Outlet flow dof is always the last dof of the element.
+            const auto dof_it = global_dof_per_ele.find(element_id);
+            FOUR_C_ASSERT_ALWAYS(dof_it != global_dof_per_ele.end(),
+                "Missing dof count for element {}.", element_id + 1);
+            dof_offset = dof_it->second - 1;
+          }
+        }
+        else
+        {
+          FOUR_C_THROW("Boundary condition type not implemented.");
+        }
+
+        const auto first_dof_it = first_global_dof_of_ele.find(element_id);
+        FOUR_C_ASSERT_ALWAYS(first_dof_it != first_global_dof_of_ele.end(),
+            "Missing dof offset for element {}.", element_id + 1);
+        const int global_dof_id = first_dof_it->second + dof_offset;
+
+        ValueSource value_source = ValueSource::constant_value;
+        int function_id = 0;
+        double value = 0.0;
+        if (bc_parameters.value_source ==
+            ReducedLungParameters::BoundaryConditions::ValueSource::bc_function_id)
+        {
+          value_source = ValueSource::function_id;
+          function_id = bc_parameters.function_id.at(bc_id, "bc_function_id");
+          if (function_id <= 0)
+          {
+            FOUR_C_THROW(
+                "Boundary condition bc_function_id must be positive, got {}.", function_id);
+          }
+        }
+        else if (bc_parameters.value_source ==
+                 ReducedLungParameters::BoundaryConditions::ValueSource::bc_value)
+        {
+          value_source = ValueSource::constant_value;
+          value = bc_parameters.value.at(bc_id, "bc_value");
+        }
+        else
+        {
+          FOUR_C_THROW("Boundary condition value source not implemented.");
+        }
+
+        // Constant values are grouped together independent of their numeric value (and have
+        // function_id = 0).
+        const int function_key = value_source == ValueSource::function_id ? function_id : 0;
+        ModelKey key{.type = bc_type, .value_source = value_source, .function_id = function_key};
+        auto model_it = model_indices.find(key);
+        if (model_it == model_indices.end())
+        {
+          // Create a new model block for this (type, value source, function) group.
+          BoundaryConditionModel model;
+          model.type = bc_type;
+          model.value_source = value_source;
+          model.function_id = function_key;
+          // Save the reference to the function instance
+          if (value_source == ValueSource::function_id)
+          {
+            model.function =
+                &Global::Problem::instance()->function_by_id<Core::Utils::FunctionOfTime>(
+                    function_key);
+          }
+          boundary_conditions.models.push_back(std::move(model));
+          const size_t new_index = boundary_conditions.models.size() - 1;
+          model_indices.emplace(key, new_index);
+          model_it = model_indices.find(key);
+        }
+
+        auto& model = boundary_conditions.models[model_it->second];
+        if (model.value_source == ValueSource::function_id && model.function == nullptr)
+        {
+          // Ensure the function pointer is cached even if the model existed already.
+          model.function =
+              &Global::Problem::instance()->function_by_id<Core::Utils::FunctionOfTime>(
+                  model.function_id);
+        }
+        model.add_condition(node_id, element_id, local_bc_id, global_dof_id, bc_id, value);
+        local_bc_id++;
+      }
+    }
+
+    int count_boundary_conditions(const BoundaryConditionContainer& boundary_conditions)
+    {
+      int count = 0;
+      for (const auto& model : boundary_conditions.models)
+      {
+        count += static_cast<int>(model.data.size());
+      }
+      return count;
+    }
+
+    void assign_local_equation_ids(
+        BoundaryConditionContainer& boundary_conditions, int& n_local_equations)
+    {
+      for (auto& model : boundary_conditions.models)
+      {
+        for (size_t i = 0; i < model.data.size(); ++i)
+        {
+          model.data.local_equation_id[i] = n_local_equations;
+          n_local_equations++;
+        }
+      }
+    }
+
+    void assign_global_equation_ids(
+        const Core::LinAlg::Map& row_map, BoundaryConditionContainer& boundary_conditions)
+    {
+      for (auto& model : boundary_conditions.models)
+      {
+        for (size_t i = 0; i < model.data.size(); ++i)
+        {
+          model.data.global_equation_id[i] = row_map.gid(model.data.local_equation_id[i]);
+        }
+      }
+    }
+
+    void assign_local_dof_ids(const Core::LinAlg::Map& locally_relevant_dof_map,
+        BoundaryConditionContainer& boundary_conditions)
+    {
+      for (auto& model : boundary_conditions.models)
+      {
+        for (size_t i = 0; i < model.data.size(); ++i)
+        {
+          model.data.local_dof_id[i] = locally_relevant_dof_map.lid(model.data.global_dof_id[i]);
+        }
+      }
+    }
+
+    void create_evaluators(BoundaryConditionContainer& boundary_conditions)
+    {
+      for (auto& model : boundary_conditions.models)
+      {
+        if (model.value_source == ValueSource::constant_value)
+        {
+          model.negative_residual_evaluator = evaluate_constant_value;
+        }
+        else
+        {
+          model.negative_residual_evaluator = evaluate_function_value;
+        }
+        model.jacobian_evaluator = assemble_diagonal_jacobian;
+      }
+    }
+
+    void update_negative_residual_vector(Core::LinAlg::Vector<double>& rhs,
+        const BoundaryConditionContainer& boundary_conditions,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs, double time)
+    {
+      for (const auto& model : boundary_conditions.models)
+      {
+        model.negative_residual_evaluator(model, rhs, locally_relevant_dofs, time);
+      }
+    }
+
+    void update_jacobian(
+        Core::LinAlg::SparseMatrix& sysmat, const BoundaryConditionContainer& boundary_conditions)
+    {
+      if (sysmat.filled())
+      {
+        return;
+      }
+
+      for (const auto& model : boundary_conditions.models)
+      {
+        model.jacobian_evaluator(model, sysmat);
+      }
+    }
+  }  // namespace BoundaryConditions
+}  // namespace ReducedLung
+
+FOUR_C_NAMESPACE_CLOSE

--- a/src/reduced_lung/src/4C_reduced_lung_boundary_conditions.hpp
+++ b/src/reduced_lung/src/4C_reduced_lung_boundary_conditions.hpp
@@ -1,0 +1,211 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef FOUR_C_REDUCED_LUNG_BOUNDARY_CONDITIONS_HPP
+#define FOUR_C_REDUCED_LUNG_BOUNDARY_CONDITIONS_HPP
+
+#include "4C_config.hpp"
+
+#include "4C_reduced_lung_input.hpp"
+
+#include <functional>
+#include <map>
+#include <vector>
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace Core::FE
+{
+  class Discretization;
+}
+
+namespace Core::LinAlg
+{
+  class Map;
+  class SparseMatrix;
+  template <typename T>
+  class Vector;
+}  // namespace Core::LinAlg
+
+namespace Core::Utils
+{
+  class FunctionOfTime;
+}
+
+namespace ReducedLung
+{
+  namespace BoundaryConditions
+  {
+    /**
+     * @brief Boundary condition equation types for the reduced lung model.
+     */
+    enum class Type
+    {
+      Pressure,
+      Flow
+    };
+
+    /**
+     * @brief Source of the boundary condition value.
+     */
+    enum class ValueSource
+    {
+      function_id,
+      constant_value
+    };
+
+    struct BoundaryConditionModel;
+
+    /**
+     * @brief Shared data container for all boundary condition entities.
+     *
+     * Stores identifiers and dof mappings for the boundary condition equations. This uses a
+     * struct-of-arrays layout for efficient assembly loops.
+     */
+    struct BoundaryConditionData
+    {
+      // Global node id for each boundary condition.
+      std::vector<int> node_id;
+      // Global element id attached to the boundary node.
+      std::vector<int> global_element_id;
+      // Input index for diagnostics (zero-based).
+      std::vector<int> input_bc_id;
+      // Local boundary condition id.
+      std::vector<int> local_bc_id;
+      // Local equation id.
+      std::vector<int> local_equation_id;
+      // Global equation id.
+      std::vector<int> global_equation_id;
+      // Global dof id for the constrained variable.
+      std::vector<int> global_dof_id;
+      // Local dof id for the constrained variable.
+      std::vector<int> local_dof_id;
+
+      /**
+       * @brief Number of entries stored in this data block.
+       */
+      [[nodiscard]] size_t size() const { return node_id.size(); }
+      /**
+       * @brief Clear all data arrays.
+       */
+      void clear();
+      /**
+       * @brief Reserve storage for @p count entries in all arrays.
+       */
+      void reserve(size_t count);
+      /**
+       * @brief Append a new boundary condition entry.
+       */
+      void add_entry(int node_id_value, int element_id_value, int local_bc_id_value,
+          int global_dof_id_value, int input_bc_id_value);
+    };
+
+    /**
+     * @brief Function handle for evaluating the negative residuals.
+     */
+    using NegativeResidualEvaluator = std::function<void(const BoundaryConditionModel& model,
+        Core::LinAlg::Vector<double>& rhs, const Core::LinAlg::Vector<double>& dofs, double time)>;
+    /**
+     * @brief Function handle for evaluating the boundary condition Jacobian.
+     */
+    using JacobianEvaluator = std::function<void(
+        const BoundaryConditionModel& model, Core::LinAlg::SparseMatrix& sysmat)>;
+
+    /**
+     * @brief Boundary condition model containing a homogeneous set of equations.
+     *
+     * Boundary conditions are grouped by type and value source. Constant values are stored per
+     * entry, whereas function-based models share a function pointer evaluated at assembly time.
+     */
+    struct BoundaryConditionModel
+    {
+      Type type;
+      ValueSource value_source;
+      int function_id = 0;
+      // Cached function pointer for time-dependent boundary conditions.
+      const Core::Utils::FunctionOfTime* function = nullptr;
+      // Per-entry constant values (only used for constant value sources or potential mixed
+      // conditions in the future).
+      std::vector<double> values;
+      BoundaryConditionData data;
+      NegativeResidualEvaluator negative_residual_evaluator;
+      JacobianEvaluator jacobian_evaluator;
+
+      /**
+       * @brief Add a boundary condition entry to this model.
+       */
+      void add_condition(int node_id_value, int element_id_value, int local_bc_id_value,
+          int global_dof_id_value, int input_bc_id_value, double value);
+    };
+
+    /**
+     * @brief Container for all boundary condition models.
+     */
+    struct BoundaryConditionContainer
+    {
+      std::vector<BoundaryConditionModel> models;
+    };
+
+    /*!
+     * @brief Create boundary condition models from the input parameters and topology.
+     *
+     * This function groups boundary conditions by type and value source, maps boundary nodes to
+     * the connected element, and assigns the constrained dof id.
+     */
+    void create_boundary_conditions(const Core::FE::Discretization& discretization,
+        const ReducedLungParameters& parameters,
+        const std::map<int, std::vector<int>>& global_ele_ids_per_node,
+        const std::map<int, int>& global_dof_per_ele,
+        const std::map<int, int>& first_global_dof_of_ele,
+        BoundaryConditionContainer& boundary_conditions);
+
+    /**
+     * @brief Count the total number of boundary condition equations.
+     */
+    int count_boundary_conditions(const BoundaryConditionContainer& boundary_conditions);
+
+    /**
+     * @brief Assign local equation ids for all boundary condition equations.
+     */
+    void assign_local_equation_ids(
+        BoundaryConditionContainer& boundary_conditions, int& n_local_equations);
+
+    /**
+     * @brief Assign global equation ids from the row map.
+     */
+    void assign_global_equation_ids(
+        const Core::LinAlg::Map& row_map, BoundaryConditionContainer& boundary_conditions);
+
+    /**
+     * @brief Assign local dof ids from the locally relevant dof map.
+     */
+    void assign_local_dof_ids(const Core::LinAlg::Map& locally_relevant_dof_map,
+        BoundaryConditionContainer& boundary_conditions);
+
+    /**
+     * @brief Create evaluator function objects for all models.
+     */
+    void create_evaluators(BoundaryConditionContainer& boundary_conditions);
+
+    /**
+     * @brief Assemble the boundary condition residual contributions.
+     */
+    void update_negative_residual_vector(Core::LinAlg::Vector<double>& rhs,
+        const BoundaryConditionContainer& boundary_conditions,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs, double time);
+
+    /**
+     * @brief Assemble the boundary condition Jacobian contributions once.
+     */
+    void update_jacobian(
+        Core::LinAlg::SparseMatrix& sysmat, const BoundaryConditionContainer& boundary_conditions);
+  }  // namespace BoundaryConditions
+}  // namespace ReducedLung
+
+FOUR_C_NAMESPACE_CLOSE
+
+#endif

--- a/src/reduced_lung/tests/4C_reduced_lung_boundary_conditions_test.cpp
+++ b/src/reduced_lung/tests/4C_reduced_lung_boundary_conditions_test.cpp
@@ -1,0 +1,423 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "4C_reduced_lung_boundary_conditions.hpp"
+
+#include "4C_fem_discretization.hpp"
+#include "4C_global_data.hpp"
+#include "4C_linalg_map.hpp"
+#include "4C_linalg_sparsematrix.hpp"
+#include "4C_linalg_vector.hpp"
+#include "4C_red_airways_elementbase.hpp"
+#include "4C_unittest_utils_assertions_test.hpp"
+#include "4C_utils_exceptions.hpp"
+#include "4C_utils_function_manager.hpp"
+#include "4C_utils_function_of_time.hpp"
+
+#include <mpi.h>
+
+#include <array>
+#include <map>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+namespace
+{
+  using namespace FourC;
+  using namespace FourC::ReducedLung;
+  using namespace FourC::ReducedLung::BoundaryConditions;
+
+  std::unique_ptr<Core::FE::Discretization> make_airway_discretization(
+      const std::vector<int>& node_ids, const std::vector<std::array<int, 2>>& element_nodes)
+  {
+    auto dis =
+        std::make_unique<Core::FE::Discretization>("boundary_conditions_test", MPI_COMM_WORLD, 3);
+
+    for (int node_id : node_ids)
+    {
+      std::array<double, 3> coords{static_cast<double>(node_id), 0.0, 0.0};
+      dis->add_node(coords, node_id, nullptr);
+    }
+
+    for (size_t i = 0; i < element_nodes.size(); ++i)
+    {
+      auto ele = std::make_shared<Discret::Elements::RedAirway>(static_cast<int>(i), 0);
+      ele->set_node_ids(2, element_nodes[i].data());
+      dis->add_element(ele);
+    }
+
+    dis->fill_complete(Core::FE::OptionsFillComplete::none());
+    return dis;
+  }
+
+  ReducedLungParameters make_constant_parameters()
+  {
+    ReducedLungParameters params{};
+    params.lung_tree.topology.num_nodes = 3;
+
+    params.boundary_conditions.num_conditions = 3;
+    params.boundary_conditions.bc_type =
+        Core::IO::InputField<ReducedLungParameters::BoundaryConditions::Type>(
+            std::unordered_map<int, ReducedLungParameters::BoundaryConditions::Type>{
+                {1, ReducedLungParameters::BoundaryConditions::Type::Pressure},
+                {2, ReducedLungParameters::BoundaryConditions::Type::Pressure},
+                {3, ReducedLungParameters::BoundaryConditions::Type::Flow},
+            });
+    params.boundary_conditions.node_id =
+        Core::IO::InputField<int>(std::unordered_map<int, int>{{1, 1}, {2, 3}, {3, 1}});
+    params.boundary_conditions.value_source =
+        ReducedLungParameters::BoundaryConditions::ValueSource::bc_value;
+    params.boundary_conditions.value = Core::IO::InputField<double>(
+        std::unordered_map<int, double>{{1, 2.5}, {2, 4.0}, {3, -1.0}});
+
+    return params;
+  }
+
+  ReducedLungParameters make_single_bc_parameters(
+      int node_id_one_based, ReducedLungParameters::BoundaryConditions::Type type)
+  {
+    ReducedLungParameters params{};
+    params.lung_tree.topology.num_nodes = 3;
+    params.boundary_conditions.num_conditions = 1;
+    params.boundary_conditions.bc_type =
+        Core::IO::InputField<ReducedLungParameters::BoundaryConditions::Type>(
+            std::unordered_map<int, ReducedLungParameters::BoundaryConditions::Type>{
+                {1, type},
+            });
+    params.boundary_conditions.node_id =
+        Core::IO::InputField<int>(std::unordered_map<int, int>{{1, node_id_one_based}});
+    params.boundary_conditions.value_source =
+        ReducedLungParameters::BoundaryConditions::ValueSource::bc_value;
+    params.boundary_conditions.value =
+        Core::IO::InputField<double>(std::unordered_map<int, double>{{1, 0.0}});
+    return params;
+  }
+
+  ReducedLungParameters make_function_bc_parameters(
+      int node_id_one_based, ReducedLungParameters::BoundaryConditions::Type type, int function_id)
+  {
+    ReducedLungParameters params{};
+    params.lung_tree.topology.num_nodes = 3;
+    params.boundary_conditions.num_conditions = 1;
+    params.boundary_conditions.bc_type =
+        Core::IO::InputField<ReducedLungParameters::BoundaryConditions::Type>(
+            std::unordered_map<int, ReducedLungParameters::BoundaryConditions::Type>{
+                {1, type},
+            });
+    params.boundary_conditions.node_id =
+        Core::IO::InputField<int>(std::unordered_map<int, int>{{1, node_id_one_based}});
+    params.boundary_conditions.value_source =
+        ReducedLungParameters::BoundaryConditions::ValueSource::bc_function_id;
+    params.boundary_conditions.function_id =
+        Core::IO::InputField<int>(std::unordered_map<int, int>{{1, function_id}});
+    params.boundary_conditions.value =
+        Core::IO::InputField<double>(std::unordered_map<int, double>{{1, 0.0}});
+    return params;
+  }
+
+  ReducedLungParameters make_duplicate_type_parameters()
+  {
+    ReducedLungParameters params{};
+    params.lung_tree.topology.num_nodes = 3;
+    params.boundary_conditions.num_conditions = 2;
+    params.boundary_conditions.bc_type =
+        Core::IO::InputField<ReducedLungParameters::BoundaryConditions::Type>(
+            std::unordered_map<int, ReducedLungParameters::BoundaryConditions::Type>{
+                {1, ReducedLungParameters::BoundaryConditions::Type::Pressure},
+                {2, ReducedLungParameters::BoundaryConditions::Type::Pressure},
+            });
+    params.boundary_conditions.node_id =
+        Core::IO::InputField<int>(std::unordered_map<int, int>{{1, 1}, {2, 1}});
+    params.boundary_conditions.value_source =
+        ReducedLungParameters::BoundaryConditions::ValueSource::bc_value;
+    params.boundary_conditions.value =
+        Core::IO::InputField<double>(std::unordered_map<int, double>{{1, 1.0}, {2, 2.0}});
+    return params;
+  }
+
+  BoundaryConditionModel* find_model(BoundaryConditionContainer& container, Type type)
+  {
+    for (auto& model : container.models)
+    {
+      if (model.type == type)
+      {
+        return &model;
+      }
+    }
+    return nullptr;
+  }
+
+  void expect_row_entry(Core::LinAlg::SparseMatrix& mat, int row, int col, double expected_value)
+  {
+    int n_entries = 0;
+    double* values = nullptr;
+    int* cols = nullptr;
+    mat.extract_my_row_view(row, n_entries, values, cols);
+
+    ASSERT_EQ(n_entries, 1);
+    EXPECT_EQ(cols[0], col);
+    EXPECT_DOUBLE_EQ(values[0], expected_value);
+  }
+
+  struct BoundaryConditionFixture
+  {
+    std::unique_ptr<Core::FE::Discretization> discretization;
+    ReducedLungParameters parameters;
+    std::map<int, std::vector<int>> ele_ids_per_node;
+    std::map<int, int> global_dof_per_ele;
+    std::map<int, int> first_global_dof_of_ele;
+  };
+
+  BoundaryConditionFixture make_fixture()
+  {
+    BoundaryConditionFixture fixture;
+    fixture.discretization = make_airway_discretization({0, 1, 2}, {{0, 1}, {1, 2}});
+    fixture.parameters = make_constant_parameters();
+    fixture.ele_ids_per_node = {{0, {0}}, {1, {0, 1}}, {2, {1}}};
+    fixture.global_dof_per_ele = {{0, 3}, {1, 3}};
+    fixture.first_global_dof_of_ele = {{0, 0}, {1, 3}};
+    return fixture;
+  }
+
+  BoundaryConditionContainer create_boundary_conditions_from_fixture(
+      const BoundaryConditionFixture& fixture)
+  {
+    BoundaryConditionContainer boundary_conditions;
+    create_boundary_conditions(*fixture.discretization, fixture.parameters,
+        fixture.ele_ids_per_node, fixture.global_dof_per_ele, fixture.first_global_dof_of_ele,
+        boundary_conditions);
+    return boundary_conditions;
+  }
+
+  void skip_if_parallel()
+  {
+    int comm_size = 1;
+    MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
+    if (comm_size != 1)
+    {
+      GTEST_SKIP() << "Boundary condition creation tests require a serial communicator.";
+    }
+  }
+
+  struct FunctionManagerGuard
+  {
+    Core::Utils::FunctionManager original;
+
+    FunctionManagerGuard() : original(Global::Problem::instance()->function_manager()) {}
+
+    ~FunctionManagerGuard()
+    {
+      Global::Problem::instance()->set_function_manager(std::move(original));
+    }
+  };
+
+  TEST(BoundaryConditionsTests, CreateBoundaryConditionsGroupsByType)
+  {
+    skip_if_parallel();
+
+    auto fixture = make_fixture();
+    auto boundary_conditions = create_boundary_conditions_from_fixture(fixture);
+
+    ASSERT_EQ(boundary_conditions.models.size(), 2u);
+
+    auto* pressure_model = find_model(boundary_conditions, Type::Pressure);
+    auto* flow_model = find_model(boundary_conditions, Type::Flow);
+    ASSERT_NE(pressure_model, nullptr);
+    ASSERT_NE(flow_model, nullptr);
+
+    EXPECT_EQ(pressure_model->value_source, ValueSource::constant_value);
+    EXPECT_EQ(flow_model->value_source, ValueSource::constant_value);
+
+    EXPECT_EQ(pressure_model->data.size(), 2u);
+    EXPECT_EQ(pressure_model->values, (std::vector<double>{2.5, 4.0}));
+    EXPECT_EQ(pressure_model->data.node_id, (std::vector<int>{0, 2}));
+    EXPECT_EQ(pressure_model->data.global_element_id, (std::vector<int>{0, 1}));
+    EXPECT_EQ(pressure_model->data.global_dof_id, (std::vector<int>{0, 4}));
+    EXPECT_EQ(pressure_model->data.local_bc_id, (std::vector<int>{0, 1}));
+
+    EXPECT_EQ(flow_model->data.size(), 1u);
+    EXPECT_EQ(flow_model->values, (std::vector<double>{-1.0}));
+    EXPECT_EQ(flow_model->data.node_id, (std::vector<int>{0}));
+    EXPECT_EQ(flow_model->data.global_element_id, (std::vector<int>{0}));
+    EXPECT_EQ(flow_model->data.global_dof_id, (std::vector<int>{2}));
+    EXPECT_EQ(flow_model->data.local_bc_id, (std::vector<int>{2}));
+  }
+
+  TEST(BoundaryConditionsTests, ResidualAssemblyConstant)
+  {
+    skip_if_parallel();
+
+    auto fixture = make_fixture();
+    auto boundary_conditions = create_boundary_conditions_from_fixture(fixture);
+
+    int n_local_equations = 0;
+    assign_local_equation_ids(boundary_conditions, n_local_equations);
+
+    std::array<int, 3> global_dofs{0, 2, 4};
+    Core::LinAlg::Map col_map(-1, global_dofs.size(), global_dofs.data(), 0, MPI_COMM_WORLD);
+    assign_local_dof_ids(col_map, boundary_conditions);
+    create_evaluators(boundary_conditions);
+
+    Core::LinAlg::Map row_map(-1, n_local_equations, 0, MPI_COMM_WORLD);
+    Core::LinAlg::Vector<double> rhs(row_map, true);
+    Core::LinAlg::Vector<double> locally_relevant_dofs(col_map, true);
+
+    auto dof_values = locally_relevant_dofs.get_values();
+    dof_values[0] = 10.0;  // global dof 0
+    dof_values[1] = 4.0;   // global dof 2
+    dof_values[2] = 7.0;   // global dof 4
+
+    update_negative_residual_vector(rhs, boundary_conditions, locally_relevant_dofs, 0.0);
+
+    for (const auto& model : boundary_conditions.models)
+    {
+      for (size_t i = 0; i < model.data.size(); ++i)
+      {
+        const int eq = model.data.local_equation_id[i];
+        const int ldof = model.data.local_dof_id[i];
+        const double expected =
+            -locally_relevant_dofs.local_values_as_span()[ldof] + model.values[i];
+        EXPECT_DOUBLE_EQ(rhs.local_values_as_span()[eq], expected);
+      }
+    }
+  }
+
+  TEST(BoundaryConditionsTests, JacobianAssembledOnce)
+  {
+    skip_if_parallel();
+
+    auto fixture = make_fixture();
+    auto boundary_conditions = create_boundary_conditions_from_fixture(fixture);
+
+    int n_local_equations = 0;
+    assign_local_equation_ids(boundary_conditions, n_local_equations);
+
+    std::array<int, 3> global_dofs{0, 2, 4};
+    Core::LinAlg::Map col_map(-1, global_dofs.size(), global_dofs.data(), 0, MPI_COMM_WORLD);
+    assign_local_dof_ids(col_map, boundary_conditions);
+    create_evaluators(boundary_conditions);
+
+    Core::LinAlg::Map row_map(-1, n_local_equations, 0, MPI_COMM_WORLD);
+    Core::LinAlg::SparseMatrix jac(row_map, col_map, 1);
+
+    update_jacobian(jac, boundary_conditions);
+    jac.complete();
+
+    for (const auto& model : boundary_conditions.models)
+    {
+      for (size_t i = 0; i < model.data.size(); ++i)
+      {
+        expect_row_entry(jac, model.data.local_equation_id[i], model.data.local_dof_id[i], 1.0);
+      }
+    }
+
+    update_jacobian(jac, boundary_conditions);
+
+    for (const auto& model : boundary_conditions.models)
+    {
+      for (size_t i = 0; i < model.data.size(); ++i)
+      {
+        expect_row_entry(jac, model.data.local_equation_id[i], model.data.local_dof_id[i], 1.0);
+      }
+    }
+  }
+
+  TEST(BoundaryConditionsTests, CreateBoundaryConditionsMissingAdjacencyThrows)
+  {
+    skip_if_parallel();
+
+    auto fixture = make_fixture();
+    fixture.parameters =
+        make_single_bc_parameters(1, ReducedLungParameters::BoundaryConditions::Type::Pressure);
+    fixture.ele_ids_per_node.erase(0);
+
+    BoundaryConditionContainer boundary_conditions;
+    FOUR_C_EXPECT_THROW_WITH_MESSAGE(
+        create_boundary_conditions(*fixture.discretization, fixture.parameters,
+            fixture.ele_ids_per_node, fixture.global_dof_per_ele, fixture.first_global_dof_of_ele,
+            boundary_conditions),
+        Core::Exception, "not part of the topology");
+  }
+
+  TEST(BoundaryConditionsTests, CreateBoundaryConditionsMultipleAdjacencyThrows)
+  {
+    skip_if_parallel();
+
+    auto fixture = make_fixture();
+    fixture.parameters =
+        make_single_bc_parameters(2, ReducedLungParameters::BoundaryConditions::Type::Pressure);
+
+    BoundaryConditionContainer boundary_conditions;
+    FOUR_C_EXPECT_THROW_WITH_MESSAGE(
+        create_boundary_conditions(*fixture.discretization, fixture.parameters,
+            fixture.ele_ids_per_node, fixture.global_dof_per_ele, fixture.first_global_dof_of_ele,
+            boundary_conditions),
+        Core::Exception, "must connect to exactly one element");
+  }
+
+  TEST(BoundaryConditionsTests, ResidualAssemblyFunctionValue)
+  {
+    skip_if_parallel();
+
+    FunctionManagerGuard guard;
+
+    Core::Utils::FunctionManager function_manager;
+    std::vector<std::any> functions;
+    auto function = std::shared_ptr<Core::Utils::FunctionOfTime>(
+        std::make_shared<Core::Utils::SymbolicFunctionOfTime>(std::vector<std::string>{"2.0 * t"},
+            std::vector<std::shared_ptr<Core::Utils::FunctionVariable>>{}));
+    functions.emplace_back(function);
+    function_manager.set_functions(functions);
+    Global::Problem::instance()->set_function_manager(std::move(function_manager));
+
+    auto fixture = make_fixture();
+    fixture.parameters = make_function_bc_parameters(
+        1, ReducedLungParameters::BoundaryConditions::Type::Pressure, 1);
+
+    auto boundary_conditions = create_boundary_conditions_from_fixture(fixture);
+
+    int n_local_equations = 0;
+    assign_local_equation_ids(boundary_conditions, n_local_equations);
+
+    std::array<int, 1> global_dofs{0};
+    Core::LinAlg::Map col_map(-1, global_dofs.size(), global_dofs.data(), 0, MPI_COMM_WORLD);
+    assign_local_dof_ids(col_map, boundary_conditions);
+    create_evaluators(boundary_conditions);
+
+    Core::LinAlg::Map row_map(-1, n_local_equations, 0, MPI_COMM_WORLD);
+    Core::LinAlg::Vector<double> rhs(row_map, true);
+    Core::LinAlg::Vector<double> locally_relevant_dofs(col_map, true);
+    locally_relevant_dofs.get_values()[0] = 1.0;
+
+    const double time = 1.5;
+    update_negative_residual_vector(rhs, boundary_conditions, locally_relevant_dofs, time);
+
+    ASSERT_EQ(boundary_conditions.models.size(), 1u);
+    const auto& model = boundary_conditions.models.front();
+    ASSERT_EQ(model.data.size(), 1u);
+    EXPECT_DOUBLE_EQ(
+        rhs.local_values_as_span()[model.data.local_equation_id[0]], -1.0 + 2.0 * time);
+  }
+
+  TEST(BoundaryConditionsTests, CreateBoundaryConditionsDuplicateTypeThrows)
+  {
+    skip_if_parallel();
+
+    auto fixture = make_fixture();
+    fixture.parameters = make_duplicate_type_parameters();
+
+    BoundaryConditionContainer boundary_conditions;
+    FOUR_C_EXPECT_THROW_WITH_MESSAGE(
+        create_boundary_conditions(*fixture.discretization, fixture.parameters,
+            fixture.ele_ids_per_node, fixture.global_dof_per_ele, fixture.first_global_dof_of_ele,
+            boundary_conditions),
+        Core::Exception, "Multiple pressure boundary conditions assigned to node");
+  }
+}  // namespace

--- a/src/reduced_lung/tests/4C_reduced_lung_input_pipeline_test.cpp
+++ b/src/reduced_lung/tests/4C_reduced_lung_input_pipeline_test.cpp
@@ -155,8 +155,8 @@ namespace
       }
     }
 
-    AirwayContainer airways;
-    TerminalUnitContainer terminal_units;
+    Airways::AirwayContainer airways;
+    TerminalUnits::TerminalUnitContainer terminal_units;
     for (const auto& element : discretization.my_row_element_range())
     {
       const int element_id = element.global_id();

--- a/src/reduced_lung/tests/4C_reduced_lung_terminal_unit_test.cpp
+++ b/src/reduced_lung/tests/4C_reduced_lung_terminal_unit_test.cpp
@@ -18,6 +18,7 @@ namespace
   using namespace FourC::ReducedLung;
   using namespace FourC::Core::LinAlg;
   using namespace FourC::ReducedLung::TestUtils;
+  using namespace FourC::ReducedLung::TerminalUnits;
 
   // Tests the implementation of different model combinations by comparing the analytic jacobian
   // with a finite difference approximation of the residual functions.


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

After porting discretization and boundary condition input in #1757, this PR now also refactors the data layout of the boundary conditions to a struct of arrays, grouped by models. For now, we support two types of boundary conditions (Pressure and Flow), which have to be directly given via a constant value or a `FunctionOfTime`. The model creation for the different equation types follows the same structure as the already refactored Airways, Terminal Units, and Junctions. One model group is characterised by its type (Pressure or Flow) and its `ValueSource` (either constant values or function IDs). 

The critical function that sets up everything is `create_boundary_conditions`, which takes the input parameters and the discretization and creates and distributes the underlying model equations for every rank. Everything else is just helpers or implementation details.

For future, more complicated boundary conditions, I think it should be just as easy as adding the corresponding bc_type to the input and implementing the evaluators.
