### PR TITLE
Implement composition-based wrapper for SerialDenseSolver

### DIFF
--- a/src/art_net/4C_art_net_art_junction.cpp
+++ b/src/art_net/4C_art_net_art_junction.cpp
@@ -473,9 +473,9 @@ int Arteries::Utils::ArtJunctionBc::solve(Teuchos::ParameterList& params)
     //--------------------------------------------------------------------
     // Solve for dx
     //--------------------------------------------------------------------
-    solver_.setMatrix(Teuchos::rcpFromRef(Jacobian.base()));
-    solver_.setVectors(Teuchos::rcpFromRef(dx.base()), Teuchos::rcpFromRef(f.base()));
-    solver_.factorWithEquilibration(true);
+    solver_.set_matrix(Jacobian);
+    solver_.set_vectors(dx, f);
+    solver_.factor_with_equilibration(true);
     int err2 = solver_.factor();
     int err = solver_.solve();
 

--- a/src/art_net/4C_art_net_art_junction.hpp
+++ b/src/art_net/4C_art_net_art_junction.hpp
@@ -13,9 +13,8 @@
 
 #include "4C_fem_discretization.hpp"
 #include "4C_io.hpp"
+#include "4C_linalg_serialdensesolver.hpp"
 #include "4C_linalg_utils_sparse_algebra_math.hpp"
-
-#include <Teuchos_SerialDenseSolver.hpp>
 
 #include <memory>
 
@@ -226,7 +225,7 @@ namespace Arteries
       std::vector<int> nodes_;
 
       //! A Teuchos wrapper for a dense matrix solver
-      Teuchos::SerialDenseSolver<ordinalType, scalarType> solver_;
+      Core::LinAlg::SerialDenseSolver solver_;
 
 
     };  // class ArtJunctionBc

--- a/src/core/fem/src/general/utils/4C_fem_general_utils_gauss_point_extrapolation.cpp
+++ b/src/core/fem/src/general/utils/4C_fem_general_utils_gauss_point_extrapolation.cpp
@@ -15,10 +15,9 @@
 #include "4C_fem_general_utils_local_connectivity_matrices.hpp"
 #include "4C_fem_general_utils_nurbs_shapefunctions.hpp"
 #include "4C_fem_nurbs_discretization_utils.hpp"
+#include "4C_linalg_serialdensesolver.hpp"
 #include "4C_linalg_serialdensevector.hpp"
 #include "4C_linalg_utils_densematrix_multiply.hpp"
-
-#include <Teuchos_SerialDenseSolver.hpp>
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -153,10 +152,9 @@ namespace
     Core::LinAlg::SerialDenseMatrix shapefunctions_at_gps_copy(shapefcns_at_gps);
     if (shapefcns_at_gps.numRows() == shapefcns_at_gps.numCols())
     {
-      using ordinalType = Core::LinAlg::SerialDenseMatrix::ordinalType;
-      using scalarType = Core::LinAlg::SerialDenseMatrix::scalarType;
-      Teuchos::SerialDenseSolver<ordinalType, scalarType> matrixInverter;
-      matrixInverter.setMatrix(Teuchos::rcpFromRef(shapefunctions_at_gps_copy.base()));
+      Core::LinAlg::SerialDenseSolver matrixInverter;
+      [[maybe_unused]] double* values_before_inversion = shapefunctions_at_gps_copy.values();
+      matrixInverter.set_matrix(shapefunctions_at_gps_copy);
       int error_code = matrixInverter.invert();
 
       if (error_code != 0)
@@ -168,8 +166,7 @@ namespace
             error_code);
       }
 
-      FOUR_C_ASSERT(
-          shapefunctions_at_gps_copy.values() == matrixInverter.getFactoredMatrix()->values(),
+      FOUR_C_ASSERT(shapefunctions_at_gps_copy.values() == values_before_inversion,
           "Inverse of the matrix was not computed in place, but we expect that. Unfortunately, the "
           "Trilinos documentation is ambiguous here.");
 
@@ -181,10 +178,9 @@ namespace
     Core::LinAlg::multiply_tn(matTmat, shapefcns_at_gps, shapefcns_at_gps);
 
     {
-      using ordinalType = Core::LinAlg::SerialDenseMatrix::ordinalType;
-      using scalarType = Core::LinAlg::SerialDenseMatrix::scalarType;
-      Teuchos::SerialDenseSolver<ordinalType, scalarType> matrixInverter;
-      matrixInverter.setMatrix(Teuchos::rcpFromRef(matTmat.base()));
+      Core::LinAlg::SerialDenseSolver matrixInverter;
+      [[maybe_unused]] double* values_before_inversion = matTmat.values();
+      matrixInverter.set_matrix(matTmat);
       int error_code = matrixInverter.invert();
 
       if (error_code != 0)
@@ -196,7 +192,7 @@ namespace
             error_code);
       }
 
-      FOUR_C_ASSERT(matTmat.values() == matrixInverter.getFactoredMatrix()->values(),
+      FOUR_C_ASSERT(matTmat.values() == values_before_inversion,
           "Inverse of the matrix was not computed in place, but we expect that. Unfortunately, the "
           "Trilinos documentation is ambiguous here.");
     }

--- a/src/core/fem/src/general/utils/4C_fem_general_utils_polynomial.cpp
+++ b/src/core/fem/src/general/utils/4C_fem_general_utils_polynomial.cpp
@@ -533,8 +533,7 @@ namespace Core::FE
       const Core::LinAlg::Matrix<nsd, 1>& point, Core::LinAlg::SerialDenseVector& values) const
   {
     legendre_.evaluate(point, values);
-    vandermonde_factor_.setVectors(
-        Teuchos::rcpFromRef(values.base()), Teuchos::rcpFromRef(values.base()));
+    vandermonde_factor_.set_vectors(values, values);
     vandermonde_factor_.solve();
   }
 
@@ -548,8 +547,7 @@ namespace Core::FE
     for (unsigned int d = 0; d < nsd; ++d)
     {
       for (unsigned int i = 0; i < size(); ++i) evaluate_vec_(i) = derivatives(d, i);
-      vandermonde_factor_.setVectors(
-          Teuchos::rcpFromRef(evaluate_vec_.base()), Teuchos::rcpFromRef(evaluate_vec_.base()));
+      vandermonde_factor_.set_vectors(evaluate_vec_, evaluate_vec_);
       vandermonde_factor_.solve();
       for (unsigned int i = 0; i < size(); ++i) derivatives(d, i) = evaluate_vec_(i);
     }
