### PR TITLE
Fix build error in unit tests

### DIFF
--- a/src/core/fem/tests/general/4C_fem_general_utils_interpolation_test.cpp
+++ b/src/core/fem/tests/general/4C_fem_general_utils_interpolation_test.cpp
@@ -9,11 +9,7 @@
 
 #include "4C_fem_general_utils_interpolation.hpp"
 
-#include "4C_fem_general_element.hpp"
-#include "4C_fem_general_element_integration_select.hpp"
-#include "4C_fem_general_utils_gauss_point_extrapolation.hpp"
-#include "4C_fem_general_utils_gausspoints.hpp"
-#include "4C_fem_general_utils_integration.hpp"
+#include "4C_unittest_utils_assertions_test.hpp"
 
 #include <vector>
 
@@ -28,7 +24,7 @@ namespace
     std::vector<double> nodal_quantity = {1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7};
     std::vector<double> ref_val{1.397875};
     auto test_val = Core::FE::interpolate_to_xi<Core::FE::CellType::hex8>(xi, nodal_quantity);
-    for (std::size_t i = 0; i < ref_val.size(); ++i) EXPECT_NEAR(test_val[i], ref_val[i], 1.0e-10);
+    FOUR_C_EXPECT_NEAR(test_val, ref_val, 1.0e-10);
   }
 
   TEST(ElementServiceTest, TestProjectNodalQuantityToXiHex27)
@@ -39,7 +35,7 @@ namespace
         2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6};
     std::vector<double> ref_val = {3.623649611383};
     auto test_val = Core::FE::interpolate_to_xi<Core::FE::CellType::hex27>(xi, nodal_quantity);
-    for (std::size_t i = 0; i < ref_val.size(); ++i) EXPECT_NEAR(test_val[i], ref_val[i], 1.0e-10);
+    FOUR_C_EXPECT_NEAR(test_val, ref_val, 1.0e-10);
   }
 
   TEST(ElementServiceTest, TestProjectNodalQuantityToXiTet4)
@@ -49,7 +45,7 @@ namespace
     std::vector<double> nodal_quantity = {1.0, 2.0, 1.1, 2.1, 1.2, 2.2, 1.3, 2.3};
     std::vector<double> ref_val = {1.0855, 2.0855};
     auto test_val = Core::FE::interpolate_to_xi<Core::FE::CellType::tet4>(xi, nodal_quantity);
-    for (std::size_t i = 0; i < ref_val.size(); ++i) EXPECT_NEAR(test_val[i], ref_val[i], 1.0e-10);
+    FOUR_C_EXPECT_NEAR(test_val, ref_val, 1.0e-10);
   }
 
   TEST(ElementServiceTest, TestProjectNodalQuantityToXiTet10)
@@ -59,7 +55,7 @@ namespace
     std::vector<double> nodal_quantity = {1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9};
     std::vector<double> ref_val = {1.645885};
     auto test_val = Core::FE::interpolate_to_xi<Core::FE::CellType::tet10>(xi, nodal_quantity);
-    for (std::size_t i = 0; i < ref_val.size(); ++i) EXPECT_NEAR(test_val[i], ref_val[i], 1.0e-10);
+    FOUR_C_EXPECT_NEAR(test_val, ref_val, 1.0e-10);
   }
 
   TEST(ElementServiceTest, TestProjectNodalQuantityToXiWedge6)
@@ -69,7 +65,7 @@ namespace
     std::vector<double> nodal_quantity = {1.0, 1.1, 1.2, 1.3, 1.4, 1.5};
     std::vector<double> ref_val = {1.34025};
     auto test_val = Core::FE::interpolate_to_xi<Core::FE::CellType::wedge6>(xi, nodal_quantity);
-    for (std::size_t i = 0; i < ref_val.size(); ++i) EXPECT_NEAR(test_val[i], ref_val[i], 1.0e-10);
+    FOUR_C_EXPECT_NEAR(test_val, ref_val, 1.0e-10);
   }
 
 }  // namespace

--- a/unittests/common/unittest_utils/4C_unittest_utils_assertions_test.hpp
+++ b/unittests/common/unittest_utils/4C_unittest_utils_assertions_test.hpp
@@ -110,7 +110,7 @@ namespace TESTING::INTERNAL
              << " has dimension " << vec2.size() << std::endl;
     }
 
-    return AssertNear(vec1Expr, vec2Expr, "" /*lengthExpr*/, toleranceExpr, vec1.begin(),
+    return assert_near(vec1Expr, vec2Expr, "" /*lengthExpr*/, toleranceExpr, vec1.begin(),
         vec2.begin(), vec1.size(), tolerance);
   }
 


### PR DESCRIPTION
A function in the unit tests utils was not declared. This error never showed because FOUR_C_EXPECT_NEAR was not used with std::vector. The error was caused by a function rename.

Some unit tests are adapted to use FOUR_C_EXPECT_NEAR with std::vector. Or do you have another suggestion on how to make sure that the testing functions work?

