### PR TITLE
Make control file writing crash safe

### DIFF
--- a/src/core/io/src/4C_io_control.cpp
+++ b/src/core/io/src/4C_io_control.cpp
@@ -58,7 +58,12 @@ struct Core::IO::ControlFileWriter::Impl
   void flush_and_reset_tree()
   {
     // Only write if there is anything to write. Otherwise, we get an ugly "[]" in the output.
-    if (tree_.rootref().num_children() > 0) out_ << tree_ << "\n" << std::flush;
+    if (tree_.rootref().num_children() > 0)
+    {
+      // Seek back to where this group started to overwrite the last partial snapshot written
+      if (group_write_start_ >= 0) out_.seekp(group_write_start_);
+      out_ << tree_ << "\n" << std::flush;
+    }
 
     // Clear the tree and reset the current node to the root
     tree_.clear();
@@ -66,6 +71,7 @@ struct Core::IO::ControlFileWriter::Impl
     current_node_id_ = tree_.rootref().id();
     group_level = 0;
     tree_.rootref() |= ryml::SEQ;
+    group_write_start_ = -1;
   }
 
   template <typename T>
@@ -77,10 +83,18 @@ struct Core::IO::ControlFileWriter::Impl
     node << ryml::key(key_str);
 
     emit_value_as_yaml(YamlNodeRef{node, ""}, value);
+
+    // Seek back to where this group started and rewrite the entire (now larger) tree snapshot
+    if (group_write_start_ >= 0) out_.seekp(group_write_start_);
+    out_ << tree_ << std::flush;
   }
 
   void start_group(std::string_view key)
   {
+    // Record the stream position before the outermost group's first byte so write() can seek
+    // back here and overwrite the previous partial snapshot with the latest (larger) one.
+    if (group_level == 0) group_write_start_ = out_.tellp();
+
     ++group_level;
 
     ryml::NodeRef outer = (current().is_seq()) ? current().append_child() : current();
@@ -117,6 +131,10 @@ struct Core::IO::ControlFileWriter::Impl
 
   //! output stream for the control file
   std::ostream& out_;
+
+  //! Stream position of the start of the current outermost group, used for seek-and-overwrite.
+  //! -1 means no group is currently open.
+  std::streamoff group_write_start_{-1};
 };
 
 

--- a/src/core/io/tests/4C_io_control_test.cpp
+++ b/src/core/io/tests/4C_io_control_test.cpp
@@ -144,4 +144,26 @@ namespace
     EXPECT_EQ("", stream.str());
   }
 
+  // Verify that each write() immediately places data in the stream, even before end_group() is
+  // called. This is the core crash-safety guarantee: if end_group() is never reached (e.g. due to
+  // a floating-point exception), all previously written key-value pairs are already in the kernel
+  // buffer and will survive the crash.
+  TEST(ControlFileWriterTest, FPESafetyDataInStreamBeforeEndGroup)
+  {
+    std::stringstream stream;
+    Core::IO::ControlFileWriter writer(true, stream);
+    writer.start_group("field");
+
+    writer.write("step", 1);
+    EXPECT_THAT(stream.str(), testing::HasSubstr("step: 1"));
+
+    writer.write("time", 0.5);
+    EXPECT_THAT(stream.str(), testing::HasSubstr("step: 1"));
+    EXPECT_THAT(stream.str(), testing::HasSubstr("time:"));
+
+    // end_group() is intentionally never called; the assertions above already verified that all
+    // written keys are in the stream. In a real crash the destructor would not run either, but
+    // the data is already in the kernel buffer at each write() call.
+  }
+
 }  // namespace


### PR DESCRIPTION
As reported in https://github.com/4C-multiphysics/4C/issues/1476, the control file is not written properly in case a floating point exception occurs. Catching the FPE and trying to flush the control file buffer before shutdown is illegal as described in the issue.

A possible remedy is to flush the control file content regularly with each writing not to loose the latest part in case of an FPE. Not to deteriorate performance, asynchronous writing is chosen (not 100% safe, however first test were all successful. Thanks to @vovannikov for this good hint.) Performance loss (with way too many restart writings and a small test case) was < 1%.

The `sync_file_range()` call is only available on linux, hence currently guarded by `#ifdef __linux__`. We might drop this guard?!

@mairehenke @rjoussen Please have a try whether this solves the corrupt control file writing in your applications.

## Related Issues and Pull Requests
https://github.com/4C-multiphysics/4C/issues/1476
