### PR TITLE
Use enum classes and parameter input in TSI

### DIFF
--- a/src/inpar/4C_inpar_plasticity.cpp
+++ b/src/inpar/4C_inpar_plasticity.cpp
@@ -82,7 +82,7 @@ Core::IO::InputSpec Inpar::Plasticity::valid_parameters()
 
           parameter<TSI::DissipationMode>(
               "DISSIPATION_MODE", {.description = "method to calculate the plastic dissipation",
-                                      .default_value = TSI::pl_multiplier})},
+                                      .default_value = TSI::DissipationMode::pl_multiplier})},
       {.required = false});
   return spec;
 }

--- a/src/mat/4C_mat_plastic_VarConstUpdate.hpp
+++ b/src/mat/4C_mat_plastic_VarConstUpdate.hpp
@@ -379,7 +379,7 @@ namespace Mat
     Mat::PAR::PlasticElastHyperVCU* mat_params() const override { return params_; }
 
     /// get dissipation mode
-    TSI::DissipationMode dis_mode() const override { return TSI::pl_flow; }
+    TSI::DissipationMode dis_mode() const override { return TSI::DissipationMode::pl_flow; }
 
     /// inverse plastic deformation gradient for each Gauss point at current state
     std::vector<Core::LinAlg::Matrix<3, 3>> plastic_defgrd_inverse_;

