### PR TITLE
PoroElast framework: enable Gauss point output / fix case output

### DIFF
--- a/src/mat/4C_mat_structporo.hpp
+++ b/src/mat/4C_mat_structporo.hpp
@@ -330,6 +330,28 @@ namespace Mat
 
     //!@}
 
+
+    //! @name Gauss point output
+
+    void register_output_data_names(
+        std::unordered_map<std::string, int>& names_and_size) const override
+    {
+      // call method of the underlying material
+      mat_->register_output_data_names(names_and_size);
+    };
+
+
+    bool evaluate_output_data(
+        const std::string& name, Core::LinAlg::SerialDenseMatrix& data) const override
+    {
+      // call method of the underlying material
+      return mat_->evaluate_output_data(name, data);
+    }
+
+    //!@}
+
+
+
    protected:
     //! compute current porosity and save it
     void compute_porosity(
@@ -338,10 +360,10 @@ namespace Mat
         const double& J,            //!< (i) determinant of jacobian at gauss point
         const int& gp,              //!< (i) number of current gauss point
         double& porosity,           //!< (o) porosity at gauss point
-        double* dphi_dp,  //!< (o) first derivative of porosity w.r.t. pressure at gauss point
-        double* dphi_dJ,  //!< (o) first derivative of porosity w.r.t. jacobian at gauss point
-        double*
-            dphi_dJdp,  //!< (o) derivative of porosity w.r.t. pressure and jacobian at gauss point
+        double* dphi_dp,       //!< (o) first derivative of porosity w.r.t. pressure at gauss point
+        double* dphi_dJ,       //!< (o) first derivative of porosity w.r.t. jacobian at gauss point
+        double* dphi_dJdp,     //!< (o) derivative of porosity w.r.t. pressure and jacobian at gauss
+                               //!< point
         double* dphi_dJJ,      //!< (o) second derivative of porosity w.r.t. jacobian at gauss point
         double* dphi_dpp,      //!< (o) second derivative of porosity w.r.t. pressure at gauss point
         double* dphi_dphiref,  //!< (o) derivative of porosity w.r.t. reference porosity (only

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_based.cpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_based.cpp
@@ -283,7 +283,8 @@ bool Discret::Elements::SolidPoroPressureBased::vis_data(
   // Put the owner of this element into the file (use base class method for this)
   if (Core::Elements::Element::vis_data(name, data)) return true;
 
-  return solid_poro_material().vis_data(name, data, id());
+  const unsigned int dummy_gp = 0;
+  return solid_poro_material().vis_data(name, data, dummy_gp, id());
 }
 
 Mat::StructPoro& Discret::Elements::SolidPoroPressureBased::struct_poro_material(int nummat) const

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_velocity_based.cpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_velocity_based.cpp
@@ -377,7 +377,11 @@ bool Discret::Elements::SolidPoroPressureVelocityBased::vis_data(
   // Put the owner of this element into the file (use base class method for this)
   if (Core::Elements::Element::vis_data(name, data)) return true;
 
-  return solid_poro_material().vis_data(name, data, id());
+
+  const unsigned int dummy_gp = 0;
+  return solid_poro_material().vis_data(name, data, dummy_gp,
+      id());  // we use 0 here for the number of Gauss points, since this is not properly tracked
+              // for the old output; works for now for the underlying struct poro material
 }
 
 Mat::StructPoro& Discret::Elements::SolidPoroPressureVelocityBased::struct_poro_material(

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_velocity_based_p1.cpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_velocity_based_p1.cpp
@@ -379,7 +379,8 @@ bool Discret::Elements::SolidPoroPressureVelocityBasedP1::vis_data(
   // Put the owner of this element into the file (use base class method for this)
   if (Core::Elements::Element::vis_data(name, data)) return true;
 
-  return solid_poro_material().vis_data(name, data, id());
+  const unsigned int dummy_gp = 0;
+  return solid_poro_material().vis_data(name, data, dummy_gp, id());
 }
 
 Mat::StructPoro& Discret::Elements::SolidPoroPressureVelocityBasedP1::struct_poro_material(


### PR DESCRIPTION
This PR enables / fixes output for the solid poro elements used in the Poroelasticity framework:

- Enabled Gauss point output by calling the dedicated methods from the underlying material of the StructPoro material.
- Fixed `vis_data` call for solid poro elements: now the implemented method from the StructPoro material is called, instead of the other empty `vis_data` method (see number of arguments). Now, we also obtain the porosity values after postprocessing, instead of the default zero values. 
@c-p-schmidt and I see this only as a temporary fix before completely enabling the new output for the Poroelasticity framework.

