### PR TITLE
Centralize Global::Problem access in porofluid_pressure_based

### DIFF
--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_algorithm.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_algorithm.cpp
@@ -11,7 +11,6 @@
 #include "4C_fem_general_assemblestrategy.hpp"
 #include "4C_fem_general_l2_projection.hpp"
 #include "4C_fem_general_node.hpp"
-#include "4C_global_data.hpp"
 #include "4C_io.hpp"
 #include "4C_io_control.hpp"
 #include "4C_io_gmsh.hpp"
@@ -28,6 +27,7 @@
 #include "4C_porofluid_pressure_based_utils.hpp"
 #include "4C_utils_enum.hpp"
 #include "4C_utils_function.hpp"
+#include "4C_utils_function_manager.hpp"
 
 #include <Teuchos_TimeMonitor.hpp>
 
@@ -37,14 +37,16 @@ FOUR_C_NAMESPACE_OPEN
 PoroPressureBased::PorofluidAlgorithm::PorofluidAlgorithm(
     std::shared_ptr<Core::FE::Discretization> actdis, const int linsolvernumber,
     const Teuchos::ParameterList& probparams, const Teuchos::ParameterList& poroparams,
-    std::shared_ptr<Core::IO::DiscretizationWriter> output)
+    std::shared_ptr<Core::IO::DiscretizationWriter> output,
+    PorofluidAlgorithmDeps algorithm_deps)
     :  // call constructor for "nontrivial" objects
       solver_(nullptr),
       linsolvernumber_(linsolvernumber),
       params_(probparams),
       poroparams_(poroparams),
+      algorithm_deps_(std::move(algorithm_deps)),
       myrank_(Core::Communication::my_mpi_rank(actdis->get_comm())),
-      nsd_(Global::Problem::instance()->n_dim()),
+      nsd_(algorithm_deps_.spatial_dimension),
       isale_(false),
       skipinitder_(poroparams_.get<bool>("skip_initial_time_derivative")),
       output_satpress_(poroparams_.sublist("output").get<bool>("saturation_and_pressure")),
