### PR TITLE
[NOX] Modify specified tolerances handling in `NOX::Nln::Solver::PrePostOp::Generic`

### DIFF
--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_solver_prepostop_generic.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_solver_prepostop_generic.cpp
@@ -19,7 +19,9 @@ FOUR_C_NAMESPACE_OPEN
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-NOX::Nln::Solver::PrePostOp::Generic::Generic()
+NOX::Nln::Solver::PrePostOp::Generic::Generic(
+    NOX::Nln::StatusTest::QuantityType status_test_tolerance_quantity)
+    : status_test_tolerance_quantity_(status_test_tolerance_quantity)
 {
   // empty constructor
 }
@@ -70,10 +72,7 @@ void NOX::Nln::Solver::PrePostOp::Generic::runPreSolve(const ::NOX::Solver::Gene
         // object
         const ::NOX::StatusTest::Generic& statusTest = lsSolver->get_outer_status_test();
         double specified_tol = NOX::Nln::Aux::get_norm_f_class_variable(
-            statusTest, NOX::Nln::StatusTest::quantity_structure, "SpecifiedTolerance");
-        if (specified_tol == -1.0)
-          specified_tol = NOX::Nln::Aux::get_norm_f_class_variable(
-              statusTest, NOX::Nln::StatusTest::quantity_levelset_reinit, "SpecifiedTolerance");
+            statusTest, status_test_tolerance_quantity_, "SpecifiedTolerance");
 
         if (specified_tol == -1.0)
         {

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_solver_prepostop_generic.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_solver_prepostop_generic.hpp
@@ -10,6 +10,8 @@
 
 #include "4C_config.hpp"
 
+#include "4C_solver_nonlin_nox_enum_lists.hpp"
+
 #include <NOX_Observer.hpp>
 
 FOUR_C_NAMESPACE_OPEN
@@ -36,11 +38,16 @@ namespace NOX
         {
          public:
           //! constructor
-          Generic();
+          Generic(NOX::Nln::StatusTest::QuantityType status_test_tolerance_quantity =
+                      NOX::Nln::StatusTest::quantity_structure);
 
           void runPreIterate(const ::NOX::Solver::Generic& solver) override;
 
           void runPreSolve(const ::NOX::Solver::Generic& nlnSolver) override;
+
+         private:
+          //! Quantity which is used to find the status test item for the tolerance reference
+          NOX::Nln::StatusTest::QuantityType status_test_tolerance_quantity_;
         };
       }  // namespace PrePostOp
     }  // namespace Solver


### PR DESCRIPTION
## Description and Context
The current handling of tolerances in `NOX::Nln::Solver::PrePostOp::Generic` looks a bit hacky. To proceed, I want at first to see how many tests crash if I simply remove the level-set related tolerance retrieval.

## Related Issues and Pull Requests
#1807