### PR TITLE
[beaminteraction] Refactor `read_restart` and `write_restart` method calls

### DIFF
--- a/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator.cpp
@@ -828,7 +828,7 @@ void Solid::ModelEvaluator::BeamInteractionModelEvaluator::write_restart(
   // sub model loop
   Vector::iterator some_iter;
   for (some_iter = me_vec_ptr_->begin(); some_iter != me_vec_ptr_->end(); ++some_iter)
-    (*some_iter)->write_restart(*ia_writer, *bin_writer);
+    (*some_iter)->write_restart(*bin_writer);
 }
 
 /*----------------------------------------------------------------------------*
@@ -867,7 +867,7 @@ void Solid::ModelEvaluator::BeamInteractionModelEvaluator::read_restart(
 
   // sub model loop
   for (some_iter = me_vec_ptr_->begin(); some_iter != me_vec_ptr_->end(); ++some_iter)
-    (*some_iter)->read_restart(ia_reader, bin_reader);
+    (*some_iter)->read_restart(bin_reader);
 
   // post sub model loop
   for (some_iter = me_vec_ptr_->begin(); some_iter != me_vec_ptr_->end(); ++some_iter)

--- a/src/beaminteraction/src/4C_beaminteraction_submodel_evaluator_generic.hpp
+++ b/src/beaminteraction/src/4C_beaminteraction_submodel_evaluator_generic.hpp
@@ -151,14 +151,12 @@ namespace BeamInteraction
       virtual void reset_step_state() = 0;
 
       //! \brief write model specific restart
-      virtual void write_restart(Core::IO::DiscretizationWriter& ia_writer,
-          Core::IO::DiscretizationWriter& bin_writer) const = 0;
+      virtual void write_restart(Core::IO::DiscretizationWriter& bin_writer) const = 0;
 
       /*! \brief read model specific restart information
        *
        *  \param ioreader (in) : input reader*/
-      virtual void read_restart(Core::IO::DiscretizationReader& ia_writer,
-          Core::IO::DiscretizationReader& bin_writer) = 0;
+      virtual void read_restart(Core::IO::DiscretizationReader& bin_writer) = 0;
 
       //! \brief do stuff pre reading of model specific restart information
       virtual void pre_read_restart() = 0;

--- a/src/beaminteraction/src/contact/4C_beaminteraction_contact_submodel_evaluator.cpp
+++ b/src/beaminteraction/src/contact/4C_beaminteraction_contact_submodel_evaluator.cpp
@@ -699,7 +699,7 @@ void BeamInteraction::SubmodelEvaluator::BeamContact::reset_step_state() { check
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 void BeamInteraction::SubmodelEvaluator::BeamContact::write_restart(
-    Core::IO::DiscretizationWriter& ia_writer, Core::IO::DiscretizationWriter& bin_writer) const
+    Core::IO::DiscretizationWriter& bin_writer) const
 {
   // empty
 }
@@ -714,7 +714,7 @@ void BeamInteraction::SubmodelEvaluator::BeamContact::pre_read_restart()
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 void BeamInteraction::SubmodelEvaluator::BeamContact::read_restart(
-    Core::IO::DiscretizationReader& ia_reader, Core::IO::DiscretizationReader& bin_reader)
+    Core::IO::DiscretizationReader& bin_reader)
 {
   // empty
 }

--- a/src/beaminteraction/src/contact/4C_beaminteraction_contact_submodel_evaluator.hpp
+++ b/src/beaminteraction/src/contact/4C_beaminteraction_contact_submodel_evaluator.hpp
@@ -108,15 +108,13 @@ namespace BeamInteraction
       void reset_step_state() override;
 
       //! derived
-      void write_restart(Core::IO::DiscretizationWriter& ia_writer,
-          Core::IO::DiscretizationWriter& bin_writer) const override;
+      void write_restart(Core::IO::DiscretizationWriter& bin_writer) const override;
 
       //! derived
       void pre_read_restart() override;
 
       //! derived
-      void read_restart(Core::IO::DiscretizationReader& ia_reader,
-          Core::IO::DiscretizationReader& bin_reader) override;
+      void read_restart(Core::IO::DiscretizationReader& bin_reader) override;
 
       //! derived
       void post_read_restart() override;

