### PR TITLE
Input: support name-based element block definition

### DIFF
--- a/src/core/io/src/4C_io_mesh.cpp
+++ b/src/core/io/src/4C_io_mesh.cpp
@@ -8,6 +8,7 @@
 #include "4C_io_mesh.hpp"
 
 #include "4C_utils_enum.hpp"
+#include "4C_utils_exceptions.hpp"
 #include "4C_utils_std23_unreachable.hpp"
 
 #include <algorithm>
@@ -66,6 +67,32 @@ template <unsigned dim>
 bool Core::IO::MeshInput::Mesh<dim>::has_point_data(const std::string& field_name) const
 {
   return raw_mesh_->point_data.find(field_name) != raw_mesh_->point_data.end();
+}
+
+
+template <unsigned dim>
+Core::IO::MeshInput::CellBlockLookupTables<dim>
+Core::IO::MeshInput::Mesh<dim>::create_cell_block_lookup_tables() const
+{
+  CellBlockLookupTables<dim> lookup_tables;
+
+  for (const auto& cell_block : cell_blocks())
+  {
+    const auto cell_block_id = cell_block.id();
+
+    bool inserted = lookup_tables.by_id.emplace(cell_block_id, cell_block).second;
+
+    FOUR_C_ASSERT_ALWAYS(inserted,
+        "Duplicate cell block ID {} found in the mesh. Cell block IDs must be unique.",
+        cell_block_id);
+
+    if (cell_block.name().has_value())
+    {
+      lookup_tables.by_name[cell_block.name().value()].emplace_back(cell_block);
+    }
+  }
+
+  return lookup_tables;
 }
 
 

