### PR TITLE
Fix bugs in old w1-poro-p1 element

### DIFF
--- a/src/w1/4C_w1_poro_evaluate.cpp
+++ b/src/w1/4C_w1_poro_evaluate.cpp
@@ -1073,7 +1073,8 @@ void Discret::Elements::Wall1Poro<distype>::fill_matrix_and_vectors(const int& g
     Core::LinAlg::Matrix<numstr_, 1> sfac(C_inv_vec);  // auxiliary integrated stress
 
     // scale and add viscous stress
-    sfac.update(detJ_w, fstress, fac2);  // detJ*w(gp)*[S11,S22,S33,S12=S21,S23=S32,S13=S31]
+    sfac.update(
+        detJ_w * porosity, fstress, fac2);  // detJ*w(gp)*[S11,S22,S33,S12=S21,S23=S32,S13=S31]
 
     std::vector<double> SmB_L(2);  // intermediate Sm.B_L
     // kgeo += (B_L^T . sigma . B_L) * detJ * w(gp)  with B_L = Ni,Xj see NiliFEM-Skript
@@ -1349,21 +1350,19 @@ void Discret::Elements::Wall1Poro<distype>::fill_matrix_and_vectors_brinkman(con
   fstress(1) = tmp(1, 1);
   fstress(2) = tmp(0, 1);
 
-  fstress.scale(detJ_w * visc * J * porosity);
+  fstress.scale(visc * J);
 
   // B^T . C^-1
   Core::LinAlg::Matrix<numdof_, 1> fstressb(Core::LinAlg::Initialization::zero);
   fstressb.multiply_tn(bop, fstress);
 
-  if (force != nullptr) force->update(1.0, fstressb, 1.0);
+  if (force != nullptr) force->update(detJ_w * porosity, fstressb, 1.0);
 
   // evaluate viscous terms (for darcy-brinkman flow only)
   if (stiffmatrix != nullptr)
   {
     Core::LinAlg::Matrix<numdim_, numdim_> tmp4;
     tmp4.multiply_nt(fvelder, defgrd_inv);
-
-    double fac = detJ_w * visc;
 
     Core::LinAlg::Matrix<numstr_, numdof_> fstress_dus(Core::LinAlg::Initialization::zero);
     for (int n = 0; n < numnod_; ++n)
@@ -1395,11 +1394,11 @@ void Discret::Elements::Wall1Poro<distype>::fill_matrix_and_vectors_brinkman(con
 
     // additional viscous fluid stress- stiffness term (B^T . fstress . dJ/d(us) * porosity * detJ
     // * w(gp))
-    tmp.multiply(fac * porosity, fstressb, dJ_dus);
+    tmp.multiply(detJ_w * porosity, fstressb, dJ_dus);
     stiffmatrix->update(1.0, tmp, 1.0);
 
     // additional fluid stress- stiffness term (B^T .  d\phi/d(us) . fstress  * J * w(gp))
-    tmp.multiply(fac * J, fstressb, dphi_dus);
+    tmp.multiply(detJ_w, fstressb, dphi_dus);
     stiffmatrix->update(1.0, tmp, 1.0);
 
     // additional fluid stress- stiffness term (B^T .  phi . dfstress/d(us)  * J * w(gp))

--- a/src/w1/4C_w1_poro_p1_evaluate.cpp
+++ b/src/w1/4C_w1_poro_p1_evaluate.cpp
@@ -630,7 +630,8 @@ void Discret::Elements::Wall1PoroP1<distype>::gauss_point_loop_p1(Teuchos::Param
         erea_v, sub_stiff, sub_force, fstress);
 
     // **********************evaluate stiffness matrix and force vector+++++++++++++++++++++++++
-    double detJ_w = Base::detJ_[gp] * Base::intpoints_.weight(gp);  // gpweights[gp];
+    double detJ_w =
+        Base::thickness_ * Base::detJ_[gp] * Base::intpoints_.weight(gp);  // gpweights[gp];
 
     const double reacoeff = Base::fluid_mat_->compute_reaction_coeff();
     {
@@ -671,7 +672,7 @@ void Discret::Elements::Wall1PoroP1<distype>::gauss_point_loop_p1(Teuchos::Param
       fstress(1) = visctress1(1, 1);
       fstress(2) = visctress1(0, 1);
 
-      fstress.scale(detJ_w * visc * J);
+      fstress.scale(visc * J);
 
       // B^T . C^-1
       Core::LinAlg::Matrix<Base::numdof_, 1> fstressb(Core::LinAlg::Initialization::zero);
@@ -869,7 +870,7 @@ void Discret::Elements::Wall1PoroP1<distype>::gauss_point_loop_p1_od(Teuchos::Pa
     //--------------------------------------------------------
 
     // **********************evaluate stiffness matrix and force vector+++++++++++++++++++++++++
-    double detJ_w = Base::detJ_[gp] * Base::intpoints_.weight(gp);
+    double detJ_w = Base::thickness_ * Base::detJ_[gp] * Base::intpoints_.weight(gp);
 
     for (int k = 0; k < Base::numnod_; k++)
     {
@@ -939,7 +940,7 @@ int Discret::Elements::Wall1PoroP1<distype>::evaluate_neumann(Teuchos::Parameter
     Base::compute_jacobian_determinant(gp, xcurr, deriv);
 
     /*------------------------------------ integration factor  -------*/
-    double fac = Base::detJ_[gp] * Base::intpoints_.weight(gp);
+    double fac = Base::thickness_ * Base::detJ_[gp] * Base::intpoints_.weight(gp);
 
     // load vector ar
     std::array<double, Base::numdim_> ar = {0.0, 0.0};

--- a/tests/input_files/poro_2D_scatra_ecm_reaction.4C.yaml
+++ b/tests/input_files/poro_2D_scatra_ecm_reaction.4C.yaml
@@ -188,37 +188,37 @@ RESULT DESCRIPTION:
       DIS: "scatra"
       NODE: 3658
       QUANTITY: "phi"
-      VALUE: 9.892983583899781
+      VALUE: 9.89303458466124574
       TOLERANCE: 1e-08
   - SCATRA:
       DIS: "scatra"
       NODE: 3705
       QUANTITY: "phi"
-      VALUE: 11.297980509183958
+      VALUE: 11.2980177533205115
       TOLERANCE: 1e-08
   - SCATRA:
       DIS: "scatra"
       NODE: 3750
       QUANTITY: "phi"
-      VALUE: 43.707673034947426
+      VALUE: 43.7074845558652640
       TOLERANCE: 1e-08
   - SCATRA:
       DIS: "scatra"
       NODE: 3799
       QUANTITY: "phi"
-      VALUE: 11.297980509184033
+      VALUE: 11.2980177533206056
       TOLERANCE: 1e-08
   - SCATRA:
       DIS: "scatra"
       NODE: 3846
       QUANTITY: "phi"
-      VALUE: 9.892983583899845
+      VALUE: 9.89303458466132746
       TOLERANCE: 1e-08
   - SCATRA:
       DIS: "scatra"
       NODE: 3893
       QUANTITY: "phi"
-      VALUE: 7.291857112808861
+      VALUE: 7.29191695243924443
       TOLERANCE: 1e-08
   - SCATRA:
       DIS: "scatra"
@@ -230,79 +230,79 @@ RESULT DESCRIPTION:
       DIS: "scatra"
       NODE: 3657
       QUANTITY: "phi2"
-      VALUE: 22.828890850359993
+      VALUE: 22.8288763026125103
       TOLERANCE: 1e-08
   - SCATRA:
       DIS: "scatra"
       NODE: 3704
       QUANTITY: "phi2"
-      VALUE: 21.5981294984908
+      VALUE: 21.5981200021674269
       TOLERANCE: 1e-08
   - SCATRA:
       DIS: "scatra"
       NODE: 3750
       QUANTITY: "phi2"
-      VALUE: 62.06287220180389
+      VALUE: 62.0629435401303979
       TOLERANCE: 1e-08
   - SCATRA:
       DIS: "scatra"
       NODE: 3798
       QUANTITY: "phi2"
-      VALUE: 21.59812949849084
+      VALUE: 21.5981200021674660
       TOLERANCE: 1e-08
   - SCATRA:
       DIS: "scatra"
       NODE: 3845
       QUANTITY: "phi4"
-      VALUE: 0.21758314801662929
+      VALUE: 0.21758295120459927
       TOLERANCE: 1e-08
   - SCATRA:
       DIS: "scatra"
       NODE: 3893
       QUANTITY: "phi4"
-      VALUE: 0.9406013741599354
+      VALUE: 0.940600961494011512
       TOLERANCE: 1e-08
   - SCATRA:
       DIS: "scatra"
       NODE: 1953
       QUANTITY: "phi3"
-      VALUE: 70.66201997801053
+      VALUE: 70.6620144305123006
       TOLERANCE: 1e-08
   - SCATRA:
       DIS: "scatra"
       NODE: 3657
       QUANTITY: "phi3"
-      VALUE: 72.49750185081503
+      VALUE: 72.4974947016144142
       TOLERANCE: 1e-08
   - SCATRA:
       DIS: "scatra"
       NODE: 3704
       QUANTITY: "phi3"
-      VALUE: 72.27654785706234
+      VALUE: 72.2765403866738438
       TOLERANCE: 1e-08
   - SCATRA:
       DIS: "scatra"
       NODE: 3750
       QUANTITY: "phi3"
-      VALUE: 40.58243018871313
+      VALUE: 40.5823488655894451
       TOLERANCE: 1e-08
   - SCATRA:
       DIS: "scatra"
       NODE: 3798
       QUANTITY: "phi3"
-      VALUE: 72.2765478570623
+      VALUE: 72.2765403866737728
       TOLERANCE: 1e-08
   - SCATRA:
       DIS: "scatra"
       NODE: 3845
       QUANTITY: "phi5"
-      VALUE: 1.2824168519833712
+      VALUE: 1.28241704879540008
       TOLERANCE: 1e-08
   - SCATRA:
       DIS: "scatra"
       NODE: 3893
       QUANTITY: "phi5"
-      VALUE: 0.5593986258400651
+      VALUE: 0.559399038505988377
       TOLERANCE: 1e-08
   - SCATRA:
       DIS: "scatra"


### PR DESCRIPTION
This should fix a few bugs in the w1-poro-p1 element. I found those as I wanted to migrate all solid-poro tests to the new solid-poro framework.

The bugs are:

* Thickness is missing during integration
* Removed one extra J in the linearization of solid-poro-brinkman-formulation
* And the same bug as in https://github.com/4C-multiphysics/4C/pull/1924 (we multiplied two times with the integration factor)