### PR TITLE
Several fixes in ReducedLung

### DIFF
--- a/src/reduced_lung/src/4C_reduced_lung_airways.cpp
+++ b/src/reduced_lung/src/4C_reduced_lung_airways.cpp
@@ -16,24 +16,23 @@ namespace ReducedLung
 {
   namespace Airways
   {
-    void evaluate_negative_rigid_wall_residual(Core::LinAlg::Vector<double>& target,
-        const AirwayData& data, const Core::LinAlg::Vector<double>& locally_relevant_dofs,
+    void evaluate_rigid_wall_residual(Core::LinAlg::Vector<double>& target, const AirwayData& data,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs,
         const std::vector<double>& resistance, const std::vector<double>& inertia, double dt)
     {
       for (size_t i = 0; i < data.number_of_elements(); i++)
       {
-        double negative_rigid_wall_residual =
-            -1 *
+        double rigid_wall_residual =
             (locally_relevant_dofs.local_values_as_span()[data.lid_p1[i]] -
                 locally_relevant_dofs.local_values_as_span()[data.lid_p2[i]] -
                 resistance[i] * locally_relevant_dofs.local_values_as_span()[data.lid_q1[i]] -
                 inertia[i] / dt *
                     (locally_relevant_dofs.local_values_as_span()[data.lid_q1[i]] - data.q1_n[i]));
-        target.replace_local_value(data.local_row_id[i], negative_rigid_wall_residual);
+        target.replace_local_value(data.local_row_id[i], rigid_wall_residual);
       }
     }
 
-    void evaluate_negative_kelvin_voigt_wall_residual(Core::LinAlg::Vector<double>& target,
+    void evaluate_kelvin_voigt_wall_residual(Core::LinAlg::Vector<double>& target,
         const KelvinVoigtWall& kelvin_voigt_wall_model, const AirwayData& data,
         const Core::LinAlg::Vector<double>& locally_relevant_dofs,
         const std::vector<double>& resistance, const std::vector<double>& inertia, double dt)
@@ -43,26 +42,26 @@ namespace ReducedLung
         const int momentum_row = data.local_row_id[i];
         const int mass_row = data.local_row_id[i] + 1;
 
-        double neg_res_momentum =
-            -1 * (locally_relevant_dofs.local_values_as_span()[data.lid_p1[i]] -
-                     locally_relevant_dofs.local_values_as_span()[data.lid_p2[i]] -
-                     (resistance[i] / 2 + inertia[i] / (2 * dt)) *
-                         (locally_relevant_dofs.local_values_as_span()[data.lid_q1[i]] +
-                             locally_relevant_dofs.local_values_as_span()[data.lid_q2[i]]) +
-                     inertia[i] / (2 * dt) * (data.q1_n[i] + data.q2_n[i]));
-        double neg_res_mass =
-            -1 * (locally_relevant_dofs.local_values_as_span()[data.lid_p1[i]] +
-                     locally_relevant_dofs.local_values_as_span()[data.lid_p2[i]] - data.p1_n[i] -
-                     data.p2_n[i] -
-                     2 *
-                         (kelvin_voigt_wall_model.viscous_resistance_Rvisc[i] +
-                             dt / kelvin_voigt_wall_model.compliance_C[i]) *
-                         (locally_relevant_dofs.local_values_as_span()[data.lid_q1[i]] -
-                             locally_relevant_dofs.local_values_as_span()[data.lid_q2[i]]) +
-                     2 * kelvin_voigt_wall_model.viscous_resistance_Rvisc[i] *
-                         (data.q1_n[i] - data.q2_n[i]));  // Pext component not implemented yet.
-        target.replace_local_value(momentum_row, neg_res_momentum);
-        target.replace_local_value(mass_row, neg_res_mass);
+        double res_momentum =
+            (locally_relevant_dofs.local_values_as_span()[data.lid_p1[i]] -
+                locally_relevant_dofs.local_values_as_span()[data.lid_p2[i]] -
+                (resistance[i] / 2 + inertia[i] / (2 * dt)) *
+                    (locally_relevant_dofs.local_values_as_span()[data.lid_q1[i]] +
+                        locally_relevant_dofs.local_values_as_span()[data.lid_q2[i]]) +
+                inertia[i] / (2 * dt) * (data.q1_n[i] + data.q2_n[i]));
+        double res_mass =
+            (locally_relevant_dofs.local_values_as_span()[data.lid_p1[i]] +
+                locally_relevant_dofs.local_values_as_span()[data.lid_p2[i]] - data.p1_n[i] -
+                data.p2_n[i] -
+                2 *
+                    (kelvin_voigt_wall_model.viscous_resistance_Rvisc[i] +
+                        dt / kelvin_voigt_wall_model.compliance_C[i]) *
+                    (locally_relevant_dofs.local_values_as_span()[data.lid_q1[i]] -
+                        locally_relevant_dofs.local_values_as_span()[data.lid_q2[i]]) +
+                2 * kelvin_voigt_wall_model.viscous_resistance_Rvisc[i] *
+                    (data.q1_n[i] - data.q2_n[i]));  // Pext component not implemented yet.
+        target.replace_local_value(momentum_row, res_momentum);
+        target.replace_local_value(mass_row, res_mass);
       }
     }
 
@@ -336,13 +335,12 @@ namespace ReducedLung
       }
     }
 
-    void update_negative_residual_vector(Core::LinAlg::Vector<double>& res_vector,
-        AirwayContainer& airways, const Core::LinAlg::Vector<double>& locally_relevant_dofs,
-        double dt)
+    void update_residual_vector(Core::LinAlg::Vector<double>& res_vector, AirwayContainer& airways,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt)
     {
       for (auto& model : airways.models)
       {
-        model.negative_residual_evaluator(model.data, res_vector, locally_relevant_dofs, dt);
+        model.residual_evaluator(model.data, res_vector, locally_relevant_dofs, dt);
       }
     }
 
