### PR TITLE
Refactor `SPHKernelBase::kernel_space_dimension()` to return a value

### DIFF
--- a/src/particle/src/4C_particle_input.cpp
+++ b/src/particle/src/4C_particle_input.cpp
@@ -204,7 +204,7 @@ std::vector<Core::IO::InputSpec> Particle::valid_parameters()
           // kernel space dimension number
           parameter<KernelSpaceDimension>(
               "KERNEL_SPACE_DIM", {.description = "kernel space dimension number",
-                                      .default_value = Particle::Kernel3D}),
+                                      .default_value = Particle::KernelSpaceDimension::Kernel3D}),
 
           parameter<double>("INITIALPARTICLESPACING",
               {.description = "initial spacing of particles", .default_value = 0.0}),

--- a/src/particle/src/4C_particle_input.hpp
+++ b/src/particle/src/4C_particle_input.hpp
@@ -74,7 +74,7 @@ namespace Particle
   };
 
   //! kernel space dimension number
-  enum KernelSpaceDimension
+  enum class KernelSpaceDimension
   {
     Kernel1D,
     Kernel2D,

--- a/src/particle/src/interaction/4C_particle_interaction_sph.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph.cpp
@@ -246,8 +246,7 @@ void Particle::ParticleInteractionSPH::insert_particle_states_of_particle_types(
 void Particle::ParticleInteractionSPH::set_initial_states()
 {
   // get kernel space dimension
-  int kernelspacedim = 0;
-  kernel_->kernel_space_dimension(kernelspacedim);
+  const int kernelspacedim = kernel_->kernel_space_dimension();
 
   // get initial particle spacing
   const double initialparticlespacing = params_sph_.get<double>("INITIALPARTICLESPACING");

--- a/src/particle/src/interaction/4C_particle_interaction_sph_kernel.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_kernel.cpp
@@ -9,6 +9,7 @@
 
 #include "4C_particle_interaction_utils.hpp"
 #include "4C_utils_exceptions.hpp"
+#include "4C_utils_std23_unreachable.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>
 
@@ -24,31 +25,24 @@ Particle::SPHKernelBase::SPHKernelBase(const Teuchos::ParameterList& params)
   // empty constructor
 }
 
-void Particle::SPHKernelBase::kernel_space_dimension(int& dim) const
+int Particle::SPHKernelBase::kernel_space_dimension() const
 {
   switch (kernelspacedim_)
   {
-    case Particle::Kernel1D:
-    {
-      dim = 1;
-      break;
-    }
-    case Particle::Kernel2D:
-    {
-      dim = 2;
-      break;
-    }
-    case Particle::Kernel3D:
-    {
-      dim = 3;
-      break;
-    }
+    case Particle::KernelSpaceDimension::Kernel1D:
+      return 1;
+
+    case Particle::KernelSpaceDimension::Kernel2D:
+      return 2;
+
+    case Particle::KernelSpaceDimension::Kernel3D:
+      return 3;
+
     default:
-    {
       FOUR_C_THROW("unknown kernel space dimension!");
-      break;
-    }
   }
+
+  std23::unreachable();
 }
 
 void Particle::SPHKernelBase::grad_wij(
@@ -72,17 +66,17 @@ double Particle::SPHKernelCubicSpline::normalization_constant(const double& inv_
 {
   switch (kernelspacedim_)
   {
-    case Particle::Kernel1D:
+    case Particle::KernelSpaceDimension::Kernel1D:
     {
       // (2.0 / 3.0) * inv_h
       return 0.6666666666666666 * inv_h;
     }
-    case Particle::Kernel2D:
+    case Particle::KernelSpaceDimension::Kernel2D:
     {
       // (10.0 / 7.0) * std::numbers::inv_pi * inv_h * inv_h
       return 0.4547284088339866 * ParticleUtils::pow<2>(inv_h);
     }
-    case Particle::Kernel3D:
+    case Particle::KernelSpaceDimension::Kernel3D:
     {
       return std::numbers::inv_pi * ParticleUtils::pow<3>(inv_h);
     }
@@ -157,17 +151,17 @@ double Particle::SPHKernelQuinticSpline::normalization_constant(const double& in
 {
   switch (kernelspacedim_)
   {
-    case Particle::Kernel1D:
+    case Particle::KernelSpaceDimension::Kernel1D:
     {
       // (inv_h / 120.0)
       return 0.0083333333333333 * inv_h;
     }
-    case Particle::Kernel2D:
+    case Particle::KernelSpaceDimension::Kernel2D:
     {
       // (7.0 / 478.0) * std::numbers::inv_pi * inv_h * inv_h
       return 0.0046614418478797 * ParticleUtils::pow<2>(inv_h);
     }
-    case Particle::Kernel3D:
+    case Particle::KernelSpaceDimension::Kernel3D:
     {
       // (3.0 / 359.0) * std::numbers::inv_pi * inv_h * inv_h * inv_h
       return 0.0026599711937364 * ParticleUtils::pow<3>(inv_h);

--- a/src/particle/src/interaction/4C_particle_interaction_sph_kernel.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_kernel.hpp
@@ -35,7 +35,7 @@ namespace Particle
     virtual ~SPHKernelBase() = default;
 
     //! get kernel space dimension
-    virtual void kernel_space_dimension(int& dim) const final;
+    virtual int kernel_space_dimension() const final;
 
     //! get smoothing length from kernel support radius
     virtual double smoothing_length(const double& support) const = 0;

--- a/src/particle/src/interaction/4C_particle_interaction_sph_momentum.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_momentum.cpp
@@ -212,6 +212,9 @@ void Particle::SPHMomentum::momentum_equation_particle_contribution() const
 {
   TEUCHOS_FUNC_TIME_MONITOR("Particle::SPHMomentum::momentum_equation_particle_contribution");
 
+  // get factor from kernel space dimension
+  const int kernelfac = kernel_->kernel_space_dimension() + 2;
+
   // get relevant particle pair indices
   std::vector<int> relindices;
   neighborpairs_->get_relevant_particle_pair_indices_for_equal_combination(
@@ -290,18 +293,10 @@ void Particle::SPHMomentum::momentum_equation_particle_contribution() const
         speccoeff_ji, particlepair.e_ij_, acc_i, acc_j);
 
     // evaluate shear forces
-    {
-      // get factor from kernel space dimension
-      int kernelfac = 0;
-      kernel_->kernel_space_dimension(kernelfac);
-      kernelfac += 2;
-
-      // evaluate shear forces
-      momentumformulation_->shear_forces(dens_i, dens_j, vel_i, vel_j, kernelfac,
-          material_i->dynamicViscosity_, material_j->dynamicViscosity_, material_i->bulkViscosity_,
-          material_j->bulkViscosity_, particlepair.absdist_, speccoeff_ij, speccoeff_ji,
-          particlepair.e_ij_, acc_i, acc_j);
-    }
+    momentumformulation_->shear_forces(dens_i, dens_j, vel_i, vel_j, kernelfac,
+        material_i->dynamicViscosity_, material_j->dynamicViscosity_, material_i->bulkViscosity_,
+        material_j->bulkViscosity_, particlepair.absdist_, speccoeff_ij, speccoeff_ji,
+        particlepair.e_ij_, acc_i, acc_j);
 
     // apply transport velocity formulation
     if (transportvelocityformulation_ ==
@@ -375,6 +370,9 @@ void Particle::SPHMomentum::momentum_equation_particle_boundary_contribution() c
 {
   TEUCHOS_FUNC_TIME_MONITOR(
       "Particle::SPHMomentum::momentum_equation_particle_boundary_contribution");
+
+  // get factor from kernel space dimension
+  const int kernelfac = kernel_->kernel_space_dimension() + 2;
 
   // get relevant particle pair indices
   std::vector<int> relindices;
@@ -478,11 +476,6 @@ void Particle::SPHMomentum::momentum_equation_particle_boundary_contribution() c
     // evaluate shear forces
     if (boundaryparticleinteraction_ == Particle::NoSlipBoundaryParticle)
     {
-      // get factor from kernel space dimension
-      int kernelfac = 0;
-      kernel_->kernel_space_dimension(kernelfac);
-      kernelfac += 2;
-
       // evaluate shear forces
       momentumformulation_->shear_forces(dens_i, dens_j, vel_i, vel_j, kernelfac,
           material_i->dynamicViscosity_, material_i->dynamicViscosity_, material_i->bulkViscosity_,
@@ -551,6 +544,9 @@ void Particle::SPHMomentum::momentum_equation_particle_boundary_contribution() c
 void Particle::SPHMomentum::momentum_equation_particle_wall_contribution() const
 {
   TEUCHOS_FUNC_TIME_MONITOR("Particle::SPHMomentum::momentum_equation_particle_wall_contribution");
+
+  // get factor from kernel space dimension
+  const int kernelfac = kernel_->kernel_space_dimension() + 2;
 
   // get wall data state container
   std::shared_ptr<Particle::WallDataState> walldatastate =
@@ -758,11 +754,6 @@ void Particle::SPHMomentum::momentum_equation_particle_wall_contribution() const
         // evaluate shear forces
         if (boundaryparticleinteraction_ == Particle::NoSlipBoundaryParticle)
         {
-          // get factor from kernel space dimension
-          int kernelfac = 0;
-          kernel_->kernel_space_dimension(kernelfac);
-          kernelfac += 2;
-
           // evaluate shear forces
           momentumformulation_->shear_forces(dens_i, dens_k, vel_i, vel_k, kernelfac,
               material_i->dynamicViscosity_, material_i->dynamicViscosity_,

--- a/src/particle/src/interaction/4C_particle_interaction_sph_virtual_wall_particle.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_virtual_wall_particle.cpp
@@ -89,8 +89,7 @@ void Particle::SPHVirtualWallParticle::init_relative_positions_of_virtual_partic
   const int numparticleperdir = std::round(maxinteractiondistance / initialparticlespacing);
 
   // get the kernel dimensionality
-  int kernel_dim = 0;
-  kernel_->kernel_space_dimension(kernel_dim);
+  const int kernel_dim = kernel_->kernel_space_dimension();
 
   const int s_start = (kernel_dim > 1) ? (-numparticleperdir + 1) : 0;
   const int s_end = (kernel_dim > 1) ? numparticleperdir : 1;

--- a/src/particle/tests/4C_particle_interaction_sph_kernel_test.cpp
+++ b/src/particle/tests/4C_particle_interaction_sph_kernel_test.cpp
@@ -31,17 +31,20 @@ namespace
       Teuchos::ParameterList params_sph_1D;
       Teuchos::setStringToIntegralParameter<Particle::KernelSpaceDimension>("KERNEL_SPACE_DIM",
           "Kernel1D", "kernel space dimension number", Teuchos::tuple<std::string>("Kernel1D"),
-          Teuchos::tuple<Particle::KernelSpaceDimension>(Particle::Kernel1D), &params_sph_1D);
+          Teuchos::tuple<Particle::KernelSpaceDimension>(Particle::KernelSpaceDimension::Kernel1D),
+          &params_sph_1D);
 
       Teuchos::ParameterList params_sph_2D;
       Teuchos::setStringToIntegralParameter<Particle::KernelSpaceDimension>("KERNEL_SPACE_DIM",
           "Kernel2D", "kernel space dimension number", Teuchos::tuple<std::string>("Kernel2D"),
-          Teuchos::tuple<Particle::KernelSpaceDimension>(Particle::Kernel2D), &params_sph_2D);
+          Teuchos::tuple<Particle::KernelSpaceDimension>(Particle::KernelSpaceDimension::Kernel2D),
+          &params_sph_2D);
 
       Teuchos::ParameterList params_sph_3D;
       Teuchos::setStringToIntegralParameter<Particle::KernelSpaceDimension>("KERNEL_SPACE_DIM",
           "Kernel3D", "kernel space dimension number", Teuchos::tuple<std::string>("Kernel3D"),
-          Teuchos::tuple<Particle::KernelSpaceDimension>(Particle::Kernel3D), &params_sph_3D);
+          Teuchos::tuple<Particle::KernelSpaceDimension>(Particle::KernelSpaceDimension::Kernel3D),
+          &params_sph_3D);
 
       // create kernel handler
       kernel_1D_ = std::make_unique<Particle::SPHKernelCubicSpline>(params_sph_1D);
@@ -54,13 +57,13 @@ namespace
   {
     int dim = 0;
 
-    kernel_1D_->kernel_space_dimension(dim);
+    dim = kernel_1D_->kernel_space_dimension();
     EXPECT_EQ(dim, 1);
 
-    kernel_2D_->kernel_space_dimension(dim);
+    dim = kernel_2D_->kernel_space_dimension();
     EXPECT_EQ(dim, 2);
 
-    kernel_3D_->kernel_space_dimension(dim);
+    dim = kernel_3D_->kernel_space_dimension();
     EXPECT_EQ(dim, 3);
   }
 
@@ -293,17 +296,20 @@ namespace
       Teuchos::ParameterList params_sph_1D;
       Teuchos::setStringToIntegralParameter<Particle::KernelSpaceDimension>("KERNEL_SPACE_DIM",
           "Kernel1D", "kernel space dimension number", Teuchos::tuple<std::string>("Kernel1D"),
-          Teuchos::tuple<Particle::KernelSpaceDimension>(Particle::Kernel1D), &params_sph_1D);
+          Teuchos::tuple<Particle::KernelSpaceDimension>(Particle::KernelSpaceDimension::Kernel1D),
+          &params_sph_1D);
 
       Teuchos::ParameterList params_sph_2D;
       Teuchos::setStringToIntegralParameter<Particle::KernelSpaceDimension>("KERNEL_SPACE_DIM",
           "Kernel2D", "kernel space dimension number", Teuchos::tuple<std::string>("Kernel2D"),
-          Teuchos::tuple<Particle::KernelSpaceDimension>(Particle::Kernel2D), &params_sph_2D);
+          Teuchos::tuple<Particle::KernelSpaceDimension>(Particle::KernelSpaceDimension::Kernel2D),
+          &params_sph_2D);
 
       Teuchos::ParameterList params_sph_3D;
       Teuchos::setStringToIntegralParameter<Particle::KernelSpaceDimension>("KERNEL_SPACE_DIM",
           "Kernel3D", "kernel space dimension number", Teuchos::tuple<std::string>("Kernel3D"),
-          Teuchos::tuple<Particle::KernelSpaceDimension>(Particle::Kernel3D), &params_sph_3D);
+          Teuchos::tuple<Particle::KernelSpaceDimension>(Particle::KernelSpaceDimension::Kernel3D),
+          &params_sph_3D);
 
       // create kernel handler
       kernel_1D_ = std::make_unique<Particle::SPHKernelQuinticSpline>(params_sph_1D);
@@ -316,13 +322,13 @@ namespace
   {
     int dim = 0;
 
-    kernel_1D_->kernel_space_dimension(dim);
+    dim = kernel_1D_->kernel_space_dimension();
     EXPECT_EQ(dim, 1);
 
-    kernel_2D_->kernel_space_dimension(dim);
+    dim = kernel_2D_->kernel_space_dimension();
     EXPECT_EQ(dim, 2);
 
-    kernel_3D_->kernel_space_dimension(dim);
+    dim = kernel_3D_->kernel_space_dimension();
     EXPECT_EQ(dim, 3);
   }
 


### PR DESCRIPTION
As observed in #1728 it is worth refactoring `SPHKernelBase::kernel_space_dimension()` to return a value instead of modifying a variable passed by reference.

## Related Issues and Pull Requests
#1728
