### PR TITLE
Deactivate fail-fast for coverage report

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -48,6 +48,7 @@ jobs:
       image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:35e0657d
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     strategy:
+      fail-fast: false
       matrix:
         test-chunk: ${{fromJson(needs.clang18_coverage_build.outputs.test-chunks)}}
     defaults:


### PR DESCRIPTION
Since we try to restart failed pipelines anyway, the fail-fast option costs more resources than it saves us in practice.

Note, fail-fast means that a matrix job is canceled once a single job failed. We already have it deactivated for the nightly and PR checks.