### PR TITLE
Add copilot instruction for fourcipp compatibility

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,3 +3,4 @@
 * **Documentation:** Docs are added for new code and updated for modified code.
 * **Modern C++:** No new `Teuchos::RCP` instances are introduced.
 * **CMake:** Newly added tests in `tests/list_of_tests.cmake` set `REQUIRED_DEPENDENCIES` when necessary.
+* **fourcipp:** Any changes made in `utilities/four_c_python/src/four_c_metadata` should be tested for compatibility with `fourcipp`. Some changes might need to be ported to `fourcipp`.


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

I turns out its fairly easy to break the fourcipp pipeline when changing things in `utilities/four_c_python/src/four_c_metadata` (See #1725 and #1688)

As discussed with @davidrudlstorfer, this adds a copilot instruction to remind everyone of checking the fourcipp pipeline when making any changes to these files.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
fourcipp PR: [https://github.com/4C-multiphysics/fourcipp/pull/118](https://github.com/4C-multiphysics/fourcipp/pull/118)