@@ -122,6 +124,15 @@ PoroPressureBased::PorofluidAlgorithm::PorofluidAlgorithm(
       theta_(params_.sublist("time_integration").get<double>("theta")),
       visualization_writer_(nullptr)
 {
+  FOUR_C_ASSERT_ALWAYS(algorithm_deps_.runtime_vtk_output_parameters != nullptr,
+      "Runtime VTK output parameters are required.");
+  FOUR_C_ASSERT_ALWAYS(
+      algorithm_deps_.output_control_file != nullptr, "Output control file is required.");
+  FOUR_C_ASSERT_ALWAYS(algorithm_deps_.function_manager != nullptr,
+      "Function manager is required for porofluid algorithm.");
+  FOUR_C_ASSERT_ALWAYS(algorithm_deps_.solver_params_by_id,
+      "Solver parameter callback is required for porofluid algorithm.");
+
   // safety check
   if (has_bodyforce_contribution_)
   {
@@ -129,24 +140,25 @@ PoroPressureBased::PorofluidAlgorithm::PorofluidAlgorithm(
     bodyforce_contribution_values_ =
         (poroparams_.get<std::optional<std::vector<double>>>("body_force")).value();
     // safety check
-    FOUR_C_ASSERT_ALWAYS(static_cast<int>(bodyforce_contribution_values_.size()) ==
-                             Global::Problem::instance()->n_dim(),
+    FOUR_C_ASSERT_ALWAYS(static_cast<int>(bodyforce_contribution_values_.size()) == nsd_,
         "The dimension of your bodyforce vector and the dimension of the problem must be equal!");
   }
 
-  const int restart_step = Global::Problem::instance()->restart();
+  const int restart_step = algorithm_deps_.restart_step;
   if (restart_step > 0)
   {
+    FOUR_C_ASSERT_ALWAYS(algorithm_deps_.input_control_file != nullptr,
+        "Input control file is required for restart.");
+
     Core::IO::DiscretizationReader reader(
-        *discret_, Global::Problem::instance()->input_control_file(), restart_step);
+        *discret_, algorithm_deps_.input_control_file, restart_step);
 
     time_ = reader.read_double("time");
   }
 
-  visualization_writer_ = std::make_unique<Core::IO::DiscretizationVisualizationWriterMesh>(
-      actdis, Core::IO::visualization_parameters_factory(
-                  Global::Problem::instance()->io_params().sublist("RUNTIME VTK OUTPUT"),
-                  *Global::Problem::instance()->output_control_file(), time_));
+  visualization_writer_ = std::make_unique<Core::IO::DiscretizationVisualizationWriterMesh>(actdis,
+      Core::IO::visualization_parameters_factory(*algorithm_deps_.runtime_vtk_output_parameters,
+          *algorithm_deps_.output_control_file, time_));
 }
 
 
@@ -265,7 +277,7 @@ void PoroPressureBased::PorofluidAlgorithm::init(bool isale, int nds_disp, int n
     // other parameters needed by the elements
     eleparams.set("total time", time_);
     eleparams.set<const Core::Utils::FunctionManager*>(
-        "function_manager", &Global::Problem::instance()->function_manager());
+        "function_manager", algorithm_deps_.function_manager);
     discret_->evaluate_dirichlet(eleparams, zeros_, nullptr, nullptr, nullptr, dbcmaps_);
     discret_->evaluate_dirichlet(
         eleparams, zeros_, nullptr, nullptr, nullptr, dbcmaps_with_volfracpress_);
@@ -305,7 +317,7 @@ void PoroPressureBased::PorofluidAlgorithm::init(bool isale, int nds_disp, int n
   {
     // setup csv writer for domain integrals
     runtime_csvwriter_domain_integrals_.emplace(
-        myrank_, *Global::Problem::instance()->output_control_file(), "domain_integrals");
+        myrank_, *algorithm_deps_.output_control_file, "domain_integrals");
     for (int funct_i = 0; funct_i < num_domainint_funct_; funct_i++)
     {
       runtime_csvwriter_domain_integrals_->register_data_vector(
@@ -320,17 +332,24 @@ void PoroPressureBased::PorofluidAlgorithm::init(bool isale, int nds_disp, int n
   {
     output_bloodvesselvolfrac_ =
         poroparams_.sublist("artery_coupling").get<bool>("output_blood_vessel_volume_fraction");
-    meshtying_ = std::make_shared<PoroPressureBased::MeshtyingArtery>(this, params_, poroparams_);
+    FOUR_C_ASSERT_ALWAYS(algorithm_deps_.artery_discretization != nullptr,
+        "Artery discretization must be provided when artery coupling is active.");
+    FOUR_C_ASSERT_ALWAYS(algorithm_deps_.artery_dynamic_parameters != nullptr,
+        "Artery dynamic parameters must be provided when artery coupling is active.");
+    FOUR_C_ASSERT_ALWAYS(algorithm_deps_.add_field_test,
+        "Result test registration callback must be provided when artery coupling is active.");
+
+    meshtying_ = std::make_shared<PoroPressureBased::MeshtyingArtery>(this, params_, poroparams_,
+        algorithm_deps_.artery_discretization, *algorithm_deps_.artery_dynamic_parameters,
+        algorithm_deps_.solver_params_by_id, algorithm_deps_.add_field_test);
     meshtying_->check_initial_fields(phinp_);
     meshtying_->set_nearby_ele_pairs(nearby_ele_pairs);
     meshtying_->setup();
   }
 
-  solver_ = std::make_shared<Core::LinAlg::Solver>(
-      Global::Problem::instance()->solver_params(linsolvernumber_), discret_->get_comm(),
-      Global::Problem::instance()->solver_params_callback(),
-      Teuchos::getIntegralValue<Core::IO::Verbositylevel>(
-          Global::Problem::instance()->io_params(), "VERBOSITY"));
+  solver_ =
+      std::make_shared<Core::LinAlg::Solver>(algorithm_deps_.solver_params_by_id(linsolvernumber_),
+          discret_->get_comm(), algorithm_deps_.solver_params_by_id, algorithm_deps_.verbosity);
   if (artery_coupling_active_)
   {
     meshtying_->initialize_linear_solver(*solver_);
@@ -690,7 +709,7 @@ void PoroPressureBased::PorofluidAlgorithm::collect_runtime_output_data()
   // fluxes
   if (flux_ != nullptr)
   {
-    const int dim = Global::Problem::instance()->n_dim();
+    const int dim = nsd_;
     const int numdof = discret_->num_dof(0, discret_->l_row_node(0));
     // get the noderowmap
     const Core::LinAlg::Map* noderowmap = discret_->node_row_map();
@@ -716,7 +735,7 @@ void PoroPressureBased::PorofluidAlgorithm::collect_runtime_output_data()
 
   if (output_phase_velocities_)
   {
-    const int num_dim = Global::Problem::instance()->n_dim();
+    const int num_dim = nsd_;
     const int num_poro_dof = discret_->num_dof(0, discret_->l_row_node(0));
 
     const Core::LinAlg::Map* element_row_map = discret_->element_row_map();
@@ -875,8 +894,7 @@ void PoroPressureBased::PorofluidAlgorithm::apply_dirichlet_bc(const double time
   // needed parameters
   Teuchos::ParameterList p;
   p.set("total time", time);  // actual time t_{n+1}
-  p.set<const Core::Utils::FunctionManager*>(
-      "function_manager", &Global::Problem::instance()->function_manager());
+  p.set<const Core::Utils::FunctionManager*>("function_manager", algorithm_deps_.function_manager);
 
   // predicted Dirichlet values
   // \c  prenp then also holds prescribed new Dirichlet values
@@ -1099,10 +1117,11 @@ void PoroPressureBased::PorofluidAlgorithm::apply_starting_dbc()
               {
                 dirichlet_dofs.push_back(gid);
               }
-              const double dbc_value = Global::Problem::instance()
-                                           ->function_by_id<Core::Utils::FunctionOfSpaceTime>(
-                                               starting_dbc_funct_[dof_idx])
-                                           .evaluate(current_node->x(), time_, 0);
+              FOUR_C_ASSERT_ALWAYS(algorithm_deps_.function_of_space_time_by_id,
+                  "Function callback is required for starting Dirichlet boundary conditions.");
+              const double dbc_value =
+                  algorithm_deps_.function_of_space_time_by_id(starting_dbc_funct_[dof_idx])
+                      .evaluate(current_node->x(), time_, 0);
               phinp_->replace_global_value(gid, dbc_value);
             }
           }
@@ -1529,16 +1548,16 @@ void PoroPressureBased::PorofluidAlgorithm::reconstruct_flux()
     // action for elements
     eleparams.set<PoroPressureBased::Action>("action", PoroPressureBased::recon_flux_at_nodes);
 
-    const int dim = Global::Problem::instance()->n_dim();
+    const int dim = nsd_;
     // we assume same number of dofs per node in the whole dis here
     const int totalnumdof = discret_->num_dof(0, discret_->l_row_node(0));
     const int numvec = totalnumdof * dim;
 
     // add state vectors according to time-integration scheme
     add_time_integration_specific_vectors();
-    const auto& solverparams = Global::Problem::instance()->solver_params(fluxreconsolvernum_);
+    const auto& solverparams = algorithm_deps_.solver_params_by_id(fluxreconsolvernum_);
     flux_ = Core::FE::compute_nodal_l2_projection(*discret_, "phinp_fluid", numvec, eleparams,
-        solverparams, Global::Problem::instance()->solver_params_callback());
+        solverparams, algorithm_deps_.solver_params_by_id);
   }
 }
 
@@ -1880,7 +1899,7 @@ void PoroPressureBased::PorofluidAlgorithm::evaluate_error_compared_to_analytica
   {
     // print last error in a separate file
 
-    const std::string simulation = Global::Problem::instance()->output_control_file()->file_name();
+    const std::string simulation = algorithm_deps_.output_control_file->file_name();
     const std::string fname = simulation + "_pressure_time.relerror";
 
     if (step_ == 0)
@@ -2037,8 +2056,9 @@ void PoroPressureBased::PorofluidAlgorithm::set_initial_field(
           const int dofgid = nodedofset[k];
           int doflid = dofrowmap->lid(dofgid);
           // evaluate component k of spatial function
-          double initialval = Global::Problem::instance()
-                                  ->function_by_id<Core::Utils::FunctionOfSpaceTime>(startfuncno)
+          FOUR_C_ASSERT_ALWAYS(algorithm_deps_.function_of_space_time_by_id,
+              "Function callback is required for initial field by function.");
+          double initialval = algorithm_deps_.function_of_space_time_by_id(startfuncno)
                                   .evaluate(lnode.x(), time_, k);
           phin_->replace_local_value(doflid, initialval);
           ;
@@ -2083,8 +2103,7 @@ void PoroPressureBased::PorofluidAlgorithm::set_initial_field(
       {
         localdofs[i] = i;
       }
-      discret_->evaluate_initial_field(
-          Global::Problem::instance()->function_manager(), field, *phin_, localdofs);
+      discret_->evaluate_initial_field(*algorithm_deps_.function_manager, field, *phin_, localdofs);
 
       // initialize also the solution vector. These values are a pretty good guess for the
       // solution after the first time step (much better than starting with a zero vector)
@@ -2118,7 +2137,7 @@ void PoroPressureBased::PorofluidAlgorithm::read_restart(const int step)
 
   std::shared_ptr<Core::IO::DiscretizationReader> reader(nullptr);
   reader = std::make_shared<Core::IO::DiscretizationReader>(
-      *discret_, Global::Problem::instance()->input_control_file(), step);
+      *discret_, algorithm_deps_.input_control_file, step);
 
   time_ = reader->read_double("time");
   step_ = reader->read_int("step");

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_algorithm.hpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_algorithm.hpp
@@ -19,6 +19,7 @@
 #include "4C_io_runtime_csv_writer.hpp"
 #include "4C_linalg_map.hpp"
 #include "4C_linalg_serialdensevector.hpp"
+#include "4C_porofluid_pressure_based_algorithm_dependencies.hpp"
 #include "4C_porofluid_pressure_based_input.hpp"
 #include "4C_utils_parameter_list.fwd.hpp"
 
@@ -80,7 +81,8 @@ namespace PoroPressureBased
     //! Standard Constructor
     PorofluidAlgorithm(std::shared_ptr<Core::FE::Discretization> dis, const int linsolvernumber,
         const Teuchos::ParameterList& probparams, const Teuchos::ParameterList& poroparams,
-        std::shared_ptr<Core::IO::DiscretizationWriter> output);
+        std::shared_ptr<Core::IO::DiscretizationWriter> output,
+        PorofluidAlgorithmDeps algorithm_deps);
 
 
     //! initialize time integration
@@ -477,6 +479,9 @@ namespace PoroPressureBased
 
     //! parameter list of poro fluid multiphase problem
     const Teuchos::ParameterList& poroparams_;
+
+    //! externally provided dependencies to decouple from global problem singleton
+    PorofluidAlgorithmDeps algorithm_deps_;
 
     //! processor id
     int myrank_;

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_algorithm_dependencies.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_algorithm_dependencies.cpp
@@ -1,0 +1,45 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "4C_porofluid_pressure_based_algorithm_dependencies.hpp"
+
+#include "4C_global_data.hpp"
+#include "4C_utils_function.hpp"
+
+#include <Teuchos_StandardParameterEntryValidators.hpp>
+
+FOUR_C_NAMESPACE_OPEN
+
+PoroPressureBased::PorofluidAlgorithmDeps PoroPressureBased::make_algorithm_deps_from_problem(
+    Global::Problem& problem)
+{
+  const bool has_artery_discretization = problem.does_exist_dis("artery");
+  const std::shared_ptr<Core::FE::Discretization> artery_discretization =
+      has_artery_discretization ? problem.get_dis("artery") : nullptr;
+
+  return PorofluidAlgorithmDeps{
+      .spatial_dimension = problem.n_dim(),
+      .restart_step = problem.restart(),
+      .verbosity =
+          Teuchos::getIntegralValue<Core::IO::Verbositylevel>(problem.io_params(), "VERBOSITY"),
+      .input_control_file = problem.input_control_file(),
+      .output_control_file = problem.output_control_file(),
+      .artery_discretization = artery_discretization,
+      .runtime_vtk_output_parameters = &problem.io_params().sublist("RUNTIME VTK OUTPUT"),
+      .artery_dynamic_parameters =
+          has_artery_discretization ? &problem.arterial_dynamic_params() : nullptr,
+      .function_manager = &problem.function_manager(),
+      .function_of_space_time_by_id =
+          [&problem](const int function_id) -> const Core::Utils::FunctionOfSpaceTime&
+      { return problem.function_by_id<Core::Utils::FunctionOfSpaceTime>(function_id); },
+      .solver_params_by_id = problem.solver_params_callback(),
+      .add_field_test = [&problem](std::shared_ptr<Core::Utils::ResultTest> result_test)
+      { problem.add_field_test(result_test); },
+  };
+}
+
+FOUR_C_NAMESPACE_CLOSE

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_algorithm_dependencies.hpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_algorithm_dependencies.hpp
@@ -1,0 +1,67 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef FOUR_C_POROFLUID_PRESSURE_BASED_ALGORITHM_DEPENDENCIES_HPP
+#define FOUR_C_POROFLUID_PRESSURE_BASED_ALGORITHM_DEPENDENCIES_HPP
+
+#include "4C_config.hpp"
+
+#include "4C_io_pstream.hpp"
+#include "4C_utils_parameter_list.fwd.hpp"
+
+#include <functional>
+#include <memory>
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace Core::IO
+{
+  class InputControl;
+  class OutputControl;
+}  // namespace Core::IO
+
+namespace Core::FE
+{
+  class Discretization;
+}
+
+namespace Core::Utils
+{
+  class FunctionManager;
+  class FunctionOfSpaceTime;
+  class ResultTest;
+}  // namespace Core::Utils
+
+namespace Global
+{
+  class Problem;
+}  // namespace Global
+
+namespace PoroPressureBased
+{
+  struct PorofluidAlgorithmDeps
+  {
+    int spatial_dimension = 0;
+    int restart_step = 0;
+    Core::IO::Verbositylevel verbosity = Core::IO::minimal;
+    std::shared_ptr<Core::IO::InputControl> input_control_file;
+    std::shared_ptr<Core::IO::OutputControl> output_control_file;
+    std::shared_ptr<Core::FE::Discretization> artery_discretization;
+    const Teuchos::ParameterList* runtime_vtk_output_parameters = nullptr;
+    const Teuchos::ParameterList* artery_dynamic_parameters = nullptr;
+    const Core::Utils::FunctionManager* function_manager = nullptr;
+    std::function<const Core::Utils::FunctionOfSpaceTime&(int)> function_of_space_time_by_id;
+    std::function<const Teuchos::ParameterList&(int)> solver_params_by_id;
+    std::function<void(std::shared_ptr<Core::Utils::ResultTest>)> add_field_test;
+  };
+
+  PorofluidAlgorithmDeps make_algorithm_deps_from_problem(Global::Problem& problem);
+}  // namespace PoroPressureBased
+
+FOUR_C_NAMESPACE_CLOSE
+
+#endif

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_dyn.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_dyn.cpp
@@ -14,138 +14,179 @@
 #include "4C_io.hpp"
 #include "4C_io_control.hpp"
 #include "4C_porofluid_pressure_based_algorithm.hpp"
+#include "4C_porofluid_pressure_based_algorithm_dependencies.hpp"
 #include "4C_porofluid_pressure_based_utils.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>
 
+#include <functional>
+
 FOUR_C_NAMESPACE_OPEN
+
+namespace
+{
+  struct PorofluidPressureBasedMainContext
+  {
+    std::shared_ptr<Core::FE::Discretization> fluid_discretization;
+    std::shared_ptr<Core::FE::Discretization> artery_discretization;
+    bool has_artery_discretization;
+    std::map<std::pair<std::string, std::string>, std::map<int, int>> cloning_material_map;
+    PoroPressureBased::PorofluidAlgorithmDeps algorithm_deps;
+    MPI_Comm comm;
+    std::string problem_name;
+    const Teuchos::ParameterList& porofluid_dynamic_parameters;
+    std::function<void(MPI_Comm)> run_result_tests;
+  };
+
+  PorofluidPressureBasedMainContext make_main_context_from_problem(Global::Problem& problem)
+  {
+    const std::string fluid_disname = "porofluid";
+    const std::string artery_disname = "artery";
+
+    std::shared_ptr<Core::FE::Discretization> fluid_discretization = problem.get_dis(fluid_disname);
+    const bool has_artery_discretization = problem.does_exist_dis(artery_disname);
+    const std::shared_ptr<Core::FE::Discretization> artery_discretization =
+        has_artery_discretization ? problem.get_dis(artery_disname) : nullptr;
+
+    return PorofluidPressureBasedMainContext{
+        .fluid_discretization = fluid_discretization,
+        .artery_discretization = artery_discretization,
+        .has_artery_discretization = has_artery_discretization,
+        .cloning_material_map = problem.cloning_material_map(),
+        .algorithm_deps = PoroPressureBased::make_algorithm_deps_from_problem(problem),
+        .comm = fluid_discretization->get_comm(),
+        .problem_name = problem.problem_name(),
+        .porofluid_dynamic_parameters = problem.porofluid_pressure_based_dynamic_params(),
+        .run_result_tests = [&problem](MPI_Comm comm) { problem.test_all(comm); },
+    };
+  }
+
+  void run_porofluid_pressure_based(
+      const PorofluidPressureBasedMainContext& context, const int restart)
+  {
+    // define the discretization names
+    const std::string fluid_disname = "porofluid";
+    const std::string struct_disname = "structure";
+    const std::string artery_disname = "artery";
+
+    // print problem type
+    if (Core::Communication::my_mpi_rank(context.comm) == 0)
+    {
+      std::cout << "###################################################" << std::endl;
+      std::cout << "# YOUR PROBLEM TYPE: " << context.problem_name << std::endl;
+      std::cout << "###################################################" << std::endl;
+    }
+
+    // Parameter reading
+    // access structural dynamic params list which will be possibly modified while creating the
+    // time integrator
+    const Teuchos::ParameterList& porodyn = context.porofluid_dynamic_parameters;
+
+    // get the solver number used for poro fluid solver
+    const int linsolvernumber = porodyn.sublist("nonlinear_solver").get<int>("linear_solver_id");
+
+    // -------------------------------------------------------------------
+    // access the discretization(s)
+    // -------------------------------------------------------------------
+    std::shared_ptr<Core::FE::Discretization> actdis = context.fluid_discretization;
+
+    // possible interaction partners as seen from the artery elements
+    // [artelegid; contelegid_1, ...contelegid_n]
+    std::map<int, std::set<int>> nearby_ele_pairs;
+
+    if (context.has_artery_discretization)
+    {
+      const std::shared_ptr<Core::FE::Discretization> arterydis = context.artery_discretization;
+      // get the coupling method
+      auto arterycoupl =
+          Teuchos::getIntegralValue<ArteryNetwork::ArteryPorofluidElastScatraCouplingMethod>(
+              porodyn.sublist("artery_coupling"), "coupling_method");
+
+      // lateral surface coupling active?
+      const bool evaluate_on_lateral_surface =
+          porodyn.sublist("artery_coupling").get<bool>("lateral_surface_coupling");
+
+      switch (arterycoupl)
+      {
+        case ArteryNetwork::ArteryPorofluidElastScatraCouplingMethod::gauss_point_to_segment:
+        case ArteryNetwork::ArteryPorofluidElastScatraCouplingMethod::mortar_penalty:
+        case ArteryNetwork::ArteryPorofluidElastScatraCouplingMethod::node_to_point:
+        {
+          actdis->fill_complete();
+          nearby_ele_pairs = PoroPressureBased::extended_ghosting_artery_discretization(
+              *actdis, arterydis, evaluate_on_lateral_surface, arterycoupl);
+          break;
+        }
+        default:
+        {
+          break;
+        }
+      }
+    }
+
+    // -------------------------------------------------------------------
+    // assign dof set for solid pressures
+    // -------------------------------------------------------------------
+    std::shared_ptr<Core::DOFSets::DofSetInterface> dofsetaux =
+        std::make_shared<Core::DOFSets::DofSetPredefinedDoFNumber>(1, 0, 0, false);
+    const int nds_solidpressure = actdis->add_dof_set(dofsetaux);
+
+    // -------------------------------------------------------------------
+    // set degrees of freedom in the discretization
+    // -------------------------------------------------------------------
+    actdis->fill_complete();
+
+    // -------------------------------------------------------------------
+    // context for output and restart
+    // -------------------------------------------------------------------
+    std::shared_ptr<Core::IO::DiscretizationWriter> output = actdis->writer();
+    output->write_mesh(0, 0.0);
+
+    // -------------------------------------------------------------------
+    // algorithm construction depending on
+    // time-integration (or stationary) scheme
+    // -------------------------------------------------------------------
+    auto timintscheme =
+        porodyn.sublist("time_integration").get<PoroPressureBased::TimeIntegrationScheme>("scheme");
+
+    // build poro fluid time integrator
+    std::shared_ptr<Adapter::PoroFluidMultiphase> algo = PoroPressureBased::create_algorithm(
+        timintscheme, actdis, linsolvernumber, porodyn, porodyn, output, context.algorithm_deps);
+
+    // initialize
+    algo->init(false,        // eulerian formulation
+        -1,                  //  no displacements
+        -1,                  // no velocities
+        nds_solidpressure,   // dof set for post processing solid pressure
+        -1,                  // no scalar field
+        &nearby_ele_pairs);  // possible interaction pairs
+
+    // read the restart information, set vectors and variables
+    if (restart) algo->read_restart(restart);
+
+    // assign poro material for evaluation of porosity
+    // note: to be done after potential restart, as in read_restart()
+    //       the secondary material is destroyed
+    PoroPressureBased::setup_material(
+        context.comm, *actdis, context.cloning_material_map, struct_disname, fluid_disname);
+
+    // 4.- Run of the actual problem.
+    algo->time_loop();
+
+    // perform the result test if required
+    context.algorithm_deps.add_field_test(algo->create_field_test());
+    context.run_result_tests(context.comm);
+  }
+}  // namespace
 
 /*-------------------------------------------------------------------------------*
  | Main control routine for poro fluid multiphase problems           vuong 08/16 |
  *-------------------------------------------------------------------------------*/
 void porofluid_pressure_based_dyn(int restart)
 {
-  // define the discretization names
-  const std::string fluid_disname = "porofluid";
-  const std::string struct_disname = "structure";
-  const std::string artery_disname = "artery";
-
-  // access the communicator
-  MPI_Comm comm = Global::Problem::instance()->get_dis(fluid_disname)->get_comm();
-
-  // access the problem
-  Global::Problem* problem = Global::Problem::instance();
-
-  // print problem type
-  if (Core::Communication::my_mpi_rank(comm) == 0)
-  {
-    std::cout << "###################################################" << std::endl;
-    std::cout << "# YOUR PROBLEM TYPE: " << Global::Problem::instance()->problem_name()
-              << std::endl;
-    std::cout << "###################################################" << std::endl;
-  }
-
-  // Parameter reading
-  // access structural dynamic params list which will be possibly modified while creating the time
-  // integrator
-  const Teuchos::ParameterList& porodyn = problem->porofluid_pressure_based_dynamic_params();
-
-  // get the solver number used for poro fluid solver
-  const int linsolvernumber = porodyn.sublist("nonlinear_solver").get<int>("linear_solver_id");
-
-  // -------------------------------------------------------------------
-  // access the discretization(s)
-  // -------------------------------------------------------------------
-  std::shared_ptr<Core::FE::Discretization> actdis = nullptr;
-  actdis = Global::Problem::instance()->get_dis(fluid_disname);
-
-  // possible interaction partners as seen from the artery elements
-  // [artelegid; contelegid_1, ...contelegid_n]
-  std::map<int, std::set<int>> nearby_ele_pairs;
-
-  if (Global::Problem::instance()->does_exist_dis(artery_disname))
-  {
-    std::shared_ptr<Core::FE::Discretization> arterydis = nullptr;
-    arterydis = Global::Problem::instance()->get_dis(artery_disname);
-    // get the coupling method
-    auto arterycoupl =
-        Teuchos::getIntegralValue<ArteryNetwork::ArteryPorofluidElastScatraCouplingMethod>(
-            porodyn.sublist("artery_coupling"), "coupling_method");
-
-    // lateral surface coupling active?
-    const bool evaluate_on_lateral_surface =
-        porodyn.sublist("artery_coupling").get<bool>("lateral_surface_coupling");
-
-    switch (arterycoupl)
-    {
-      case ArteryNetwork::ArteryPorofluidElastScatraCouplingMethod::gauss_point_to_segment:
-      case ArteryNetwork::ArteryPorofluidElastScatraCouplingMethod::mortar_penalty:
-      case ArteryNetwork::ArteryPorofluidElastScatraCouplingMethod::node_to_point:
-      {
-        actdis->fill_complete();
-        nearby_ele_pairs = PoroPressureBased::extended_ghosting_artery_discretization(
-            *actdis, arterydis, evaluate_on_lateral_surface, arterycoupl);
-        break;
-      }
-      default:
-      {
-        break;
-      }
-    }
-  }
-
-  // -------------------------------------------------------------------
-  // assign dof set for solid pressures
-  // -------------------------------------------------------------------
-  std::shared_ptr<Core::DOFSets::DofSetInterface> dofsetaux =
-      std::make_shared<Core::DOFSets::DofSetPredefinedDoFNumber>(1, 0, 0, false);
-  const int nds_solidpressure = actdis->add_dof_set(dofsetaux);
-
-  // -------------------------------------------------------------------
-  // set degrees of freedom in the discretization
-  // -------------------------------------------------------------------
-  actdis->fill_complete();
-
-  // -------------------------------------------------------------------
-  // context for output and restart
-  // -------------------------------------------------------------------
-  std::shared_ptr<Core::IO::DiscretizationWriter> output = actdis->writer();
-  output->write_mesh(0, 0.0);
-
-  // -------------------------------------------------------------------
-  // algorithm construction depending on
-  // time-integration (or stationary) scheme
-  // -------------------------------------------------------------------
-  auto timintscheme =
-      porodyn.sublist("time_integration").get<PoroPressureBased::TimeIntegrationScheme>("scheme");
-
-  // build poro fluid time integrator
-  std::shared_ptr<Adapter::PoroFluidMultiphase> algo = PoroPressureBased::create_algorithm(
-      timintscheme, actdis, linsolvernumber, porodyn, porodyn, output);
-
-  // initialize
-  algo->init(false,        // eulerian formulation
-      -1,                  //  no displacements
-      -1,                  // no velocities
-      nds_solidpressure,   // dof set for post processing solid pressure
-      -1,                  // no scalar field
-      &nearby_ele_pairs);  // possible interaction pairs
-
-  // read the restart information, set vectors and variables
-  if (restart) algo->read_restart(restart);
-
-  // assign poro material for evaluation of porosity
-  // note: to be done after potential restart, as in read_restart()
-  //       the secondary material is destroyed
-  PoroPressureBased::setup_material(comm, struct_disname, fluid_disname);
-
-  // 4.- Run of the actual problem.
-  algo->time_loop();
-
-  // perform the result test if required
-  problem->add_field_test(algo->create_field_test());
-  problem->test_all(comm);
-
+  const PorofluidPressureBasedMainContext context =
+      make_main_context_from_problem(*Global::Problem::instance());
+  run_porofluid_pressure_based(context, restart);
 }  // poromultiphase_dyn
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_meshtying_strategy_artery.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_meshtying_strategy_artery.cpp
@@ -9,7 +9,6 @@
 
 #include "4C_art_net_input.hpp"
 #include "4C_art_net_utils.hpp"
-#include "4C_global_data.hpp"
 #include "4C_io.hpp"
 #include "4C_io_control.hpp"
 #include "4C_linalg_utils_sparse_algebra_io.hpp"
@@ -23,25 +22,30 @@
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>
 
+#include <utility>
+
 FOUR_C_NAMESPACE_OPEN
 
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 PoroPressureBased::MeshtyingArtery::MeshtyingArtery(PorofluidAlgorithm* porofluid_algorithm,
-    const Teuchos::ParameterList& problem_params, const Teuchos::ParameterList& porofluid_params)
+    const Teuchos::ParameterList& problem_params, const Teuchos::ParameterList& porofluid_params,
+    std::shared_ptr<Core::FE::Discretization> artery_discretization,
+    const Teuchos::ParameterList& artery_params,
+    std::function<const Teuchos::ParameterList&(int)> solver_params_by_id,
+    std::function<void(std::shared_ptr<Core::Utils::ResultTest>)> add_field_test)
     : porofluid_algorithm_(porofluid_algorithm),
       params_(problem_params),
       porofluid_params_(porofluid_params),
+      solver_params_by_id_(std::move(solver_params_by_id)),
+      add_field_test_(std::move(add_field_test)),
       vector_norm_res_(Teuchos::getIntegralValue<VectorNorm>(
           porofluid_params_.sublist("nonlinear_solver").sublist("residual"), "vector_norm")),
       vector_norm_inc_(Teuchos::getIntegralValue<VectorNorm>(
           porofluid_params_.sublist("nonlinear_solver").sublist("increment"), "vector_norm"))
 {
-  const Teuchos::ParameterList& artery_params =
-      Global::Problem::instance()->arterial_dynamic_params();
-
-  artery_dis_ = Global::Problem::instance()->get_dis("artery");
+  artery_dis_ = std::move(artery_discretization);
 
   if (!artery_dis_->filled()) artery_dis_->fill_complete();
 
@@ -89,9 +93,7 @@ PoroPressureBased::MeshtyingArtery::MeshtyingArtery(PorofluidAlgorithm* poroflui
       [&]()
       {
         if (Teuchos::getIntegralValue<ArteryNetwork::ArteryPorofluidElastScatraCouplingMethod>(
-                Global::Problem::instance()->porofluid_pressure_based_dynamic_params().sublist(
-                    "artery_coupling"),
-                "coupling_method") ==
+                porofluid_params_.sublist("artery_coupling"), "coupling_method") ==
             ArteryNetwork::ArteryPorofluidElastScatraCouplingMethod::node_to_point)
         {
           return "ArtPorofluidCouplConNodeToPoint";
@@ -150,12 +152,9 @@ void PoroPressureBased::MeshtyingArtery::update() const { artery_algorithm_->tim
 void PoroPressureBased::MeshtyingArtery::initialize_linear_solver(
     Core::LinAlg::Solver& solver) const
 {
-  const Teuchos::ParameterList& porofluid_params =
-      Global::Problem::instance()->porofluid_pressure_based_dynamic_params();
   const int linear_solver_num =
-      porofluid_params.sublist("nonlinear_solver").get<int>("linear_solver_id");
-  const Teuchos::ParameterList& solver_params =
-      Global::Problem::instance()->solver_params(linear_solver_num);
+      porofluid_params_.sublist("nonlinear_solver").get<int>("linear_solver_id");
+  const Teuchos::ParameterList& solver_params = solver_params_by_id_(linear_solver_num);
   const auto solver_type =
       Teuchos::getIntegralValue<Core::LinearSolver::SolverType>(solver_params, "SOLVER");
   // no need to do the rest for direct solvers
@@ -243,7 +242,7 @@ void PoroPressureBased::MeshtyingArtery::create_result_test() const
 {
   const std::shared_ptr<Core::Utils::ResultTest> artery_result_test =
       artery_algorithm_->create_field_test();
-  Global::Problem::instance()->add_field_test(artery_result_test);
+  add_field_test_(artery_result_test);
 }
 
 /*----------------------------------------------------------------------*

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_meshtying_strategy_artery.hpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_meshtying_strategy_artery.hpp
@@ -13,6 +13,8 @@
 #include "4C_linear_solver_method_linalg.hpp"
 #include "4C_porofluid_pressure_based_algorithm.hpp"
 
+#include <functional>
+
 FOUR_C_NAMESPACE_OPEN
 
 // forward declaration
@@ -21,15 +23,24 @@ namespace PoroPressureBased
   class PorofluidElastScatraArteryCouplingBaseAlgorithm;
 }
 
+namespace Core::Utils
+{
+  class ResultTest;
+}
+
 namespace PoroPressureBased
 {
   class MeshtyingArtery
   {
    public:
     //! constructor
-    explicit MeshtyingArtery(PorofluidAlgorithm* porofluid_algorithm,
+    MeshtyingArtery(PorofluidAlgorithm* porofluid_algorithm,
         const Teuchos::ParameterList& problem_params,
-        const Teuchos::ParameterList& porofluid_params);
+        const Teuchos::ParameterList& porofluid_params,
+        std::shared_ptr<Core::FE::Discretization> artery_discretization,
+        const Teuchos::ParameterList& artery_params,
+        std::function<const Teuchos::ParameterList&(int)> solver_params_by_id,
+        std::function<void(std::shared_ptr<Core::Utils::ResultTest>)> add_field_test);
 
 
     //! prepare time loop
@@ -108,6 +119,12 @@ namespace PoroPressureBased
 
     //! parameter list of porofluid algorithm
     const Teuchos::ParameterList& porofluid_params_;
+
+    //! callback to access solver parameters by solver id
+    std::function<const Teuchos::ParameterList&(int)> solver_params_by_id_;
+
+    //! callback to register field tests
+    std::function<void(std::shared_ptr<Core::Utils::ResultTest>)> add_field_test_;
 
     //! vector norm for residuals
     VectorNorm vector_norm_res_;

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_resulttest.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_resulttest.cpp
@@ -10,7 +10,6 @@
 #include "4C_fem_discretization.hpp"
 #include "4C_fem_general_element.hpp"
 #include "4C_fem_general_node.hpp"
-#include "4C_global_data.hpp"
 #include "4C_io_input_parameter_container.hpp"
 #include "4C_porofluid_pressure_based_algorithm.hpp"
 #include "4C_porofluid_pressure_based_meshtying_strategy_artery.hpp"
@@ -266,7 +265,7 @@ double PoroPressureBased::ResultTest::result_element(
   }
   else if (!quantity.compare(0, 13, "phasevelocity"))
   {
-    const int num_dim = Global::Problem::instance()->n_dim();
+    const int num_dim = static_cast<int>(porofluid_algorithm_.discretization()->n_dim());
     // get phase ID
     // example: "phasevelocity3x" -> k = 2 (phase IDs start at index 0)
     std::string k_string = quantity.substr(13);

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_utils.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_utils.cpp
@@ -15,7 +15,6 @@
 #include "4C_fem_geometry_position_array.hpp"
 #include "4C_fem_geometry_searchtree.hpp"
 #include "4C_fem_geometry_searchtree_service.hpp"
-#include "4C_global_data.hpp"
 #include "4C_linalg_utils_densematrix_communication.hpp"
 #include "4C_mat_cnst_1d_art.hpp"
 #include "4C_mat_material_factory.hpp"
@@ -64,25 +63,25 @@ namespace
 
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-void PoroPressureBased::setup_material(
-    MPI_Comm comm, const std::string& struct_disname, const std::string& fluid_disname)
+void PoroPressureBased::setup_material(MPI_Comm comm,
+    Core::FE::Discretization& fluid_discretization,
+    const std::map<std::pair<std::string, std::string>, std::map<int, int>>& cloning_material_map,
+    const std::string& struct_disname, const std::string& fluid_disname)
 {
-  // get the fluid discretization
-  std::shared_ptr<Core::FE::Discretization> fluiddis =
-      Global::Problem::instance()->get_dis(fluid_disname);
-
   // initialize material map
   std::map<int, int> matmap;
   {
-    // get the cloning material map from the input file
-    std::map<std::pair<std::string, std::string>, std::map<int, int>> clonefieldmatmap =
-        Global::Problem::instance()->cloning_material_map();
-    if (clonefieldmatmap.size() < 1)
+    if (cloning_material_map.size() < 1)
       FOUR_C_THROW("At least one material pairing required in --CLONING MATERIAL MAP.");
 
     // check if the current discretization is included in the material map
     std::pair<std::string, std::string> key(fluid_disname, struct_disname);
-    matmap = clonefieldmatmap[key];
+    const auto clone_field_mat_map_it = cloning_material_map.find(key);
+    if (clone_field_mat_map_it == cloning_material_map.end())
+      FOUR_C_THROW(
+          "Key pair '{}/{}' not defined in --CLONING MATERIAL MAP.", fluid_disname, struct_disname);
+
+    matmap = clone_field_mat_map_it->second;
     if (matmap.size() < 1)
       FOUR_C_THROW(
           "Key pair '{}/{}' not defined in --CLONING MATERIAL MAP.", fluid_disname, struct_disname);
@@ -90,13 +89,13 @@ void PoroPressureBased::setup_material(
 
 
   // number of column elements within fluid discretization
-  const int numelements = fluiddis->num_my_col_elements();
+  const int numelements = fluid_discretization.num_my_col_elements();
 
   // loop over column elements
   for (int i = 0; i < numelements; ++i)
   {
     // get current element
-    Core::Elements::Element* ele = fluiddis->l_col_element(i);
+    Core::Elements::Element* ele = fluid_discretization.l_col_element(i);
 
     // find the corresponding material in the matmap
     int src_matid = ele->material()->parameter()->id();
@@ -135,7 +134,7 @@ std::shared_ptr<Adapter::PoroFluidMultiphase> PoroPressureBased::create_algorith
     PoroPressureBased::TimeIntegrationScheme timintscheme,
     std::shared_ptr<Core::FE::Discretization> dis, const int linsolvernumber,
     const Teuchos::ParameterList& probparams, const Teuchos::ParameterList& poroparams,
-    std::shared_ptr<Core::IO::DiscretizationWriter> output)
+    std::shared_ptr<Core::IO::DiscretizationWriter> output, PorofluidAlgorithmDeps algorithm_deps)
 {
   // Creation of Coupled Problem algorithm.
   std::shared_ptr<Adapter::PoroFluidMultiphase> algo = nullptr;
@@ -151,7 +150,7 @@ std::shared_ptr<Adapter::PoroFluidMultiphase> PoroPressureBased::create_algorith
     {
       // create algorithm
       algo = std::make_shared<PorofluidAlgorithm>(
-          dis, linsolvernumber, probparams, poroparams, output);
+          dis, linsolvernumber, probparams, poroparams, output, std::move(algorithm_deps));
       break;
     }
     default:

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_utils.hpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_utils.hpp
@@ -14,6 +14,7 @@
 #include "4C_io.hpp"
 #include "4C_linalg_fixedsizematrix.hpp"
 #include "4C_linalg_vector.hpp"
+#include "4C_porofluid_pressure_based_algorithm_dependencies.hpp"
 #include "4C_porofluid_pressure_based_input.hpp"
 #include "4C_utils_parameter_list.fwd.hpp"
 
@@ -40,17 +41,19 @@ namespace Adapter
 namespace PoroPressureBased
 {
   /// setup second materials for porosity evaluation within solid phase
-  void setup_material(
-      MPI_Comm comm, const std::string& struct_disname, const std::string& fluid_disname);
+  void setup_material(MPI_Comm comm, Core::FE::Discretization& fluid_discretization,
+      const std::map<std::pair<std::string, std::string>, std::map<int, int>>& cloning_material_map,
+      const std::string& struct_disname, const std::string& fluid_disname);
 
   /// create solution algorithm depending on input file
   std::shared_ptr<Adapter::PoroFluidMultiphase> create_algorithm(
-      PoroPressureBased::TimeIntegrationScheme timintscheme,  //!< time discretization scheme
-      std::shared_ptr<Core::FE::Discretization> dis,          //!< discretization
-      const int linsolvernumber,                              //!< number of linear solver
-      const Teuchos::ParameterList& probparams,               //!< parameter list of global problem
-      const Teuchos::ParameterList& poroparams,               //!< parameter list of poro problem
-      std::shared_ptr<Core::IO::DiscretizationWriter> output  //!< output writer
+      PoroPressureBased::TimeIntegrationScheme timintscheme,   //!< time discretization scheme
+      std::shared_ptr<Core::FE::Discretization> dis,           //!< discretization
+      const int linsolvernumber,                               //!< number of linear solver
+      const Teuchos::ParameterList& probparams,                //!< parameter list of global problem
+      const Teuchos::ParameterList& poroparams,                //!< parameter list of poro problem
+      std::shared_ptr<Core::IO::DiscretizationWriter> output,  //!< output writer
+      PorofluidAlgorithmDeps algorithm_deps                    //!< algorithm dependencies
   );
 
   /**

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_base.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_base.cpp
@@ -81,8 +81,7 @@ void PoroPressureBased::PorofluidElastAlgorithm::init(
       porofluid_elast_params.sublist("nonlinear_solver").get<int>("linear_solver_id");
 
   // access the fluid discretization
-  std::shared_ptr<Core::FE::Discretization> porofluid_dis =
-      Global::Problem::instance()->get_dis(porofluid_disname);
+  std::shared_ptr<Core::FE::Discretization> porofluid_dis = problem->get_dis(porofluid_disname);
 
   // set degrees of freedom in the discretization
   if (!porofluid_dis->filled()) porofluid_dis->fill_complete();
@@ -96,10 +95,13 @@ void PoroPressureBased::PorofluidElastAlgorithm::init(
       Teuchos::getIntegralValue<PoroPressureBased::TimeIntegrationScheme>(
           porofluid_params.sublist("time_integration"), "scheme");
 
+  const PoroPressureBased::PorofluidAlgorithmDeps algorithm_deps =
+      PoroPressureBased::make_algorithm_deps_from_problem(*problem);
+
   // build porofluid algorithm
   std::shared_ptr<Adapter::PoroFluidMultiphase> porofluid_algo =
       PoroPressureBased::create_algorithm(time_integration_scheme, porofluid_dis, linsolvernumber,
-          global_time_params, porofluid_params, output);
+          global_time_params, porofluid_params, output, algorithm_deps);
 
   porofluid_algo_ = std::make_shared<Adapter::PoroFluidMultiphaseWrapper>(porofluid_algo);
   porofluid_algo_->init(


### PR DESCRIPTION
This PR centralizes `Global::Problem` access in `porofluid_pressure_based` and removes direct singleton usage from the internal algorithm path. Please let me know what you think and if you have suggestions for improvement or better naming :smiley:. 

## Changes

- Added `PorofluidAlgorithmDeps` (`4C_porofluid_pressure_based_algorithm_dependencies.hpp/.cpp`) as the shared dependency wrapper for algorithm code.
- Added `make_algorithm_deps_from_problem(Global::Problem&)` as the single adapter that maps `Global::Problem` data/callbacks into `PorofluidAlgorithmDeps`.
- Kept `PorofluidPressureBasedMainContext` local in `4C_porofluid_pressure_based_dyn.cpp` for dyn/run orchestration state only.
- Updated algorithm creation call sites (including porofluid-elast path) to pass `PorofluidAlgorithmDeps`.
- Removed direct `Global::Problem` usage from internal `porofluid_pressure_based` components (algorithm/utils/meshtying/resulttest).

## Wrappers

Two wrappers, one for 'PoroFluidAlgorithm', one a step above for the dyn.
- `PorofluidAlgorithmDeps`: explicit inputs/services needed by algorithm internals.
- `PorofluidPressureBasedMainContext`: local dyn execution context (discretizations, params, comm, test execution hooks).

## Related Issues and Pull Requests

#1796 