### PR TITLE
Introduce specific solver for the calculation of the initial potential field

### DIFF
--- a/src/ssi/4C_ssi_input.cpp
+++ b/src/ssi/4C_ssi_input.cpp
@@ -225,7 +225,11 @@ std::vector<Core::IO::InputSpec> SSI::valid_parameters()
 
           parameter<bool>("INITPOTCALC",
               {.description = "Automatically calculate initial field for electric potential",
-                  .default_value = false})},
+                  .default_value = false}),
+          parameter<std::optional<int>>("INIT_POT_CALC_LINEAR_SOLVER",
+              {.description = "ID of linear solver for global system of equations for calculation "
+                              "of the initial potential field"}),
+      },
       {.required = false}));
   return specs;
 }

--- a/src/ssi/4C_ssi_monolithic.cpp
+++ b/src/ssi/4C_ssi_monolithic.cpp
@@ -67,6 +67,23 @@ SSI::SsiMono::SsiMono(MPI_Comm comm, const Teuchos::ParameterList& globaltimepar
               Global::Problem::instance()->io_params(), "VERBOSITY"))),
       timer_(std::make_shared<Teuchos::Time>("SSI_Mono", true))
 {
+  const auto init_pot_calc_linear_solver =
+      globaltimeparams.sublist("ELCH").get<std::optional<int>>("INIT_POT_CALC_LINEAR_SOLVER");
+
+  if (init_pot_calc_linear_solver.has_value())
+  {
+    init_pot_calc_solver_ = std::make_shared<Core::LinAlg::Solver>(
+        Global::Problem::instance()->solver_params(init_pot_calc_linear_solver.value()), comm,
+        Global::Problem::instance()->solver_params_callback(),
+        Teuchos::getIntegralValue<Core::IO::Verbositylevel>(
+            Global::Problem::instance()->io_params(), "VERBOSITY"));
+  }
+  else
+  {
+    // use the linear solver of the main algorithm if no dedicated solver for the initial potential
+    // calculation has been set
+    init_pot_calc_solver_ = solver_;
+  }
 }
 
 /*-------------------------------------------------------------------------------*
@@ -374,7 +391,7 @@ void SSI::SsiMono::evaluate_off_diag_contributions() const
 
 /*-------------------------------------------------------------------------------*
  *-------------------------------------------------------------------------------*/
-void SSI::SsiMono::build_null_spaces() const
+void SSI::SsiMono::build_null_spaces(Core::LinAlg::Solver& solver) const
 {
   switch (scatra_field()->matrix_type())
   {
@@ -383,11 +400,11 @@ void SSI::SsiMono::build_null_spaces() const
     {
       // equip smoother for scatra matrix blocks with null space
       scatra_field()->build_block_null_spaces(
-          *solver_, ssi_maps_->get_block_positions(Subproblem::scalar_transport).at(0));
+          solver, ssi_maps_->get_block_positions(Subproblem::scalar_transport).at(0));
       if (is_scatra_manifold())
       {
         scatra_manifold()->build_block_null_spaces(
-            *solver_, ssi_maps_->get_block_positions(Subproblem::manifold).at(0));
+            solver, ssi_maps_->get_block_positions(Subproblem::manifold).at(0));
       }
       break;
     }
@@ -397,7 +414,7 @@ void SSI::SsiMono::build_null_spaces() const
       std::ostringstream scatrablockstr;
       scatrablockstr << ssi_maps_->get_block_positions(Subproblem::scalar_transport).at(0) + 1;
       Teuchos::ParameterList& blocksmootherparamsscatra =
-          solver_->params().sublist("Inverse" + scatrablockstr.str());
+          solver.params().sublist("Inverse" + scatrablockstr.str());
 
       Core::LinearSolver::Parameters::compute_solver_parameters(
           *scatra_field()->discretization(), blocksmootherparamsscatra);
@@ -407,7 +424,7 @@ void SSI::SsiMono::build_null_spaces() const
         std::ostringstream scatramanifoldblockstr;
         scatramanifoldblockstr << ssi_maps_->get_block_positions(Subproblem::manifold).at(0) + 1;
         Teuchos::ParameterList& blocksmootherparamsscatramanifold =
