### PR TITLE
Fix stale bot message

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,20 +18,14 @@ jobs:
     steps:
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
-          stale-pr-message: |
-            This pull request has been inactive for **${{ env.PR_INACTIVITY_AFTER }}** days.
-
-            If this feature is still intended to be merged, please leave a brief comment outlining the
-            next intended steps and remove the `stale` label.
-            This will reset the inactivity counter.
-
-            If the pull request can be closed, feel free to close it. Otherwise do **not** change any
-            label or comment as this will wrongly reset the inactivity counter.
-            If no action is taken, this pull request will be automatically closed in
-            **${{ env.PR_CLOSE_AFTER }}** days.
-          close-pr-message: >
-            This pull request is closed due to inactivity. If this was a mistake, feel free to re-open
-            the PR.
+          stale-pr-message: "This pull request has been inactive for **${{ env.PR_INACTIVITY_AFTER }}**
+            days.\n\nIf this feature is still intended to be merged, please leave a brief comment outlining
+            the next intended steps and remove the `stale` label. This will reset the inactivity counter.\n\nIf
+            the pull request can be closed, feel free to close it. Otherwise do **not** change any label
+            or comment as this will wrongly reset the inactivity counter. If no action is taken, this
+            pull request will be automatically closed in **${{ env.PR_CLOSE_AFTER }}** days."
+          close-pr-message: "This pull request is closed due to inactivity. If this was a mistake, feel
+            free to re-open the PR."
           days-before-pr-stale: ${{ env.PR_INACTIVITY_AFTER }}
           days-before-pr-close: ${{ env.PR_CLOSE_AFTER }}
           stale-pr-label: 'stale'


### PR DESCRIPTION
Switch to a single string with \n escapes to format the message properly. Block style scalars do not work because due to the automatic formatting of yamlfmt.
Literal block style scalars `|` do not work because this will insert a newline for every line (Lines are automatically broken by yamlfmt). Folded block style scalars `>` do not work because we need two empty lines to get an empty line in the output. But yamlfmt only keeps one empty line.
