### PR TITLE
Check element maps too to decide if geometry needs an update in `DiscretizationVisualizationWriterMesh`

### DIFF
--- a/src/core/io/src/4C_io_discretization_visualization_writer_mesh.cpp
+++ b/src/core/io/src/4C_io_discretization_visualization_writer_mesh.cpp
@@ -136,6 +136,10 @@ namespace Core::IO
         std::make_shared<Core::LinAlg::Map>(*discretization_->node_row_map());
     nodecolmap_last_geometry_set_ =
         std::make_shared<Core::LinAlg::Map>(*discretization_->node_col_map());
+    elemrowmap_last_geometry_set_ =
+        std::make_shared<Core::LinAlg::Map>(*discretization_->element_row_map());
+    elemcolmap_last_geometry_set_ =
+        std::make_shared<Core::LinAlg::Map>(*discretization_->element_col_map());
   }
 
   /*-----------------------------------------------------------------------------------------------*
@@ -145,7 +149,9 @@ namespace Core::IO
     // check if parallel distribution of discretization changed
     int map_changed =
         ((not noderowmap_last_geometry_set_->same_as(*discretization_->node_row_map())) or
-            (not nodecolmap_last_geometry_set_->same_as(*discretization_->node_col_map())));
+            (not nodecolmap_last_geometry_set_->same_as(*discretization_->node_col_map())) or
+            (not elemrowmap_last_geometry_set_->same_as(*discretization_->element_row_map())) or
+            (not elemcolmap_last_geometry_set_->same_as(*discretization_->element_col_map())));
     int map_changed_allproc(0);
     map_changed_allproc = Core::Communication::max_all(map_changed, discretization_->get_comm());
 

--- a/src/core/io/src/4C_io_discretization_visualization_writer_mesh.hpp
+++ b/src/core/io/src/4C_io_discretization_visualization_writer_mesh.hpp
@@ -236,6 +236,8 @@ namespace Core::IO
     //! Node row and col maps the geometry of visualization writer is based on
     std::shared_ptr<Core::LinAlg::Map> noderowmap_last_geometry_set_;
     std::shared_ptr<Core::LinAlg::Map> nodecolmap_last_geometry_set_;
+    std::shared_ptr<Core::LinAlg::Map> elemrowmap_last_geometry_set_;
+    std::shared_ptr<Core::LinAlg::Map> elemcolmap_last_geometry_set_;
   };
 
   /**


### PR DESCRIPTION
## Description and Context
It turned out, that checking only the node maps when deciding whether the update of the internal data structures inside `DiscretizationVisualizationWriterMesh` is not sufficient. Some output implementations may produce only cell output and it may happen that the corresponding nodes remain intact whereas the elements get updated: in this situation an error is later triggered here:
https://github.com/4C-multiphysics/4C/blob/9e574908659d621cc4249582411a7e7addb7bf85/src/core/io/src/4C_io_visualization_data.cpp#L114-L117

This error was encountered by @mairehenke when working with a Taylor-Couette flow SPH benchmark of @slfuchs, I also then managed to reproduce it on a larger SPH benchmark.