@@ -565,8 +563,7 @@ namespace Core::FE
     for (unsigned int d = 0; d < (nsd * (nsd + 1)) / 2; ++d)
     {
       for (unsigned int i = 0; i < size(); ++i) evaluate_vec_(i) = derivatives(d, i);
-      vandermonde_factor_.setVectors(
-          Teuchos::rcpFromRef(evaluate_vec_.base()), Teuchos::rcpFromRef(evaluate_vec_.base()));
+      vandermonde_factor_.set_vectors(evaluate_vec_, evaluate_vec_);
       vandermonde_factor_.solve();
       for (unsigned int i = 0; i < size(); ++i) derivatives(d, i) = evaluate_vec_(i);
     }
@@ -669,7 +666,7 @@ namespace Core::FE
       for (unsigned int j = 0; j < size(); ++j) vandermonde_(j, i) = values(j);
     }
 
-    vandermonde_factor_.setMatrix(Teuchos::rcpFromRef(vandermonde_.base()));
+    vandermonde_factor_.set_matrix(vandermonde_);
     vandermonde_factor_.factor();
     evaluate_vec_.resize(size());
 

--- a/src/core/fem/src/general/utils/4C_fem_general_utils_polynomial.hpp
+++ b/src/core/fem/src/general/utils/4C_fem_general_utils_polynomial.hpp
@@ -11,9 +11,8 @@
 #include "4C_config.hpp"
 
 #include "4C_fem_general_utils_local_connectivity_matrices.hpp"
+#include "4C_linalg_serialdensesolver.hpp"
 #include "4C_linalg_serialdensevector.hpp"
-
-#include <Teuchos_SerialDenseSolver.hpp>
 
 #include <numeric>
 #include <utility>
@@ -604,7 +603,7 @@ namespace Core::FE
     void compute_vandermonde_matrices(const unsigned int degree);
 
     Core::LinAlg::SerialDenseMatrix vandermonde_;
-    mutable Teuchos::SerialDenseSolver<ordinalType, scalarType> vandermonde_factor_;
+    mutable Core::LinAlg::SerialDenseSolver vandermonde_factor_;
     mutable Core::LinAlg::SerialDenseVector evaluate_vec_;
     Core::LinAlg::SerialDenseMatrix fekete_points_;
     LegendreBasis<nsd> legendre_;

--- a/src/core/linalg/src/dense/4C_linalg_serialdensesolver.cpp
+++ b/src/core/linalg/src/dense/4C_linalg_serialdensesolver.cpp
@@ -1,0 +1,48 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "4C_linalg_serialdensesolver.hpp"
+
+#include <Teuchos_RCP.hpp>
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace Core::LinAlg
+{
+  void SerialDenseSolver::set_matrix(SerialDenseMatrix& matrix)
+  {
+    solver_.setMatrix(Teuchos::rcpFromRef(matrix.base()));
+  }
+
+  void SerialDenseSolver::set_vectors(SerialDenseVector& lhs, SerialDenseVector& rhs)
+  {
+    solver_.setVectors(Teuchos::rcpFromRef(lhs.base()), Teuchos::rcpFromRef(rhs.base()));
+  }
+
+  void SerialDenseSolver::set_vectors(SerialDenseMatrix& lhs, SerialDenseMatrix& rhs)
+  {
+    solver_.setVectors(Teuchos::rcpFromRef(lhs.base()), Teuchos::rcpFromRef(rhs.base()));
+  }
+
+  void SerialDenseSolver::factor_with_equilibration(bool enable)
+  {
+    solver_.factorWithEquilibration(enable);
+  }
+
+  void SerialDenseSolver::solve_to_refined_solution(bool enable)
+  {
+    solver_.solveToRefinedSolution(enable);
+  }
+
+  int SerialDenseSolver::factor() { return solver_.factor(); }
+
+  int SerialDenseSolver::solve() { return solver_.solve(); }
+
+  int SerialDenseSolver::invert() { return solver_.invert(); }
+}  // namespace Core::LinAlg
+
+FOUR_C_NAMESPACE_CLOSE

--- a/src/core/linalg/src/dense/4C_linalg_serialdensesolver.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_serialdensesolver.hpp
@@ -1,0 +1,93 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef FOUR_C_LINALG_SERIALDENSESOLVER_HPP
+#define FOUR_C_LINALG_SERIALDENSESOLVER_HPP
+
+#include "4C_config.hpp"
+
+#include "4C_linalg_serialdensematrix.hpp"
+#include "4C_linalg_serialdensevector.hpp"
+
+#include <Teuchos_SerialDenseSolver.hpp>
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace Core::LinAlg
+{
+  /*!
+   * \brief Wrapper for Teuchos::SerialDenseSolver.
+   *
+   * \note The solver stores non-owning references to matrix/vector arguments
+   *       via Teuchos::RCP. Referenced objects must remain alive until
+   *       factor(), solve(), and invert() complete.
+   */
+  class SerialDenseSolver
+  {
+   public:
+    using Base = Teuchos::SerialDenseSolver<int, double>;
+
+    /** \name System setup */
+    //@{
+    /*! \brief Set system matrix A of the system A*x = b. */
+    void set_matrix(SerialDenseMatrix& matrix);
+
+    /*!
+     * \brief Set vector unknowns and right-hand side for A*x = b.
+     *
+     * \param lhs Unknown vector x (solution written here).
+     * \param rhs Right-hand side vector b.
+     */
+    void set_vectors(SerialDenseVector& lhs, SerialDenseVector& rhs);
+
+    /*!
+     * \brief Set matrix unknowns and right-hand side for multi-RHS systems of A*x = b.
+     *
+     * \param lhs Unknown x (stored as a matrix; solution written here).
+     * \param rhs Right-hand side b (stored as a matrix).
+     */
+    void set_vectors(SerialDenseMatrix& lhs, SerialDenseMatrix& rhs);
+    //@}
+
+    /** \name Solver options */
+    //@{
+    /*! \brief Enable or disable matrix equilibration before factorization. */
+    void factor_with_equilibration(bool enable);
+
+    /*! \brief Enable or disable iterative refinement in solve(). */
+    void solve_to_refined_solution(bool enable);
+    //@}
+
+    /** \name Operations */
+    //@{
+    /*!
+     * \brief Factor current matrix.
+     * \return Trilinos/LAPACK-style error code (0 on success).
+     */
+    int factor();
+
+    /*!
+     * \brief Solve for current vectors with current matrix settings.
+     * \return Trilinos/LAPACK-style error code (0 on success).
+     */
+    int solve();
+
+    /*!
+     * \brief Invert current matrix in place.
+     * \return Trilinos/LAPACK-style error code (0 on success).
+     */
+    int invert();
+    //@}
+
+   private:
+    Base solver_;
+  };
+}  // namespace Core::LinAlg
+
+FOUR_C_NAMESPACE_CLOSE
+
+#endif