--- a/src/beaminteraction/src/crosslinking/4C_beaminteraction_crosslinking_submodel_evaluator.cpp
+++ b/src/beaminteraction/src/crosslinking/4C_beaminteraction_crosslinking_submodel_evaluator.cpp
@@ -1332,7 +1332,7 @@ void BeamInteraction::SubmodelEvaluator::Crosslinking::reset_step_state() { chec
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 void BeamInteraction::SubmodelEvaluator::Crosslinking::write_restart(
-    Core::IO::DiscretizationWriter& ia_writer, Core::IO::DiscretizationWriter& bin_writer) const
+    Core::IO::DiscretizationWriter& bin_writer) const
 {
   check_init_setup();
 
@@ -1407,7 +1407,7 @@ void BeamInteraction::SubmodelEvaluator::Crosslinking::pre_read_restart()
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 void BeamInteraction::SubmodelEvaluator::Crosslinking::read_restart(
-    Core::IO::DiscretizationReader& ia_reader, Core::IO::DiscretizationReader& bin_reader)
+    Core::IO::DiscretizationReader& bin_reader)
 {
   check_init_setup();
 

--- a/src/beaminteraction/src/crosslinking/4C_beaminteraction_crosslinking_submodel_evaluator.hpp
+++ b/src/beaminteraction/src/crosslinking/4C_beaminteraction_crosslinking_submodel_evaluator.hpp
@@ -224,15 +224,13 @@ namespace BeamInteraction
       void reset_step_state() override;
 
       //! derived
-      void write_restart(Core::IO::DiscretizationWriter& ia_writer,
-          Core::IO::DiscretizationWriter& bin_writer) const override;
+      void write_restart(Core::IO::DiscretizationWriter& bin_writer) const override;
 
       //! derived
       void pre_read_restart() override;
 
       //! derived
-      void read_restart(Core::IO::DiscretizationReader& ia_reader,
-          Core::IO::DiscretizationReader& bin_reader) override;
+      void read_restart(Core::IO::DiscretizationReader& bin_reader) override;
 
       //! derived
       void post_read_restart() override;

--- a/src/beaminteraction/src/potential/4C_beaminteraction_potential_submodel_evaluator.cpp
+++ b/src/beaminteraction/src/potential/4C_beaminteraction_potential_submodel_evaluator.cpp
@@ -560,7 +560,7 @@ void BeamInteraction::SubmodelEvaluator::BeamPotential::reset_step_state() { che
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 void BeamInteraction::SubmodelEvaluator::BeamPotential::write_restart(
-    Core::IO::DiscretizationWriter& ia_writer, Core::IO::DiscretizationWriter& bin_writer) const
+    Core::IO::DiscretizationWriter& bin_writer) const
 {
   // empty
 }
@@ -575,7 +575,7 @@ void BeamInteraction::SubmodelEvaluator::BeamPotential::pre_read_restart()
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 void BeamInteraction::SubmodelEvaluator::BeamPotential::read_restart(
-    Core::IO::DiscretizationReader& ia_reader, Core::IO::DiscretizationReader& bin_reader)
+    Core::IO::DiscretizationReader& bin_reader)
 {
   // empty
 }

--- a/src/beaminteraction/src/potential/4C_beaminteraction_potential_submodel_evaluator.hpp
+++ b/src/beaminteraction/src/potential/4C_beaminteraction_potential_submodel_evaluator.hpp
@@ -92,15 +92,13 @@ namespace BeamInteraction
       void reset_step_state() override;
 
       //! derived
-      void write_restart(Core::IO::DiscretizationWriter& ia_writer,
-          Core::IO::DiscretizationWriter& bin_writer) const override;
+      void write_restart(Core::IO::DiscretizationWriter& bin_writer) const override;
 
       //! derived
       void pre_read_restart() override;
 
       //! derived
-      void read_restart(Core::IO::DiscretizationReader& ia_reader,
-          Core::IO::DiscretizationReader& bin_reader) override;
+      void read_restart(Core::IO::DiscretizationReader& bin_reader) override;
 
       //! derived
       void post_read_restart() override;

--- a/src/beaminteraction/src/spherebeamlinking/4C_beaminteraction_spherebeamlinking_submodel_evaluator.cpp
+++ b/src/beaminteraction/src/spherebeamlinking/4C_beaminteraction_spherebeamlinking_submodel_evaluator.cpp
@@ -498,7 +498,7 @@ void BeamInteraction::SubmodelEvaluator::SphereBeamLinking::reset_step_state()
 /*-------------------------------------------------------------------------------*
  *-------------------------------------------------------------------------------*/
 void BeamInteraction::SubmodelEvaluator::SphereBeamLinking::write_restart(
-    Core::IO::DiscretizationWriter& ia_writer, Core::IO::DiscretizationWriter& bin_writer) const
+    Core::IO::DiscretizationWriter& bin_writer) const
 {
   check_init_setup();
 
@@ -515,7 +515,7 @@ void BeamInteraction::SubmodelEvaluator::SphereBeamLinking::pre_read_restart()
 /*-------------------------------------------------------------------------------*
  *-------------------------------------------------------------------------------*/
 void BeamInteraction::SubmodelEvaluator::SphereBeamLinking::read_restart(
-    Core::IO::DiscretizationReader& ia_reader, Core::IO::DiscretizationReader& bin_reader)
+    Core::IO::DiscretizationReader& bin_reader)
 {
   check_init_setup();
 

--- a/src/beaminteraction/src/spherebeamlinking/4C_beaminteraction_spherebeamlinking_submodel_evaluator.hpp
+++ b/src/beaminteraction/src/spherebeamlinking/4C_beaminteraction_spherebeamlinking_submodel_evaluator.hpp
@@ -93,15 +93,13 @@ namespace BeamInteraction
       void reset_step_state() override;
 
       //! derived
-      void write_restart(Core::IO::DiscretizationWriter& ia_writer,
-          Core::IO::DiscretizationWriter& bin_writer) const override;
+      void write_restart(Core::IO::DiscretizationWriter& bin_writer) const override;
 
       //! derived
       void pre_read_restart() override;
 
       //! derived
-      void read_restart(Core::IO::DiscretizationReader& ia_reader,
-          Core::IO::DiscretizationReader& bin_reader) override;
+      void read_restart(Core::IO::DiscretizationReader& bin_reader) override;
 
       //! derived
       void post_read_restart() override;


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
This PR removes the `ia_reader` from `read_restart` and `write_restart`.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
Part of #1523