### PR TITLE
Fix FOUR_C error message formatting

### DIFF
--- a/src/core/utils/src/exceptions/4C_utils_exceptions.cpp
+++ b/src/core/utils/src/exceptions/4C_utils_exceptions.cpp
@@ -41,8 +41,8 @@ namespace Core
       }
 
       std::stringstream compound_message;
-      compound_message << "PROC " << myrank << " ERROR in " << loc.file_name() << ", line "
-                       << loc.line() << ":\n";
+      compound_message << "PROC " << myrank << " ERROR in " << loc.file_name() << ":" << loc.line()
+                       << ":\n";
 
       compound_message << formatted_message;
       compound_message << "\n------------------\n";


### PR DESCRIPTION
The error message location should now be clickable in most IDEs.

Before:

```shell
PROC 0 ERROR in </path/to/file/with_error>, line <line number>:
<error message>
``` 
-> The comma and the written-out line make it not very useful.
Now:
```shell
PROC 0 ERROR in </path/to/file/with_error>:<line number>:
<error message>
``` 
-> Brings you directly where you want.