### PR TITLE
Add headers gcc 15.2.1 required

### DIFF
--- a/src/core/fem/src/general/element/4C_fem_general_element.hpp
+++ b/src/core/fem/src/general/element/4C_fem_general_element.hpp
@@ -22,6 +22,7 @@
 
 #include <map>
 #include <memory>
+#include <variant>
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/core/io/src/4C_io_mesh.hpp
+++ b/src/core/io/src/4C_io_mesh.hpp
@@ -31,6 +31,7 @@
 #include <typeindex>
 #include <unordered_map>
 #include <unordered_set>
+#include <variant>
 #include <vector>
 
 FOUR_C_NAMESPACE_OPEN


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context

When building 4C, my compiler (gcc 15.2.1+mpich) needed me to add these two headers.

Minor note - because my venv is installing ryaml 0.1.0 instead of 0.10.0, I had to skip the pre-commit hooks, as `Github workflow dependencies hash is up to date` failed with the message `AttributeError: module 'ryml' has no attribute 'emit_json'` (due to the archaic ryaml version).

## Related Issues and Pull Requests
#1823
