### PR TITLE
Clean up remodelfibers

### DIFF
--- a/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
+++ b/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
@@ -4221,9 +4221,6 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
             parameter<bool>("INELASTIC_GROWTH",
                 {.description = "Mixture rule has inelastic growth (default false)",
                     .default_value = false}),
-            parameter<double>("GAMMA",
-                {.description = "Angle of fiber alignment in degree (default = 0.0 degrees)",
-                    .default_value = 0.0}),
         },
         {.description = "A 1D constituent that remodels"});
   }

--- a/src/mixture/src/4C_mixture_constituent_full_constrained_mixture_fiber.cpp
+++ b/src/mixture/src/4C_mixture_constituent_full_constrained_mixture_fiber.cpp
@@ -29,7 +29,7 @@ FOUR_C_NAMESPACE_OPEN
 // anonymous namespace for helper classes and functions
 namespace
 {
-  [[nodiscard]] static inline Core::LinAlg::SymmetricTensor<double, 3, 3> evaluate_c(
+  [[nodiscard]] static inline Core::LinAlg::SymmetricTensor<double, 3, 3> evaluate_cauchy_green(
       const Core::LinAlg::Tensor<double, 3, 3>& F)
   {
     return Core::LinAlg::assume_symmetry(Core::LinAlg::transpose(F) * F);
@@ -189,7 +189,7 @@ void Mixture::MixtureConstituentFullConstrainedMixtureFiber::update(
   const double time = *context.total_time;
   full_constrained_mixture_fiber_[gp].set_deposition_stretch(
       evaluate_initial_deposition_stretch(time));
-  last_lambda_f_[gp] = evaluate_lambdaf(evaluate_c(F), gp, eleGID);
+  last_lambda_f_[gp] = evaluate_lambdaf(evaluate_cauchy_green(F), gp, eleGID);
 
   // Update state
   full_constrained_mixture_fiber_[gp].update();
@@ -254,7 +254,7 @@ Mixture::MixtureConstituentFullConstrainedMixtureFiber::evaluate_d_lambdafsq_dc(
 }
 
 Core::LinAlg::SymmetricTensor<double, 3, 3>
-Mixture::MixtureConstituentFullConstrainedMixtureFiber::evaluate_current_p_k2(
+Mixture::MixtureConstituentFullConstrainedMixtureFiber::evaluate_current_pk2(
     int gp, int eleGID) const
 {
   const double fiber_pk2 = full_constrained_mixture_fiber_[gp].evaluate_current_second_pk_stress();
@@ -296,12 +296,12 @@ void Mixture::MixtureConstituentFullConstrainedMixtureFiber::evaluate(
     structural_tensors_.emplace_back(Core::LinAlg::self_dyadic(orientation));
   }
 
-  Core::LinAlg::SymmetricTensor<double, 3, 3> C = evaluate_c(F);
+  Core::LinAlg::SymmetricTensor<double, 3, 3> C = evaluate_cauchy_green(F);
 
   const double lambda_f = evaluate_lambdaf(C, gp, eleGID);
   full_constrained_mixture_fiber_[gp].recompute_state(lambda_f, time, delta_time);
 
-  S_stress = evaluate_current_p_k2(gp, eleGID);
+  S_stress = evaluate_current_pk2(gp, eleGID);
   cmat = evaluate_current_cmat(gp, eleGID);
 }
 

--- a/src/mixture/src/4C_mixture_constituent_full_constrained_mixture_fiber.hpp
+++ b/src/mixture/src/4C_mixture_constituent_full_constrained_mixture_fiber.hpp
@@ -110,7 +110,7 @@ namespace Mixture
     [[nodiscard]] Core::LinAlg::SymmetricTensor<double, 3, 3> evaluate_d_lambdafsq_dc(
         int gp, int eleGID) const;
 
-    [[nodiscard]] Core::LinAlg::SymmetricTensor<double, 3, 3> evaluate_current_p_k2(
+    [[nodiscard]] Core::LinAlg::SymmetricTensor<double, 3, 3> evaluate_current_pk2(
         int gp, int eleGID) const;
     [[nodiscard]] Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3> evaluate_current_cmat(
         int gp, int eleGID) const;

--- a/src/mixture/src/4C_mixture_constituent_remodelfiber_expl.cpp
+++ b/src/mixture/src/4C_mixture_constituent_remodelfiber_expl.cpp
@@ -31,13 +31,13 @@ FOUR_C_NAMESPACE_OPEN
 // anonymous namespace for helper classes and functions
 namespace
 {
-  [[nodiscard]] Core::LinAlg::SymmetricTensor<double, 3, 3> evaluate_c(
+  [[nodiscard]] Core::LinAlg::SymmetricTensor<double, 3, 3> evaluate_cauchy_green(
       const Core::LinAlg::Tensor<double, 3, 3>& F)
   {
     return Core::LinAlg::assume_symmetry(Core::LinAlg::transpose(F) * F);
   }
 
-  [[nodiscard]] Core::LinAlg::SymmetricTensor<double, 3, 3> evaluatei_cext(
+  [[nodiscard]] Core::LinAlg::SymmetricTensor<double, 3, 3> evaluate_inelastic_inv_cauchy_green(
       const Core::LinAlg::Tensor<double, 3, 3>& iFext)
   {
     return Core::LinAlg::assume_symmetry(iFext * Core::LinAlg::transpose(iFext));
@@ -145,16 +145,13 @@ void Mixture::MixtureConstituentRemodelFiberExpl::update_elastic_part(
         "inelastic growth. You have to set INELASTIC_GROWTH to true or use a different growth "
         "rule.");
   }
-  const double lambda_f = evaluate_lambdaf(evaluate_c(F), gp, eleGID);
+  const double lambda_f = evaluate_lambdaf(evaluate_cauchy_green(F), gp, eleGID);
   const double lambda_ext = evaluate_lambda_ext(iFext, gp, eleGID);
   remodel_fiber_[gp].set_state(lambda_f, lambda_ext);
   remodel_fiber_[gp].update();
 
   if (params_->enable_growth_)
   {
-    FOUR_C_ASSERT(context.time_step_size, "Time step size not given in evaluation context.");
-    const double dt = *context.time_step_size;
-
     remodel_fiber_[gp].integrate_local_evolution_equations_explicit(dt);
   }
 }
@@ -165,18 +162,16 @@ void Mixture::MixtureConstituentRemodelFiberExpl::update(
 {
   MixtureConstituent::update(F, params, context, gp, eleGID);
 
-  FOUR_C_ASSERT(context.time_step_size, "Time not given in evaluation context.");
+  FOUR_C_ASSERT(context.total_time, "Time not given in evaluation context.");
   update_homeostatic_values(params, *context.total_time, eleGID);
 
   if (!params_->inelastic_external_deformation_)
   {
     // Update state
-    const double lambda_f = evaluate_lambdaf(evaluate_c(F), gp, eleGID);
+    const double lambda_f = evaluate_lambdaf(evaluate_cauchy_green(F), gp, eleGID);
     remodel_fiber_[gp].set_state(lambda_f, 1.0);
     remodel_fiber_[gp].update();
 
-    FOUR_C_ASSERT(context.total_time, "Time not given in evaluation context.");
-    update_homeostatic_values(params, *context.total_time, eleGID);
     if (params_->enable_growth_)
     {
       FOUR_C_ASSERT(context.time_step_size, "Time step size not given in evaluation context.");
@@ -236,7 +231,7 @@ bool Mixture::MixtureConstituentRemodelFiberExpl::evaluate_output_data(
 }
 
 Core::LinAlg::SymmetricTensor<double, 3, 3>
-Mixture::MixtureConstituentRemodelFiberExpl::evaluate_current_p_k2(int gp, int eleGID) const
+Mixture::MixtureConstituentRemodelFiberExpl::evaluate_current_pk2(int gp, int eleGID) const
 {
   const double fiber_pk2 = remodel_fiber_[gp].evaluate_current_fiber_pk2_stress();
 
@@ -281,12 +276,12 @@ void Mixture::MixtureConstituentRemodelFiberExpl::evaluate(
     structural_tensors_.emplace_back(Core::LinAlg::self_dyadic(orientation));
   }
 
-  Core::LinAlg::SymmetricTensor<double, 3, 3> C = evaluate_c(F);
+  Core::LinAlg::SymmetricTensor<double, 3, 3> C = evaluate_cauchy_green(F);
 
   const double lambda_f = evaluate_lambdaf(C, gp, eleGID);
   remodel_fiber_[gp].set_state(lambda_f, 1.0);
 
-  S_stress = evaluate_current_p_k2(gp, eleGID);
+  S_stress = evaluate_current_pk2(gp, eleGID);
   cmat = evaluate_current_cmat(gp, eleGID);
 }
 
@@ -316,13 +311,13 @@ void Mixture::MixtureConstituentRemodelFiberExpl::evaluate_elastic_part(
     structural_tensors_.emplace_back(Core::LinAlg::self_dyadic(orientation));
   }
 
-  Core::LinAlg::SymmetricTensor<double, 3, 3> C = evaluate_c(FM);
+  Core::LinAlg::SymmetricTensor<double, 3, 3> C = evaluate_cauchy_green(FM);
 
   const double lambda_f = evaluate_lambdaf(C, gp, eleGID);
   const double lambda_ext = evaluate_lambda_ext(iFextin, gp, eleGID);
   remodel_fiber_[gp].set_state(lambda_f, lambda_ext);
 
-  S_stress = evaluate_current_p_k2(gp, eleGID);
+  S_stress = evaluate_current_pk2(gp, eleGID);
   cmat = evaluate_current_cmat(gp, eleGID);
 }
 
@@ -363,6 +358,7 @@ double Mixture::MixtureConstituentRemodelFiberExpl::evaluate_lambdaf(
 double Mixture::MixtureConstituentRemodelFiberExpl::evaluate_lambda_ext(
     const Core::LinAlg::Tensor<double, 3, 3>& iFext, const int gp, const int eleGID) const
 {
-  return 1.0 / std::sqrt(Core::LinAlg::ddot(evaluatei_cext(iFext), structural_tensors_[gp]));
+  return 1.0 / std::sqrt(Core::LinAlg::ddot(
+                   evaluate_inelastic_inv_cauchy_green(iFext), structural_tensors_[gp]));
 }
 FOUR_C_NAMESPACE_CLOSE

--- a/src/mixture/src/4C_mixture_constituent_remodelfiber_expl.hpp
+++ b/src/mixture/src/4C_mixture_constituent_remodelfiber_expl.hpp
@@ -110,7 +110,7 @@ namespace Mixture
     [[nodiscard]] double evaluate_lambda_ext(
         const Core::LinAlg::Tensor<double, 3, 3>& iFext, int gp, int eleGID) const;
 
-    [[nodiscard]] Core::LinAlg::SymmetricTensor<double, 3, 3> evaluate_current_p_k2(
+    [[nodiscard]] Core::LinAlg::SymmetricTensor<double, 3, 3> evaluate_current_pk2(
         int gp, int eleGID) const;
     [[nodiscard]] Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3> evaluate_current_cmat(
         int gp, int eleGID) const;

--- a/src/mixture/src/4C_mixture_constituent_remodelfiber_impl.cpp
+++ b/src/mixture/src/4C_mixture_constituent_remodelfiber_impl.cpp
@@ -9,7 +9,6 @@
 
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
-#include "4C_linalg_fixedsizematrix_voigt_notation.hpp"
 #include "4C_linalg_serialdensematrix.hpp"
 #include "4C_mat_elast_aniso_structuraltensor_strategy.hpp"
 #include "4C_mat_par_bundle.hpp"
@@ -30,7 +29,7 @@ FOUR_C_NAMESPACE_OPEN
 // anonymous namespace for helper classes and functions
 namespace
 {
-  [[nodiscard]] Core::LinAlg::SymmetricTensor<double, 3, 3> evaluate_c(
+  [[nodiscard]] Core::LinAlg::SymmetricTensor<double, 3, 3> evaluate_cauchy_green(
       const Core::LinAlg::Tensor<double, 3, 3>& F)
   {
     return Core::LinAlg::assume_symmetry(Core::LinAlg::transpose(F) * F);
@@ -190,7 +189,7 @@ Mixture::MixtureConstituentRemodelFiberImpl::evaluate_d_lambdafsq_dc(int gp, int
 }
 
 Core::LinAlg::SymmetricTensor<double, 3, 3>
-Mixture::MixtureConstituentRemodelFiberImpl::evaluate_current_p_k2(int gp, int eleGID) const
+Mixture::MixtureConstituentRemodelFiberImpl::evaluate_current_pk2(int gp, int eleGID) const
 {
   const double fiber_pk2 = remodel_fiber_[gp].evaluate_current_fiber_pk2_stress();
 
@@ -231,8 +230,7 @@ void Mixture::MixtureConstituentRemodelFiberImpl::integrate_local_evolution_equa
       "enabled!");
 
   // Integrate local evolution equations
-  Core::LinAlg::Matrix<2, 2> K =
-      remodel_fiber_[gp].integrate_local_evolution_equations_implicit(dt);
+  remodel_fiber_[gp].integrate_local_evolution_equations_implicit(dt);
 }
 
 void Mixture::MixtureConstituentRemodelFiberImpl::evaluate(
@@ -256,14 +254,14 @@ void Mixture::MixtureConstituentRemodelFiberImpl::evaluate(
     structural_tensors_.emplace_back(Core::LinAlg::self_dyadic(orientation));
   }
 
-  Core::LinAlg::SymmetricTensor<double, 3, 3> C = evaluate_c(F);
+  Core::LinAlg::SymmetricTensor<double, 3, 3> C = evaluate_cauchy_green(F);
 
   const double lambda_f = evaluate_lambdaf(C, gp, eleGID);
   remodel_fiber_[gp].set_state(lambda_f, 1.0);
 
   if (params_->enable_growth_) integrate_local_evolution_equations(dt, gp, eleGID);
 
-  S_stress = evaluate_current_p_k2(gp, eleGID);
+  S_stress = evaluate_current_pk2(gp, eleGID);
   cmat = evaluate_current_cmat(gp, eleGID);
 }
 

--- a/src/mixture/src/4C_mixture_constituent_remodelfiber_impl.hpp
+++ b/src/mixture/src/4C_mixture_constituent_remodelfiber_impl.hpp
@@ -107,7 +107,7 @@ namespace Mixture
     [[nodiscard]] Core::LinAlg::SymmetricTensor<double, 3, 3> evaluate_d_lambdafsq_dc(
         int gp, int eleGID) const;
 
-    [[nodiscard]] Core::LinAlg::SymmetricTensor<double, 3, 3> evaluate_current_p_k2(
+    [[nodiscard]] Core::LinAlg::SymmetricTensor<double, 3, 3> evaluate_current_pk2(
         int gp, int eleGID) const;
     [[nodiscard]] Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3> evaluate_current_cmat(
         int gp, int eleGID) const;

--- a/src/mixture/src/4C_mixture_remodelfiber-internal.hpp
+++ b/src/mixture/src/4C_mixture_remodelfiber-internal.hpp
@@ -174,11 +174,8 @@ namespace Mixture
        * @brief Integrate the local evolution equation with an implicit time integration scheme.
        *
        * @param dt (in) : timestep
-       *
-       * @return Derivative of the residuum of the time integration scheme w.r.t. growth scalar
-       * and lambda_r
        */
-      Core::LinAlg::Matrix<2, 2, T> integrate_local_evolution_equations_implicit(T dt);
+      void integrate_local_evolution_equations_implicit(T dt);
 
       /*!
        * @brief Integrate the local evolution equation with an explicit time integration scheme.

--- a/src/mixture/src/4C_mixture_remodelfiber.cpp
+++ b/src/mixture/src/4C_mixture_remodelfiber.cpp
@@ -219,7 +219,7 @@ Mixture::Implementation::RemodelFiberImplementation<numstates, T>::get_integrati
 }
 
 template <int numstates, typename T>
-Core::LinAlg::Matrix<2, 2, T> Mixture::Implementation::RemodelFiberImplementation<numstates,
+void Mixture::Implementation::RemodelFiberImplementation<numstates,
     T>::integrate_local_evolution_equations_implicit(const T dt)
 {
   FOUR_C_ASSERT(state_is_set_, "You have to call set_state() before!");
@@ -319,8 +319,6 @@ Core::LinAlg::Matrix<2, 2, T> Mixture::Implementation::RemodelFiberImplementatio
   // store current derivative of lambda_r and growth_scalar w.r.t. lambda_f
   d_growth_scalar_d_lambda_f_sq_ = -d_growth_scalar_d_residuum.dot(d_residuum_d_lambda_f_sq);
   d_lambda_r_d_lambda_f_sq_ = -d_lambda_r_d_residuum.dot(d_residuum_d_lambda_f_sq);
-
-  return K;
 }
 
 
@@ -783,11 +781,10 @@ void Mixture::RemodelFiber<numstates>::set_lambda_r(const double lambda_r)
 }
 
 template <int numstates>
-Core::LinAlg::Matrix<2, 2>
-Mixture::RemodelFiber<numstates>::integrate_local_evolution_equations_implicit(const double dt)
+void Mixture::RemodelFiber<numstates>::integrate_local_evolution_equations_implicit(const double dt)
 {
-  return impl_->integrate_local_evolution_equations_implicit(dt);
-};
+  impl_->integrate_local_evolution_equations_implicit(dt);
+}
 
 template <int numstates>
 void Mixture::RemodelFiber<numstates>::integrate_local_evolution_equations_explicit(const double dt)

--- a/src/mixture/src/4C_mixture_remodelfiber.hpp
+++ b/src/mixture/src/4C_mixture_remodelfiber.hpp
@@ -10,7 +10,6 @@
 
 #include "4C_config.hpp"
 
-#include "4C_linalg_fixedsizematrix.hpp"
 #include "4C_mixture_growth_evolution_linear_cauchy_poisson_turnover.hpp"
 
 #include <memory>
@@ -102,11 +101,8 @@ namespace Mixture
      * @brief Integrate the local evolution equation with an implicit time integration scheme.
      *
      * @param dt (in) : timestep
-     *
-     * @return Derivative of the residuum of the time integration scheme w.r.t. growth scalar and
-     * lambda_r
      */
-    Core::LinAlg::Matrix<2, 2> integrate_local_evolution_equations_implicit(double dt);
+    void integrate_local_evolution_equations_implicit(double dt);
 
     /*!
      * @brief Integrate the local evolution equation with an explicit time integration scheme.


### PR DESCRIPTION

Title: Clean up of the remodel fibers

## Description and Context
Adapted the naming of several helper functions to match the code style discussed in PR #1805.
Removed redundant function calls in `ExplicitRemodelFiber`
Change the signature of `integrate_local_evolution_equations_implicit` to `void`, since the output wasn't used. 


