### PR TITLE
Deactivate Python bindings in asan build

### DIFF
--- a/cmake/setup_py4C.cmake
+++ b/cmake/setup_py4C.cmake
@@ -21,6 +21,14 @@ if(FOUR_C_ENABLE_PYTHON_BINDINGS)
       )
   endif()
 
+  # Python bindings are currently not compatible with an address sanitizer build
+  if(FOUR_C_ENABLE_ADDRESS_SANITIZER)
+    message(
+      FATAL_ERROR
+        "4C Python bindings are currently not compatible with an address sanitizer build. Either set FOUR_C_ENABLE_ADDRESS_SANITIZER=OFF or FOUR_C_ENABLE_PYTHON_BINDINGS=OFF."
+      )
+  endif()
+
   # define the name of the python module
   set(FOUR_C_PYTHON_BINDINGS_PROJECT_NAME py4C)
 

--- a/presets/docker/CMakePresets.json
+++ b/presets/docker/CMakePresets.json
@@ -78,7 +78,8 @@
       ],
       "cacheVariables": {
         "FOUR_C_ENABLE_ADDRESS_SANITIZER": "ON",
-        "FOUR_C_TEST_TIMEOUT_SCALE": "10"
+        "FOUR_C_TEST_TIMEOUT_SCALE": "10",
+        "FOUR_C_ENABLE_PYTHON_BINDINGS": "OFF"
       }
     },
     {


### PR DESCRIPTION
Fixes nightly failing tests.

Currently, it does not work to run python bindings with asan enabled. One would need to manually load the asan dynamic library (since python is not built with asan typically), and even if one does, submodules are not found (I don't understand why).