--- a/src/mat/4C_mat_plasticelasthyper.cpp
+++ b/src/mat/4C_mat_plasticelasthyper.cpp
@@ -55,7 +55,7 @@ Mat::PAR::PlasticElastHyper::PlasticElastHyper(const Core::Mat::PAR::Parameter::
       rY_13_(matdata.parameters.get<double>("rY_13")),
       cpl_(0.),
       stab_s_(0.),
-      dis_mode_(TSI::pl_multiplier)
+      dis_mode_(TSI::DissipationMode::pl_multiplier)
 {
   // check if sizes fit
   if (nummat_ != (int)matids_.size())
@@ -372,7 +372,7 @@ void Mat::PlasticElastHyper::setup_tsi(
     const int numgp, const int numdofperelement, const bool eas, const TSI::DissipationMode mode)
 {
   // dissipation mode
-  if (mode == TSI::pl_multiplier)
+  if (mode == TSI::DissipationMode::pl_multiplier)
     if (mat_params()->rY_11_ != 0. || mat_params()->rY_22_ != 0. || mat_params()->rY_33_ != 0. ||
         mat_params()->rY_12_ != 0. || mat_params()->rY_23_ != 0. || mat_params()->rY_13_ != 0.)
       FOUR_C_THROW("TSI with Hill plasticity not available with DISSIPATION_MODE pl_multiplier");
@@ -400,11 +400,11 @@ void Mat::PlasticElastHyper::setup_tsi(
   if (pl_spin_chi() != 0.) FOUR_C_THROW("no thermo-plasticitiy with plastic spin");
 
   /// Hill TSI only with pl_flow dissipation
-  if (mat_params()->rY_11_ != 0. && mode == TSI::pl_multiplier)
+  if (mat_params()->rY_11_ != 0. && mode == TSI::DissipationMode::pl_multiplier)
     FOUR_C_THROW("hill thermo plasticity not with dissipation mode pl_multiplier");
 
   /// viscoplastic TSI only with  pl_flow dissipation
-  if (visc() != 0. && mode == TSI::pl_multiplier)
+  if (visc() != 0. && mode == TSI::DissipationMode::pl_multiplier)
     FOUR_C_THROW("thermo-visco-plasticity not with dissipation mode pl_multiplier");
 }
 
@@ -1052,7 +1052,7 @@ void Mat::PlasticElastHyper::evaluate_ncp(const Core::LinAlg::Matrix<3, 3>* mStr
     // TSI
     if (dNCPdT != nullptr)
     {
-      if (dis_mode() == TSI::Taylor_Quinney)
+      if (dis_mode() == TSI::DissipationMode::Taylor_Quinney)
       {
         double plHeating = taylor_quinney() * eta_v_strainlike.dot(deltaDp_v);
         Core::LinAlg::Matrix<6, 1> dHpDeta(Core::LinAlg::Initialization::zero);
@@ -1074,14 +1074,14 @@ void Mat::PlasticElastHyper::evaluate_ncp(const Core::LinAlg::Matrix<3, 3>* mStr
                            (*temp) * delta_alpha_i_[gp];
         switch (dis_mode())
         {
-          case TSI::pl_multiplier:
+          case TSI::DissipationMode::pl_multiplier:
             plHeating += delta_alpha_i_[gp] * (0. + inityield() * (1. - yield_soft() * dT) +
                                                   isohard() * (1. - hard_soft() * dT) * aI +
                                                   (infyield() * (1. - hard_soft() * dT) -
                                                       inityield() * (1. - yield_soft() * dT)) *
                                                       (1. - exp(-expisohard() * aI)));
             break;
-          case TSI::pl_flow:
+          case TSI::DissipationMode::pl_flow:
             plHeating += eta_v_strainlike.dot(deltaDp_v);
             break;
           default:
@@ -1096,13 +1096,13 @@ void Mat::PlasticElastHyper::evaluate_ncp(const Core::LinAlg::Matrix<3, 3>* mStr
                               delta_alpha_i_[gp];
         switch (dis_mode())
         {
-          case TSI::pl_multiplier:
+          case TSI::DissipationMode::pl_multiplier:
             dPlHeatingDT += -delta_alpha_i_[gp] *
                             (0. + inityield() * yield_soft() + isohard() * hard_soft() * aI +
                                 (infyield() * hard_soft() - inityield() * yield_soft()) *
                                     (1. - exp(-expisohard() * aI)));
             break;
-          case TSI::pl_flow:
+          case TSI::DissipationMode::pl_flow:
             // do nothing
             break;
           default:
@@ -1121,7 +1121,7 @@ void Mat::PlasticElastHyper::evaluate_ncp(const Core::LinAlg::Matrix<3, 3>* mStr
                         exp(-expisohard() * aI));
         switch (dis_mode())
         {
-          case TSI::pl_multiplier:
+          case TSI::DissipationMode::pl_multiplier:
             dPlHeatingDdai +=
                 +inityield() * (1. - yield_soft() * dT) +
                 isohard() * (1. - hard_soft() * dT) *
@@ -1130,7 +1130,7 @@ void Mat::PlasticElastHyper::evaluate_ncp(const Core::LinAlg::Matrix<3, 3>* mStr
                     ((1. - exp(-expisohard() * aI)) +
                         delta_alpha_i_[gp] * expisohard() * exp(-expisohard() * aI));
             break;
-          case TSI::pl_flow:
+          case TSI::DissipationMode::pl_flow:
             // do nothing
             break;
           default:
@@ -1152,7 +1152,8 @@ void Mat::PlasticElastHyper::evaluate_ncp(const Core::LinAlg::Matrix<3, 3>* mStr
               -2. * dPlHeatingDdai * abseta_H * dDpHeta / (pow(absHeta, 4.)), HetaH_strainlike, 1.);
         }
 
-        if (dis_mode() == TSI::pl_flow) dHpDeta.update(1., deltaDp_v_strainlike, 1.);
+        if (dis_mode() == TSI::DissipationMode::pl_flow)
+          dHpDeta.update(1., deltaDp_v_strainlike, 1.);
 
         // derivative w.r.t. C
         dHdC->multiply_tn(*dMdC, dHpDeta);
@@ -1164,7 +1165,7 @@ void Mat::PlasticElastHyper::evaluate_ncp(const Core::LinAlg::Matrix<3, 3>* mStr
           tmp61.multiply(PlAniso_full_, eta_v_strainlike);
           dHdDp->update(dPlHeatingDdai * abseta_H / (absHeta * absHeta), tmp61, 1.);
         }
-        if (dis_mode() == TSI::pl_flow) dHdDp->update(1., eta_v_strainlike, 1.);
+        if (dis_mode() == TSI::DissipationMode::pl_flow) dHdDp->update(1., eta_v_strainlike, 1.);
 
         // scaling with time step
         plHeating /= dt;

--- a/src/tsi/4C_tsi_input.cpp
+++ b/src/tsi/4C_tsi_input.cpp
@@ -58,14 +58,9 @@ std::vector<Core::IO::InputSpec> TSI::valid_parameters()
           parameter<int>("RESULTSEVERY",
               {.description = "increment for writing solution", .default_value = 1}),
 
-          deprecated_selection<ConvNorm>("NORM_INC",
-              {
-                  {"Abs", convnorm_abs},
-                  {"Rel", convnorm_rel},
-                  {"Mix", convnorm_mix},
-              },
+          parameter<ConvNorm>("NORM_INC",
               {.description = "type of norm for convergence check of primary variables in TSI",
-                  .default_value = convnorm_abs})},
+                  .default_value = ConvNorm::Abs})},
       {.required = false}));
 
   /*----------------------------------------------------------------------*/
@@ -81,45 +76,29 @@ std::vector<Core::IO::InputSpec> TSI::valid_parameters()
               {.description = "tolerance for convergence check of TSI-increment in monolithic TSI",
                   .default_value = 1.0e-6}),
 
-          deprecated_selection<ConvNorm>("NORM_RESF",
-              {
-                  {"Abs", convnorm_abs},
-                  {"Rel", convnorm_rel},
-                  {"Mix", convnorm_mix},
-              },
-              {.description = "type of norm for residual convergence check",
-                  .default_value = convnorm_abs}),
+          parameter<ConvNorm>(
+              "NORM_RESF", {.description = "type of norm for residual convergence check",
+                               .default_value = ConvNorm::Abs}),
 
           deprecated_selection<BinaryOp>("NORMCOMBI_RESFINC",
               {
-                  {"And", bop_and},
-                  {"Or", bop_or},
-                  {"Coupl_Or_Single", bop_coupl_or_single},
-                  {"Coupl_And_Single", bop_coupl_and_single},
-                  {"And_Single", bop_and_single},
-                  {"Or_Single", bop_or_single},
+                  {"And", BinaryOp::bop_and},
+                  {"Or", BinaryOp::bop_or},
+                  {"Coupl_Or_Single", BinaryOp::bop_coupl_or_single},
+                  {"Coupl_And_Single", BinaryOp::bop_coupl_and_single},
+                  {"And_Single", BinaryOp::bop_and_single},
+                  {"Or_Single", BinaryOp::bop_or_single},
               },
               {.description =
                       "binary operator to combine primary variables and residual force values",
-                  .default_value = bop_coupl_and_single}),
+                  .default_value = BinaryOp::bop_coupl_and_single}),
 
-          deprecated_selection<VectorNorm>("ITERNORM",
-              {
-                  {"L1", norm_l1},
-                  {"L1_Scaled", norm_l1_scaled},
-                  {"L2", norm_l2},
-                  {"Rms", norm_rms},
-                  {"Inf", norm_inf},
-              },
-              {.description = "type of norm to be applied to residuals",
-                  .default_value = norm_rms}),
+          parameter<VectorNorm>(
+              "ITERNORM", {.description = "type of norm to be applied to residuals",
+                              .default_value = VectorNorm::Rms}),
 
-          deprecated_selection<NlnSolTech>("NLNSOL",
-              {
-                  {"fullnewton", soltech_newtonfull},
-                  {"ptc", soltech_ptc},
-              },
-              {.description = "Nonlinear solution technique", .default_value = soltech_newtonfull}),
+          parameter<NlnSolTech>("NLNSOL", {.description = "Nonlinear solution technique",
+                                              .default_value = NlnSolTech::fullnewton}),
 
 
           parameter<double>(
@@ -152,13 +131,13 @@ std::vector<Core::IO::InputSpec> TSI::valid_parameters()
 
           deprecated_selection<LineSearch>("TSI_LINE_SEARCH",
               {
-                  {"none", LS_none},
-                  {"structure", LS_structure},
-                  {"thermo", LS_thermo},
-                  {"and", LS_and},
-                  {"or", LS_or},
+                  {"none", LineSearch::LS_none},
+                  {"structure", LineSearch::LS_structure},
+                  {"thermo", LineSearch::LS_thermo},
+                  {"and", LineSearch::LS_and},
+                  {"or", LineSearch::LS_or},
               },
-              {.description = "line-search strategy", .default_value = LS_none})},
+              {.description = "line-search strategy", .default_value = LineSearch::LS_none})},
       {.required = false}));
 
   /*----------------------------------------------------------------------*/
