### PR TITLE
Update superlu_dist dependency to version 9.2.1

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -16,7 +16,7 @@ jobs:
   gcc13_assertions_build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:718a74e5
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:24b228a5
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/main'
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:718a74e5
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:24b228a5
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     strategy:
       fail-fast: false
@@ -104,7 +104,7 @@ jobs:
   clang18_build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:718a74e5
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:24b228a5
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -158,7 +158,7 @@ jobs:
     needs: clang18_build
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:718a74e5
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:24b228a5
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -184,7 +184,7 @@ jobs:
     needs: clang18_build
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:718a74e5
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:24b228a5
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -243,7 +243,7 @@ jobs:
   gcc13_no_optional_dependencies_build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:718a74e5
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:24b228a5
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -269,7 +269,7 @@ jobs:
     needs: gcc13_no_optional_dependencies_build
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:718a74e5
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:24b228a5
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:

--- a/.github/workflows/checkcode.yml
+++ b/.github/workflows/checkcode.yml
@@ -29,7 +29,7 @@ jobs:
   clang-tidy:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:718a74e5
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:24b228a5
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -55,7 +55,7 @@ jobs:
   verify-headers:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:718a74e5
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:24b228a5
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,7 +8,7 @@ jobs:
   clang18_coverage_build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:718a74e5
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:24b228a5
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -45,7 +45,7 @@ jobs:
     needs: clang18_coverage_build
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:718a74e5
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:24b228a5
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     strategy:
       matrix:
@@ -111,7 +111,7 @@ jobs:
     needs: [clang18_coverage_test, clang18_coverage_build]
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:718a74e5
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:24b228a5
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,7 +18,7 @@ jobs:
   doxygen:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:718a74e5
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:24b228a5
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -44,7 +44,7 @@ jobs:
   documentation:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:718a74e5
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:24b228a5
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:

--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -8,7 +8,7 @@ jobs:
   gcc13_assertions_build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:718a74e5
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:24b228a5
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -43,7 +43,7 @@ jobs:
     needs: gcc13_assertions_build
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:718a74e5
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:24b228a5
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     strategy:
       fail-fast: false
@@ -95,7 +95,7 @@ jobs:
   clang18_build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:718a74e5
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:24b228a5
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -193,7 +193,7 @@ jobs:
     needs: clang18_build
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:718a74e5
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:24b228a5
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     strategy:
       fail-fast: false
@@ -245,7 +245,7 @@ jobs:
   clang18_build_oldest_supported_dependencies:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04-oldest-supported:718a74e5
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04-oldest-supported:24b228a5
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -280,7 +280,7 @@ jobs:
     needs: clang18_build_oldest_supported_dependencies
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04-oldest-supported:718a74e5
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04-oldest-supported:24b228a5
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     strategy:
       fail-fast: false
@@ -319,7 +319,7 @@ jobs:
   gcc13_no_optional_dependencies_build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:718a74e5
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:24b228a5
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -354,7 +354,7 @@ jobs:
     needs: gcc13_no_optional_dependencies_build
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:718a74e5
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:24b228a5
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     strategy:
       fail-fast: false
@@ -406,7 +406,7 @@ jobs:
   gcc13_asan_build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:718a74e5
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:24b228a5
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -441,7 +441,7 @@ jobs:
     needs: gcc13_asan_build
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:718a74e5
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:24b228a5
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     strategy:
       fail-fast: false

--- a/dependencies/current/superlu_dist/install.sh
+++ b/dependencies/current/superlu_dist/install.sh
@@ -16,8 +16,8 @@ set -e
 INSTALL_DIR="$1"
 # Number of procs for building (default 4)
 NPROCS=${NPROCS=4}
-VERSION="7.2.0"
-CHECKSUM="20b60bd8a3d88031c9ce6511ae9700b7a8dcf12e2fd704e74b1af762b3468b8c"
+VERSION="9.2.1"
+CHECKSUM="c80a1c2edaaa451ee9a54e005e5f3f56dc55cabe2b0a8d7acf5a1447a648157a"
 
 SUPERLU_TAR="superlu_dist-${VERSION}.tar.gz"
 

--- a/doc/documentation/src/installation/installation.rst
+++ b/doc/documentation/src/installation/installation.rst
@@ -30,7 +30,7 @@ External solver and linear algebra:
 
 - :ref:`Trilinos <trilinos>` (supported versions are listed in ``dependencies/supported_version/Trilinos.txt``, currently only supported version: 16.2.0)
 - :ref:`SuiteSparse <suitesparse>`
-- :ref:`SuperLUDist <superludist>` (recommended version: 7.2.0)
+- :ref:`SuperLUDist <superludist>` (recommended version: 9.2.1)
 - BLAS
 - LAPACK
 - Mumps


### PR DESCRIPTION
## Description and Context
We have constantly failing nightly tests that use Superlu. Thus, @amgebauer, @ischeider, and I looked into that issue a bit using `valgrind` and found that, with the current Superlu_dist version (9.2.1), not all issues are solved, but some are. Consequently, updating the Superlu_dist version sounds like a good idea.

I've attached the outputs of two test cases: one with the old superlu_dist version and one with the new one.
[homogenized-valgrind-output-old-superlu-dist.txt](https://github.com/user-attachments/files/26082707/homogenized-valgrind-output-old-superlu-dist.txt)
[homogenized-valgrind-output-new-superlu-dist.txt](https://github.com/user-attachments/files/26082708/homogenized-valgrind-output-new-superlu-dist.txt)
[valgrind-output-new-superlu-dist.txt](https://github.com/user-attachments/files/26082709/valgrind-output-new-superlu-dist.txt)
[valgrind-output-old-superlu-dist.txt](https://github.com/user-attachments/files/26082710/valgrind-output-old-superlu-dist.txt)

FYI: I'll update the documentation accordingly and push after the manually triggered Docker build was successful.