@@ -422,8 +420,8 @@ namespace ReducedLung
     {
       for (auto& model : airways.models)
       {
-        model.negative_residual_evaluator =
-            std::visit(MakeNegativeResidualEvaluator{model.flow_model}, model.wall_model);
+        model.residual_evaluator =
+            std::visit(MakeResidualEvaluator{model.flow_model}, model.wall_model);
         model.jacobian_evaluator =
             std::visit(MakeJacobianEvaluator{model.flow_model}, model.wall_model);
         model.internal_state_updater =

--- a/src/reduced_lung/src/4C_reduced_lung_airways.hpp
+++ b/src/reduced_lung/src/4C_reduced_lung_airways.hpp
@@ -143,8 +143,8 @@ namespace ReducedLung
 
     // ----- Evaluator function types -----
 
-    // Function handle for evaluating the negative model residuals.
-    using NegativeResidualEvaluator =
+    // Function handle for evaluating the model residuals.
+    using ResidualEvaluator =
         std::function<void(const AirwayData& data, Core::LinAlg::Vector<double>& target_vector,
             const Core::LinAlg::Vector<double>& locally_relevant_dofs, double time_step_size_dt)>;
 
@@ -177,7 +177,7 @@ namespace ReducedLung
       AirwayData data;
       FlowModel flow_model;
       WallModel wall_model;
-      NegativeResidualEvaluator negative_residual_evaluator;
+      ResidualEvaluator residual_evaluator;
       JacobianEvaluatorAW jacobian_evaluator;
       InternalStateUpdaterAW internal_state_updater;
       EndOfTimestepRoutine end_of_timestep_routine;
@@ -251,15 +251,15 @@ namespace ReducedLung
     };
 
     /**
-    * @brief Assembles the negative residual vector of airways with rigid walls.
+    * @brief Assembles the residual vector of airways with rigid walls.
     * Each airway is described by one state equation (momentum conservation).
     *
-    * \f$ -f_1 = -(P_1 - P_2 - R\,Q_1 - \frac{I}{\Delta t} \, (Q_1 - Q_1^n)) = -(P_1 - P_2  +
+    * \f$ f_1 = (P_1 - P_2 - R\,Q_1 - \frac{I}{\Delta t} \, (Q_1 - Q_1^n)) = -(P_1 - P_2  +
     f_{1,QR}
     * + f_{1,QI})\f$ \n
     * with \f$ f_{1,QR} = - R\,Q_1 \f$ and \f$ f_{1,QI} = - \frac{I}{\Delta t} \, (Q_1 - Q_1^n) \f$
 
-    * @param target The target RHS vector to store the negative residuals.
+    * @param target The target RHS vector to store the residuals.
     * @param data The airway data containing element information.
     * @param locally_relevant_dofs The DOF vector containing current flows and pressures in column
     map layout.
@@ -267,18 +267,18 @@ namespace ReducedLung
     * @param inertia The inertia \f$ I \f$ for each airway element.
     * @param dt The time step size.
     */
-    void evaluate_negative_rigid_wall_residual(Core::LinAlg::Vector<double>& target,
-        const AirwayData& data, const Core::LinAlg::Vector<double>& locally_relevant_dofs,
+    void evaluate_rigid_wall_residual(Core::LinAlg::Vector<double>& target, const AirwayData& data,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs,
         const std::vector<double>& resistance, const std::vector<double>& inertia, double dt);
 
     /**
-     * @brief Assembles the negative residual vector of airways with Kelvin-Voigt walls.
+     * @brief Assembles the residual vector of airways with Kelvin-Voigt walls.
      * Each airway is described by two state equations (momentum and mass conservation).
      *
-     * \f$ -f_1 = -(P_1 - P_2 - ( \frac{R}{2} + \frac{I}{2 \Delta t}) (Q_1 + Q_2) + \frac{I}{2
+     * \f$ f_1 = (P_1 - P_2 - ( \frac{R}{2} + \frac{I}{2 \Delta t}) (Q_1 + Q_2) + \frac{I}{2
      * \Delta t} (Q_1^n + Q_2^n)) = -(P_1 -P_2 + f_{1,QR} + f_{1,QI}) \f$
      *
-     * \f$ -f_2 = -(P_1 + P_2 - P_1^n - P_2^n - 2 (R_{visc} + \frac{\Delta t}{C}) (Q_1 - Q_2) + 2
+     * \f$ f_2 = (P_1 + P_2 - P_1^n - P_2^n - 2 (R_{visc} + \frac{\Delta t}{C}) (Q_1 - Q_2) + 2
      * R_{visc} (Q_1^n - Q_2^n)) = -(P_1 + P_2 - P_1^n - P_2^n + f_{2,QR_{visc}})\f$
      *
      * with \f$ f_{1,QR} = - \frac{R}{2} (Q_1 + Q_2) \f$, \f$ f_{1,QI} = - \frac{I}{2 \Delta t} (Q_1
@@ -286,7 +286,7 @@ namespace ReducedLung
      * and \f$ f_{2,QR_{visc}} = - 2 (R_{visc} + \frac{\Delta t}{C}) (Q_1 - Q_2) + 2 R_{visc} (Q_1^n
      * - Q_2^n) \f$
      *
-     * @param target The target RHS vector to store the negative residuals.
+     * @param target The target RHS vector to store the residuals.
      * @param kelvin_voigt_wall_model The Kelvin-Voigt wall model containing wall parameters and
      * internal states.
      * @param data The airway data containing element information.
@@ -296,7 +296,7 @@ namespace ReducedLung
      * @param inertia The inertia \f$ I \f$ for each airway element.
      * @param dt The time step size.
      */
-    void evaluate_negative_kelvin_voigt_wall_residual(Core::LinAlg::Vector<double>& target,
+    void evaluate_kelvin_voigt_wall_residual(Core::LinAlg::Vector<double>& target,
         const KelvinVoigtWall& kelvin_voigt_wall_model, const AirwayData& data,
         const Core::LinAlg::Vector<double>& locally_relevant_dofs,
         const std::vector<double>& resistance, const std::vector<double>& inertia, double dt);
@@ -541,9 +541,9 @@ namespace ReducedLung
     };
 
     /**
-     * Creates the model-specific negative residual evaluator function for airways.
+     * Creates the model-specific residual evaluator function for airways.
      */
-    struct MakeNegativeResidualEvaluator
+    struct MakeResidualEvaluator
     {
       /**
        * Creates the model-specific flow resistance evaluator.
@@ -615,7 +615,7 @@ namespace ReducedLung
         }
       };
 
-      NegativeResidualEvaluator operator()(RigidWall& rigid_wall_model)
+      ResidualEvaluator operator()(RigidWall& rigid_wall_model)
       {
         auto resistance_factory = MakeFlowResistanceEvaluator{};
         auto resistance_evaluator = std::visit([&resistance_factory](const auto& flow_model)
@@ -631,12 +631,12 @@ namespace ReducedLung
 
           std::vector<double> inertia = inertia_evaluator(airway_data, airway_data.ref_area);
 
-          evaluate_negative_rigid_wall_residual(
+          evaluate_rigid_wall_residual(
               target_vector, airway_data, locally_relevant_dofs, resistance, inertia, dt);
         };
       }
 
-      NegativeResidualEvaluator operator()(KelvinVoigtWall& kelvin_voigt_wall_model)
+      ResidualEvaluator operator()(KelvinVoigtWall& kelvin_voigt_wall_model)
       {
         auto resistance_factory = MakeFlowResistanceEvaluator{};
         auto resistance_evaluator = std::visit(
@@ -657,8 +657,8 @@ namespace ReducedLung
           std::vector<double> inertia =
               inertia_evaluator(airway_data, kelvin_voigt_wall_model.area);
 
-          evaluate_negative_kelvin_voigt_wall_residual(target_vector, kelvin_voigt_wall_model,
-              airway_data, locally_relevant_dofs, resistance, inertia, dt);
+          evaluate_kelvin_voigt_wall_residual(target_vector, kelvin_voigt_wall_model, airway_data,
+              locally_relevant_dofs, resistance, inertia, dt);
         };
       }
       FlowModel& flow_model;
@@ -1082,7 +1082,7 @@ namespace ReducedLung
     }
 
     /**
-     * @brief Assembles the negative residual vector of all airways.
+     * @brief Assembles the residual vector of all airways.
      *
      * Applies model-specific logic and calculates the residuals of each airway element and stores
      * them.
@@ -1093,9 +1093,8 @@ namespace ReducedLung
      * column map layout.
      * @param dt Current time step size.
      */
-    void update_negative_residual_vector(Core::LinAlg::Vector<double>& res_vector,
-        AirwayContainer& airways, const Core::LinAlg::Vector<double>& locally_relevant_dofs,
-        double dt);
+    void update_residual_vector(Core::LinAlg::Vector<double>& res_vector, AirwayContainer& airways,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt);
 
 
     /**

--- a/src/reduced_lung/src/4C_reduced_lung_boundary_conditions.cpp
+++ b/src/reduced_lung/src/4C_reduced_lung_boundary_conditions.cpp
@@ -70,7 +70,7 @@ namespace ReducedLung
         for (size_t i = 0; i < model.data.size(); ++i)
         {
           const int local_dof_id = model.data.local_dof_id[i];
-          const double res = -dofs.local_values_as_span()[local_dof_id] + model.values[i];
+          const double res = dofs.local_values_as_span()[local_dof_id] - model.values[i];
           rhs.replace_local_value(model.data.local_equation_id[i], res);
         }
       }
@@ -87,7 +87,7 @@ namespace ReducedLung
         for (size_t i = 0; i < model.data.size(); ++i)
         {
           const int local_dof_id = model.data.local_dof_id[i];
-          const double res = -dofs.local_values_as_span()[local_dof_id] + bc_value;
+          const double res = dofs.local_values_as_span()[local_dof_id] - bc_value;
           rhs.replace_local_value(model.data.local_equation_id[i], res);
         }
       }
@@ -373,23 +373,23 @@ namespace ReducedLung
       {
         if (model.value_source == ValueSource::constant_value)
         {
-          model.negative_residual_evaluator = evaluate_constant_value;
+          model.residual_evaluator = evaluate_constant_value;
         }
         else
         {
-          model.negative_residual_evaluator = evaluate_function_value;
+          model.residual_evaluator = evaluate_function_value;
         }
         model.jacobian_evaluator = assemble_diagonal_jacobian;
       }
     }
 
-    void update_negative_residual_vector(Core::LinAlg::Vector<double>& rhs,
+    void update_residual_vector(Core::LinAlg::Vector<double>& rhs,
         const BoundaryConditionContainer& boundary_conditions,
         const Core::LinAlg::Vector<double>& locally_relevant_dofs, double time)
     {
       for (const auto& model : boundary_conditions.models)
       {
-        model.negative_residual_evaluator(model, rhs, locally_relevant_dofs, time);
+        model.residual_evaluator(model, rhs, locally_relevant_dofs, time);
       }
     }
 

--- a/src/reduced_lung/src/4C_reduced_lung_boundary_conditions.hpp
+++ b/src/reduced_lung/src/4C_reduced_lung_boundary_conditions.hpp
@@ -106,9 +106,9 @@ namespace ReducedLung
     };
 
     /**
-     * @brief Function handle for evaluating the negative residuals.
+     * @brief Function handle for evaluating the residuals.
      */
-    using NegativeResidualEvaluator = std::function<void(const BoundaryConditionModel& model,
+    using ResidualEvaluator = std::function<void(const BoundaryConditionModel& model,
         Core::LinAlg::Vector<double>& rhs, const Core::LinAlg::Vector<double>& dofs, double time)>;
     /**
      * @brief Function handle for evaluating the boundary condition Jacobian.
@@ -133,7 +133,7 @@ namespace ReducedLung
       // conditions in the future).
       std::vector<double> values;
       BoundaryConditionData data;
-      NegativeResidualEvaluator negative_residual_evaluator;
+      ResidualEvaluator residual_evaluator;
       JacobianEvaluator jacobian_evaluator;
 
       /**
@@ -196,7 +196,7 @@ namespace ReducedLung
     /**
      * @brief Assemble the boundary condition residual contributions.
      */
-    void update_negative_residual_vector(Core::LinAlg::Vector<double>& rhs,
+    void update_residual_vector(Core::LinAlg::Vector<double>& rhs,
         const BoundaryConditionContainer& boundary_conditions,
         const Core::LinAlg::Vector<double>& locally_relevant_dofs, double time);
 

--- a/src/reduced_lung/src/4C_reduced_lung_junctions.cpp
+++ b/src/reduced_lung/src/4C_reduced_lung_junctions.cpp
@@ -255,7 +255,7 @@ namespace ReducedLung
       }
     }
 
-    void update_negative_residual_vector(Core::LinAlg::Vector<double>& rhs,
+    void update_residual_vector(Core::LinAlg::Vector<double>& rhs,
         const ConnectionData& connections, const BifurcationData& bifurcations,
         const Core::LinAlg::Vector<double>& locally_relevant_dofs)
     {
@@ -263,14 +263,14 @@ namespace ReducedLung
       {
         const auto& local_dof_ids = connections.local_dof_ids[i];
         double res =
-            -locally_relevant_dofs
-                 .local_values_as_span()[local_dof_ids[ConnectionData::p_out_parent]] +
+            locally_relevant_dofs
+                .local_values_as_span()[local_dof_ids[ConnectionData::p_out_parent]] -
             locally_relevant_dofs.local_values_as_span()[local_dof_ids[ConnectionData::p_in_child]];
         rhs.replace_local_value(connections.first_local_equation_id[i], res);
 
         res =
-            -locally_relevant_dofs
-                 .local_values_as_span()[local_dof_ids[ConnectionData::q_out_parent]] +
+            locally_relevant_dofs
+                .local_values_as_span()[local_dof_ids[ConnectionData::q_out_parent]] -
             locally_relevant_dofs.local_values_as_span()[local_dof_ids[ConnectionData::q_in_child]];
         rhs.replace_local_value(connections.first_local_equation_id[i] + 1, res);
       }
@@ -278,22 +278,22 @@ namespace ReducedLung
       for (size_t i = 0; i < bifurcations.size(); ++i)
       {
         const auto& local_dof_ids = bifurcations.local_dof_ids[i];
-        double res = -locally_relevant_dofs
-                          .local_values_as_span()[local_dof_ids[BifurcationData::p_out_parent]] +
+        double res = locally_relevant_dofs
+                         .local_values_as_span()[local_dof_ids[BifurcationData::p_out_parent]] -
                      locally_relevant_dofs
                          .local_values_as_span()[local_dof_ids[BifurcationData::p_in_child_1]];
         rhs.replace_local_value(bifurcations.first_local_equation_id[i], res);
 
-        res = -locally_relevant_dofs
-                   .local_values_as_span()[local_dof_ids[BifurcationData::p_out_parent]] +
+        res = locally_relevant_dofs
+                  .local_values_as_span()[local_dof_ids[BifurcationData::p_out_parent]] -
               locally_relevant_dofs
                   .local_values_as_span()[local_dof_ids[BifurcationData::p_in_child_2]];
         rhs.replace_local_value(bifurcations.first_local_equation_id[i] + 1, res);
 
-        res = -locally_relevant_dofs
-                   .local_values_as_span()[local_dof_ids[BifurcationData::q_out_parent]] +
+        res = locally_relevant_dofs
+                  .local_values_as_span()[local_dof_ids[BifurcationData::q_out_parent]] -
               locally_relevant_dofs
-                  .local_values_as_span()[local_dof_ids[BifurcationData::q_in_child_1]] +
+                  .local_values_as_span()[local_dof_ids[BifurcationData::q_in_child_1]] -
               locally_relevant_dofs
                   .local_values_as_span()[local_dof_ids[BifurcationData::q_in_child_2]];
         rhs.replace_local_value(bifurcations.first_local_equation_id[i] + 2, res);

--- a/src/reduced_lung/src/4C_reduced_lung_junctions.hpp
+++ b/src/reduced_lung/src/4C_reduced_lung_junctions.hpp
@@ -119,7 +119,7 @@ namespace ReducedLung
     void assign_junction_local_dof_ids(const Core::LinAlg::Map& locally_relevant_dof_map,
         ConnectionData& connections, BifurcationData& bifurcations);
 
-    void update_negative_residual_vector(Core::LinAlg::Vector<double>& rhs,
+    void update_residual_vector(Core::LinAlg::Vector<double>& rhs,
         const ConnectionData& connections, const BifurcationData& bifurcations,
         const Core::LinAlg::Vector<double>& locally_relevant_dofs);
 

--- a/src/reduced_lung/src/4C_reduced_lung_main.cpp
+++ b/src/reduced_lung/src/4C_reduced_lung_main.cpp
@@ -212,18 +212,16 @@ namespace ReducedLung
         }
         dofs_n.update(1.0, dofs, 0.0);
 
-        Airways::update_negative_residual_vector(rhs, airways, locally_relevant_dofs, dt);
+        Airways::update_residual_vector(rhs, airways, locally_relevant_dofs, dt);
         Airways::update_jacobian(sysmat, airways, locally_relevant_dofs, dt);
 
-        TerminalUnits::update_negative_residual_vector(
-            rhs, terminal_units, locally_relevant_dofs, dt);
+        TerminalUnits::update_residual_vector(rhs, terminal_units, locally_relevant_dofs, dt);
         TerminalUnits::update_jacobian(sysmat, terminal_units, locally_relevant_dofs, dt);
 
-        Junctions::update_negative_residual_vector(
-            rhs, connections, bifurcations, locally_relevant_dofs);
+        Junctions::update_residual_vector(rhs, connections, bifurcations, locally_relevant_dofs);
         Junctions::update_jacobian(sysmat, connections, bifurcations);
 
-        BoundaryConditions::update_negative_residual_vector(
+        BoundaryConditions::update_residual_vector(
             rhs, boundary_conditions, locally_relevant_dofs, n * dt);
         BoundaryConditions::update_jacobian(sysmat, boundary_conditions);
 
@@ -234,6 +232,7 @@ namespace ReducedLung
         }
 
         // Solve.
+        rhs.scale(-1.0);
         solver.solve(Core::Utils::shared_ptr_from_ref(sysmat), Core::Utils::shared_ptr_from_ref(x),
             Core::Utils::shared_ptr_from_ref(rhs), {});
 

--- a/src/reduced_lung/src/4C_reduced_lung_terminal_unit.cpp
+++ b/src/reduced_lung/src/4C_reduced_lung_terminal_unit.cpp
@@ -47,47 +47,47 @@ namespace ReducedLung
       return ogden_hyperelastic_model.elastic_pressure_p_el;
     }
 
-    void evaluate_negative_kelvin_voigt_residual(Core::LinAlg::Vector<double>& target,
+    void evaluate_kelvin_voigt_residual(Core::LinAlg::Vector<double>& target,
         const KelvinVoigt& kelvin_voigt_model, const TerminalUnitData& data,
         const Core::LinAlg::Vector<double>& locally_relevant_dofs,
         const std::vector<double>& elastic_pressure_p_el)
     {
       for (size_t i = 0; i < data.number_of_elements(); i++)
       {
-        double negative_kelvin_voigt_residual =
-            -1 * (locally_relevant_dofs.local_values_as_span()[data.lid_p1[i]] -
-                     locally_relevant_dofs.local_values_as_span()[data.lid_p2[i]] -
-                     elastic_pressure_p_el[i] -
-                     kelvin_voigt_model.viscosity_eta[i] *
-                         locally_relevant_dofs.local_values_as_span()[data.lid_q[i]] /
-                         data.reference_volume_v0[i]);
-        target.replace_local_value(data.local_row_id[i], negative_kelvin_voigt_residual);
+        double kelvin_voigt_residual =
+            (locally_relevant_dofs.local_values_as_span()[data.lid_p1[i]] -
+                locally_relevant_dofs.local_values_as_span()[data.lid_p2[i]] -
+                elastic_pressure_p_el[i] -
+                kelvin_voigt_model.viscosity_eta[i] *
+                    locally_relevant_dofs.local_values_as_span()[data.lid_q[i]] /
+                    data.reference_volume_v0[i]);
+        target.replace_local_value(data.local_row_id[i], kelvin_voigt_residual);
       }
     }
 
-    void evaluate_negative_four_element_maxwell_residual(Core::LinAlg::Vector<double>& target,
+    void evaluate_four_element_maxwell_residual(Core::LinAlg::Vector<double>& target,
         const FourElementMaxwell& four_element_maxwell_model, const TerminalUnitData& data,
         const Core::LinAlg::Vector<double>& locally_relevant_dofs,
         const std::vector<double>& elastic_pressure_p_el, double dt)
     {
       for (size_t i = 0; i < data.number_of_elements(); i++)
       {
-        double negative_four_element_maxwell_residual =
-            -1 * (locally_relevant_dofs.local_values_as_span()[data.lid_p1[i]] -
-                     locally_relevant_dofs.local_values_as_span()[data.lid_p2[i]] -
-                     elastic_pressure_p_el[i] -
-                     (four_element_maxwell_model.viscosity_eta[i] +
-                         (four_element_maxwell_model.elasticity_E_m[i] * dt *
-                             four_element_maxwell_model.viscosity_eta_m[i]) /
-                             (four_element_maxwell_model.elasticity_E_m[i] * dt +
-                                 four_element_maxwell_model.viscosity_eta_m[i])) /
-                         data.reference_volume_v0[i] *
-                         locally_relevant_dofs.local_values_as_span()[data.lid_q[i]] +
-                     four_element_maxwell_model.viscosity_eta_m[i] /
-                         (four_element_maxwell_model.elasticity_E_m[i] * dt +
-                             four_element_maxwell_model.viscosity_eta_m[i]) *
-                         four_element_maxwell_model.maxwell_pressure_p_m[i]);
-        target.replace_local_value(data.local_row_id[i], negative_four_element_maxwell_residual);
+        double four_element_maxwell_residual =
+            (locally_relevant_dofs.local_values_as_span()[data.lid_p1[i]] -
+                locally_relevant_dofs.local_values_as_span()[data.lid_p2[i]] -
+                elastic_pressure_p_el[i] -
+                (four_element_maxwell_model.viscosity_eta[i] +
+                    (four_element_maxwell_model.elasticity_E_m[i] * dt *
+                        four_element_maxwell_model.viscosity_eta_m[i]) /
+                        (four_element_maxwell_model.elasticity_E_m[i] * dt +
+                            four_element_maxwell_model.viscosity_eta_m[i])) /
+                    data.reference_volume_v0[i] *
+                    locally_relevant_dofs.local_values_as_span()[data.lid_q[i]] +
+                four_element_maxwell_model.viscosity_eta_m[i] /
+                    (four_element_maxwell_model.elasticity_E_m[i] * dt +
+                        four_element_maxwell_model.viscosity_eta_m[i]) *
+                    four_element_maxwell_model.maxwell_pressure_p_m[i]);
+        target.replace_local_value(data.local_row_id[i], four_element_maxwell_residual);
       }
     }
 
@@ -184,13 +184,13 @@ namespace ReducedLung
       }
     }
 
-    void update_negative_residual_vector(Core::LinAlg::Vector<double>& res_vector,
+    void update_residual_vector(Core::LinAlg::Vector<double>& res_vector,
         TerminalUnitContainer& terminal_units,
         const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt)
     {
       for (auto& model : terminal_units.models)
       {
-        model.negative_residual_evaluator(model.data, res_vector, locally_relevant_dofs, dt);
+        model.residual_evaluator(model.data, res_vector, locally_relevant_dofs, dt);
       }
     }
 
@@ -267,8 +267,8 @@ namespace ReducedLung
     {
       for (auto& model : terminal_units.models)
       {
-        model.negative_residual_evaluator = std::visit(
-            MakeNegativeResidualEvaluator{model.elasticity_model}, model.rheological_model);
+        model.residual_evaluator =
+            std::visit(MakeResidualEvaluator{model.elasticity_model}, model.rheological_model);
         model.jacobian_evaluator =
             std::visit(MakeJacobianEvaluator{model.elasticity_model}, model.rheological_model);
         model.internal_state_updater =

--- a/src/reduced_lung/src/4C_reduced_lung_terminal_unit.hpp
+++ b/src/reduced_lung/src/4C_reduced_lung_terminal_unit.hpp
@@ -132,8 +132,8 @@ namespace ReducedLung
       std::vector<double> elastic_pressure_grad_dp_el;
     };
 
-    // Function handle for evaluating the negative model residuals.
-    using NegativeResidualEvaluator = std::function<void(TerminalUnitData& model_data,
+    // Function handle for evaluating the model residuals.
+    using ResidualEvaluator = std::function<void(TerminalUnitData& model_data,
         Core::LinAlg::Vector<double>& target_vector,
         const Core::LinAlg::Vector<double>& locally_relevant_dof_vector, double time_step_size_dt)>;
 
@@ -166,7 +166,7 @@ namespace ReducedLung
       TerminalUnitData data;
       RheologicalModel rheological_model;
       ElasticityModel elasticity_model;
-      NegativeResidualEvaluator negative_residual_evaluator;
+      ResidualEvaluator residual_evaluator;
       JacobianEvaluator jacobian_evaluator;
       InternalStateUpdater internal_state_updater;
       EndOfTimestepRoutine end_of_timestep_routine;
@@ -222,7 +222,7 @@ namespace ReducedLung
         const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt);
 
     /**
-     * @brief Assembles the negative residual for a Kelvin-Voigt viscoelastic model.
+     * @brief Assembles the residual for a Kelvin-Voigt viscoelastic model.
      *
      * @param[out] target Target vector to which the residual is written.
      * @param[in] kelvin_voigt_model Model containing viscosity parameters. Must belong to the same
@@ -234,13 +234,13 @@ namespace ReducedLung
      *
      * @note The function writes directly into the `target` vector using the row IDs from `data`.
      */
-    void evaluate_negative_kelvin_voigt_residual(Core::LinAlg::Vector<double>& target,
+    void evaluate_kelvin_voigt_residual(Core::LinAlg::Vector<double>& target,
         const KelvinVoigt& kelvin_voigt_model, const TerminalUnitData& data,
         const Core::LinAlg::Vector<double>& locally_relevant_dofs,
         const std::vector<double>& elastic_pressure_p_el);
 
     /**
-     * @brief Assembles the negative residual for a four-element Maxwell viscoelastic model.
+     * @brief Assembles the residual for a four-element Maxwell viscoelastic model.
      *
      * @param[out] target Target vector to which the residual is written.
      * @param[in] four_element_maxwell_model Model parameters and internal Maxwell body pressure
@@ -256,7 +256,7 @@ namespace ReducedLung
      * relies on an up-to-date internal Maxwell pressure state (p_m updated with DOFs from the last
      * time step).
      */
-    void evaluate_negative_four_element_maxwell_residual(Core::LinAlg::Vector<double>& target,
+    void evaluate_four_element_maxwell_residual(Core::LinAlg::Vector<double>& target,
         const FourElementMaxwell& four_element_maxwell_model, const TerminalUnitData& data,
         const Core::LinAlg::Vector<double>& locally_relevant_dofs,
         const std::vector<double>& elastic_pressure_p_el, double dt);
@@ -330,9 +330,9 @@ namespace ReducedLung
 
 
     /**
-     * Creates the model-specific evaluator function for assembling the negative model residual.
+     * Creates the model-specific evaluator function for assembling the model residual.
      */
-    struct MakeNegativeResidualEvaluator
+    struct MakeResidualEvaluator
     {
       /**
        * Creates a function for evaluating the elastic pressure given a specific elasticity model.
@@ -355,7 +355,7 @@ namespace ReducedLung
         }
       };
 
-      NegativeResidualEvaluator operator()(KelvinVoigt& kelvin_voigt_model)
+      ResidualEvaluator operator()(KelvinVoigt& kelvin_voigt_model)
       {
         auto elastic_pressure_evaluator =
             std::visit(MakeElasticPressureEvaluator{}, elasticity_model);
@@ -364,10 +364,10 @@ namespace ReducedLung
                    double dt)
         {
           auto& p_el = elastic_pressure_evaluator(data, dofs, dt);
-          evaluate_negative_kelvin_voigt_residual(target, kelvin_voigt_model, data, dofs, p_el);
+          evaluate_kelvin_voigt_residual(target, kelvin_voigt_model, data, dofs, p_el);
         };
       }
-      NegativeResidualEvaluator operator()(FourElementMaxwell& four_element_maxwell_model)
+      ResidualEvaluator operator()(FourElementMaxwell& four_element_maxwell_model)
       {
         auto elastic_pressure_evaluator =
             std::visit(MakeElasticPressureEvaluator{}, elasticity_model);
@@ -376,7 +376,7 @@ namespace ReducedLung
                    double dt)
         {
           auto& p_el = elastic_pressure_evaluator(data, dofs, dt);
-          evaluate_negative_four_element_maxwell_residual(
+          evaluate_four_element_maxwell_residual(
               target, four_element_maxwell_model, data, dofs, p_el, dt);
         };
       }
@@ -620,7 +620,7 @@ namespace ReducedLung
     }
 
     /**
-     * @brief Assembles the negative residual vector of all terminal units.
+     * @brief Assembles the residual vector of all terminal units.
      *
      * Applies model-specific logic to compute viscoelastic responses of all terminal units and
      * store them in the residual.
@@ -631,7 +631,7 @@ namespace ReducedLung
      * column map layout.
      * @param dt Current time step size.
      */
-    void update_negative_residual_vector(Core::LinAlg::Vector<double>& res_vector,
+    void update_residual_vector(Core::LinAlg::Vector<double>& res_vector,
         TerminalUnitContainer& terminal_units,
         const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt);
 

--- a/src/reduced_lung/tests/4C_reduced_lung_airways_test.cpp
+++ b/src/reduced_lung/tests/4C_reduced_lung_airways_test.cpp
@@ -79,8 +79,8 @@ namespace
 
       model.internal_state_updater =
           std::visit(Airways::MakeInternalStateUpdater{model.flow_model}, model.wall_model);
-      model.negative_residual_evaluator =
-          std::visit(Airways::MakeNegativeResidualEvaluator{model.flow_model}, model.wall_model);
+      model.residual_evaluator =
+          std::visit(Airways::MakeResidualEvaluator{model.flow_model}, model.wall_model);
       model.jacobian_evaluator =
           std::visit(Airways::MakeJacobianEvaluator{model.flow_model}, model.wall_model);
 
@@ -103,8 +103,8 @@ namespace
 
       model.internal_state_updater =
           std::visit(Airways::MakeInternalStateUpdater{model.flow_model}, model.wall_model);
-      model.negative_residual_evaluator =
-          std::visit(Airways::MakeNegativeResidualEvaluator{model.flow_model}, model.wall_model);
+      model.residual_evaluator =
+          std::visit(Airways::MakeResidualEvaluator{model.flow_model}, model.wall_model);
       model.jacobian_evaluator =
           std::visit(Airways::MakeJacobianEvaluator{model.flow_model}, model.wall_model);
 
@@ -130,8 +130,8 @@ namespace
 
       model.internal_state_updater =
           std::visit(Airways::MakeInternalStateUpdater{model.flow_model}, model.wall_model);
-      model.negative_residual_evaluator =
-          std::visit(Airways::MakeNegativeResidualEvaluator{model.flow_model}, model.wall_model);
+      model.residual_evaluator =
+          std::visit(Airways::MakeResidualEvaluator{model.flow_model}, model.wall_model);
       model.jacobian_evaluator =
           std::visit(Airways::MakeJacobianEvaluator{model.flow_model}, model.wall_model);
 
@@ -158,8 +158,8 @@ namespace
 
       model.internal_state_updater =
           std::visit(Airways::MakeInternalStateUpdater{model.flow_model}, model.wall_model);
-      model.negative_residual_evaluator =
-          std::visit(Airways::MakeNegativeResidualEvaluator{model.flow_model}, model.wall_model);
+      model.residual_evaluator =
+          std::visit(Airways::MakeResidualEvaluator{model.flow_model}, model.wall_model);
       model.jacobian_evaluator =
           std::visit(Airways::MakeJacobianEvaluator{model.flow_model}, model.wall_model);
 
@@ -243,8 +243,8 @@ namespace
 
       model.internal_state_updater =
           std::visit(Airways::MakeInternalStateUpdater{model.flow_model}, model.wall_model);
-      model.negative_residual_evaluator =
-          std::visit(Airways::MakeNegativeResidualEvaluator{model.flow_model}, model.wall_model);
+      model.residual_evaluator =
+          std::visit(Airways::MakeResidualEvaluator{model.flow_model}, model.wall_model);
       model.jacobian_evaluator =
           std::visit(Airways::MakeJacobianEvaluator{model.flow_model}, model.wall_model);
       model.internal_state_updater(model.data, locally_relevant_dofs, dt);
@@ -268,8 +268,8 @@ namespace
 
       model.internal_state_updater =
           std::visit(Airways::MakeInternalStateUpdater{model.flow_model}, model.wall_model);
-      model.negative_residual_evaluator =
-          std::visit(Airways::MakeNegativeResidualEvaluator{model.flow_model}, model.wall_model);
+      model.residual_evaluator =
+          std::visit(Airways::MakeResidualEvaluator{model.flow_model}, model.wall_model);
       model.jacobian_evaluator =
           std::visit(Airways::MakeJacobianEvaluator{model.flow_model}, model.wall_model);
       model.internal_state_updater(model.data, locally_relevant_dofs, dt);
@@ -294,8 +294,8 @@ namespace
 
       model.internal_state_updater =
           std::visit(Airways::MakeInternalStateUpdater{model.flow_model}, model.wall_model);
-      model.negative_residual_evaluator =
-          std::visit(Airways::MakeNegativeResidualEvaluator{model.flow_model}, model.wall_model);
+      model.residual_evaluator =
+          std::visit(Airways::MakeResidualEvaluator{model.flow_model}, model.wall_model);
       model.jacobian_evaluator =
           std::visit(Airways::MakeJacobianEvaluator{model.flow_model}, model.wall_model);
       model.internal_state_updater(model.data, locally_relevant_dofs, dt);
@@ -320,8 +320,8 @@ namespace
 
       model.internal_state_updater =
           std::visit(Airways::MakeInternalStateUpdater{model.flow_model}, model.wall_model);
-      model.negative_residual_evaluator =
-          std::visit(Airways::MakeNegativeResidualEvaluator{model.flow_model}, model.wall_model);
+      model.residual_evaluator =
+          std::visit(Airways::MakeResidualEvaluator{model.flow_model}, model.wall_model);
       model.jacobian_evaluator =
           std::visit(Airways::MakeJacobianEvaluator{model.flow_model}, model.wall_model);
       model.internal_state_updater(model.data, locally_relevant_dofs, dt);

--- a/src/reduced_lung/tests/4C_reduced_lung_boundary_conditions_test.cpp
+++ b/src/reduced_lung/tests/4C_reduced_lung_boundary_conditions_test.cpp
@@ -263,7 +263,7 @@ namespace
     dof_values[1] = 4.0;   // global dof 2
     dof_values[2] = 7.0;   // global dof 4
 
-    update_negative_residual_vector(rhs, boundary_conditions, locally_relevant_dofs, 0.0);
+    update_residual_vector(rhs, boundary_conditions, locally_relevant_dofs, 0.0);
 
     for (const auto& model : boundary_conditions.models)
     {
@@ -272,7 +272,7 @@ namespace
         const int eq = model.data.local_equation_id[i];
         const int ldof = model.data.local_dof_id[i];
         const double expected =
-            -locally_relevant_dofs.local_values_as_span()[ldof] + model.values[i];
+            locally_relevant_dofs.local_values_as_span()[ldof] - model.values[i];
         EXPECT_DOUBLE_EQ(rhs.local_values_as_span()[eq], expected);
       }
     }
@@ -386,13 +386,12 @@ namespace
     locally_relevant_dofs.get_values()[0] = 1.0;
 
     const double time = 1.5;
-    update_negative_residual_vector(rhs, boundary_conditions, locally_relevant_dofs, time);
+    update_residual_vector(rhs, boundary_conditions, locally_relevant_dofs, time);
 
     ASSERT_EQ(boundary_conditions.models.size(), 1u);
     const auto& model = boundary_conditions.models.front();
     ASSERT_EQ(model.data.size(), 1u);
-    EXPECT_DOUBLE_EQ(
-        rhs.local_values_as_span()[model.data.local_equation_id[0]], -1.0 + 2.0 * time);
+    EXPECT_DOUBLE_EQ(rhs.local_values_as_span()[model.data.local_equation_id[0]], 1.0 - 2.0 * time);
   }
 
   TEST(BoundaryConditionsTests, CreateBoundaryConditionsDuplicateTypeThrows)

--- a/src/reduced_lung/tests/4C_reduced_lung_junctions_test.cpp
+++ b/src/reduced_lung/tests/4C_reduced_lung_junctions_test.cpp
@@ -96,10 +96,10 @@ namespace
     locally_relevant_dofs.get_values()[2] = 3.0;
     locally_relevant_dofs.get_values()[3] = 4.0;
 
-    update_negative_residual_vector(rhs, connections, bifurcations, locally_relevant_dofs);
+    update_residual_vector(rhs, connections, bifurcations, locally_relevant_dofs);
 
-    EXPECT_DOUBLE_EQ(rhs.local_values_as_span()[0], -10.0 + 5.0);
-    EXPECT_DOUBLE_EQ(rhs.local_values_as_span()[1], -3.0 + 4.0);
+    EXPECT_DOUBLE_EQ(rhs.local_values_as_span()[0], 10.0 - 5.0);
+    EXPECT_DOUBLE_EQ(rhs.local_values_as_span()[1], 3.0 - 4.0);
   }
 
   TEST(JunctionsTests, BifurcationResidualAssembly)
@@ -123,11 +123,11 @@ namespace
     locally_relevant_dofs.get_values()[4] = 3.0;
     locally_relevant_dofs.get_values()[5] = 4.0;
 
-    update_negative_residual_vector(rhs, connections, bifurcations, locally_relevant_dofs);
+    update_residual_vector(rhs, connections, bifurcations, locally_relevant_dofs);
 
-    EXPECT_DOUBLE_EQ(rhs.local_values_as_span()[0], -10.0 + 7.0);
-    EXPECT_DOUBLE_EQ(rhs.local_values_as_span()[1], -10.0 + 6.0);
-    EXPECT_DOUBLE_EQ(rhs.local_values_as_span()[2], -8.0 + 3.0 + 4.0);
+    EXPECT_DOUBLE_EQ(rhs.local_values_as_span()[0], 10.0 - 7.0);
+    EXPECT_DOUBLE_EQ(rhs.local_values_as_span()[1], 10.0 - 6.0);
+    EXPECT_DOUBLE_EQ(rhs.local_values_as_span()[2], 8.0 - 3.0 - 4.0);
   }
 
   TEST(JunctionsTests, ConnectionJacobianAssembledOnce)

--- a/src/reduced_lung/tests/4C_reduced_lung_terminal_unit_test.cpp
+++ b/src/reduced_lung/tests/4C_reduced_lung_terminal_unit_test.cpp
@@ -59,9 +59,8 @@ namespace
           std::vector<double>{0.0, 0.0, 0.0}, std::vector<double>{0.0, 0.0, 0.0}};
       model.internal_state_updater =
           std::visit(TerminalUnits::MakeInternalStateUpdater{}, model.rheological_model);
-      model.negative_residual_evaluator =
-          std::visit(TerminalUnits::MakeNegativeResidualEvaluator{model.elasticity_model},
-              model.rheological_model);
+      model.residual_evaluator = std::visit(
+          TerminalUnits::MakeResidualEvaluator{model.elasticity_model}, model.rheological_model);
       model.jacobian_evaluator = std::visit(
           TerminalUnits::MakeJacobianEvaluator{model.elasticity_model}, model.rheological_model);
       model.jacobian_evaluator(model.data, jac, locally_relevant_dofs, dt);
@@ -83,9 +82,8 @@ namespace
           std::vector<double>{0.0, 0.0, 0.0}};
       model.internal_state_updater =
           std::visit(TerminalUnits::MakeInternalStateUpdater{}, model.rheological_model);
-      model.negative_residual_evaluator =
-          std::visit(TerminalUnits::MakeNegativeResidualEvaluator{model.elasticity_model},
-              model.rheological_model);
+      model.residual_evaluator = std::visit(
+          TerminalUnits::MakeResidualEvaluator{model.elasticity_model}, model.rheological_model);
       model.jacobian_evaluator = std::visit(
           TerminalUnits::MakeJacobianEvaluator{model.elasticity_model}, model.rheological_model);
       model.jacobian_evaluator(model.data, jac, locally_relevant_dofs, dt);
@@ -108,9 +106,8 @@ namespace
           std::vector<double>{0.0, 0.0, 0.0}, std::vector<double>{0.0, 0.0, 0.0}};
       model.internal_state_updater =
           std::visit(TerminalUnits::MakeInternalStateUpdater{}, model.rheological_model);
-      model.negative_residual_evaluator =
-          std::visit(TerminalUnits::MakeNegativeResidualEvaluator{model.elasticity_model},
-              model.rheological_model);
+      model.residual_evaluator = std::visit(
+          TerminalUnits::MakeResidualEvaluator{model.elasticity_model}, model.rheological_model);
       model.jacobian_evaluator = std::visit(
           TerminalUnits::MakeJacobianEvaluator{model.elasticity_model}, model.rheological_model);
       model.jacobian_evaluator(model.data, jac, locally_relevant_dofs, dt);
@@ -143,9 +140,8 @@ namespace
           std::vector<double>{0.0, 0.0, 0.0}};
       model.internal_state_updater =
           std::visit(TerminalUnits::MakeInternalStateUpdater{}, model.rheological_model);
-      model.negative_residual_evaluator =
-          std::visit(TerminalUnits::MakeNegativeResidualEvaluator{model.elasticity_model},
-              model.rheological_model);
+      model.residual_evaluator = std::visit(
+          TerminalUnits::MakeResidualEvaluator{model.elasticity_model}, model.rheological_model);
       model.jacobian_evaluator = std::visit(
           TerminalUnits::MakeJacobianEvaluator{model.elasticity_model}, model.rheological_model);
       model.jacobian_evaluator(model.data, jac, locally_relevant_dofs, dt);

--- a/src/reduced_lung/tests/4C_reduced_lung_test_utils_test.hpp
+++ b/src/reduced_lung/tests/4C_reduced_lung_test_utils_test.hpp
@@ -28,7 +28,7 @@ namespace ReducedLung::TestUtils
 {
   // Generalized helper to check a Jacobian column against a central finite-difference
   // approximation of the residual. Works for both TerminalUnitModel and AirwayModel as long
-  // as the model exposes `data`, `negative_residual_evaluator` and the data structure
+  // as the model exposes `data`, `residual_evaluator` and the data structure
   // provides `number_of_elements()` and per-element lid vectors passed in `dof_lids`.
   template <typename Model>
   void check_jacobian_column_against_fd(const std::vector<int>& dof_lids, int jac_col, Model& model,
@@ -42,20 +42,20 @@ namespace ReducedLung::TestUtils
     for (int lid : dof_lids) locally_relevant_dofs.get_values()[lid] += eps;
     Core::LinAlg::Vector<double> res_plus(row_map, true);
     model.internal_state_updater(model.data, locally_relevant_dofs, dt);
-    model.negative_residual_evaluator(model.data, res_plus, locally_relevant_dofs, dt);
+    model.residual_evaluator(model.data, res_plus, locally_relevant_dofs, dt);
 
     // Perturb in -epsilon direction
     for (int lid : dof_lids) locally_relevant_dofs.get_values()[lid] -= 2 * eps;
     Core::LinAlg::Vector<double> res_minus(row_map, true);
     model.internal_state_updater(model.data, locally_relevant_dofs, dt);
-    model.negative_residual_evaluator(model.data, res_minus, locally_relevant_dofs, dt);
+    model.residual_evaluator(model.data, res_minus, locally_relevant_dofs, dt);
 
     // Restore original state
     for (int lid : dof_lids) locally_relevant_dofs.get_values()[lid] += eps;
 
     // Compute FD approximation
     Core::LinAlg::Vector<double> fd_derivative(row_map, true);
-    fd_derivative.update(-1.0 / (2 * eps), res_plus, 1.0 / (2 * eps), res_minus, 0.0);
+    fd_derivative.update(1.0 / (2 * eps), res_plus, -1.0 / (2 * eps), res_minus, 0.0);
 
     // Compare with Jacobian column
     const int n_rows_per_element = []<typename DataType>(const DataType& data)


### PR DESCRIPTION
## Description and Context
This PR fixes several bugs/issues in the reduced lung framework as a preparation to introduce NOX in #1807 

- Fix Kelvin-Voigt airway equation row indexing for the Kelvin Voigt compliant wall model
- Fix airway timestep updates
- Fix flipped sign in four element Maxwell residual
- Fix internal model parameters for airway and TU
- Change sign in residual evaluators