--- a/src/core/io/src/4C_io_mesh.hpp
+++ b/src/core/io/src/4C_io_mesh.hpp
@@ -561,6 +561,18 @@ namespace Core::IO::MeshInput
   };
 
   /**
+   * Lookup tables for resolving mesh cell blocks by ID and by optional name.
+   */
+  template <unsigned dim>
+  struct CellBlockLookupTables
+  {
+    /// map from id to cell blocks
+    std::unordered_map<ExternalIdType, CellBlockReference<dim, true>> by_id{};
+    /// map from name to cell blocks (there can be multiple blocks with the same name)
+    std::unordered_map<std::string, std::vector<CellBlockReference<dim, true>>> by_name{};
+  };
+
+  /**
    * @brief An interface to a mesh.
    *
    * This class internally uses a RawMesh and exposes a reduced interface to it that is easier
@@ -604,6 +616,13 @@ namespace Core::IO::MeshInput
              std::views::transform(
                  [this](size_t id) { return CellBlockReference<dim, false>(raw_mesh_.get(), id); });
     }
+
+    /** @brief Builds lookup tables for cell blocks, indexed by ID and by name.
+     *
+     * Iterates over all cell blocks in the mesh and populates tables for efficient lookup during
+     * mesh reading. Blocks without a name are only accessible by ID.
+     */
+    [[nodiscard]] CellBlockLookupTables<dim> create_cell_block_lookup_tables() const;
 
     /**
      * Get a range of all points defined in this mesh. This only returns the coordinates of the

--- a/src/core/io/src/4C_io_mesh.hpp
+++ b/src/core/io/src/4C_io_mesh.hpp
@@ -360,208 +360,205 @@ namespace Core::IO::MeshInput
 
       return *converter;
     }
-
-    /**
-     * A lightweight reference to a point in a Mesh used to provide a nicer interface.
-     *
-     * @note This class does not own any data and only refers to data in the RawMesh. Thus, it can
-     * only be used as long as the corresponding RawMesh is alive.
-     */
-    template <unsigned dim, bool is_const>
-    struct PointReference
-    {
-      template <typename T>
-      using MaybeConst = std::conditional_t<is_const, const T, T>;
-
-      PointReference(MaybeConst<RawMesh<dim>>* raw_mesh, size_t index)
-          : raw_mesh_(raw_mesh), index_(index)
-      {
-        FOUR_C_ASSERT(raw_mesh_ != nullptr, "RawMesh pointer must not be null.");
-        FOUR_C_ASSERT(
-            index_ < raw_mesh_->points.size(), "Point index {} is out of bounds.", index_);
-      }
-
-      /**
-       * Get the spatial coordinates of the point.
-       */
-      [[nodiscard]] MaybeConst<std::array<double, dim>>& coordinate() const
-      {
-        return raw_mesh_->points[index_];
-      }
-
-      /**
-       * Get the ID of the point in the mesh. This is the ID that cells use to form their
-       * connectivity.
-       */
-      [[nodiscard]] size_t id() const { return index_; }
-
-      /**
-       * Get the external ID of the point (if available). If not available, returns
-       * #invalid_external_id.
-       */
-      [[nodiscard]] ExternalIdType external_id() const
-      {
-        return raw_mesh_->external_ids ? (*raw_mesh_->external_ids)[index_] : invalid_external_id;
-      }
-
-      /**
-       * @brief Returns the number of data-fields associated with this point
-       */
-      [[nodiscard]] std::size_t data_size() const { return raw_mesh_->point_data.size(); }
-
-      [[nodiscard]] FieldRawDataSpanVariantType data(const std::string& field_name) const
-      {
-        return std::visit([&](const auto& data) -> FieldRawDataSpanVariantType
-            { return data.at(index_); }, raw_mesh_->point_data.at(field_name));
-      }
-
-      /**
-       * @brief Return the data as a specific type by making use of all known converters
-       */
-      template <typename T>
-      [[nodiscard]] T data_as(const std::string& field_name) const
-      {
-        return std::visit(
-            [&](const auto& data) -> T
-            {
-              using TargetType = std::decay_t<T>;
-              using SourceType = std::decay_t<decltype(data)>::value_type;
-
-              const auto converter =
-                  get_eligible_converter<SourceType, TargetType>(raw_mesh_->converters);
-
-              return converter(data[index_]);
-            },
-            raw_mesh_->point_data.at(field_name));
-      }
-
-     private:
-      MaybeConst<RawMesh<dim>>* raw_mesh_;
-      size_t index_;
-    };
-
-
-    /**
-     * A lightweight reference to a cell in a Mesh used to provide a nicer interface.
-     *
-     * @note This class does not own any data and only refers to data in the RawMesh. Thus, it can
-     * only be used as long as the corresponding RawMesh is alive.
-     */
-    template <unsigned dim, bool is_const>
-    struct CellReference
-    {
-      template <typename T>
-      using MaybeConst = std::conditional_t<is_const, const T, T>;
-
-      CellReference(
-          MaybeConst<RawMesh<dim>>* raw_mesh, MaybeConst<CellBlock<dim>>* cell_block, size_t index)
-          : raw_mesh_(raw_mesh), cell_block_(cell_block), index_(index)
-      {
-        FOUR_C_ASSERT(raw_mesh_ != nullptr, "RawMesh pointer must not be null.");
-        FOUR_C_ASSERT(cell_block_ != nullptr, "CellBlock pointer must not be null.");
-        FOUR_C_ASSERT(index_ < cell_block_->size(), "Cell index {} is out of bounds.", index_);
-      }
-
-      /**
-       * Get the ID of the cell in the mesh.
-       */
-      [[nodiscard]] size_t id() const { return index_; }
-
-      /**
-       * Get the external ID of the cell (if available). If not available, returns
-       * #invalid_external_id.
-       */
-      [[nodiscard]] ExternalIdType external_id() const
-      {
-        return cell_block_->external_ids ? (*cell_block_->external_ids)[index_]
-                                         : invalid_external_id;
-      }
-
-      [[nodiscard]] FieldRawDataSpanVariantType data(const std::string& field_name) const
-      {
-        return std::visit([&](const auto& data) -> FieldRawDataSpanVariantType
-            { return data.at(index_); }, cell_block_->cell_data.at(field_name));
-      }
-
-      template <typename T>
-      [[nodiscard]] T data_as(const std::string& field_name) const
-      {
-        return std::visit(
-            [&](const auto& data) -> T
-            {
-              using TargetType = std::decay_t<T>;
-              using SourceType = std::decay_t<decltype(data)>::value_type;
-
-              const auto converter =
-                  get_eligible_converter<SourceType, TargetType>(raw_mesh_->converters);
-
-              return converter(data[index_]);
-            },
-            cell_block_->cell_data.at(field_name));
-      }
-
-     private:
-      MaybeConst<RawMesh<dim>>* raw_mesh_;
-      MaybeConst<CellBlock<dim>>* cell_block_;
-      size_t index_;
-    };
-
-
-    /**
-     * A lightweight reference to a cell-block in a Mesh used to provide a nicer interface.
-     *
-     * @note This class does not own any data and only refers to data in the RawMesh. Thus, it can
-     * only be used as long as the corresponding RawMesh is alive.
-     */
-    template <unsigned dim, bool is_const>
-    struct CellBlockReference
-    {
-      template <typename T>
-      using MaybeConst = std::conditional_t<is_const, const T, T>;
-
-      CellBlockReference(MaybeConst<RawMesh<dim>>* raw_mesh, size_t id)
-          : raw_mesh_(raw_mesh), cell_block_(&raw_mesh_->cell_blocks.at(id)), id_(id)
-      {
-        FOUR_C_ASSERT(raw_mesh_ != nullptr, "RawMesh pointer must not be null.");
-      }
-
-      [[nodiscard]] MaybeConst<CellBlock<dim>>& get() { return *cell_block_; }
-
-      [[nodiscard]] const CellBlock<dim>& get() const { return *cell_block_; }
-
-      /**
-       * Get the ID of the cell-block in the mesh.
-       */
-      [[nodiscard]] size_t id() const { return id_; }
-
-      [[nodiscard]] const std::optional<std::string>& name() const { return cell_block_->name; }
-
-
-      [[nodiscard]] std::size_t size() const { return cell_block_->size(); }
-
-      [[nodiscard]] FE::CellType cell_type() const { return cell_block_->cell_type; }
-
-      [[nodiscard]] auto cells() const { return cell_block_->cells(); }
-
-      /**
-       * Get a lightweight cells iterator in this block along with their associated data (if any).
-       */
-      [[nodiscard]] auto cells_with_data() const
-      {
-        auto indices = std::views::iota(size_t{0}, cell_block_->size());
-        return indices |
-               std::views::transform([this](std::size_t i)
-                   { return Internal::CellReference<dim, true>(raw_mesh_, cell_block_, i); });
-      }
-
-      [[nodiscard]] const auto& cell_data() const { return cell_block_->cell_data; }
-
-     private:
-      MaybeConst<RawMesh<dim>>* raw_mesh_;
-      MaybeConst<CellBlock<dim>>* cell_block_;
-      size_t id_;
-    };
   }  // namespace Internal
