### PR TITLE
Require gmsh in csv comparison test for gmsh input

### DIFF
--- a/tests/list_of_tests.cmake
+++ b/tests/list_of_tests.cmake
@@ -2565,10 +2565,10 @@ four_c_test(TEST_FILE solid_gmsh_input.4C.yaml NP 2 REQUIRED_DEPENDENCIES GMSH R
 four_c_test_restart(BASED_ON ${current} SAME_FILE NP 2 RESTART_STEP 5 REQUIRED_DEPENDENCIES GMSH)
 four_c_test(TEST_FILE solid_gmsh_input_node_set_names_monitor_dbc_csv.4C.yaml NP 2 REQUIRED_DEPENDENCIES GMSH RETURN_AS current)
 four_c_test_restart(BASED_ON ${current} SAME_FILE NP 2 RESTART_STEP 5 REQUIRED_DEPENDENCIES GMSH RETURN_AS current_restart)
-four_c_test_add_csv_yaml_comparison(BASED_ON ${current_restart} RESULT_FILE xxx-1-left_faces_monitor_dbc.csv REFERENCE_FILE ref/solid_gmsh_input-left_faces_monitor_dbc.csv TOL_R 1e-6 TOL_A 1e-10)
+four_c_test_add_csv_yaml_comparison(BASED_ON ${current_restart} RESULT_FILE xxx-1-left_faces_monitor_dbc.csv REFERENCE_FILE ref/solid_gmsh_input-left_faces_monitor_dbc.csv TOL_R 1e-6 TOL_A 1e-10 REQUIRED_DEPENDENCIES GMSH)
 four_c_test(TEST_FILE solid_gmsh_input_node_set_names_monitor_dbc_yaml.4C.yaml NP 2 REQUIRED_DEPENDENCIES GMSH RETURN_AS current)
 four_c_test_restart(BASED_ON ${current} SAME_FILE NP 2 RESTART_STEP 5 REQUIRED_DEPENDENCIES GMSH RETURN_AS current_restart)
-four_c_test_add_csv_yaml_comparison(BASED_ON ${current_restart} RESULT_FILE xxx-1-left_faces_monitor_dbc.yaml REFERENCE_FILE ref/solid_gmsh_input-left_faces_monitor_dbc.yaml TOL_R 1e-6 TOL_A 1e-10)
+four_c_test_add_csv_yaml_comparison(BASED_ON ${current_restart} RESULT_FILE xxx-1-left_faces_monitor_dbc.yaml REFERENCE_FILE ref/solid_gmsh_input-left_faces_monitor_dbc.yaml TOL_R 1e-6 TOL_A 1e-10 REQUIRED_DEPENDENCIES GMSH)
 
 # Tests requiring ArborX
 four_c_test(TEST_FILE rve2d_periodic_bcs_with_mpcs.4C.yaml REQUIRED_DEPENDENCIES ArborX)


### PR DESCRIPTION
I added the `REQUIRED_DEPENDENCIES GMSH` to the csv comparison tests with gmsh mesh input. Note, this test depends on another test that already declares the `REQUIRED_DEPENDENCIES GMSH`. In the nightly pipeline, the test is marked as skipped (see https://github.com/4C-multiphysics/4C/actions/runs/23270351600/job/67670838748), however, on our configurations at LNM, the test still runs, which fails, of course.

~~I don't understand why we actually need this locally and not in our pipeline :thinking: I will try to investigate it further.~~