--- a/src/core/linalg/src/dense/4C_linalg_utils_tensor_interpolation.cpp
+++ b/src/core/linalg/src/dense/4C_linalg_utils_tensor_interpolation.cpp
@@ -11,6 +11,7 @@
 
 #include "4C_linalg_fixedsizematrix.hpp"
 #include "4C_linalg_fixedsizematrix_voigt_notation.hpp"
+#include "4C_linalg_serialdensesolver.hpp"
 #include "4C_linalg_utils_densematrix_eigen.hpp"
 #include "4C_linalg_utils_scalar_interpolation.hpp"
 #include "4C_utils_exceptions.hpp"
@@ -508,15 +509,13 @@ Core::LinAlg::SecondOrderTensorInterpolator<loc_dim>::get_interpolated_matrix(
 
     // setup solver
     Core::LinAlg::SerialDenseMatrix copy_P = Core::LinAlg::SerialDenseMatrix(P);
-    using ordinalType = Core::LinAlg::SerialDenseMatrix::ordinalType;
-    using scalarType = Core::LinAlg::SerialDenseMatrix::scalarType;
-    Teuchos::SerialDenseSolver<ordinalType, scalarType> solver;
+    Core::LinAlg::SerialDenseSolver solver;
 
     // solve for the coefficients of Q
-    solver.setMatrix(Teuchos::rcpFromRef(P.base()));
-    solver.setVectors(Teuchos::rcpFromRef(a_Q.base()), Teuchos::rcpFromRef(b_Q.base()));
-    solver.factorWithEquilibration(true);
-    solver.solveToRefinedSolution(true);
+    solver.set_matrix(P);
+    solver.set_vectors(a_Q, b_Q);
+    solver.factor_with_equilibration(true);
+    solver.solve_to_refined_solution(true);
     if (solver.factor() or solver.solve())
     {
       err_type = TensorInterpolationErrorType::LinSolveFailQMatrix;
@@ -524,10 +523,10 @@ Core::LinAlg::SecondOrderTensorInterpolator<loc_dim>::get_interpolated_matrix(
     }
 
     // solve for the coefficients of R
-    solver.setMatrix(Teuchos::rcpFromRef(copy_P.base()));
-    solver.setVectors(Teuchos::rcpFromRef(a_R.base()), Teuchos::rcpFromRef(b_R.base()));
-    solver.factorWithEquilibration(true);
-    solver.solveToRefinedSolution(true);
+    solver.set_matrix(copy_P);
+    solver.set_vectors(a_R, b_R);
+    solver.factor_with_equilibration(true);
+    solver.solve_to_refined_solution(true);
     if (solver.factor() or solver.solve())
     {
       err_type = TensorInterpolationErrorType::LinSolveFailRMatrix;

--- a/src/core/linalg/src/sparse/4C_linalg_krylov_projector.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_krylov_projector.cpp
@@ -9,6 +9,7 @@
 
 #include "4C_linalg_map.hpp"
 #include "4C_linalg_serialdensematrix.hpp"
+#include "4C_linalg_serialdensesolver.hpp"
 #include "4C_linalg_serialdensevector.hpp"
 #include "4C_linalg_sparsematrix.hpp"
 #include "4C_linalg_utils_densematrix_communication.hpp"
@@ -16,8 +17,6 @@
 #include "4C_linalg_utils_sparse_algebra_math.hpp"
 #include "4C_linalg_vector.hpp"
 #include "4C_utils_exceptions.hpp"
-
-#include <Teuchos_SerialDenseSolver.hpp>
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -149,10 +148,8 @@ void Core::LinAlg::KrylovProjector::fill_complete()
 
   // invert wTc-matrix (also done if it's only a scalar - check with Micheal
   // Gee before changing this)
-  using ordinalType = Core::LinAlg::SerialDenseMatrix::ordinalType;
-  using scalarType = Core::LinAlg::SerialDenseMatrix::scalarType;
-  Teuchos::SerialDenseSolver<ordinalType, scalarType> densesolver;
-  densesolver.setMatrix(Teuchos::rcpFromRef(invw_tc_->base()));
+  Core::LinAlg::SerialDenseSolver densesolver;
+  densesolver.set_matrix(*invw_tc_);
   int err = densesolver.invert();
   if (err)
     FOUR_C_THROW(

--- a/src/core/utils/src/numerics/4C_utils_cubic_spline_interpolation.cpp
+++ b/src/core/utils/src/numerics/4C_utils_cubic_spline_interpolation.cpp
@@ -7,9 +7,8 @@
 
 #include "4C_utils_cubic_spline_interpolation.hpp"
 
+#include "4C_linalg_serialdensesolver.hpp"
 #include "4C_utils_exceptions.hpp"
-
-#include <Teuchos_SerialDenseSolver.hpp>
 
 #include <utility>
 
@@ -122,13 +121,11 @@ void Core::Utils::CubicSplineInterpolation::solve_linear_system(Core::LinAlg::Se
     Core::LinAlg::SerialDenseVector& c, Core::LinAlg::SerialDenseVector& b) const
 {
   // solve for third-order coefficients for cubic spline interpolation
-  using ordinalType = Core::LinAlg::SerialDenseMatrix::ordinalType;
-  using scalarType = Core::LinAlg::SerialDenseMatrix::scalarType;
-  Teuchos::SerialDenseSolver<ordinalType, scalarType> solver;
-  solver.setMatrix(Teuchos::rcpFromRef(A.base()));
-  solver.setVectors(Teuchos::rcpFromRef(c.base()), Teuchos::rcpFromRef(b.base()));
-  solver.factorWithEquilibration(true);
-  solver.solveToRefinedSolution(true);
+  Core::LinAlg::SerialDenseSolver solver;
+  solver.set_matrix(A);
+  solver.set_vectors(c, b);
+  solver.factor_with_equilibration(true);
+  solver.solve_to_refined_solution(true);
   if (solver.factor() or solver.solve())
     FOUR_C_THROW("Solution of linear system of equations failed!");
 }

--- a/src/core/utils/src/numerics/4C_utils_local_newton.hpp
+++ b/src/core/utils/src/numerics/4C_utils_local_newton.hpp
@@ -13,11 +13,10 @@
 #include "4C_linalg_fixedsizematrix.hpp"
 #include "4C_linalg_fixedsizematrix_solver.hpp"
 #include "4C_linalg_serialdensematrix.hpp"
+#include "4C_linalg_serialdensesolver.hpp"
 #include "4C_linalg_serialdensevector.hpp"
 #include "4C_linalg_tensor.hpp"
 #include "4C_utils_fad.hpp"
-
-#include <Teuchos_SerialDenseSolver.hpp>
 
 #include <functional>
 
@@ -71,10 +70,10 @@ namespace Core::Utils
   {
     Core::LinAlg::SerialDenseVector dx(x.length(), true);
     Core::LinAlg::SerialDenseVector rhs(residuum);
-    Teuchos::SerialDenseSolver<int, double> solver;
-    solver.setMatrix(Teuchos::rcpFromRef(jacobian.base()));
-    solver.setVectors(Teuchos::rcpFromRef(dx.base()), Teuchos::rcpFromRef(rhs.base()));
-    solver.factorWithEquilibration(true);
+    Core::LinAlg::SerialDenseSolver solver;
+    solver.set_matrix(jacobian);
+    solver.set_vectors(dx, rhs);
+    solver.factor_with_equilibration(true);
     solver.factor();
     solver.solve();
 

--- a/src/fluid_ele/4C_fluid_ele_calc_hdg.cpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_hdg.cpp
@@ -14,6 +14,7 @@
 #include "4C_fluid_ele_parameter_timint.hpp"
 #include "4C_fluid_functions.hpp"
 #include "4C_global_data.hpp"
+#include "4C_linalg_serialdensesolver.hpp"
 #include "4C_linalg_utils_densematrix_multiply.hpp"
 #include "4C_mat_fluid_murnaghantait.hpp"
 #include "4C_mat_newtonianfluid.hpp"
@@ -22,7 +23,6 @@
 
 #include <Teuchos_BLAS.hpp>
 #include <Teuchos_LAPACK.hpp>
-#include <Teuchos_SerialDenseSolver.hpp>
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -510,16 +510,13 @@ int Discret::Elements::FluidEleCalcHDG<distype>::project_field(Discret::Elements
     // Creating and solving a system of the form Ax = b where
     // A is a matrix and x and b are vectors
     // solve mass matrix system, return values in localMat = elevec2 correctly ordered
-    using ordinalType = Core::LinAlg::SerialDenseMatrix::ordinalType;
-    using scalarType = Core::LinAlg::SerialDenseMatrix::scalarType;
-    Teuchos::SerialDenseSolver<ordinalType, scalarType> inverseMass;
+    Core::LinAlg::SerialDenseSolver inverseMass;
     // Setting A matrix
-    inverseMass.setMatrix(Teuchos::rcpFromRef(local_solver_->massMat.base()));
+    inverseMass.set_matrix(local_solver_->massMat);
     // localMat is, in this case, used both as the RHS and as the unknown vector
     // localMat is placed in the memory where elevec2 was and therefore it takes
     // its place as result vector
-    inverseMass.setVectors(
-        Teuchos::rcpFromRef(localMat.base()), Teuchos::rcpFromRef(localMat.base()));
+    inverseMass.set_vectors(localMat, localMat);
     // Solving
     inverseMass.solve();
   }
@@ -632,13 +629,11 @@ int Discret::Elements::FluidEleCalcHDG<distype>::project_field(Discret::Elements
     }
 
     // Solving step, nothing fancy
-    using ordinalType = Core::LinAlg::SerialDenseMatrix::ordinalType;
-    using scalarType = Core::LinAlg::SerialDenseMatrix::scalarType;
-    Teuchos::SerialDenseSolver<ordinalType, scalarType> inverseMass;
-    inverseMass.setMatrix(Teuchos::rcpFromRef(mass.base()));
+    Core::LinAlg::SerialDenseSolver inverseMass;
+    inverseMass.set_matrix(mass);
     // In this cas trVec is a proper vector and not a matrix used as multiple
     // RHS vectors
-    inverseMass.setVectors(Teuchos::rcpFromRef(trVec.base()), Teuchos::rcpFromRef(trVec.base()));
+    inverseMass.set_vectors(trVec, trVec);
     inverseMass.solve();
 
     // In this case we fill elevec1 with the values of trVec because we have not
@@ -1024,12 +1019,9 @@ int Discret::Elements::FluidEleCalcHDG<distype>::project_force_on_dof_vec_for_hi
         local_solver_->massMat, local_solver_->massPart, local_solver_->massPartW);
 
     // solve mass matrix system, return values in localMat = elevec2 correctly ordered
-    using ordinalType = Core::LinAlg::SerialDenseMatrix::ordinalType;
-    using scalarType = Core::LinAlg::SerialDenseMatrix::scalarType;
-    Teuchos::SerialDenseSolver<ordinalType, scalarType> inverseMass;
-    inverseMass.setMatrix(Teuchos::rcpFromRef(local_solver_->massMat.base()));
-    inverseMass.setVectors(
-        Teuchos::rcpFromRef(localMat.base()), Teuchos::rcpFromRef(localMat.base()));
+    Core::LinAlg::SerialDenseSolver inverseMass;
+    inverseMass.set_matrix(local_solver_->massMat);
+    inverseMass.set_vectors(localMat, localMat);
     inverseMass.solve();
   }
 
@@ -1134,12 +1126,9 @@ int Discret::Elements::FluidEleCalcHDG<distype>::project_initial_field_for_hit(
         local_solver_->massMat, local_solver_->massPart, local_solver_->massPartW);
 
     // solve mass matrix system, return values in localMat = elevec2 correctly ordered
-    using ordinalType = Core::LinAlg::SerialDenseMatrix::ordinalType;
-    using scalarType = Core::LinAlg::SerialDenseMatrix::scalarType;
-    Teuchos::SerialDenseSolver<ordinalType, scalarType> inverseMass;
-    inverseMass.setMatrix(Teuchos::rcpFromRef(local_solver_->massMat.base()));
-    inverseMass.setVectors(
-        Teuchos::rcpFromRef(localMat.base()), Teuchos::rcpFromRef(localMat.base()));
+    Core::LinAlg::SerialDenseSolver inverseMass;
+    inverseMass.set_matrix(local_solver_->massMat);
+    inverseMass.set_vectors(localMat, localMat);
     inverseMass.solve();
   }
 
@@ -1196,11 +1185,9 @@ int Discret::Elements::FluidEleCalcHDG<distype>::project_initial_field_for_hit(
       }
     }
 
-    using ordinalType = Core::LinAlg::SerialDenseMatrix::ordinalType;
-    using scalarType = Core::LinAlg::SerialDenseMatrix::scalarType;
-    Teuchos::SerialDenseSolver<ordinalType, scalarType> inverseMass;
-    inverseMass.setMatrix(Teuchos::rcpFromRef(mass.base()));
-    inverseMass.setVectors(Teuchos::rcpFromRef(trVec.base()), Teuchos::rcpFromRef(trVec.base()));
+    Core::LinAlg::SerialDenseSolver inverseMass;
+    inverseMass.set_matrix(mass);
+    inverseMass.set_vectors(trVec, trVec);
     inverseMass.solve();
 
 
@@ -2241,10 +2228,8 @@ void Discret::Elements::FluidEleCalcHDG<distype>::LocalSolver::eliminate_velocit
 
   // invert mass matrix. Inverse will be stored in massMat, too
   {
-    using ordinalType = Core::LinAlg::SerialDenseMatrix::ordinalType;
-    using scalarType = Core::LinAlg::SerialDenseMatrix::scalarType;
-    Teuchos::SerialDenseSolver<ordinalType, scalarType> inverseMass;
-    inverseMass.setMatrix(Teuchos::rcpFromRef(massMat.base()));
+    Core::LinAlg::SerialDenseSolver inverseMass;
+    inverseMass.set_matrix(massMat);
     inverseMass.invert();
   }
 

--- a/src/fluid_ele/4C_fluid_ele_calc_hdg_weak_comp.cpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_hdg_weak_comp.cpp
@@ -14,11 +14,10 @@
 #include "4C_fluid_ele_parameter_timint.hpp"
 #include "4C_fluid_functions.hpp"
 #include "4C_global_data.hpp"
+#include "4C_linalg_serialdensesolver.hpp"
 #include "4C_linalg_utils_densematrix_multiply.hpp"
 #include "4C_mat_fluid_weakly_compressible.hpp"
 #include "4C_utils_shared_ptr_from_ref.hpp"
-
-#include <Teuchos_SerialDenseSolver.hpp>
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -508,12 +507,9 @@ int Discret::Elements::FluidEleCalcHDGWeakComp<distype>::project_field(
     // The integration is made by computing the matrix product
     Core::LinAlg::multiply_nt(
         local_solver_->massMat, local_solver_->massPart, local_solver_->massPartW);
-    using ordinalType = Core::LinAlg::SerialDenseMatrix::ordinalType;
-    using scalarType = Core::LinAlg::SerialDenseMatrix::scalarType;
-    Teuchos::SerialDenseSolver<ordinalType, scalarType> inverseMass;
-    inverseMass.setMatrix(Teuchos::rcpFromRef(local_solver_->massMat.base()));
-    inverseMass.setVectors(
-        Teuchos::rcpFromRef(localMat.base()), Teuchos::rcpFromRef(localMat.base()));
+    Core::LinAlg::SerialDenseSolver inverseMass;
+    inverseMass.set_matrix(local_solver_->massMat);
+    inverseMass.set_vectors(localMat, localMat);
     inverseMass.solve();
   }
 
@@ -614,13 +610,11 @@ int Discret::Elements::FluidEleCalcHDGWeakComp<distype>::project_field(
     }
 
     // Solving step, nothing fancy
-    using ordinalType = Core::LinAlg::SerialDenseMatrix::ordinalType;
-    using scalarType = Core::LinAlg::SerialDenseMatrix::scalarType;
-    Teuchos::SerialDenseSolver<ordinalType, scalarType> inverseMass;
-    inverseMass.setMatrix(Teuchos::rcpFromRef(mass.base()));
+    Core::LinAlg::SerialDenseSolver inverseMass;
+    inverseMass.set_matrix(mass);
     // In this cas trVec is a proper vector and not a matrix used as multiple
     // RHS vectors
-    inverseMass.setVectors(Teuchos::rcpFromRef(trVec.base()), Teuchos::rcpFromRef(trVec.base()));
+    inverseMass.set_vectors(trVec, trVec);
     inverseMass.solve();
 
     // In this case we fill elevec1 with the values of trVec because we have not
@@ -2034,7 +2028,7 @@ template <Core::FE::CellType distype>
 void Discret::Elements::FluidEleCalcHDGWeakComp<distype>::LocalSolver::invert_local_local_matrix()
 {
   KlocallocalInv = Klocallocal;
-  KlocallocalInvSolver.setMatrix(Teuchos::rcpFromRef(KlocallocalInv.base()));
+  KlocallocalInvSolver.set_matrix(KlocallocalInv);
   int err = KlocallocalInvSolver.invert();
   if (err != 0) FOUR_C_THROW("Inversion of local-local matrix failed with errorcode {}", err);
 }

--- a/src/fluid_ele/4C_fluid_ele_calc_hdg_weak_comp.hpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_hdg_weak_comp.hpp
@@ -15,6 +15,7 @@
 #include "4C_fluid_ele_hdg_weak_comp.hpp"
 #include "4C_fluid_ele_interface.hpp"
 #include "4C_inpar_fluid.hpp"
+#include "4C_linalg_serialdensesolver.hpp"
 #include "4C_utils_singleton_owner.hpp"
 
 FOUR_C_NAMESPACE_OPEN
@@ -405,7 +406,7 @@ namespace Discret
         Core::LinAlg::SerialDenseVector Rlocal;          /// local residual vector
         Core::LinAlg::SerialDenseVector Rglobal;         /// global residual vector
         Core::LinAlg::SerialDenseMatrix KlocallocalInv;  /// inverse local-local matrix
-        Teuchos::SerialDenseSolver<ordinalType, scalarType>
+        Core::LinAlg::SerialDenseSolver
             KlocallocalInvSolver;  /// solver for inverse local-local matrix
 
         // Voigt related quantities

--- a/src/mat/4C_mat_anisotropy_extension.cpp
+++ b/src/mat/4C_mat_anisotropy_extension.cpp
@@ -11,8 +11,6 @@
 #include "4C_comm_parobject.hpp"
 #include "4C_mat_anisotropy_utils.hpp"
 
-#include <Teuchos_SerialDenseSolver.hpp>
-
 FOUR_C_NAMESPACE_OPEN
 
 template <unsigned int numfib>

--- a/src/mat/4C_mat_fluidporo_multiphase.cpp
+++ b/src/mat/4C_mat_fluidporo_multiphase.cpp
@@ -9,12 +9,11 @@
 
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
+#include "4C_linalg_serialdensesolver.hpp"
 #include "4C_mat_fluidporo_singlephase.hpp"
 #include "4C_mat_par_bundle.hpp"
 #include "4C_porofluid_pressure_based_ele_calc_utils.hpp"
 #include "4C_utils_enum.hpp"
-
-#include <Teuchos_SerialDenseSolver.hpp>
 
 #include <vector>
 
@@ -179,10 +178,8 @@ void Mat::PAR::FluidPoroMultiPhase::initialize()
   // invert dof2pres_ to get conversion from dofs to pressures for the fluid phases
   if (numfluidphases_ > 0)
   {
-    using ordinalType = Core::LinAlg::SerialDenseMatrix::ordinalType;
-    using scalarType = Core::LinAlg::SerialDenseMatrix::scalarType;
-    Teuchos::SerialDenseSolver<ordinalType, scalarType> inverse;
-    inverse.setMatrix(Teuchos::rcpFromRef(dof2pres_->base()));
+    Core::LinAlg::SerialDenseSolver inverse;
+    inverse.set_matrix(*dof2pres_);
     int err = inverse.invert();
     if (err != 0)
       FOUR_C_THROW(

--- a/src/mat/4C_mat_growthremodel_elasthyper.cpp
+++ b/src/mat/4C_mat_growthremodel_elasthyper.cpp
@@ -11,6 +11,7 @@
 #include "4C_global_data.hpp"
 #include "4C_linalg_fixedsizematrix_tensor_products.hpp"
 #include "4C_linalg_fixedsizematrix_voigt_notation.hpp"
+#include "4C_linalg_serialdensesolver.hpp"
 #include "4C_linalg_tensor.hpp"
 #include "4C_linalg_tensor_conversion.hpp"
 #include "4C_linalg_tensor_generators.hpp"
@@ -25,8 +26,6 @@
 #include "4C_mat_so3_material.hpp"
 #include "4C_solid_ele_fibers.hpp"
 #include "4C_utils_enum.hpp"
-
-#include <Teuchos_SerialDenseSolver.hpp>
 
 #include <cmath>
 
@@ -954,9 +953,7 @@ void Mat::GrowthRemodelElastHyper::solve_for_rho_lambr(Core::LinAlg::SerialDense
   static std::vector<std::vector<double>> dEdlambr(
       nr_rf_tot_, std::vector<double>(nr_rf_tot_, 0.0));
   static std::vector<double> E(nr_rf_tot_, 0.0);
-  using ordinalType = Core::LinAlg::SerialDenseMatrix::ordinalType;
-  using scalarType = Core::LinAlg::SerialDenseMatrix::scalarType;
-  static Teuchos::SerialDenseSolver<ordinalType, scalarType> solver;
+  static Core::LinAlg::SerialDenseSolver solver;
   // residual vector of assembled system of equation
   static Core::LinAlg::SerialDenseMatrix R(2 * nr_rf_tot_, 1);
   for (unsigned i = 0; i < 2 * nr_rf_tot_; ++i) R(i, 0) = 1.0;
@@ -971,10 +968,10 @@ void Mat::GrowthRemodelElastHyper::solve_for_rho_lambr(Core::LinAlg::SerialDense
     if (iter != 0)
     {
       // Solve linearized system of equations
-      solver.setMatrix(Teuchos::rcpFromRef(K_T.base()));
-      solver.setVectors(Teuchos::rcpFromRef(dsol.base()), Teuchos::rcpFromRef(R.base()));
-      solver.solveToRefinedSolution(true);
-      solver.factorWithEquilibration(true);
+      solver.set_matrix(K_T);
+      solver.set_vectors(dsol, R);
+      solver.solve_to_refined_solution(true);
+      solver.factor_with_equilibration(true);
       solver.solve();
 
       l = 0;
@@ -1064,14 +1061,12 @@ void Mat::GrowthRemodelElastHyper::solve_fordrhod_cdlambrd_c(
   }
 
   // Solve
-  using ordinalType = Core::LinAlg::SerialDenseMatrix::ordinalType;
-  using scalarType = Core::LinAlg::SerialDenseMatrix::scalarType;
-  static Teuchos::SerialDenseSolver<ordinalType, scalarType> solver;
+  static Core::LinAlg::SerialDenseSolver solver;
   static Core::LinAlg::SerialDenseMatrix dsolcmat(2 * nr_rf_tot_, 6);
-  solver.setMatrix(Teuchos::rcpFromRef(K_T.base()));
-  solver.setVectors(Teuchos::rcpFromRef(dsolcmat.base()), Teuchos::rcpFromRef(Rcmat.base()));
-  solver.solveToRefinedSolution(true);
-  solver.factorWithEquilibration(true);
+  solver.set_matrix(K_T);
+  solver.set_vectors(dsolcmat, Rcmat);
+  solver.solve_to_refined_solution(true);
+  solver.factor_with_equilibration(true);
   solver.solve();
 
   sum_drhodC.clear();

--- a/src/mat/4C_mat_plastic_VarConstUpdate.cpp
+++ b/src/mat/4C_mat_plastic_VarConstUpdate.cpp
@@ -20,8 +20,6 @@
 #include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 
-#include <Teuchos_SerialDenseSolver.hpp>
-
 FOUR_C_NAMESPACE_OPEN
 
 using vmap = Core::LinAlg::Voigt::IndexMappings;

--- a/src/mat/4C_mat_plasticelasthyper.cpp
+++ b/src/mat/4C_mat_plasticelasthyper.cpp
@@ -20,8 +20,6 @@
 #include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 
-#include <Teuchos_SerialDenseSolver.hpp>
-
 FOUR_C_NAMESPACE_OPEN
 
 namespace

--- a/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele_phasemanager.cpp
+++ b/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele_phasemanager.cpp
@@ -7,6 +7,7 @@
 
 #include "4C_porofluid_pressure_based_ele_phasemanager.hpp"
 
+#include "4C_linalg_serialdensesolver.hpp"
 #include "4C_linalg_utils_densematrix_multiply.hpp"
 #include "4C_mat_fluidporo_multiphase.hpp"
 #include "4C_mat_fluidporo_multiphase_reactions.hpp"
@@ -20,7 +21,6 @@
 #include "4C_utils_enum.hpp"
 
 #include <Teuchos_ParameterList.hpp>
-#include <Teuchos_SerialDenseSolver.hpp>
 
 #include <numeric>
 
@@ -797,10 +797,8 @@ void Discret::Elements::PoroFluidManager::PhaseManagerDeriv::evaluate_gp_state(
   // now invert the derivatives of the dofs w.r.t. pressure to get the derivatives
   // of the pressure w.r.t. the dofs
   {
-    using ordinalType = Core::LinAlg::SerialDenseMatrix::ordinalType;
-    using scalarType = Core::LinAlg::SerialDenseMatrix::scalarType;
-    Teuchos::SerialDenseSolver<ordinalType, scalarType> inverse;
-    inverse.setMatrix(Teuchos::rcpFromRef(pressurederiv_->base()));
+    Core::LinAlg::SerialDenseSolver inverse;
+    inverse.set_matrix(*pressurederiv_);
     int err = inverse.invert();
     if (err != 0)
       FOUR_C_THROW("Inversion of matrix for pressure derivative failed with error code {}.", err);

--- a/src/red_airways/4C_red_airways_interacinardep_evaluate.cpp
+++ b/src/red_airways/4C_red_airways_interacinardep_evaluate.cpp
@@ -15,7 +15,6 @@
 #include "4C_utils_exceptions.hpp"
 
 #include <Teuchos_ParameterList.hpp>
-#include <Teuchos_SerialDenseSolver.hpp>
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/scatra_ele/4C_scatra_ele_calc_cardiac_monodomain_hdg.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_cardiac_monodomain_hdg.cpp
@@ -17,6 +17,7 @@
 #include "4C_fem_general_utils_integration.hpp"
 #include "4C_fem_general_utils_polynomial.hpp"
 #include "4C_global_data.hpp"
+#include "4C_linalg_serialdensesolver.hpp"
 #include "4C_linalg_tensor_conversion.hpp"
 #include "4C_linalg_utils_densematrix_multiply.hpp"
 #include "4C_mat_list.hpp"
@@ -622,12 +623,10 @@ int Discret::Elements::ScaTraEleCalcHDGCardiacMonodomain<distype,
       shapes->ndofs_, actmat->get_number_of_internal_state_variables());
   Core::LinAlg::multiply(tempMat1, massPartOldW, state_variables);
 
-  using ordinalType = Core::LinAlg::SerialDenseMatrix::ordinalType;
-  using scalarType = Core::LinAlg::SerialDenseMatrix::scalarType;
-  Teuchos::SerialDenseSolver<ordinalType, scalarType> inverseMat;
-  inverseMat.setMatrix(Teuchos::rcpFromRef(Mmat.base()));
-  inverseMat.setVectors(Teuchos::rcpFromRef(tempMat1.base()), Teuchos::rcpFromRef(tempMat1.base()));
-  inverseMat.factorWithEquilibration(true);
+  Core::LinAlg::SerialDenseSolver inverseMat;
+  inverseMat.set_matrix(Mmat);
+  inverseMat.set_vectors(tempMat1, tempMat1);
+  inverseMat.factor_with_equilibration(true);
   int err2 = inverseMat.factor();
   int err = inverseMat.solve();
   if (err != 0 || err2 != 0) FOUR_C_THROW("Inversion of matrix failed with errorcode {}", err);
@@ -752,12 +751,10 @@ int Discret::Elements::ScaTraEleCalcHDGCardiacMonodomain<distype,
       polySpace->size(), actmat->get_number_of_internal_state_variables());
   Core::LinAlg::multiply(tempMat1, massPartOldW, state_variables);
 
-  using ordinalType = Core::LinAlg::SerialDenseMatrix::ordinalType;
-  using scalarType = Core::LinAlg::SerialDenseMatrix::scalarType;
-  Teuchos::SerialDenseSolver<ordinalType, scalarType> inverseMat;
-  inverseMat.setMatrix(Teuchos::rcpFromRef(Mmat.base()));
-  inverseMat.setVectors(Teuchos::rcpFromRef(tempMat1.base()), Teuchos::rcpFromRef(tempMat1.base()));
-  inverseMat.factorWithEquilibration(true);
+  Core::LinAlg::SerialDenseSolver inverseMat;
+  inverseMat.set_matrix(Mmat);
+  inverseMat.set_vectors(tempMat1, tempMat1);
+  inverseMat.factor_with_equilibration(true);
   int err2 = inverseMat.factor();
   int err = inverseMat.solve();
   if (err != 0 || err2 != 0) FOUR_C_THROW("Inversion of matrix failed with errorcode {}", err);

--- a/src/scatra_ele/4C_scatra_ele_calc_hdg.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_hdg.cpp
@@ -16,6 +16,7 @@
 #include "4C_fem_general_utils_polynomial.hpp"
 #include "4C_fem_geometry_position_array.hpp"
 #include "4C_global_data.hpp"
+#include "4C_linalg_serialdensesolver.hpp"
 #include "4C_linalg_utils_densematrix_multiply.hpp"
 #include "4C_mat_list.hpp"
 #include "4C_mat_scatra.hpp"
@@ -25,7 +26,6 @@
 #include "4C_scatra_ele_parameter_timint.hpp"
 #include "4C_utils_function.hpp"
 
-#include <Teuchos_SerialDenseSolver.hpp>
 #include <Teuchos_TimeMonitor.hpp>
 
 FOUR_C_NAMESPACE_OPEN
@@ -440,11 +440,9 @@ int Discret::Elements::ScaTraEleCalcHDG<distype, probdim>::project_dirich_field(
 
   }  // loop over integration points
 
-  using ordinalType = Core::LinAlg::SerialDenseMatrix::ordinalType;
-  using scalarType = Core::LinAlg::SerialDenseMatrix::scalarType;
-  Teuchos::SerialDenseSolver<ordinalType, scalarType> inverseMass;
-  inverseMass.setMatrix(Teuchos::rcpFromRef(mass.base()));
-  inverseMass.setVectors(Teuchos::rcpFromRef(trVec.base()), Teuchos::rcpFromRef(trVec.base()));
+  Core::LinAlg::SerialDenseSolver inverseMass;
+  inverseMass.set_matrix(mass);
+  inverseMass.set_vectors(trVec, trVec);
   inverseMass.solve();
 
   for (unsigned int node = 0; node < shapesface_->nfdofs_; node++) elevec1[node] = trVec(node);
@@ -600,10 +598,8 @@ void Discret::Elements::ScaTraEleCalcHDG<distype, probdim>::LocalSolver::compute
   hdgele->invAMmat_ = hdgele->Mmat_;
   hdgele->invAMmat_.scale(1.0 / (dt * theta));
   hdgele->invAMmat_ += hdgele->Amat_;
-  using ordinalType = Core::LinAlg::SerialDenseMatrix::ordinalType;
-  using scalarType = Core::LinAlg::SerialDenseMatrix::scalarType;
-  Teuchos::SerialDenseSolver<ordinalType, scalarType> inverseAMmat;
-  inverseAMmat.setMatrix(Teuchos::rcpFromRef(hdgele->invAMmat_.base()));
+  Core::LinAlg::SerialDenseSolver inverseAMmat;
+  inverseAMmat.set_matrix(hdgele->invAMmat_);
   int err = inverseAMmat.invert();
   if (err != 0)
   {
@@ -1163,10 +1159,8 @@ void Discret::Elements::ScaTraEleCalcHDG<distype, probdim>::LocalSolver::condens
   tempMat3 = hdgele->Emat_;
   Core::LinAlg::multiply(1.0, tempMat3, -1.0, tempMat1, hdgele->Cmat_);  // = E - (-B^T) AM^{-1} C
 
-  using ordinalType = Core::LinAlg::SerialDenseMatrix::ordinalType;
-  using scalarType = Core::LinAlg::SerialDenseMatrix::scalarType;
-  Teuchos::SerialDenseSolver<ordinalType, scalarType> inverseinW;
-  inverseinW.setMatrix(Teuchos::rcpFromRef(tempMat2.base()));
+  Core::LinAlg::SerialDenseSolver inverseinW;
+  inverseinW.set_matrix(tempMat2);
   int err = inverseinW.invert();
   if (err != 0)
     FOUR_C_THROW(
@@ -1617,13 +1611,10 @@ int Discret::Elements::ScaTraEleCalcHDG<distype, probdim>::set_initial_field(
 
     Core::LinAlg::multiply_nt(Mmat, massPart, massPartW);
     {
-      using ordinalType = Core::LinAlg::SerialDenseMatrix::ordinalType;
-      using scalarType = Core::LinAlg::SerialDenseMatrix::scalarType;
-      Teuchos::SerialDenseSolver<ordinalType, scalarType> inverseMass;
-      inverseMass.setMatrix(Teuchos::rcpFromRef(Mmat.base()));
-      inverseMass.setVectors(
-          Teuchos::rcpFromRef(localMat.base()), Teuchos::rcpFromRef(localMat.base()));
-      inverseMass.factorWithEquilibration(true);
+      Core::LinAlg::SerialDenseSolver inverseMass;
+      inverseMass.set_matrix(Mmat);
+      inverseMass.set_vectors(localMat, localMat);
+      inverseMass.factor_with_equilibration(true);
       int err2 = inverseMass.factor();
       int err = inverseMass.solve();
       if (err != 0 || err2 != 0) FOUR_C_THROW("Inversion of matrix failed with errorcode {}", err);
@@ -1668,12 +1659,10 @@ int Discret::Elements::ScaTraEleCalcHDG<distype, probdim>::set_initial_field(
       }
     }
 
-    using ordinalType = Core::LinAlg::SerialDenseMatrix::ordinalType;
-    using scalarType = Core::LinAlg::SerialDenseMatrix::scalarType;
-    Teuchos::SerialDenseSolver<ordinalType, scalarType> inverseMass;
-    inverseMass.setMatrix(Teuchos::rcpFromRef(mass.base()));
-    inverseMass.setVectors(Teuchos::rcpFromRef(trVec.base()), Teuchos::rcpFromRef(trVec.base()));
-    inverseMass.factorWithEquilibration(true);
+    Core::LinAlg::SerialDenseSolver inverseMass;
+    inverseMass.set_matrix(mass);
+    inverseMass.set_vectors(trVec, trVec);
+    inverseMass.factor_with_equilibration(true);
     int err2 = inverseMass.factor();
     int err = inverseMass.solve();
     if (err != 0 || err2 != 0) FOUR_C_THROW("Inversion of matrix failed with errorcode {}", err);
@@ -1747,10 +1736,8 @@ void Discret::Elements::ScaTraEleCalcHDG<distype, probdim>::LocalSolver::prepare
     Core::LinAlg::SerialDenseMatrix& difftensor  //!< diffusion tensor
 )
 {
-  using ordinalType = Core::LinAlg::SerialDenseMatrix::ordinalType;
-  using scalarType = Core::LinAlg::SerialDenseMatrix::scalarType;
-  Teuchos::SerialDenseSolver<ordinalType, scalarType> inverseindifftensor;
-  inverseindifftensor.setMatrix(Teuchos::rcpFromRef(difftensor.base()));
+  Core::LinAlg::SerialDenseSolver inverseindifftensor;
+  inverseindifftensor.set_matrix(difftensor);
   int err = inverseindifftensor.invert();
   if (err != 0) FOUR_C_THROW("Inversion of diffusion tensor failed with errorcode {}", err);
 

--- a/src/scatra_ele/4C_scatra_ele_calc_service_elch_diffcond_multiscale.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_service_elch_diffcond_multiscale.cpp
@@ -7,6 +7,7 @@
 
 #include "4C_fem_discretization.hpp"
 #include "4C_fem_general_extract_values.hpp"
+#include "4C_linalg_serialdensesolver.hpp"
 #include "4C_linalg_utils_densematrix_multiply.hpp"
 #include "4C_mat_elchmat.hpp"
 #include "4C_mat_elchphase.hpp"
@@ -15,7 +16,6 @@
 #include "4C_scatra_ele_parameter_std.hpp"
 
 #include <Teuchos_ParameterList.hpp>
-#include <Teuchos_SerialDenseSolver.hpp>
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -125,10 +125,8 @@ void Discret::Elements::ScaTraEleCalcElchDiffCondMultiScale<distype,
   }
 
   // conc_gp = N * conc --> conc = N^-1 * conc_gp
-  using ordinalType = Core::LinAlg::SerialDenseMatrix::ordinalType;
-  using scalarType = Core::LinAlg::SerialDenseMatrix::scalarType;
-  Teuchos::SerialDenseSolver<ordinalType, scalarType> invert;
-  invert.setMatrix(Teuchos::rcpFromRef(N.base()));
+  Core::LinAlg::SerialDenseSolver invert;
+  invert.set_matrix(N);
   invert.invert();
   Core::LinAlg::multiply(conc, N, conc_gp);
 }

--- a/src/solid_poro_ele/4C_solid_poro_ele_calc_lib.hpp
+++ b/src/solid_poro_ele/4C_solid_poro_ele_calc_lib.hpp
@@ -22,6 +22,7 @@
 #include "4C_linalg_fixedsizematrix.hpp"
 #include "4C_linalg_fixedsizematrix_voigt_notation.hpp"
 #include "4C_linalg_serialdensematrix.hpp"
+#include "4C_linalg_serialdensesolver.hpp"
 #include "4C_linalg_serialdensevector.hpp"
 #include "4C_linalg_symmetric_tensor.hpp"
 #include "4C_linalg_tensor_conversion.hpp"
@@ -37,8 +38,6 @@
 #include "4C_solid_poro_ele_properties.hpp"
 #include "4C_utils_exceptions.hpp"
 #include "4C_utils_parameter_list.fwd.hpp"
-
-#include <Teuchos_SerialDenseSolver.hpp>
 
 #include <algorithm>
 #include <cstdint>
@@ -1994,9 +1993,9 @@ namespace Discret::Elements
     // now invert the derivatives of the dofs w.r.t. pressure to get the derivatives
     // of the pressure w.r.t. the dofs
     {
-      Teuchos::SerialDenseSolver<int, double> inverse;
+      Core::LinAlg::SerialDenseSolver inverse;
 
-      inverse.setMatrix(Teuchos::rcpFromRef(pressderiv.base()));
+      inverse.set_matrix(pressderiv);
       int err = inverse.invert();
       if (err != 0)
         FOUR_C_THROW("Inversion of matrix for pressure derivative failed with error code {}.", err);


### PR DESCRIPTION
## Description and Context

This PR wraps `Teuchos::SerialDenseSolver` and thus hides user code exposure to Trilinos. Now, all these SerialDense objects are handled by our own implementation.

## Related Issues and Pull Requests

#1923, #1209 
