### PR TITLE
Check for early stoppage in struct field

### DIFF
--- a/src/ssi/4C_ssi_monolithic.cpp
+++ b/src/ssi/4C_ssi_monolithic.cpp
@@ -891,7 +891,7 @@ void SSI::SsiMono::timeloop()
   if (step() == 0) prepare_time_loop();
 
   // time loop
-  while (not_finished() and scatra_field()->not_finished())
+  while (not_finished() and scatra_field()->not_finished() and structure_field()->not_finished())
   {
     TEUCHOS_FUNC_TIME_MONITOR("SSI mono: solve time step");
     // prepare time step

--- a/src/ssi/4C_ssi_partitioned_1wc.cpp
+++ b/src/ssi/4C_ssi_partitioned_1wc.cpp
@@ -320,7 +320,8 @@ bool SSI::SSIPart1WCScatraToSolid::finished() const
   if (diff_time_step_size())
     return !not_finished();
   else
-    return !(not_finished() and scatra_field()->not_finished());
+    return !(
+        not_finished() and scatra_field()->not_finished() and structure_field()->not_finished());
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/ssi/4C_ssi_partitioned_2wc.cpp
+++ b/src/ssi/4C_ssi_partitioned_2wc.cpp
@@ -100,7 +100,7 @@ void SSI::SSIPart2WC::timeloop()
   prepare_time_loop();
 
   // time loop
-  while (not_finished() and scatra_field()->not_finished())
+  while (not_finished() and scatra_field()->not_finished() and structure_field()->not_finished())
   {
     prepare_time_step();
 


### PR DESCRIPTION
In growth and remodeling simulations, a prestressing algorithm is often used to obtain a desired configuration. Therefore, an additional convergence criterion is introduced that checks whether the displacement falls below a prescribed tolerance.

To stop the time loop for this additional criterion, an `early_stopping()` mechanism is implemented. See
`bool Solid::IMPLICIT::PreStress::early_stopping() const` in `4C_structure_new_impl_prestress.cpp`.

This PR adds the additional convergence check for 2wc, 1wc, and monolithic coupling via
`structure_field()->not_finished()`.