### PR TITLE
Unify preconditioners for xfluid test cases

### DIFF
--- a/tests/input_files/xfluid_ifpack.xml
+++ b/tests/input_files/xfluid_ifpack.xml
@@ -1,7 +1,0 @@
-<ParameterList name="Ifpack">
-  <Parameter name="Prec Type" type="string" value="ILU"/>
-  <Parameter name="Overlap" type="int" value="3"/>
-  <ParameterList name="Ifpack Settings">
-    <Parameter name="fact: level-of-fill" type="int" value="3"/>
-  </ParameterList>
-</ParameterList>

--- a/tests/input_files/xfluid_kimmoin_stat_24x24x1_wedge15_levelset.4C.yaml
+++ b/tests/input_files/xfluid_kimmoin_stat_24x24x1_wedge15_levelset.4C.yaml
@@ -49,7 +49,7 @@ XFLUID DYNAMIC/STABILIZATION:
   IS_PSEUDO_2D: true
 SOLVER 1:
   SOLVER: "Belos"
-  IFPACK_XML_FILE: "xfluid_ifpack.xml"
+  IFPACK_XML_FILE: "xml/preconditioner/ifpack_level-of-fill_3.xml"
   AZOUTPUT: 50
   AZREUSE: 1
   NAME: "Fluid_Solver"

--- a/tests/input_files/xfluid_kimmoin_stat_24x24x1_wedge15_levelset_normal_2ndGP.4C.yaml
+++ b/tests/input_files/xfluid_kimmoin_stat_24x24x1_wedge15_levelset_normal_2ndGP.4C.yaml
@@ -51,7 +51,7 @@ XFLUID DYNAMIC/STABILIZATION:
   IS_PSEUDO_2D: true
 SOLVER 1:
   SOLVER: "Belos"
-  IFPACK_XML_FILE: "xfluid_ifpack.xml"
+  IFPACK_XML_FILE: "xml/preconditioner/ifpack_level-of-fill_3.xml"
   AZOUTPUT: 50
   AZREUSE: 1
   NAME: "Fluid_Solver"

--- a/tests/input_files/xfluid_oseen_urquiza_square_NavSlip_eps1.0_40x40_mesh_altgeogeneration.4C.yaml
+++ b/tests/input_files/xfluid_oseen_urquiza_square_NavSlip_eps1.0_40x40_mesh_altgeogeneration.4C.yaml
@@ -56,7 +56,7 @@ XFLUID DYNAMIC/STABILIZATION:
   IS_PSEUDO_2D: true
 SOLVER 1:
   SOLVER: "Belos"
-  IFPACK_XML_FILE: "xfluid_ifpack.xml"
+  IFPACK_XML_FILE: "xml/preconditioner/ifpack_level-of-fill_3.xml"
   AZTOL: 1e-14
   AZOUTPUT: 50
   AZREUSE: 1

--- a/tests/input_files/xfluid_taylor_couette_NavSlip_eps1.0_50x50_krylov_levelset.4C.yaml
+++ b/tests/input_files/xfluid_taylor_couette_NavSlip_eps1.0_50x50_krylov_levelset.4C.yaml
@@ -71,7 +71,7 @@ SCALAR TRANSPORT DYNAMIC/STABILIZATION:
   DEFINITION_TAU: "Taylor_Hughes_Zarins_wo_dt"
 SOLVER 1:
   SOLVER: "Belos"
-  IFPACK_XML_FILE: "xfluid_ifpack.xml"
+  IFPACK_XML_FILE: "xml/preconditioner/ifpack_level-of-fill_3.xml"
   AZTOL: 1.1e-06
   AZOUTPUT: 50
   THROW_IF_UNCONVERGED: false


### PR DESCRIPTION
## Description and Context
We regularly have problems in the pipeline with xfluid_ tests due to timeouts. A closer look revealed that we used a "custom" XML file for the preconditioner settings, whereas templates are available in xml/preconditioners.

Switching to one of those templates (the one recently added by @rjoussen) reduced runtime from approximately 60 to 20 seconds on my workstation across 3 consecutive runs. Thus, I decided to delete the "custom" XML file and replace it with the one from the xml/preconditioners folder.

## Related Issues and Pull Requests
Follows #1737