### PR TITLE
Unify input and calculation wall time in time monitor

### DIFF
--- a/apps/global_full/4C_global_full_io.cpp
+++ b/apps/global_full/4C_global_full_io.cpp
@@ -103,14 +103,6 @@ void setup_global_problem(Core::IO::InputFile& input_file, const CommandlineArgu
   Global::read_fields(*problem, input_file, *mesh_reader);
 }
 
-double walltime_in_seconds()
-{
-  return std::chrono::duration_cast<std::chrono::milliseconds>(
-             std::chrono::high_resolution_clock::now().time_since_epoch())
-             .count() *
-         1.0e-3;
-}
-
 void write_timemonitor(MPI_Comm comm)
 {
   std::shared_ptr<const Teuchos::Comm<int>> TeuchosComm =

--- a/apps/global_full/4C_global_full_io.hpp
+++ b/apps/global_full/4C_global_full_io.hpp
@@ -60,12 +60,6 @@ struct CommandlineArguments
  */
 void setup_global_problem(Core::IO::InputFile& input_file, const CommandlineArguments& arguments,
     const Core::Communication::Communicators& communicators);
-/**
- * \brief Returns the wall time in seconds.
- */
-double walltime_in_seconds();
-
-
 
 /**
  * \brief Writes the Teuchos::TimeMonitor information to std::cout

--- a/apps/global_full/4C_global_full_main.cpp
+++ b/apps/global_full/4C_global_full_main.cpp
@@ -221,39 +221,30 @@ void run(CommandlineArguments& cli_args, Core::Communication::Communicators& com
 
   /* input phase, input of all information */
   global_legacy_module_callbacks().RegisterParObjectTypes();
-  double t0 = walltime_in_seconds();
 
-  // and now the actual reading
-  Core::IO::InputFile input_file = setup_input_file(communicators.local_comm());
-  input_file.read(cli_args.input_file_name);
-  setup_global_problem(input_file, cli_args, communicators);
+  {
+    TEUCHOS_FUNC_TIME_MONITOR("Input");
+
+    // and now the actual reading
+    Core::IO::InputFile input_file = setup_input_file(communicators.local_comm());
+    input_file.read(cli_args.input_file_name);
+    setup_global_problem(input_file, cli_args, communicators);
+  }
 
   // we wait till all procs are here. Otherwise a hang up might occur where
   // one proc ended with FOUR_C_THROW but other procs were not finished and waited...
   // we also want to have the printing above being finished.
   Core::Communication::barrier(communicators.local_comm());
 
-
-  const double ti = walltime_in_seconds() - t0;
-  if (Core::Communication::my_mpi_rank(communicators.global_comm()) == 0)
-  {
-    Core::IO::cout << "\nTotal wall time for INPUT:       " << std::setw(10) << std::setprecision(3)
-                   << std::scientific << ti << " sec \n\n";
-  }
-
   /*--------------------------------------------------calculation phase */
-  t0 = walltime_in_seconds();
 
-  entrypoint_switch();
+  {
+    TEUCHOS_FUNC_TIME_MONITOR("Calculation");
+
+    entrypoint_switch();
+  }
 
   write_timemonitor(communicators.local_comm());
-
-  const double tc = walltime_in_seconds() - t0;
-  if (Core::Communication::my_mpi_rank(communicators.global_comm()) == 0)
-  {
-    Core::IO::cout << "\nTotal wall time for CALCULATION: " << std::setw(10) << std::setprecision(3)
-                   << std::scientific << tc << " sec \n\n";
-  }
 }
 
 CommandlineArguments parse_command_line(int argc, char** argv)


### PR DESCRIPTION
With this PR, we now use the Teuchos time monitor to track the wall time of the input and the calculation. They are now also part of the summary at the end of the simulation. I will also add to write a machine readable format of the timings in a followup so that we can work on a performance test suite.