### PR TITLE
Change peridynamic contact formulation

### DIFF
--- a/src/particle/src/interaction/4C_particle_interaction_pd_neighbor_pairs.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_pd_neighbor_pairs.cpp
@@ -41,7 +41,9 @@ namespace
       const int localid, const int globalid, Particle::ParticleContainer* container);
 }  // namespace
 
-Particle::PDNeighborPairs::PDNeighborPairs(const MPI_Comm& comm) : comm_(comm)
+Particle::PDNeighborPairs::PDNeighborPairs(
+    const MPI_Comm& comm, const Teuchos::ParameterList& params_pd)
+    : comm_(comm), peridynamic_grid_spacing_(params_pd.get<double>("PERIDYNAMIC_GRID_SPACING"))
 {
   // empty constructor
 }
@@ -135,10 +137,7 @@ void Particle::PDNeighborPairs::evaluate_particle_pairs()
     // all close and non-bonded particle pairs are considered as potential colliding partners
     // undergoing short range force interaction
     const double* pos_i = container_i->get_ptr_to_state(Particle::Position, particle_i);
-    const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
-
     const double* pos_j = container_j->get_ptr_to_state(Particle::Position, particle_j);
-    const double* rad_j = container_j->get_ptr_to_state(Particle::Radius, particle_j);
 
     // vector from particle i to j
     double r_ji[3];
@@ -150,12 +149,15 @@ void Particle::PDNeighborPairs::evaluate_particle_pairs()
     const double absdist = ParticleUtils::vec_norm_two(r_ji);
 
 #ifdef FOUR_C_ENABLE_ASSERTIONS
+    const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
+    const double* rad_j = container_j->get_ptr_to_state(Particle::Radius, particle_j);
+
     if (absdist < (1.0e-10 * rad_i[0]) or absdist < (1.0e-10 * rad_j[0]))
       FOUR_C_THROW("absolute distance %f between particles close to zero!", absdist);
 #endif
 
-    // gap between particles
-    const double gap = absdist - rad_i[0] - rad_j[0];
+    // gap calculation based on initial spacing
+    const double gap = absdist - peridynamic_grid_spacing_;
 
     // neighboring particles within interaction distance
     if (gap < 0.0)

--- a/src/particle/src/interaction/4C_particle_interaction_pd_neighbor_pairs.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_pd_neighbor_pairs.hpp
@@ -17,6 +17,7 @@
 #include "4C_particle_engine_enums.hpp"
 #include "4C_particle_engine_typedefs.hpp"
 #include "4C_particle_interaction_pd_neighbor_pair_struct.hpp"
+#include "4C_utils_parameter_list.fwd.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -53,7 +54,7 @@ namespace Particle
   {
    public:
     //! constructor
-    explicit PDNeighborPairs(const MPI_Comm& comm);
+    explicit PDNeighborPairs(const MPI_Comm& comm, const Teuchos::ParameterList& params_pd);
 
     //! setup neighbor pair handler
     void setup(const std::shared_ptr<Particle::ParticleEngineInterface> particleengineinterface,
@@ -126,6 +127,9 @@ namespace Particle
 
     //! communicator
     const MPI_Comm& comm_;
+
+    //! peridynamic grid spacing
+    const double peridynamic_grid_spacing_;
   };
 
 }  // namespace Particle

--- a/src/particle/src/interaction/4C_particle_interaction_sph.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph.cpp
@@ -536,7 +536,7 @@ void Particle::ParticleInteractionSPH::init_neighbor_pair_handler()
   if (params_.get<bool>("PD_BODY_INTERACTION"))
   {
     // create neighbor pair handler
-    neighborpairs_pd_ = std::make_shared<Particle::PDNeighborPairs>(comm_);
+    neighborpairs_pd_ = std::make_shared<Particle::PDNeighborPairs>(comm_, params_.sublist("PD"));
   }
 }
 


### PR DESCRIPTION
## Description and Context
The current assumption when contact between peridynamic bodies occurs was motivated by DEM, meaning the radii of the involved particles were considered. The SPH framework however relies on a contact formulation that does not account for the radii but compares the current distance of the particle centers with the initial grid spacing. To have a consistent formulation, this is adapted in the peridynamic interaction accordingly.