### PR TITLE
Add mumps as direct solver

### DIFF
--- a/src/adapter/4C_adapter_str_structure.cpp
+++ b/src/adapter/4C_adapter_str_structure.cpp
@@ -415,19 +415,20 @@ Adapter::StructureBaseAlgorithm::create_contact_meshtying_solver(
           Global::Problem::instance()->solver_params(linsolvernumber), "SOLVER");
       const auto prec = Teuchos::getIntegralValue<Core::LinearSolver::PreconditionerType>(
           Global::Problem::instance()->solver_params(linsolvernumber), "AZPREC");
-      if (sol != Core::LinearSolver::SolverType::UMFPACK &&
-          sol != Core::LinearSolver::SolverType::Superlu)
+      if (Core::LinearSolver::is_iterative_linear_solver(sol))
       {
         // if an iterative solver is chosen we need a block preconditioner
         if (prec != Core::LinearSolver::PreconditionerType::multigrid_muelu &&
             prec != Core::LinearSolver::PreconditionerType::block_teko &&
             prec != Core::LinearSolver::PreconditionerType::ilu)
+        {
           FOUR_C_THROW(
               "You have chosen an iterative linear solver. For mortar meshtying/contact problems "
               "in saddle-point formulation, a block preconditioner is required. Choose an "
               "appropriate block preconditioner such as CheapSIMPLE or MueLu "
               "(if MueLu is available) in the SOLVER {} block in your input file.",
               linsolvernumber);
+        }
       }
 
       // build meshtying/contact solver

--- a/src/core/fem/src/general/utils/4C_fem_general_l2_projection.cpp
+++ b/src/core/fem/src/general/utils/4C_fem_general_l2_projection.cpp
@@ -218,8 +218,7 @@ std::shared_ptr<Core::LinAlg::MultiVector<double>> Core::FE::solve_nodal_l2_proj
       solverparams, comm, get_solver_params, Core::IO::Verbositylevel::standard);
 
   // skip setup of preconditioner in case of a direct solver