@@ -166,8 +145,9 @@ std::vector<Core::IO::InputSpec> TSI::valid_parameters()
   specs.push_back(group("TSI DYNAMIC/PARTITIONED",
       {
 
-          deprecated_selection<std::string>("COUPVARIABLE", {"Displacement", "Temperature"},
-              {.description = "Coupling variable", .default_value = "Displacement"}),
+          parameter<CouplingVariable>(
+              "COUPVARIABLE", {.description = "Coupling variable",
+                                  .default_value = CouplingVariable::Displacement}),
 
 
           // Solver parameter for relaxation of iterative staggered partitioned TSI

--- a/src/tsi/4C_tsi_input.hpp
+++ b/src/tsi/4C_tsi_input.hpp
@@ -31,18 +31,25 @@ namespace TSI
     Monolithic
   };
 
+  //! Type of coupling variable for TSI problems
+  enum class CouplingVariable
+  {
+    Displacement,
+    Temperature
+  };
+
   //! @name Solution technique and related stuff
 
   //! type of norm to check for convergence
-  enum ConvNorm
+  enum class ConvNorm
   {
-    convnorm_abs,  //!< absolute norm
-    convnorm_rel,  //!< relative norm of TSI problem with initial TSI rhs
-    convnorm_mix   //!< mixed absolute-relative norm
+    Abs,  //!< absolute norm
+    Rel,  //!< relative norm of TSI problem with initial TSI rhs
+    Mix   //!< mixed absolute-relative norm
   };
 
   //! type of norm to check for convergence
-  enum BinaryOp
+  enum class BinaryOp
   {
     bop_and,               //!< and
     bop_or,                //!< or
@@ -53,14 +60,14 @@ namespace TSI
   };
 
   //! type of solution techniques
-  enum NlnSolTech
+  enum class NlnSolTech
   {
-    soltech_newtonfull,  //!< full Newton-Raphson iteration
-    soltech_ptc,         //!< pseudo transient continuation nonlinear iteration
+    fullnewton,  //!< full Newton-Raphson iteration
+    ptc,         //!< pseudo transient continuation nonlinear iteration
   };
 
   //! type of line-search strategy
-  enum LineSearch
+  enum class LineSearch
   {
     LS_none = 0,   //!< no line search
     LS_structure,  //!< line-search based on structural residual
@@ -75,18 +82,17 @@ namespace TSI
   //@{
 
   //! type of vector norm used for error/residual vectors
-  enum VectorNorm
+  enum class VectorNorm
   {
-    norm_vague = 0,  //!< undetermined norm
-    norm_l1,         //!< L1/linear norm
-    norm_l1_scaled,  //!< L1/linear norm scaled by length of vector
-    norm_l2,         //!< L2/Euclidean norm
-    norm_rms,        //!< root mean square (RMS) norm
-    norm_inf         //!< Maximum/infinity norm
+    L1,         //!< L1/linear norm
+    L1_Scaled,  //!< L1/linear norm scaled by length of vector
+    L2,         //!< L2/Euclidean norm
+    Rms,        //!< root mean square (RMS) norm
+    Inf         //!< Maximum/infinity norm
   };
 
   //! Method used to calculate plastic dissipation
-  enum DissipationMode
+  enum class DissipationMode
   {
     pl_multiplier,  //!< Dissipation = yield stress times plastic multiplier
     pl_flow,        //!< Dissipation = Mandel stress : sym(L^p)

--- a/src/tsi/4C_tsi_monolithic.cpp
+++ b/src/tsi/4C_tsi_monolithic.cpp
@@ -303,11 +303,11 @@ void TSI::Monolithic::solve()
   switch (soltech_)
   {
     // Newton-Raphson iteration
-    case TSI::soltech_newtonfull:
+    case TSI::NlnSolTech::fullnewton:
       newton_full();
       break;
     // Pseudo-transient continuation
-    case TSI::soltech_ptc:
+    case TSI::NlnSolTech::ptc:
       ptc();
       break;
     // catch problems
@@ -450,12 +450,12 @@ void TSI::Monolithic::newton_full()
     // do line search
     switch (ls_strategy_)
     {
-      case TSI::LS_none:
+      case TSI::LineSearch::LS_none:
         break;
-      case TSI::LS_structure:
-      case TSI::LS_thermo:
-      case TSI::LS_and:
-      case TSI::LS_or:
+      case TSI::LineSearch::LS_structure:
+      case TSI::LineSearch::LS_thermo:
+      case TSI::LineSearch::LS_and:
+      case TSI::LineSearch::LS_or:
       {
         normstrrhs_ = calculate_vector_norm(iternormstr_, *structure_field()->rhs());
         normthrrhs_ = calculate_vector_norm(iternormthr_, *thermo_field()->rhs());
@@ -1143,13 +1143,13 @@ bool TSI::Monolithic::converged()
   // residual TSI forces
   switch (normtyperhs_)
   {
-    case TSI::convnorm_abs:
+    case TSI::ConvNorm::Abs:
       convrhs = normrhs_ < tolrhs_;
       break;
-    case TSI::convnorm_rel:
+    case TSI::ConvNorm::Rel:
       convrhs = normrhs_ < std::max(tolrhs_ * normrhsiter0_, 1.0e-15);
       break;
-    case TSI::convnorm_mix:
+    case TSI::ConvNorm::Mix:
       convrhs = ((normrhs_ < tolrhs_) and (normrhs_ < std::max(normrhsiter0_ * tolrhs_, 1.0e-15)));
       break;
     default:
@@ -1160,11 +1160,11 @@ bool TSI::Monolithic::converged()
   // residual TSI increments
   switch (normtypeinc_)
   {
-    case TSI::convnorm_abs:
+    case TSI::ConvNorm::Abs:
       convinc = norminc_ < tolinc_;
       break;
-    case TSI::convnorm_rel:
-    case TSI::convnorm_mix:
+    case TSI::ConvNorm::Rel:
+    case TSI::ConvNorm::Mix:
       convinc = norminc_ < std::max(norminciter0_ * tolinc_, 1e-15);
       break;
     default:
@@ -1249,17 +1249,17 @@ bool TSI::Monolithic::converged()
   // combine increment-like and force-like residuals, combine TSI and single
   // field values
   bool conv = false;
-  if (combincrhs_ == TSI::bop_and)
+  if (combincrhs_ == TSI::BinaryOp::bop_and)
     conv = convinc and convrhs;
-  else if (combincrhs_ == TSI::bop_or)
+  else if (combincrhs_ == TSI::BinaryOp::bop_or)
     conv = convinc or convrhs;
-  else if (combincrhs_ == TSI::bop_coupl_and_single)
+  else if (combincrhs_ == TSI::BinaryOp::bop_coupl_and_single)
     conv = convinc and convrhs and convdisp and convstrrhs and convtemp and convthrrhs;
-  else if (combincrhs_ == TSI::bop_coupl_or_single)
+  else if (combincrhs_ == TSI::BinaryOp::bop_coupl_or_single)
     conv = (convinc and convrhs) or (convdisp and convstrrhs and convtemp and convthrrhs);
-  else if (combincrhs_ == TSI::bop_and_single)
+  else if (combincrhs_ == TSI::BinaryOp::bop_and_single)
     conv = convdisp and convstrrhs and convtemp and convthrrhs;
-  else if (combincrhs_ == TSI::bop_or_single)
+  else if (combincrhs_ == TSI::BinaryOp::bop_or_single)
     conv = (convdisp or convstrrhs or convtemp or convthrrhs);
   else
     FOUR_C_THROW("Something went terribly wrong with binary operator!");
@@ -1311,20 +1311,20 @@ void TSI::Monolithic::print_newton_iter_header(FILE* ofile)
   oss << std::setw(5) << "# iter";
 
   // line search
-  if (ls_strategy_) oss << std::setw(11) << " ls_step";
+  if (ls_strategy_ != LineSearch::LS_none) oss << std::setw(11) << " ls_step";
 
   // ---------------------------------------------------------------- TSI
   // different style due relative or absolute error checking
   // displacement
   switch (normtyperhs_)
   {
-    case TSI::convnorm_abs:
+    case TSI::ConvNorm::Abs:
       oss << std::setw(15) << "abs-res-norm";
       break;
-    case TSI::convnorm_rel:
+    case TSI::ConvNorm::Rel:
       oss << std::setw(15) << "rel-res-norm";
       break;
-    case TSI::convnorm_mix:
+    case TSI::ConvNorm::Mix:
       oss << std::setw(15) << "mix-res-norm";
       break;
     default:
@@ -1334,10 +1334,10 @@ void TSI::Monolithic::print_newton_iter_header(FILE* ofile)
 
   switch (normtypeinc_)
   {
-    case TSI::convnorm_abs:
+    case TSI::ConvNorm::Abs:
       oss << std::setw(15) << "abs-inc-norm";
       break;
-    case TSI::convnorm_rel:
+    case TSI::ConvNorm::Rel:
       oss << std::setw(15) << "rel-inc-norm";
       break;
     default:
@@ -1420,7 +1420,7 @@ void TSI::Monolithic::print_newton_iter_header(FILE* ofile)
   }
 
 
-  if (soltech_ == TSI::soltech_ptc)
+  if (soltech_ == TSI::NlnSolTech::ptc)
   {
     oss << std::setw(16) << "        PTC-dti";
   }
@@ -1463,7 +1463,7 @@ void TSI::Monolithic::print_newton_iter_text(FILE* ofile)
   oss << std::setw(6) << iter_;
 
   // line search step
-  if (ls_strategy_)
+  if (ls_strategy_ != LineSearch::LS_none)
     oss << std::setw(11) << std::setprecision(3) << std::scientific << ls_step_length_;
 
   // different style due relative or absolute error checking
@@ -1471,13 +1471,13 @@ void TSI::Monolithic::print_newton_iter_text(FILE* ofile)
   // ----------------------------------------------- test coupled problem
   switch (normtyperhs_)
   {
-    case TSI::convnorm_abs:
+    case TSI::ConvNorm::Abs:
       oss << std::setw(15) << std::setprecision(5) << std::scientific << normrhs_;
       break;
-    case TSI::convnorm_rel:
+    case TSI::ConvNorm::Rel:
       oss << std::setw(15) << std::setprecision(5) << std::scientific << normrhs_ / normrhsiter0_;
       break;
-    case TSI::convnorm_mix:
+    case TSI::ConvNorm::Mix:
       oss << std::setw(15) << std::setprecision(5) << std::scientific
           << std::min(normrhs_, normrhs_ / normrhsiter0_);
       break;
@@ -1488,13 +1488,13 @@ void TSI::Monolithic::print_newton_iter_text(FILE* ofile)
 
   switch (normtypeinc_)
   {
-    case TSI::convnorm_abs:
+    case TSI::ConvNorm::Abs:
       oss << std::setw(15) << std::setprecision(5) << std::scientific << norminc_;
       break;
-    case TSI::convnorm_rel:
+    case TSI::ConvNorm::Rel:
       oss << std::setw(15) << std::setprecision(5) << std::scientific << norminc_ / norminciter0_;
       break;
-    case TSI::convnorm_mix:
+    case TSI::ConvNorm::Mix:
       oss << std::setw(15) << std::setprecision(5) << std::scientific
           << std::min(norminc_, norminc_ / norminciter0_);
       break;
@@ -1589,7 +1589,7 @@ void TSI::Monolithic::print_newton_iter_text(FILE* ofile)
         << contact_strategy_lagrange_->thermo_contact_incr_;
   }
 
-  if (soltech_ == TSI::soltech_ptc)
+  if (soltech_ == TSI::NlnSolTech::ptc)
   {
     oss << std::setw(16) << std::setprecision(5) << std::scientific << dti_;
   }
@@ -2010,7 +2010,7 @@ double TSI::Monolithic::calculate_vector_norm(
 {
   // L1 norm
   // norm = sum_0^i vect[i]
-  if (norm == TSI::norm_l1)
+  if (norm == TSI::VectorNorm::L1)
   {
     double vectnorm;
     vect.norm_1(&vectnorm);
@@ -2018,7 +2018,7 @@ double TSI::Monolithic::calculate_vector_norm(
   }
   // L2/Euclidian norm
   // norm = sqrt{sum_0^i vect[i]^2 }
-  else if (norm == TSI::norm_l2)
+  else if (norm == TSI::VectorNorm::L2)
   {
     double vectnorm;
     vect.norm_2(&vectnorm);
@@ -2026,7 +2026,7 @@ double TSI::Monolithic::calculate_vector_norm(
   }
   // RMS norm
   // norm = sqrt{sum_0^i vect[i]^2 }/ sqrt{length_vect}
-  else if (norm == TSI::norm_rms)
+  else if (norm == TSI::VectorNorm::Rms)
   {
     double vectnorm;
     vect.norm_2(&vectnorm);
@@ -2034,14 +2034,14 @@ double TSI::Monolithic::calculate_vector_norm(
   }
   // infinity/maximum norm
   // norm = max( vect[i] )
-  else if (norm == TSI::norm_inf)
+  else if (norm == TSI::VectorNorm::Inf)
   {
     double vectnorm;
     vect.norm_inf(&vectnorm);
     return vectnorm;
   }
   // norm = sum_0^i vect[i]/length_vect
-  else if (norm == TSI::norm_l1_scaled)
+  else if (norm == TSI::VectorNorm::L1_Scaled)
   {
     double vectnorm;
     vect.norm_1(&vectnorm);
@@ -2085,38 +2085,38 @@ void TSI::Monolithic::set_default_parameters()
 
   switch (combincrhs_)
   {
-    case TSI::bop_and:
+    case TSI::BinaryOp::bop_and:
     {
       if (Core::Communication::my_mpi_rank(get_comm()) == 0)
         std::cout << "Convergence test of TSI:\n res, inc with 'AND'.\n";
       break;
     }
-    case TSI::bop_or:
+    case TSI::BinaryOp::bop_or:
     {
       if (Core::Communication::my_mpi_rank(get_comm()) == 0)
         std::cout << "Convergence test of TSI:\n res, inc with 'OR'.\n";
       break;
     }
-    case TSI::bop_coupl_and_single:
+    case TSI::BinaryOp::bop_coupl_and_single:
     {
       if (Core::Communication::my_mpi_rank(get_comm()) == 0)
         std::cout
             << "Convergence test of TSI:\n res, inc, str-res, thermo-res, dis, temp with 'AND'.\n";
       break;
     }
-    case TSI::bop_coupl_or_single:
+    case TSI::BinaryOp::bop_coupl_or_single:
     {
       if (Core::Communication::my_mpi_rank(get_comm()) == 0)
         std::cout << "Convergence test of TSI:\n (res, inc) or (str-res, thermo-res, dis, temp).\n";
       break;
     }
-    case TSI::bop_and_single:
+    case TSI::BinaryOp::bop_and_single:
     {
       if (Core::Communication::my_mpi_rank(get_comm()) == 0)
         std::cout << "Convergence test of TSI:\n str-res, thermo-res, dis, temp with 'AND'.\n";
       break;
     }
-    case TSI::bop_or_single:
+    case TSI::BinaryOp::bop_or_single:
     {
       if (Core::Communication::my_mpi_rank(get_comm()) == 0)
         std::cout << "Convergence test of TSI:\n str-res, thermo-res, dis, temp with 'OR'.\n";
@@ -2134,16 +2134,16 @@ void TSI::Monolithic::set_default_parameters()
   switch (striternorm)
   {
     case Inpar::Solid::norm_l1:
-      iternormstr_ = TSI::norm_l1;
+      iternormstr_ = TSI::VectorNorm::L1;
       break;
     case Inpar::Solid::norm_l2:
-      iternormstr_ = TSI::norm_l2;
+      iternormstr_ = TSI::VectorNorm::L2;
       break;
     case Inpar::Solid::norm_rms:
-      iternormstr_ = TSI::norm_rms;
+      iternormstr_ = TSI::VectorNorm::Rms;
       break;
     case Inpar::Solid::norm_inf:
-      iternormstr_ = TSI::norm_inf;
+      iternormstr_ = TSI::VectorNorm::Inf;
       break;
     case Inpar::Solid::norm_vague:
     default:
@@ -2155,16 +2155,16 @@ void TSI::Monolithic::set_default_parameters()
   switch (thriternorm)
   {
     case Thermo::norm_l1:
-      iternormthr_ = TSI::norm_l1;
+      iternormthr_ = TSI::VectorNorm::L1;
       break;
     case Thermo::norm_l2:
-      iternormthr_ = TSI::norm_l2;
+      iternormthr_ = TSI::VectorNorm::L2;
       break;
     case Thermo::norm_rms:
-      iternormthr_ = TSI::norm_rms;
+      iternormthr_ = TSI::VectorNorm::Rms;
       break;
     case Thermo::norm_inf:
-      iternormthr_ = TSI::norm_inf;
+      iternormthr_ = TSI::VectorNorm::Inf;
       break;
     case Thermo::norm_vague:
     default:
@@ -2175,11 +2175,12 @@ void TSI::Monolithic::set_default_parameters()
   }  // switch (thriternorm)
 
   // if scaled L1-norm is wished to be used
-  if ((iternorm_ == TSI::norm_l1_scaled) and
-      ((combincrhs_ == TSI::bop_coupl_and_single) or (combincrhs_ == TSI::bop_coupl_or_single)))
+  if ((iternorm_ == TSI::VectorNorm::L1_Scaled) and
+      ((combincrhs_ == TSI::BinaryOp::bop_coupl_and_single) or
+          (combincrhs_ == TSI::BinaryOp::bop_coupl_or_single)))
   {
-    iternormstr_ = TSI::norm_l1_scaled;
-    iternormthr_ = TSI::norm_l1_scaled;
+    iternormstr_ = TSI::VectorNorm::L1_Scaled;
+    iternormthr_ = TSI::VectorNorm::L1_Scaled;
   }
 
   // test the TSI-residual and the TSI-increment
@@ -2352,15 +2353,15 @@ bool TSI::Monolithic::l_sadmissible()
 {
   switch (ls_strategy_)
   {
-    case TSI::LS_structure:
+    case TSI::LineSearch::LS_structure:
       return normstrrhs_ < last_iter_res_.first;
-    case TSI::LS_thermo:
+    case TSI::LineSearch::LS_thermo:
       return normthrrhs_ < last_iter_res_.second;
-    case TSI::LS_or:
+    case TSI::LineSearch::LS_or:
       return (normstrrhs_ < last_iter_res_.first || normthrrhs_ < last_iter_res_.second);
-    case TSI::LS_and:
+    case TSI::LineSearch::LS_and:
       return (normstrrhs_ < last_iter_res_.first && normthrrhs_ < last_iter_res_.second);
-    case TSI::LS_none:
+    case TSI::LineSearch::LS_none:
     default:
       FOUR_C_THROW("you should not be here");
       return false;

--- a/src/tsi/4C_tsi_partitioned.cpp
+++ b/src/tsi/4C_tsi_partitioned.cpp
@@ -53,7 +53,8 @@ TSI::Partitioned::Partitioned(MPI_Comm comm)
   coupling_ = Teuchos::getIntegralValue<TSI::SolutionSchemeOverFields>(tsidyn, "COUPALGO");
 
   // coupling variable
-  displacementcoupling_ = tsidynpart.get<std::string>("COUPVARIABLE") == "Displacement";
+  displacementcoupling_ = Teuchos::getIntegralValue<CouplingVariable>(tsidynpart, "COUPVARIABLE") ==
+                          CouplingVariable::Displacement;
   if (displacementcoupling_)
     std::cout << "Coupling variable: displacement" << std::endl;
   else
@@ -1087,7 +1088,7 @@ bool TSI::Partitioned::convergence_check(int itnum, const int itmax, const doubl
   switch (normtypeinc_)
   {
     // default check:
-    case TSI::convnorm_abs:
+    case TSI::ConvNorm::Abs:
     {
       // print the incremental based convergence check to the screen
       // test here increment
@@ -1150,10 +1151,10 @@ bool TSI::Partitioned::convergence_check(int itnum, const int itmax, const doubl
           printf("\n");
         }
       }
-    }  // TSI::convnorm_abs
+    }  // TSI::ConvNorm::convnorm_abs
     break;
 
-    case TSI::convnorm_rel:
+    case TSI::ConvNorm::Rel:
     {
       // print the incremental based convergence check to the screen
       // test here increment/variable
@@ -1213,10 +1214,10 @@ bool TSI::Partitioned::convergence_check(int itnum, const int itmax, const doubl
           printf("\n");
         }
       }
-    }  // TSI::convnorm_rel
+    }  // TSI::ConvNorm::convnorm_rel
     break;
 
-    case TSI::convnorm_mix:
+    case TSI::ConvNorm::Mix:
     default:
       FOUR_C_THROW("Cannot check for convergence of residual values!");
       break;


### PR DESCRIPTION
Make a few enums into enum classes and use `parameter<Enum>` instead of `deprecated_selection`.

I was experimenting to see how hard it would be to remove the remaining `deprecated_selection` occurrences with scripts + agents. If one wants to keep backwards compatibility, there will be problems when the input string is a reserved C++ keyword (like `and`, `or`, `explicit`). We could add a path for these cases in the InputSpec, but I am not yet sure this is the best approach.  