-            solver_->params().sublist("Inverse" + scatramanifoldblockstr.str());
+            solver.params().sublist("Inverse" + scatramanifoldblockstr.str());
 
         Core::LinearSolver::Parameters::compute_solver_parameters(
             *scatra_manifold()->discretization(), blocksmootherparamsscatramanifold);
@@ -427,9 +444,9 @@ void SSI::SsiMono::build_null_spaces() const
   iblockstr << ssi_maps_->get_block_positions(Subproblem::structure).at(0) + 1;
 
   Teuchos::ParameterList& blocksmootherparams =
-      solver_->params().sublist("Inverse" + iblockstr.str());
+      solver.params().sublist("Inverse" + iblockstr.str());
 
-  if (solver_->params().isSublist("AMGnxn Parameters"))
+  if (solver.params().isSublist("AMGnxn Parameters"))
   {
     blocksmootherparams.sublist("Belos Parameters");
     blocksmootherparams.sublist("MueLu Parameters");
@@ -720,7 +737,8 @@ void SSI::SsiMono::setup_system()
     {
       // feed block preconditioner with null space information for each block of global block system
       // matrix
-      build_null_spaces();
+      build_null_spaces(*solver_);
+      if (init_pot_calc_solver_ != nullptr) build_null_spaces(*init_pot_calc_solver_);
 
       break;
     }
@@ -790,7 +808,7 @@ void SSI::SsiMono::setup_system()
 
 /*---------------------------------------------------------------------------------*
  *---------------------------------------------------------------------------------*/
-void SSI::SsiMono::solve_linear_system() const
+void SSI::SsiMono::solve_linear_system(Core::LinAlg::Solver& solver) const
 {
   TEUCHOS_FUNC_TIME_MONITOR("SSI mono: solve linear system");
   strategy_equilibration_->equilibrate_system(
@@ -803,14 +821,14 @@ void SSI::SsiMono::solve_linear_system() const
   solver_params.reset = iteration_count() == 1;
   if (relax_lin_solver_iter_step_ > 0)
   {
-    solver_->reset_tolerance();
+    solver.reset_tolerance();
     if (iteration_count() <= relax_lin_solver_iter_step_)
     {
-      solver_params.tolerance = solver_->get_tolerance() * relax_lin_solver_tolerance_;
+      solver_params.tolerance = solver.get_tolerance() * relax_lin_solver_tolerance_;
     }
   }
-  solver_->solve(ssi_matrices_->system_matrix(), ssi_vectors_->increment(),
-      ssi_vectors_->residual(), solver_params);
+  solver.solve(ssi_matrices_->system_matrix(), ssi_vectors_->increment(), ssi_vectors_->residual(),
+      solver_params);
 
   strategy_equilibration_->unequilibrate_increment(ssi_vectors_->increment());
 }
@@ -866,7 +884,7 @@ void SSI::SsiMono::newton_loop()
     // store time before solving global system of equations
     const double time_before_solving = timer_->wallTime();
 
-    solve_linear_system();
+    solve_linear_system(*solver_);
 
     // time needed for solving global system of equations
     double my_solve_time = timer_->wallTime() - time_before_solving;
@@ -985,8 +1003,8 @@ void SSI::SsiMono::update_iter_structure() const
   {
     for (const auto& meshtying : ssi_structure_mesh_tying()->mesh_tying_handlers())
     {
-      auto coupling_adapter = meshtying->slave_master_coupling();
-      auto coupling_map_extractor = meshtying->slave_master_extractor();
+      const auto coupling_adapter = meshtying->slave_master_coupling();
+      const auto coupling_map_extractor = meshtying->slave_master_extractor();
 
       // displacements
       coupling_map_extractor->insert_vector(
@@ -1032,11 +1050,12 @@ std::vector<Core::LinAlg::EquilibrationMethod> SSI::SsiMono::get_block_equilibra
       }
       else
       {
-        auto block_positions_scatra = ssi_maps_->get_block_positions(Subproblem::scalar_transport);
-        auto block_position_structure = ssi_maps_->get_block_positions(Subproblem::structure);
+        const auto block_positions_scatra =
+            ssi_maps_->get_block_positions(Subproblem::scalar_transport);
+        const auto block_position_structure = ssi_maps_->get_block_positions(Subproblem::structure);
         if (is_scatra_manifold())
         {
-          auto block_positions_scatra_manifold =
+          const auto block_positions_scatra_manifold =
               ssi_maps_->get_block_positions(Subproblem::manifold);
 
           equilibration_method_vector =
@@ -1173,12 +1192,12 @@ void SSI::SsiMono::calc_initial_potential_field()
   }
 
   // store initial velocity to restore them afterwards
-  auto init_velocity = *structure_field()->velnp();
+  const auto init_velocity = *structure_field()->velnp();
 
   // cast scatra time integrators to elch to call elch specific methods
-  auto scatra_elch = std::dynamic_pointer_cast<ScaTra::ScaTraTimIntElch>(scatra_field());
-  auto manifold_elch = is_scatra_manifold()
-                           ? std::dynamic_pointer_cast<ScaTra::ScaTraTimIntElch>(scatra_manifold())
+  const auto scatra_elch = std::dynamic_pointer_cast<ScaTra::ScaTraTimIntElch>(scatra_field());
+  const auto manifold_elch =
+      is_scatra_manifold() ? std::dynamic_pointer_cast<ScaTra::ScaTraTimIntElch>(scatra_manifold())
                            : nullptr;
   if (scatra_elch == nullptr or (is_scatra_manifold() and manifold_elch == nullptr))
     FOUR_C_THROW("Cast to Elch time integrator failed. Scatra is not an Elch problem");
@@ -1187,8 +1206,9 @@ void SSI::SsiMono::calc_initial_potential_field()
   scatra_elch->pre_calc_initial_potential_field();
   if (is_scatra_manifold()) manifold_elch->pre_calc_initial_potential_field();
 
-  auto scatra_elch_splitter = scatra_field()->splitter();
-  auto manifold_elch_splitter = is_scatra_manifold() ? scatra_manifold()->splitter() : nullptr;
+  const auto scatra_elch_splitter = scatra_field()->splitter();
+  const auto manifold_elch_splitter =
+      is_scatra_manifold() ? scatra_manifold()->splitter() : nullptr;
 
   reset_iteration_count();
 
@@ -1245,7 +1265,7 @@ void SSI::SsiMono::calc_initial_potential_field()
     // store time before solving global system of equations
     const double time_before_solving = timer_->wallTime();
 
-    solve_linear_system();
+    solve_linear_system(*init_pot_calc_solver_);
 
     // time needed for solving global system of equations
     double my_solve_time = timer_->wallTime() - time_before_solving;

--- a/src/ssi/4C_ssi_monolithic.hpp
+++ b/src/ssi/4C_ssi_monolithic.hpp
@@ -106,17 +106,18 @@ namespace SSI
 
     /*!
      * @brief solves the linear system
+     * @param[in] solver solver used to solve the linear system
      *
      * @note in case an equilibration method (scaling of rows and columns) is defined, this is also
      * performed within this call
      */
-    void solve_linear_system() const;
+    void solve_linear_system(Core::LinAlg::Solver& solver) const;
 
     //! this object holds all maps relevant to monolithic scalar transport - structure interaction
     [[nodiscard]] std::shared_ptr<SSI::Utils::SSIMaps> ssi_maps() const { return ssi_maps_; }
 
     //! return algebraic solver for the global system of equations
-    [[nodiscard]] const Core::LinAlg::Solver& solver() const { return *solver_; };
+    [[nodiscard]] const Core::LinAlg::Solver& solver() const { return *solver_; }
 
     void timeloop() override;
 
@@ -151,8 +152,12 @@ namespace SSI
     //! assemble linearization of structural residuals to system matrix
     void assemble_mat_structure() const;
 
-    //! build null spaces associated with blocks of global system matrix
-    void build_null_spaces() const;
+    /*!
+     * @brief build null spaces associated with blocks of global system matrix
+     *
+     * @param[in] solver solver used to solve the linear system
+     */
+    void build_null_spaces(Core::LinAlg::Solver& solver) const;
 
     //! calc initial potential field for the monolithic SSI problem including scatra and scatra
     //! manifold fields
@@ -253,6 +258,10 @@ namespace SSI
 
     //! all OD evaluation is in here
     std::shared_ptr<SSI::ScatraStructureOffDiagCoupling> scatrastructure_off_diagcoupling_;
+
+    //! algebraic solver for the global system of equations during calculation of the initial
+    //! potential field
+    std::shared_ptr<Core::LinAlg::Solver> init_pot_calc_solver_;
 
     //! algebraic solver for global system of equations
     std::shared_ptr<Core::LinAlg::Solver> solver_;

--- a/tests/input_files/ssi_mono_3D_hex8_elch_s2i_butlervolmer_grain_boundary_meshtying_BGS-AMG_5x5.4C.yaml
+++ b/tests/input_files/ssi_mono_3D_hex8_elch_s2i_butlervolmer_grain_boundary_meshtying_BGS-AMG_5x5.4C.yaml
@@ -58,6 +58,7 @@ SSI CONTROL/MANIFOLD:
   LINEAR_SOLVER: 4
 SSI CONTROL/ELCH:
   INITPOTCALC: true
+  INIT_POT_CALC_LINEAR_SOLVER: 5
 SOLVER 1:
   SOLVER: UMFPACK
 SOLVER 2:
@@ -75,6 +76,11 @@ SOLVER 4:
   SOLVER_XML_FILE: "xml/linear_solver/iterative_gmres_template.xml"
   AZPREC: MueLu
   MUELU_XML_FILE: "xml/multigrid/scatra_template.xml"
+SOLVER 5:
+  SOLVER: Belos
+  SOLVER_XML_FILE: "xml/linear_solver/iterative_gmres_template.xml"
+  AZPREC: Teko
+  TEKO_XML_FILE: "xml/block_preconditioner/solid_scatra_BGS-AMG_5x5_init_pot_calc.xml"
 MATERIALS:
   - MAT: 1
     MAT_electrode:

--- a/tests/input_files/xml/block_preconditioner/solid_scatra_BGS-AMG_5x5_init_pot_calc.xml
+++ b/tests/input_files/xml/block_preconditioner/solid_scatra_BGS-AMG_5x5_init_pot_calc.xml
@@ -1,0 +1,89 @@
+<ParameterList name="Teko">
+  <!--
+                        For electrochemistry problems, these are the recommended settings for the block preconditioner
+                        containing a block Gauss-Seidel from Teko, using MueLu as multigrid preconditioner for the single
+                        field inverses.
+                        -->
+  <!-- ===========  BLOCK PRECONDITIONER ================ -->
+  <!-- Definition of the block preconditioner, which has to be defined under sub-list "Preconditioner",
+                             which is used by Teko. The single field inverse approximation methods have to be given under
+                             sub-lists "Inverse<1..n>". -->
+  <Parameter name="Inverse Type" type="string" value="Preconditioner"/>
+  <ParameterList name="Inverse Factory Library">
+    <ParameterList name="Preconditioner">
+      <Parameter name="Type" type="string" value="Block Gauss-Seidel"/>
+      <Parameter name="Use Upper Triangle" type="bool" value="false"/>
+      <Parameter name="Inverse Type 1" type="string" value="Inverse1"/>
+      <Parameter name="Inverse Type 2" type="string" value="Inverse2"/>
+      <Parameter name="Inverse Type 3" type="string" value="Inverse3"/>
+      <Parameter name="Inverse Type 4" type="string" value="Inverse4"/>
+      <Parameter name="Inverse Type 5" type="string" value="Inverse5"/>
+    </ParameterList>
+    <!-- ===========  SINGLE FIELD PRECONDITIONER FOR STRUCTURE ============= -->
+    <ParameterList name="Inverse1">
+      <Parameter name="Type" type="string" value="Ifpack"/>
+      <Parameter name="Prec Type" type="string" value="ILU"/>
+      <Parameter name="Overlap" type="int" value="0"/>
+      <ParameterList name="Ifpack Settings">
+        <Parameter name="fact: level-of-fill" type="int" value="2"/>
+      </ParameterList>
+    </ParameterList>
+    <!-- ===========  SINGLE FIELD PRECONDITIONER FOR SCATRA ================ -->
+    <ParameterList name="Inverse2">
+      <Parameter name="Type" type="string" value="MueLu"/>
+      <Parameter name="multigrid algorithm" type="string" value="pg"/>
+      <Parameter name="problem: symmetric" type="bool" value="false"/>
+      <Parameter name="verbosity" type="string" value="None"/>
+      <Parameter name="coarse: max size" type="int" value="200"/>
+      <Parameter name="smoother: type" type="string" value="RILUK"/>
+      <ParameterList name="smoother: params">
+        <Parameter name="fact: iluk level-of-fill" type="int" value="1"/>
+        <Parameter name="fact: absolute threshold" type="double" value="0.0"/>
+        <Parameter name="fact: relative threshold" type="double" value="1.0"/>
+        <Parameter name="fact: relax value" type="double" value="0.0"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Inverse3">
+      <Parameter name="Type" type="string" value="MueLu"/>
+      <Parameter name="multigrid algorithm" type="string" value="pg"/>
+      <Parameter name="problem: symmetric" type="bool" value="false"/>
+      <Parameter name="verbosity" type="string" value="None"/>
+      <Parameter name="coarse: max size" type="int" value="200"/>
+      <Parameter name="smoother: type" type="string" value="RILUK"/>
+      <ParameterList name="smoother: params">
+        <Parameter name="fact: iluk level-of-fill" type="int" value="1"/>
+        <Parameter name="fact: absolute threshold" type="double" value="0.0"/>
+        <Parameter name="fact: relative threshold" type="double" value="1.0"/>
+        <Parameter name="fact: relax value" type="double" value="0.0"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Inverse4">
+      <Parameter name="Type" type="string" value="MueLu"/>
+      <Parameter name="multigrid algorithm" type="string" value="pg"/>
+      <Parameter name="problem: symmetric" type="bool" value="false"/>
+      <Parameter name="verbosity" type="string" value="None"/>
+      <Parameter name="coarse: max size" type="int" value="200"/>
+      <Parameter name="smoother: type" type="string" value="RILUK"/>
+      <ParameterList name="smoother: params">
+        <Parameter name="fact: iluk level-of-fill" type="int" value="1"/>
+        <Parameter name="fact: absolute threshold" type="double" value="0.0"/>
+        <Parameter name="fact: relative threshold" type="double" value="1.0"/>
+        <Parameter name="fact: relax value" type="double" value="0.0"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Inverse5">
+      <Parameter name="Type" type="string" value="MueLu"/>
+      <Parameter name="multigrid algorithm" type="string" value="pg"/>
+      <Parameter name="problem: symmetric" type="bool" value="false"/>
+      <Parameter name="verbosity" type="string" value="None"/>
+      <Parameter name="coarse: max size" type="int" value="200"/>
+      <Parameter name="smoother: type" type="string" value="RILUK"/>
+      <ParameterList name="smoother: params">
+        <Parameter name="fact: iluk level-of-fill" type="int" value="1"/>
+        <Parameter name="fact: absolute threshold" type="double" value="0.0"/>
+        <Parameter name="fact: relative threshold" type="double" value="1.0"/>
+        <Parameter name="fact: relax value" type="double" value="0.0"/>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+</ParameterList>


### PR DESCRIPTION
## Description and Context
While working on simulations for the HPSF community summit, it turned out to be valuable to allow different preconditioner settings for the calculation of the initial potential field compared to all other solves later.

Thus, this PR enables explicitly setting a different solver for this. If no such solver is set, just the solver for the main part is reused. And adapts an input file that does this.