-  if (solvertype != Core::LinearSolver::SolverType::UMFPACK and
-      solvertype != Core::LinearSolver::SolverType::Superlu)
+  if (Core::LinearSolver::is_iterative_linear_solver(solvertype))
   {
     const auto prectype =
         Teuchos::getIntegralValue<Core::LinearSolver::PreconditionerType>(solverparams, "AZPREC");

--- a/src/core/linear_solver/src/method/4C_linear_solver_method.hpp
+++ b/src/core/linear_solver/src/method/4C_linear_solver_method.hpp
@@ -45,6 +45,7 @@ namespace Core::LinearSolver
   enum class SolverType
   {
     KLU2,     ///< Amesos direct solver using KLU2
+    MUMPS,    ///< Amesos direct solver using MUMPS
     UMFPACK,  ///< Amesos direct solver using UMFPACK
     Superlu,  ///< Amesos direct solver using SuperLU_Dist
     Belos,    ///< Belos iterative solver
@@ -66,6 +67,38 @@ namespace Core::LinearSolver
     multigrid_nxn,  ///< multigrid preconditioner for a nxn block matrix (indirectly MueLu package)
     block_teko      ///< block preconditioning (Teko package, recommended!)
   };
+
+  /*!
+   * @brief return whether the chosen solver for the linear system is a direct solver or not
+   *
+   * @param solver_type[in] solver type of the linear system
+   * @return true, if it is a direct solver, false else
+   */
+  [[nodiscard]] inline bool is_direct_linear_solver(const SolverType& solver_type)
+  {
+    switch (solver_type)
+    {
+      case SolverType::KLU2:
+      case SolverType::MUMPS:
+      case SolverType::UMFPACK:
+      case SolverType::Superlu:
+        return true;
+      case SolverType::Belos:
+        return false;
+    }
+    FOUR_C_THROW("Unknown type of solver!");
+  }
+
+  /*!
+   * @brief return whether the chosen solver for the linear system is an iterative solver or not
+   *
+   * @param solver_type[in] solver type of the linear system
+   * @return true, if it is an iterative solver, false else
+   */
+  [[nodiscard]] inline bool is_iterative_linear_solver(const SolverType& solver_type)
+  {
+    return !is_direct_linear_solver(solver_type);
+  }
 
   /// linear solver type base class
   class SolverTypeBase

--- a/src/core/linear_solver/src/method/4C_linear_solver_method_direct.cpp
+++ b/src/core/linear_solver/src/method/4C_linear_solver_method_direct.cpp
@@ -79,6 +79,13 @@ void Core::LinearSolver::DirectSolver::setup(std::shared_ptr<Core::LinAlg::Spars
         klu_params.set("IsContiguous", false, "Are GIDs Contiguous");
         break;
       }
+      case SolverType::MUMPS:
+      {
+        solver_type = "MUMPS";
+        auto& mumps_params = params.sublist(solver_type);
+        mumps_params.set("IsContiguous", false, "Are GIDs Contiguous");
+        break;
+      }
       case SolverType::UMFPACK:
       {
         solver_type = "Umfpack";

--- a/src/core/linear_solver/src/method/4C_linear_solver_method_linalg.cpp
+++ b/src/core/linear_solver/src/method/4C_linear_solver_method_linalg.cpp
@@ -184,9 +184,10 @@ void Core::LinAlg::Solver::setup(std::shared_ptr<Core::LinAlg::SparseOperator> m
         solver_ = std::make_shared<Core::LinearSolver::IterativeSolver>(comm_, Solver::params());
         break;
       }
+      case Core::LinearSolver::SolverType::KLU2:
+      case Core::LinearSolver::SolverType::MUMPS:
       case Core::LinearSolver::SolverType::UMFPACK:
       case Core::LinearSolver::SolverType::Superlu:
-      case Core::LinearSolver::SolverType::KLU2:
       {
         solver_ = std::make_shared<Core::LinearSolver::DirectSolver>(solvertype);
         break;
@@ -411,6 +412,10 @@ Teuchos::ParameterList Core::LinAlg::Solver::translate_solver_parameters(
   {
     case Core::LinearSolver::SolverType::KLU2:
       outparams.set<Core::LinearSolver::SolverType>("solver", Core::LinearSolver::SolverType::KLU2);
+      break;
+    case Core::LinearSolver::SolverType::MUMPS:
+      outparams.set<Core::LinearSolver::SolverType>(
+          "solver", Core::LinearSolver::SolverType::MUMPS);
       break;
     case Core::LinearSolver::SolverType::UMFPACK:
       outparams.set<Core::LinearSolver::SolverType>(

--- a/src/fpsi/4C_fpsi_monolithic.cpp
+++ b/src/fpsi/4C_fpsi_monolithic.cpp
@@ -521,14 +521,15 @@ void FPSI::Monolithic::setup_solver()
   const auto solvertype =
       Teuchos::getIntegralValue<Core::LinearSolver::SolverType>(solverparams, "SOLVER");
 
-  directsolve_ = (solvertype == Core::LinearSolver::SolverType::UMFPACK or
-                  solvertype == Core::LinearSolver::SolverType::Superlu);
+  directsolve_ = Core::LinearSolver::is_direct_linear_solver(solvertype);
 
   if (directsolve_)
+  {
     solver_ = std::make_shared<Core::LinAlg::Solver>(solverparams, get_comm(),
         Global::Problem::instance()->solver_params_callback(),
         Teuchos::getIntegralValue<Core::IO::Verbositylevel>(
             Global::Problem::instance()->io_params(), "VERBOSITY"));
+  }
   else
     // create a linear solver
     create_linear_solver();

--- a/src/fsi_xfem/4C_fsi_xfem_monolithic.cpp
+++ b/src/fsi_xfem/4C_fsi_xfem_monolithic.cpp
@@ -2013,8 +2013,7 @@ void FSI::MonolithicXFEM::create_linear_solver()
   //----------------------------------------------
   // create direct solver for merged block matrix
   //----------------------------------------------
-  if (solvertype == Core::LinearSolver::SolverType::UMFPACK ||
-      solvertype == Core::LinearSolver::SolverType::Superlu)
+  if (Core::LinearSolver::is_direct_linear_solver(solvertype))
   {
     if (Core::Communication::my_mpi_rank(get_comm()) == 0)
       std::cout << "Merged XFSI block matrix is used!\n" << std::endl;

--- a/src/poroelast/4C_poroelast_monolithic.cpp
+++ b/src/poroelast/4C_poroelast_monolithic.cpp
@@ -1608,8 +1608,7 @@ bool PoroElast::Monolithic::setup_solver()
   const auto solvertype =
       Teuchos::getIntegralValue<Core::LinearSolver::SolverType>(solverparams, "SOLVER");
 
-  directsolve_ = (solvertype == Core::LinearSolver::SolverType::UMFPACK or
-                  solvertype == Core::LinearSolver::SolverType::Superlu);
+  directsolve_ = Core::LinearSolver::is_direct_linear_solver(solvertype);
 
   if (directsolve_)
   {

--- a/src/poroelast_scatra/4C_poroelast_scatra_monolithic.cpp
+++ b/src/poroelast_scatra/4C_poroelast_scatra_monolithic.cpp
@@ -576,7 +576,7 @@ bool PoroElastScaTra::PoroScatraMono::setup_solver()
   const auto solvertype =
       Teuchos::getIntegralValue<Core::LinearSolver::SolverType>(solverparams, "SOLVER");
 
-  directsolve_ = (solvertype == Core::LinearSolver::SolverType::UMFPACK);
+  directsolve_ = Core::LinearSolver::is_direct_linear_solver(solvertype);
 
   if (directsolve_)
   {

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_meshtying_strategy_artery.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_meshtying_strategy_artery.cpp
@@ -159,9 +159,7 @@ void PoroPressureBased::MeshtyingArtery::initialize_linear_solver(
   const auto solver_type =
       Teuchos::getIntegralValue<Core::LinearSolver::SolverType>(solver_params, "SOLVER");
   // no need to do the rest for direct solvers
-  if (solver_type == Core::LinearSolver::SolverType::UMFPACK or
-      solver_type == Core::LinearSolver::SolverType::Superlu)
-    return;
+  if (Core::LinearSolver::is_direct_linear_solver(solver_type)) return;
 
   if (solver_type != Core::LinearSolver::SolverType::Belos)
     FOUR_C_THROW("Iterative solver expected");

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_monolithic.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_monolithic.cpp
@@ -641,9 +641,7 @@ void PoroPressureBased::PorofluidElastMonolithicAlgorithm::create_linear_solver(
       Teuchos::getIntegralValue<Core::IO::Verbositylevel>(
           Global::Problem::instance()->io_params(), "VERBOSITY"));
   // no need to do the rest for direct solvers
-  if (solvertype == Core::LinearSolver::SolverType::UMFPACK or
-      solvertype == Core::LinearSolver::SolverType::Superlu)
-    return;
+  if (Core::LinearSolver::is_direct_linear_solver(solvertype)) return;
 
   if (solvertype != Core::LinearSolver::SolverType::Belos)
   {

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_monolithic.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_monolithic.cpp
@@ -291,9 +291,7 @@ void PoroPressureBased::PorofluidElastScatraMonolithicAlgorithm::create_linear_s
       Teuchos::getIntegralValue<Core::IO::Verbositylevel>(
           Global::Problem::instance()->io_params(), "VERBOSITY"));
   // no need to do the rest for direct solvers
-  if (solvertype == Core::LinearSolver::SolverType::UMFPACK or
-      solvertype == Core::LinearSolver::SolverType::Superlu)
-    return;
+  if (Core::LinearSolver::is_direct_linear_solver(solvertype)) return;
 
   if (solvertype != Core::LinearSolver::SolverType::Belos)
   {

--- a/src/scatra/4C_scatra_timint_meshtying_strategy_artery.cpp
+++ b/src/scatra/4C_scatra_timint_meshtying_strategy_artery.cpp
@@ -160,9 +160,7 @@ void ScaTra::MeshtyingStrategyArtery::initialize_linear_solver(
   const auto solvertype =
       Teuchos::getIntegralValue<Core::LinearSolver::SolverType>(solverparams, "SOLVER");
   // no need to do the rest for direct solvers
-  if (solvertype == Core::LinearSolver::SolverType::UMFPACK or
-      solvertype == Core::LinearSolver::SolverType::Superlu)
-    return;
+  if (Core::LinearSolver::is_direct_linear_solver(solvertype)) return;
 
   if (solvertype != Core::LinearSolver::SolverType::Belos)
     FOUR_C_THROW("Iterative solver expected");

--- a/src/structure_new/src/linear_solver/4C_structure_new_solver_factory.cpp
+++ b/src/structure_new/src/linear_solver/4C_structure_new_solver_factory.cpp
@@ -326,14 +326,11 @@ std::shared_ptr<Core::LinAlg::Solver> Solid::SOLVER::Factory::build_meshtying_co
             " set LINEAR_SOLVER in CONTACT DYNAMIC to a valid number!");
 
       // plausibility check
-
-      // solver can be either UMFPACK (direct solver) or an iterative solver
       const auto sol = Teuchos::getIntegralValue<Core::LinearSolver::SolverType>(
           Global::Problem::instance()->solver_params(lin_solver_id), "SOLVER");
       const auto prec = Teuchos::getIntegralValue<Core::LinearSolver::PreconditionerType>(
           Global::Problem::instance()->solver_params(lin_solver_id), "AZPREC");
-      if (sol != Core::LinearSolver::SolverType::UMFPACK &&
-          sol != Core::LinearSolver::SolverType::Superlu)
+      if (Core::LinearSolver::is_iterative_linear_solver(sol))
       {
         // if an iterative solver is chosen we need a block preconditioner
         if (prec != Core::LinearSolver::PreconditionerType::multigrid_muelu &&

--- a/tests/input_files/ssi_mono_3D_6hex8_elch_s2i_butlervolmer.4C.yaml
+++ b/tests/input_files/ssi_mono_3D_6hex8_elch_s2i_butlervolmer.4C.yaml
@@ -49,7 +49,7 @@ SSI CONTROL/MONOLITHIC:
 SSI CONTROL/ELCH:
   INITPOTCALC: true
 SOLVER 1:
-  SOLVER: "UMFPACK"
+  SOLVER: MUMPS
 MATERIALS:
   - MAT: 1
     MAT_MultiplicativeSplitDefgradElastHyper:
@@ -178,25 +178,25 @@ RESULT DESCRIPTION:
       DIS: "scatra"
       NODE: 5
       QUANTITY: "phi1"
-      VALUE: 11.166198679011396
+      VALUE: 1.11661986790114600e+01
       TOLERANCE: 1.1e-07
   - SCATRA:
       DIS: "scatra"
       NODE: 5
       QUANTITY: "phi2"
-      VALUE: -9.487463033456896e-08
+      VALUE: -9.48746303346055845e-08
       TOLERANCE: 9.5e-16
   - SCATRA:
       DIS: "scatra"
       NODE: 9
       QUANTITY: "phi1"
-      VALUE: 10.708936667019938
+      VALUE: 1.07089366670198345e+01
       TOLERANCE: 1.1e-07
   - SCATRA:
       DIS: "scatra"
       NODE: 9
       QUANTITY: "phi2"
-      VALUE: -1.8974970840037044e-07
+      VALUE: -1.89749708400442940e-07
       TOLERANCE: 1.9e-15
   - SCATRA:
       DIS: "scatra"
@@ -208,7 +208,7 @@ RESULT DESCRIPTION:
       DIS: "scatra"
       NODE: 13
       QUANTITY: "phi2"
-      VALUE: -0.09071627653648522
+      VALUE: -9.07162765364882967e-02
       TOLERANCE: 9.1e-10
   - SCATRA:
       DIS: "scatra"
@@ -220,67 +220,67 @@ RESULT DESCRIPTION:
       DIS: "scatra"
       NODE: 17
       QUANTITY: "phi2"
-      VALUE: -0.09071794695177553
+      VALUE: -9.07179469517785941e-02
       TOLERANCE: 9.1e-10
   - SCATRA:
       DIS: "scatra"
       SPECIAL: true
       QUANTITY: "soc1"
-      VALUE: 0.9943509299628314
+      VALUE: 9.94350929962831032e-01
       TOLERANCE: 9.9e-09
   - SCATRA:
       DIS: "scatra"
       SPECIAL: true
       QUANTITY: "soc2"
-      VALUE: 0.9957677901459299
-      TOLERANCE: 1e-08
+      VALUE: 9.95767790145929310e-01
+      TOLERANCE: 1.0e-08
   - SCATRA:
       DIS: "scatra"
       SPECIAL: true
       QUANTITY: "c-rate1"
-      VALUE: 3.0854469626390713
+      VALUE: 3.08544696240271010e+00
       TOLERANCE: 3.1e-06
   - SCATRA:
       DIS: "scatra"
       SPECIAL: true
       QUANTITY: "c-rate2"
-      VALUE: -158.542390103342
+      VALUE: -1.58542390103118265e+02
       TOLERANCE: 0.00016
   - SCATRA:
       DIS: "scatra"
       SPECIAL: true
       QUANTITY: "cellvoltage"
-      VALUE: 3.8533254862210016
+      VALUE: 3.85332548622099402e+00
       TOLERANCE: 3.9e-08
   - STRUCTURE:
       DIS: "structure"
       NODE: 5
       QUANTITY: "dispx"
-      VALUE: -1.6693826928374345e-05
+      VALUE: -1.66938269283751513e-05
       TOLERANCE: 1.7e-13
   - STRUCTURE:
       DIS: "structure"
       NODE: 9
       QUANTITY: "dispx"
-      VALUE: -3.338301344989527e-05
+      VALUE: -3.33830134498949813e-05
       TOLERANCE: 3.3e-13
   - STRUCTURE:
       DIS: "structure"
       NODE: 13
       QUANTITY: "dispx"
-      VALUE: -3.338301344989527e-05
+      VALUE: -3.33830134498949813e-05
       TOLERANCE: 3.3e-13
   - STRUCTURE:
       DIS: "structure"
       NODE: 17
       QUANTITY: "dispx"
-      VALUE: -5.006281648656702e-05
-      TOLERANCE: 5e-13
+      VALUE: -5.00628164865677512e-05
+      TOLERANCE: 5.0e-13
   - SSI:
       SPECIAL: true
       QUANTITY: "numiterlastnonlinearsolve"
       VALUE: 3
-      TOLERANCE: 1e-16
+      TOLERANCE: 1.0e-16
 DESIGN SURF TRANSPORT NEUMANN CONDITIONS:
   - E: 6
     NUMDOF: 2


### PR DESCRIPTION
## Description and Context
This is a draft showing how MUMPS can be added as a direct solver through Amesos2. The pipeline will fail, as MUMPS will only be available after #1813 is merged.
In addition, I added convenience functions to check whether the solver is an iterative or a direct linear solver.
One test case is already adapted to run with MUMPS, which should fail, as it is not yet available. ;-)

## Related Issues and Pull Requests
Dependent on #1813 