+
+  /**
+   * A lightweight reference to a point in a Mesh used to provide a nicer interface.
+   *
+   * @note This class does not own any data and only refers to data in the RawMesh. Thus, it can
+   * only be used as long as the corresponding RawMesh is alive.
+   */
+  template <unsigned dim, bool is_const>
+  struct PointReference
+  {
+    template <typename T>
+    using MaybeConst = std::conditional_t<is_const, const T, T>;
+
+    PointReference(MaybeConst<RawMesh<dim>>* raw_mesh, size_t index)
+        : raw_mesh_(raw_mesh), index_(index)
+    {
+      FOUR_C_ASSERT(raw_mesh_ != nullptr, "RawMesh pointer must not be null.");
+      FOUR_C_ASSERT(index_ < raw_mesh_->points.size(), "Point index {} is out of bounds.", index_);
+    }
+
+    /**
+     * Get the spatial coordinates of the point.
+     */
+    [[nodiscard]] MaybeConst<std::array<double, dim>>& coordinate() const
+    {
+      return raw_mesh_->points[index_];
+    }
+
+    /**
+     * Get the ID of the point in the mesh. This is the ID that cells use to form their
+     * connectivity.
+     */
+    [[nodiscard]] size_t id() const { return index_; }
+
+    /**
+     * Get the external ID of the point (if available). If not available, returns
+     * #invalid_external_id.
+     */
+    [[nodiscard]] ExternalIdType external_id() const
+    {
+      return raw_mesh_->external_ids ? (*raw_mesh_->external_ids)[index_] : invalid_external_id;
+    }
+
+    /**
+     * @brief Returns the number of data-fields associated with this point
+     */
+    [[nodiscard]] std::size_t data_size() const { return raw_mesh_->point_data.size(); }
+
+    [[nodiscard]] FieldRawDataSpanVariantType data(const std::string& field_name) const
+    {
+      return std::visit([&](const auto& data) -> FieldRawDataSpanVariantType
+          { return data.at(index_); }, raw_mesh_->point_data.at(field_name));
+    }
+
+    /**
+     * @brief Return the data as a specific type by making use of all known converters
+     */
+    template <typename T>
+    [[nodiscard]] T data_as(const std::string& field_name) const
+    {
+      return std::visit(
+          [&](const auto& data) -> T
+          {
+            using TargetType = std::decay_t<T>;
+            using SourceType = std::decay_t<decltype(data)>::value_type;
+
+            const auto converter =
+                Internal::get_eligible_converter<SourceType, TargetType>(raw_mesh_->converters);
+
+            return converter(data[index_]);
+          },
+          raw_mesh_->point_data.at(field_name));
+    }
+
+   private:
+    MaybeConst<RawMesh<dim>>* raw_mesh_;
+    size_t index_;
+  };
+
+
+  /**
+   * A lightweight reference to a cell in a Mesh used to provide a nicer interface.
+   *
+   * @note This class does not own any data and only refers to data in the RawMesh. Thus, it can
+   * only be used as long as the corresponding RawMesh is alive.
+   */
+  template <unsigned dim, bool is_const>
+  struct CellReference
+  {
+    template <typename T>
+    using MaybeConst = std::conditional_t<is_const, const T, T>;
+
+    CellReference(
+        MaybeConst<RawMesh<dim>>* raw_mesh, MaybeConst<CellBlock<dim>>* cell_block, size_t index)
+        : raw_mesh_(raw_mesh), cell_block_(cell_block), index_(index)
+    {
+      FOUR_C_ASSERT(raw_mesh_ != nullptr, "RawMesh pointer must not be null.");
+      FOUR_C_ASSERT(cell_block_ != nullptr, "CellBlock pointer must not be null.");
+      FOUR_C_ASSERT(index_ < cell_block_->size(), "Cell index {} is out of bounds.", index_);
+    }
+
+    /**
+     * Get the ID of the cell in the mesh.
+     */
+    [[nodiscard]] size_t id() const { return index_; }
+
+    /**
+     * Get the external ID of the cell (if available). If not available, returns
+     * #invalid_external_id.
+     */
+    [[nodiscard]] ExternalIdType external_id() const
+    {
+      return cell_block_->external_ids ? (*cell_block_->external_ids)[index_] : invalid_external_id;
+    }
+
+    [[nodiscard]] FieldRawDataSpanVariantType data(const std::string& field_name) const
+    {
+      return std::visit([&](const auto& data) -> FieldRawDataSpanVariantType
+          { return data.at(index_); }, cell_block_->cell_data.at(field_name));
+    }
+
+    template <typename T>
+    [[nodiscard]] T data_as(const std::string& field_name) const
+    {
+      return std::visit(
+          [&](const auto& data) -> T
+          {
+            using TargetType = std::decay_t<T>;
+            using SourceType = std::decay_t<decltype(data)>::value_type;
+
+            const auto converter =
+                Internal::get_eligible_converter<SourceType, TargetType>(raw_mesh_->converters);
+
+            return converter(data[index_]);
+          },
+          cell_block_->cell_data.at(field_name));
+    }
+
+   private:
+    MaybeConst<RawMesh<dim>>* raw_mesh_;
+    MaybeConst<CellBlock<dim>>* cell_block_;
+    size_t index_;
+  };
+
+
+  /**
+   * A lightweight reference to a cell-block in a Mesh used to provide a nicer interface.
+   *
+   * @note This class does not own any data and only refers to data in the RawMesh. Thus, it can
+   * only be used as long as the corresponding RawMesh is alive.
+   */
+  template <unsigned dim, bool is_const>
+  struct CellBlockReference
+  {
+    template <typename T>
+    using MaybeConst = std::conditional_t<is_const, const T, T>;
+
+    CellBlockReference(MaybeConst<RawMesh<dim>>* raw_mesh, size_t id)
+        : raw_mesh_(raw_mesh), cell_block_(&raw_mesh_->cell_blocks.at(id)), id_(id)
+    {
+      FOUR_C_ASSERT(raw_mesh_ != nullptr, "RawMesh pointer must not be null.");
+    }
+
+    [[nodiscard]] MaybeConst<CellBlock<dim>>& get() { return *cell_block_; }
+
+    [[nodiscard]] const CellBlock<dim>& get() const { return *cell_block_; }
+
+    /**
+     * Get the ID of the cell-block in the mesh.
+     */
+    [[nodiscard]] size_t id() const { return id_; }
+
+    [[nodiscard]] const std::optional<std::string>& name() const { return cell_block_->name; }
+
+
+    [[nodiscard]] std::size_t size() const { return cell_block_->size(); }
+
+    [[nodiscard]] FE::CellType cell_type() const { return cell_block_->cell_type; }
+
+    [[nodiscard]] auto cells() const { return cell_block_->cells(); }
+
+    /**
+     * Get a lightweight cells iterator in this block along with their associated data (if any).
+     */
+    [[nodiscard]] auto cells_with_data() const
+    {
+      auto indices = std::views::iota(size_t{0}, cell_block_->size());
+      return indices | std::views::transform([this](std::size_t i)
+                           { return CellReference<dim, true>(raw_mesh_, cell_block_, i); });
+    }
+
+    [[nodiscard]] const auto& cell_data() const { return cell_block_->cell_data; }
+
+   private:
+    MaybeConst<RawMesh<dim>>* raw_mesh_;
+    MaybeConst<CellBlock<dim>>* cell_block_;
+    size_t id_;
+  };
 
   /**
    * @brief An interface to a mesh.
@@ -597,15 +594,15 @@ namespace Core::IO::MeshInput
     [[nodiscard]] auto cell_blocks() const
     {
       return cell_blocks_ids_filter_ |
-             std::views::transform([this](size_t id)
-                 { return Internal::CellBlockReference<dim, true>(raw_mesh_.get(), id); });
+             std::views::transform(
+                 [this](size_t id) { return CellBlockReference<dim, true>(raw_mesh_.get(), id); });
     }
 
     [[nodiscard]] auto cell_blocks()
     {
       return cell_blocks_ids_filter_ |
-             std::views::transform([this](size_t id)
-                 { return Internal::CellBlockReference<dim, false>(raw_mesh_.get(), id); });
+             std::views::transform(
+                 [this](size_t id) { return CellBlockReference<dim, false>(raw_mesh_.get(), id); });
     }
 
     /**
@@ -639,16 +636,14 @@ namespace Core::IO::MeshInput
      */
     [[nodiscard]] auto points_with_data() const
     {
-      return point_ids_filter_ |
-             std::views::transform([this](std::size_t i)
-                 { return Internal::PointReference<dim, true>(raw_mesh_.get(), i); });
+      return point_ids_filter_ | std::views::transform([this](std::size_t i)
+                                     { return PointReference<dim, true>(raw_mesh_.get(), i); });
     }
 
     [[nodiscard]] auto points_with_data()
     {
-      return point_ids_filter_ |
-             std::views::transform([this](std::size_t i)
-                 { return Internal::PointReference<dim, false>(raw_mesh_.get(), i); });
+      return point_ids_filter_ | std::views::transform([this](std::size_t i)
+                                     { return PointReference<dim, false>(raw_mesh_.get(), i); });
     }
 
     /**

--- a/src/core/io/src/4C_io_meshreader.cpp
+++ b/src/core/io/src/4C_io_meshreader.cpp
@@ -25,12 +25,15 @@
 #include "4C_rebalance.hpp"
 #include "4C_rebalance_graph_based.hpp"
 #include "4C_rebalance_print.hpp"
+#include "4C_utils_exceptions.hpp"
 
 #include <Teuchos_TimeMonitor.hpp>
 
+#include <iostream>
 #include <set>
 #include <string>
 #include <utility>
+#include <vector>
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -564,87 +567,150 @@ namespace
     }
   }
 
+  const auto& find_element_block_by_id(
+      const int id, const std::unordered_map<Core::IO::MeshInput::ExternalIdType,
+                        Core::IO::MeshInput::CellBlockReference<3, true>>& mesh_blocks_by_id)
+  {
+    // try to find the block with the given ID in the external mesh
+    if (auto it = mesh_blocks_by_id.find(id); it != mesh_blocks_by_id.end())
+    {
+      return it->second;
+    }
+    else
+    {
+      FOUR_C_THROW("Element block with ID: {} not found in the external mesh file.", id);
+    }
+  }
+
+  const auto& find_element_block_by_name(const std::string& name,
+      const std::unordered_map<std::string,
+          std::vector<Core::IO::MeshInput::CellBlockReference<3, true>>>& mesh_blocks_by_name)
+  {
+    // try to find the block(s) with the given NAME in the external mesh.
+    // We allow multiple blocks with the same name in the external mesh,
+    // but we do not allow the input to select multiple blocks with the same name.
+    if (auto it = mesh_blocks_by_name.find(name); it != mesh_blocks_by_name.end())
+    {
+      FOUR_C_ASSERT_ALWAYS(it->second.size() == 1,
+          "Element block with NAME: '{}' is not unique in the external mesh file ({} occurrences "
+          "found).",
+          name, it->second.size());
+
+      // use the first (and only) block ID
+      return it->second.front();
+    }
+    FOUR_C_THROW("Element block with NAME: '{}' not found in the external mesh file.", name);
+  }
+
   void read_external_mesh(const Core::IO::InputFile& input,
       Core::IO::Internal::MeshReader& mesh_reader,
       const Core::Rebalance::RebalanceParameters& parameters, MPI_Comm comm)
   {
     TEUCHOS_FUNC_TIME_MONITOR("Core::IO::MeshReader::read_external_mesh");
-    auto my_rank = Core::Communication::my_mpi_rank(comm);
 
-    if (my_rank == 0)
+    // Non-root ranks get an empty mesh and return early
+    if (Core::Communication::my_mpi_rank(comm) != 0)
     {
-      FOUR_C_ASSERT(mesh_reader.mesh_on_rank_zero != nullptr, "Internal error.");
-      auto& mesh = *mesh_reader.mesh_on_rank_zero;
-
-      Core::IO::InputParameterContainer data;
-      input.match_section(mesh_reader.section_name, data);
-
-      const auto& geometry_data = data.group(mesh_reader.section_name);
-      const auto& element_block_data = geometry_data.get_list("ELEMENT_BLOCKS");
-
-      Core::Elements::ElementDefinition element_definition;
-
-      std::vector<int> skipped_blocks;
-
-      std::map<Core::IO::MeshInput::ExternalIdType, std::shared_ptr<Core::Elements::Element>>
-          user_elements;
-
-      int ele_count = 0;
-      std::vector<Core::IO::MeshInput::ExternalIdType> relevant_blocks;
-      for (const auto& cell_block : mesh.cell_blocks())
-      {
-        // Look into the input file to find out which elements we need to assign to this block.
-        const int eb_id = cell_block.id();
-        auto current_block_data = std::ranges::find_if(element_block_data,
-            [eb_id](const auto& e) { return e.template get<int>("ID") == eb_id; });
-        if (current_block_data == element_block_data.end())
-        {
-          skipped_blocks.emplace_back(eb_id);
-          continue;
-        }
-
-        relevant_blocks.emplace_back(eb_id);
-
-        const auto [element_name, cell_type, specific_data] =
-            element_definition.unpack_element_data(*current_block_data);
-
-        FOUR_C_ASSERT_ALWAYS(cell_type == cell_block.cell_type(),
-            "Element block '{}' has cell type '{}' but your given element definition for '{}' has "
-            "cell type '{}'.",
-            eb_id, cell_block.cell_type(), element_name, cell_type);
-
-        size_t cell_id_in_block = 0;
-        for (const auto& cell : cell_block.cells())
-        {
-          // Do not yet use the external cell ID. 4C is not yet prepared to deal with this!
-          // replace ele_count with cell.external_id once possible
-          auto ele =
-              Core::Communication::factory(element_name, cell_block.cell_type(), ele_count, 0);
-          if (!ele) FOUR_C_THROW("element creation failed");
-          ele->set_node_ids(cell.size(), cell.data());
-          Core::IO::MeshInput::ElementDataFromCellData element_data{
-              cell_block.cell_data(), cell_id_in_block, mesh.converters()};
-          ele->read_element(element_name, cell_block.cell_type(), specific_data, element_data);
-
-          user_elements.emplace(ele_count, std::move(ele));
-          ele_count++;
-          cell_id_in_block++;
-        }
-      }
-
-      mesh_reader.filtered_mesh_on_rank_zero.emplace(
-          mesh.filter_by_cell_block_ids(relevant_blocks));
-
-      // Rank zero provides the actual data.
       mesh_reader.target_discretization.fill_from_mesh(
-          *mesh_reader.filtered_mesh_on_rank_zero, user_elements, {}, parameters);
+          Core::IO::MeshInput::Mesh<3>{}, {}, {}, parameters);
+      return;
     }
-    // Other ranks
-    else
+
+    // Only rank 0 reads the mesh file and fills the discretization
+
+    FOUR_C_ASSERT(mesh_reader.mesh_on_rank_zero != nullptr, "Internal error.");
+    const auto& mesh = *mesh_reader.mesh_on_rank_zero;
+    const auto& [mesh_blocks_by_id, mesh_blocks_by_name] = mesh.create_cell_block_lookup_tables();
+
+    /// Collection of valid element definitions
+    Core::Elements::ElementDefinition element_definition;
+
+    /// Initialize a map to store all elements read from the external mesh
+    std::map<Core::IO::MeshInput::ExternalIdType, std::shared_ptr<Core::Elements::Element>>
+        user_elements;
+
+    int ele_count = 0;
+
+    /// All element block IDs that are referenced in the input and found in the external mesh.
+    std::set<Core::IO::MeshInput::ExternalIdType> relevant_blocks;
+
+    // Parse input section
+    Core::IO::InputParameterContainer data;
+    input.match_section(mesh_reader.section_name, data);
+    const auto& element_block_data =
+        data.group(mesh_reader.section_name).get_list("ELEMENT_BLOCKS");
+
+    // loop over element block definitions in the input
+    for (const auto& current_element_block_input : element_block_data)
     {
-      Core::IO::MeshInput::Mesh<3> empty_mesh_other_ranks;
-      mesh_reader.target_discretization.fill_from_mesh(empty_mesh_other_ranks, {}, {}, parameters);
+      const auto input_id = current_element_block_input.get<std::optional<int>>("ID");
+      const auto input_name = current_element_block_input.get<std::optional<std::string>>("NAME");
+
+      FOUR_C_ASSERT_ALWAYS((input_id.has_value() != input_name.has_value()),
+          "Element block definition must specify exactly one of ID or NAME but got {}.",
+          input_id.has_value()
+              ? "ID: " + std::to_string(*input_id) + " and NAME: '" + *input_name + "'"
+              : "neither");
+
+      const auto& cell_block = [&]() -> const Core::IO::MeshInput::CellBlockReference<3, true>&
+      {
+        if (input_id.has_value())
+        {
+          return find_element_block_by_id(*input_id, mesh_blocks_by_id);
+        }
+        if (input_name.has_value())
+        {
+          return find_element_block_by_name(*input_name, mesh_blocks_by_name);
+        }
+        FOUR_C_THROW(
+            "Element block definition must specify exactly one of ID or NAME but got neither.");
+      }();
+
+      const auto inserted = relevant_blocks.insert(cell_block.id()).second;
+      FOUR_C_ASSERT_ALWAYS(inserted,
+          "Element block with {} is referenced more than once in the input file.",
+          (input_id.has_value() ? "ID: " + std::to_string(*input_id)
+                                : "NAME: '" + *input_name + "'"));
+
+      const auto& [element_name, cell_type, specific_data] =
+          element_definition.unpack_element_data(current_element_block_input);
+
+      FOUR_C_ASSERT_ALWAYS(cell_type == cell_block.cell_type(),
+          "Element block with {} has cell type '{}' but your given element definition for '{}' "
+          "has cell type '{}'.",
+          (input_id.has_value() ? "ID: " + std::to_string(*input_id)
+                                : "NAME: '" + *input_name + "'"),
+          cell_block.cell_type(), element_name, cell_type);
+
+      // Build elements from cells
+      size_t cell_id_in_block = 0;
+      for (const auto& cell : cell_block.cells())
+      {
+        // Do not yet use the external cell ID. 4C is not yet prepared to deal with this!
+        // replace ele_count with cell.external_id once possible
+        auto ele = Core::Communication::factory(element_name, cell_block.cell_type(), ele_count, 0);
+        if (!ele) FOUR_C_THROW("element creation failed");
+        ele->set_node_ids(cell.size(), cell.data());
+        Core::IO::MeshInput::ElementDataFromCellData element_data{
+            cell_block.cell_data(), cell_id_in_block, mesh.converters()};
+        ele->read_element(element_name, cell_block.cell_type(), specific_data, element_data);
+
+        user_elements.emplace(ele_count, std::move(ele));
+        ele_count++;
+        cell_id_in_block++;
+      }
     }
+
+    FOUR_C_ASSERT_ALWAYS(!relevant_blocks.empty(),
+        "None of the element blocks specified in the input file could be found in the external "
+        "mesh. Please check your input and mesh files.");
+
+    mesh_reader.filtered_mesh_on_rank_zero.emplace(
+        mesh.filter_by_cell_block_ids(std::vector(relevant_blocks.begin(), relevant_blocks.end())));
+
+    // Rank zero provides the actual data.
+    mesh_reader.target_discretization.fill_from_mesh(
+        *mesh_reader.filtered_mesh_on_rank_zero, user_elements, {}, parameters);
   }
 }  // namespace
 

--- a/src/global_legacy_module/4C_global_legacy_module_validparameters.cpp
+++ b/src/global_legacy_module/4C_global_legacy_module_validparameters.cpp
@@ -180,17 +180,24 @@ namespace CommonParameters
         parameter<Core::IO::MeshInput::VerbosityLevel>("SHOW_INFO",
             {
                 .description = "Choose verbosity of reporting element, node and set info for "
-                               "the exodus file after reading.",
+                               "the external mesh file after reading.",
                 .enum_value_description = Core::IO::MeshInput::describe,
                 .default_value = Core::IO::MeshInput::VerbosityLevel::none,
             }),
         // Once we support more formats, we should add a "TYPE" parameter for the file format.
         list("ELEMENT_BLOCKS",
             all_of({
-                parameter<int>(
-                    "ID", {.description = "ID of the element block in the exodus file."}),
+                parameter<std::optional<int>>(
+                    "ID", {.description = "ID of the element block in the external mesh file. Only "
+                                          "allowed if NAME is not specified."}),
+                parameter<std::optional<std::string>>(
+                    "NAME", {.description = "Name of the element block in the external mesh file. "
+                                            "Only allowed if ID is not specified."}),
                 all_possible_elements_spec,
-            })),
+            }),
+            {.description = "List of element blocks to read from the external mesh file. Element "
+                            "blocks can be identified by either their ID or their NAME in the "
+                            "external mesh file."}),
     });
 
     const auto add_geometry_section = [&](auto& specs, const std::string& field_identifier)

--- a/tests/input_files/solid_gmsh_input_element_block_names.4C.yaml
+++ b/tests/input_files/solid_gmsh_input_element_block_names.4C.yaml
@@ -1,0 +1,121 @@
+TITLE:
+  - "msh input for solid mechanics"
+PROBLEM TYPE:
+  PROBLEMTYPE: "Structure"
+IO:
+  OUTPUT_SPRING: true
+  STRUCT_STRESS: "Cauchy"
+  STRUCT_STRAIN: "GL"
+  VERBOSITY: "Standard"
+IO/RUNTIME VTK OUTPUT:
+  INTERVAL_STEPS: 5
+  OUTPUT_DATA_FORMAT: ascii
+IO/RUNTIME VTK OUTPUT/STRUCTURE:
+  OUTPUT_STRUCTURE: true
+  DISPLACEMENT: true
+  STRESS_STRAIN: true
+  GAUSS_POINT_DATA_OUTPUT_TYPE: element_center
+SOLVER 1:
+  SOLVER: "Superlu"
+  NAME: "Structure_Solver"
+STRUCTURAL DYNAMIC:
+  RESTARTEVERY: 5
+  DYNAMICTYPE: "Statics"
+  TIMESTEP: 0.1
+  NUMSTEP: 10
+  MAXTIME: 1
+  TOLDISP: 1e-09
+  TOLRES: 1e-09
+  LOADLIN: true
+  LINEAR_SOLVER: 1
+STRUCT NOX/Printing:
+  Inner Iteration: false
+  Outer Iteration StatusTest: false
+MATERIALS:
+  - MAT: 1
+    MAT_ElastHyper:
+      NUMMAT: 2
+      MATIDS: [11, 12]
+      DENS: 1
+  - MAT: 11
+    ELAST_IsoExpoPow:
+      K1: 500
+      K2: 10
+      C: 1
+  - MAT: 12
+    ELAST_VolSussmanBathe:
+      KAPPA: 1000
+FUNCT1:
+  - COMPONENT: 0
+    SYMBOLIC_FUNCTION_OF_SPACE_TIME: "t"
+DESIGN POINT DIRICH CONDITIONS:
+  - E: 3 # Physical group with tag 3
+    ENTITY_TYPE: node_set_id
+    NUMDOF: 3
+    ONOFF: [1, 1, 1]
+    VAL: [0, 0, 0]
+    FUNCT: [0, 0, 0]
+  - E: 10 # Physical group with tag 10
+    ENTITY_TYPE: node_set_id
+    NUMDOF: 3
+    ONOFF: [1, 0, 0]
+    VAL: [1, 0, 0]
+    FUNCT: [1, 0, 0]
+  - E: 12 # Physical group with tag 12
+    ENTITY_TYPE: node_set_id
+    NUMDOF: 3
+    ONOFF: [0, 1, 0]
+    VAL: [0, 0.2, 0]
+    FUNCT: [0, 1, 0]
+STRUCTURE GEOMETRY:
+  SHOW_INFO: "detailed_summary"
+  ELEMENT_BLOCKS:
+    - NAME: FirstBox
+      SOLID:
+        HEX8:
+          MAT: 1
+          KINEM: nonlinear
+    - NAME: SecondBox
+      SOLID:
+        TET4:
+          MAT: 1
+          KINEM: nonlinear
+  FILE: solid_gmsh_input.msh
+RESULT DESCRIPTION:
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 100
+      QUANTITY: "dispx"
+      VALUE: 7.97928752678465192e-01
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 100
+      QUANTITY: "dispy"
+      VALUE: 7.97919139840810449e-02
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 100
+      QUANTITY: "dispz"
+      VALUE: 8.63386325331269230e-03
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 124
+      QUANTITY: "dispx"
+      VALUE: 5.80607612146844199e-01
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 124
+      QUANTITY: "dispy"
+      VALUE: 4.69773518441524846e-02
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 124
+      QUANTITY: "dispz"
+      VALUE: 1.58397904088701635e-01
+      TOLERANCE: 1e-08
+

--- a/tests/list_of_tests.cmake
+++ b/tests/list_of_tests.cmake
@@ -2684,6 +2684,8 @@ __four_c_test_add_csv_yaml_comparison(BASED_ON ${current_restart} RESULT_FILE xx
 four_c_test(TEST_FILE solid_gmsh_input_node_set_names_monitor_dbc_yaml.4C.yaml NP 2 REQUIRED_DEPENDENCIES GMSH RETURN_AS current)
 __four_c_test_restart(BASED_ON ${current} SAME_FILE NP 2 RESTART_STEP 5 REQUIRED_DEPENDENCIES GMSH RETURN_AS current_restart)
 __four_c_test_add_csv_yaml_comparison(BASED_ON ${current_restart} RESULT_FILE xxx-1-left_faces_monitor_dbc.yaml REFERENCE_FILE ref/solid_gmsh_input-left_faces_monitor_dbc.yaml TOL_R 1e-6 TOL_A 1e-10 REQUIRED_DEPENDENCIES GMSH)
+four_c_test(TEST_FILE solid_gmsh_input_element_block_names.4C.yaml NP 2 REQUIRED_DEPENDENCIES GMSH RETURN_AS current)
+__four_c_test_restart(BASED_ON ${current} SAME_FILE NP 2 RESTART_STEP 5 REQUIRED_DEPENDENCIES GMSH RETURN_AS current_restart)
 
 # Tests requiring ArborX
 four_c_test(TEST_FILE rve2d_periodic_bcs_with_mpcs.4C.yaml REQUIRED_DEPENDENCIES ArborX)

--- a/tests/tutorials/fsi/tutorial_fsi_2d.4C.yaml
+++ b/tests/tutorials/fsi/tutorial_fsi_2d.4C.yaml
@@ -123,7 +123,7 @@ RESULT DESCRIPTION:
 STRUCTURE GEOMETRY:
   FILE: tutorial_fsi_2d.e
   ELEMENT_BLOCKS:
-    - ID: 1
+    - NAME: flexible_bottom
       SOLID:
         QUAD4:
           MAT: 2
@@ -135,7 +135,7 @@ FLUID GEOMETRY:
   FILE: tutorial_fsi_2d.e
   SHOW_INFO: "summary"
   ELEMENT_BLOCKS:
-    - ID: 2
+    - NAME: fluid
       FLUID:
         QUAD4:
           MAT: 1


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

This adds support for defining element blocks by the new input parameter `NAME` instead of `ID` when reading external meshes. For name-based resolution to work, the name must occur only once in the external mesh file. This looks as follows in the input:

```yaml
STRUCTURE GEOMETRY:
  SHOW_INFO: "detailed_summary"
  ELEMENT_BLOCKS:
    - NAME: FirstBox
      SOLID:
        HEX8:
          MAT: 1
          KINEM: nonlinear
``` 

For this, the `read_external_mesh` function is refactored: it loops over the element block definition in the input instead of the cell blocks in the mesh file now, which made it easier to allow for both name- and id-based input. In addition, this allowed to introduce more strict error handling:
   - An error is thrown if an input element block is not present in the external mesh.
   - An error is thrown when an element block is referenced more than once in the input. This was not the case so far (hence breaking)

I added a new integration test with gmsh and modified the 2D fsi tutorial to test the exodus case.

Note: this should also work for vtu input if vtu input interprets integer cell arrays as element block by default (similar to #1918).

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
Part of #825  
