### PR TITLE
Fix nested parallelism cmake test function

### DIFF
--- a/cmake/functions/four_c_testing_functions.cmake
+++ b/cmake/functions/four_c_testing_functions.cmake
@@ -716,6 +716,8 @@ function(four_c_test_nested_parallelism)
       "${test_file_full_path1}"
       OUTPUT_DIR
       "${test_directory}"
+      ADDITIONAL_FIXTURE
+      ${name_of_test}
       REQUIRED_DEPENDENCIES
       "${_parsed_REQUIRED_DEPENDENCIES}"
       )


### PR DESCRIPTION
This PR fixes a missing fixture for the nested-parallelism cmake test function that caused the coverage report to fail.