### PR TITLE
Remove master/slave in beaminteraction

### DIFF
--- a/src/beaminteraction/src/4C_beaminteraction_geometry_utils.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_geometry_utils.cpp
@@ -18,10 +18,10 @@ FOUR_C_NAMESPACE_OPEN
 /*-----------------------------------------------------------------------------------------------*
  *-----------------------------------------------------------------------------------------------*/
 template <unsigned int numnodes, unsigned int numnodalvalues, typename T>
-bool BeamInteraction::Geo::point_to_curve_projection(Core::LinAlg::Matrix<3, 1, T> const& r_slave,
-    T& xi_master, double const& xi_master_initial_guess,
-    const Core::LinAlg::Matrix<3 * numnodes * numnodalvalues, 1, T>& master_centerline_dof_values,
-    const Core::FE::CellType& master_distype, double master_ele_ref_length)
+bool BeamInteraction::Geo::point_to_curve_projection(Core::LinAlg::Matrix<3, 1, T> const& r_source,
+    T& xi_target, double const& xi_target_initial_guess,
+    const Core::LinAlg::Matrix<3 * numnodes * numnodalvalues, 1, T>& target_centerline_dof_values,
+    const Core::FE::CellType& target_distype, double target_ele_ref_length)
 {
   // vectors for shape functions values and their derivatives
   Core::LinAlg::Matrix<1, numnodes * numnodalvalues, T> N_i(Core::LinAlg::Initialization::zero);
@@ -30,9 +30,9 @@ bool BeamInteraction::Geo::point_to_curve_projection(Core::LinAlg::Matrix<3, 1, 
       Core::LinAlg::Initialization::zero);
 
   // coords and derivatives of the two contacting points
-  Core::LinAlg::Matrix<3, 1, T> r_master(Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 1, T> r_xi_master(Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 1, T> r_xixi_master(Core::LinAlg::Initialization::zero);
+  Core::LinAlg::Matrix<3, 1, T> r_target(Core::LinAlg::Initialization::zero);
+  Core::LinAlg::Matrix<3, 1, T> r_xi_target(Core::LinAlg::Initialization::zero);
+  Core::LinAlg::Matrix<3, 1, T> r_xixi_target(Core::LinAlg::Initialization::zero);
 
   Core::LinAlg::Matrix<3, 1, T> delta_r(Core::LinAlg::Initialization::zero);  // = r1-r2
 
@@ -44,8 +44,8 @@ bool BeamInteraction::Geo::point_to_curve_projection(Core::LinAlg::Matrix<3, 1, 
   double residual = 0.0;
   double residual0 = 0.0;
 
-  xi_master = xi_master_initial_guess;
-  double xi_master_previous_iteration = xi_master_initial_guess;
+  xi_target = xi_target_initial_guess;
+  double xi_target_previous_iteration = xi_target_initial_guess;
 
 
   // local Newton iteration
@@ -53,18 +53,18 @@ bool BeamInteraction::Geo::point_to_curve_projection(Core::LinAlg::Matrix<3, 1, 
   {
     // update shape functions and their derivatives
     Discret::Utils::Beam::evaluate_shape_functions_and_derivs_and2nd_derivs_at_xi<numnodes,
-        numnodalvalues, T>(xi_master, N_i, N_i_xi, N_i_xixi, master_distype, master_ele_ref_length);
+        numnodalvalues, T>(xi_target, N_i, N_i_xi, N_i_xixi, target_distype, target_ele_ref_length);
 
     // update coordinates and derivatives of contact points
     Discret::Utils::Beam::calc_interpolation<numnodes, numnodalvalues, 3, T, T>(
-        master_centerline_dof_values, N_i, r_master);
+        target_centerline_dof_values, N_i, r_target);
     Discret::Utils::Beam::calc_interpolation<numnodes, numnodalvalues, 3, T, T>(
-        master_centerline_dof_values, N_i_xi, r_xi_master);
+        target_centerline_dof_values, N_i_xi, r_xi_target);
     Discret::Utils::Beam::calc_interpolation<numnodes, numnodalvalues, 3, T, T>(
-        master_centerline_dof_values, N_i_xixi, r_xixi_master);
+        target_centerline_dof_values, N_i_xixi, r_xixi_target);
 
     // use delta_r = r1-r2 as auxiliary quantity
-    delta_r = Core::FADUtils::diff_vector(r_slave, r_master);
+    delta_r = Core::FADUtils::diff_vector(r_source, r_target);
 
     // compute norm of difference vector to scale the equations
     // (this yields better conditioning)
@@ -83,19 +83,19 @@ bool BeamInteraction::Geo::point_to_curve_projection(Core::LinAlg::Matrix<3, 1, 
 
 
     // evaluate f at current eta1, eta2
-    evaluate_point_to_curve_orthogonality_condition(f, delta_r, norm_delta_r, r_xi_master);
+    evaluate_point_to_curve_orthogonality_condition(f, delta_r, norm_delta_r, r_xi_target);
 
     // compute the scalar residuum
     /* The residual is scaled with 1/element_length of the beam element representing the curve
      * since r_xi scales with the element_length */
-    residual = std::abs(Core::FADUtils::cast_to_double(f / master_ele_ref_length));
+    residual = std::abs(Core::FADUtils::cast_to_double(f / target_ele_ref_length));
 
     // store initial residual
     if (iter == 0) residual0 = residual;
 
     // check if Newton iteration has converged
     if (Core::FADUtils::cast_to_double(residual) < POINT_TO_CURVE_PROJECTION_TOLERANCE_RESIDUUM and
-        std::abs(xi_master_previous_iteration - Core::FADUtils::cast_to_double(xi_master)) <
+        std::abs(xi_target_previous_iteration - Core::FADUtils::cast_to_double(xi_target)) <
             POINT_TO_CURVE_PROJECTION_TOLERANCE_INCREMENT)
     {
       Core::IO::cout(Core::IO::debug)
@@ -108,17 +108,17 @@ bool BeamInteraction::Geo::point_to_curve_projection(Core::LinAlg::Matrix<3, 1, 
     // evaluate Jacobian of f at current point
     // Note: It has to be checked, if the linearization is equal to zero;
     bool validlinearization = evaluate_linearization_point_to_curve_orthogonality_condition(
-        df, delta_r, norm_delta_r, r_xi_master, r_xixi_master);
+        df, delta_r, norm_delta_r, r_xi_target, r_xixi_target);
 
     if (not validlinearization)
       FOUR_C_THROW(
           "Linearization of point to line projection is zero, i.e. the minimal distance "
           "problem seems to be non-unique!");
 
-    xi_master_previous_iteration = Core::FADUtils::cast_to_double(xi_master);
+    xi_target_previous_iteration = Core::FADUtils::cast_to_double(xi_target);
 
-    // update master element coordinate of closest point
-    xi_master += -f / df;
+    // update target element coordinate of closest point
+    xi_target += -f / df;
   }
 
   // Newton iteration unconverged after maximum number of iterations, print debug info to screen
@@ -127,10 +127,10 @@ bool BeamInteraction::Geo::point_to_curve_projection(Core::LinAlg::Matrix<3, 1, 
                                   << " iterations!" << Core::IO::endl;
   Core::IO::cout(Core::IO::debug) << "residual in first iteration: " << residual0 << Core::IO::endl;
   Core::IO::cout(Core::IO::debug) << "residual: " << residual << Core::IO::endl;
-  Core::IO::cout(Core::IO::debug) << "xi_master: " << Core::FADUtils::cast_to_double(xi_master)
+  Core::IO::cout(Core::IO::debug) << "xi_target: " << Core::FADUtils::cast_to_double(xi_target)
                                   << Core::IO::endl;
-  Core::IO::cout(Core::IO::debug) << "xi_master_previous_iteration: "
-                                  << xi_master_previous_iteration << Core::IO::endl;
+  Core::IO::cout(Core::IO::debug) << "xi_target_previous_iteration: "
+                                  << xi_target_previous_iteration << Core::IO::endl;
 
   return false;
 }
@@ -140,7 +140,7 @@ bool BeamInteraction::Geo::point_to_curve_projection(Core::LinAlg::Matrix<3, 1, 
 template <typename T>
 void BeamInteraction::Geo::evaluate_point_to_curve_orthogonality_condition(T& f,
     const Core::LinAlg::Matrix<3, 1, T>& delta_r, const double norm_delta_r,
-    const Core::LinAlg::Matrix<3, 1, T>& r_xi_master)
+    const Core::LinAlg::Matrix<3, 1, T>& r_xi_target)
 {
   // reset f
   f = 0.0;
@@ -148,7 +148,7 @@ void BeamInteraction::Geo::evaluate_point_to_curve_orthogonality_condition(T& f,
   // evaluate f
   for (unsigned int i = 0; i < 3; ++i)
   {
-    f += -delta_r(i) * r_xi_master(i) / norm_delta_r;
+    f += -delta_r(i) * r_xi_target(i) / norm_delta_r;
   }
 }
 
@@ -157,8 +157,8 @@ void BeamInteraction::Geo::evaluate_point_to_curve_orthogonality_condition(T& f,
 template <typename T>
 bool BeamInteraction::Geo::evaluate_linearization_point_to_curve_orthogonality_condition(T& df,
     const Core::LinAlg::Matrix<3, 1, T>& delta_r, const double norm_delta_r,
-    const Core::LinAlg::Matrix<3, 1, T>& r_xi_master,
-    const Core::LinAlg::Matrix<3, 1, T>& r_xixi_master)
+    const Core::LinAlg::Matrix<3, 1, T>& r_xi_target,
+    const Core::LinAlg::Matrix<3, 1, T>& r_xixi_target)
 {
   // reset df
   df = 0.0;
@@ -166,12 +166,12 @@ bool BeamInteraction::Geo::evaluate_linearization_point_to_curve_orthogonality_c
   // evaluate df
   for (unsigned int i = 0; i < 3; ++i)
   {
-    df += (r_xi_master(i) * r_xi_master(i) - delta_r(i) * r_xixi_master(i)) / norm_delta_r;
+    df += (r_xi_target(i) * r_xi_target(i) - delta_r(i) * r_xixi_target(i)) / norm_delta_r;
   }
 
   /* check for df==0.0, i.e. non-uniqueness of the minimal distance problem
    * This can happen e.g. when the curve describes a circle geometry and
-   * the projecting slave point coincides with the center of the circle */
+   * the projecting source point coincides with the center of the circle */
   if (std::abs(Core::FADUtils::cast_to_double(df)) <
       POINT_TO_CURVE_PROJECTION_NONUNIQUE_MINIMAL_DISTANCE_TOLERANCE)
     return false;
@@ -182,381 +182,381 @@ bool BeamInteraction::Geo::evaluate_linearization_point_to_curve_orthogonality_c
 /*-----------------------------------------------------------------------------------------------*
  *-----------------------------------------------------------------------------------------------*/
 template <unsigned int numnodes, unsigned int numnodalvalues, typename T>
-void BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coord_master(
-    Core::LinAlg::Matrix<1, 3 * numnodes * numnodalvalues, T>& lin_xi_master_slaveDofs,
-    Core::LinAlg::Matrix<1, 3 * numnodes * numnodalvalues, T>& lin_xi_master_masterDofs,
-    const Core::LinAlg::Matrix<3, 1, T>& delta_r, const Core::LinAlg::Matrix<3, 1, T>& r_xi_master,
-    const Core::LinAlg::Matrix<3, 1, T>& r_xixi_master,
-    const Core::LinAlg::Matrix<3, 3 * numnodes * numnodalvalues, double>& N_slave,
-    const Core::LinAlg::Matrix<3, 3 * numnodes * numnodalvalues, T>& N_master,
-    const Core::LinAlg::Matrix<3, 3 * numnodes * numnodalvalues, T>& N_xi_master)
+void BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coord_target(
+    Core::LinAlg::Matrix<1, 3 * numnodes * numnodalvalues, T>& lin_xi_target_sourceDofs,
+    Core::LinAlg::Matrix<1, 3 * numnodes * numnodalvalues, T>& lin_xi_target_targetDofs,
+    const Core::LinAlg::Matrix<3, 1, T>& delta_r, const Core::LinAlg::Matrix<3, 1, T>& r_xi_target,
+    const Core::LinAlg::Matrix<3, 1, T>& r_xixi_target,
+    const Core::LinAlg::Matrix<3, 3 * numnodes * numnodalvalues, double>& N_source,
+    const Core::LinAlg::Matrix<3, 3 * numnodes * numnodalvalues, T>& N_target,
+    const Core::LinAlg::Matrix<3, 3 * numnodes * numnodalvalues, T>& N_xi_target)
 {
   const unsigned int dim1 = 3 * numnodes * numnodalvalues;
   const unsigned int dim2 = 3 * numnodes * numnodalvalues;
 
   /* partial derivative of the orthogonality condition with respect to parameter coordinate on
-   * master xi_master */
-  T orthogon_condition_partial_xi_master = 0.0;
+   * target xi_target */
+  T orthogon_condition_partial_xi_target = 0.0;
 
-  calc_ptc_projection_orthogonality_condition_partial_deriv_parameter_coord_master(
-      orthogon_condition_partial_xi_master, delta_r, r_xi_master, r_xixi_master);
+  calc_ptc_projection_orthogonality_condition_partial_deriv_parameter_coord_target(
+      orthogon_condition_partial_xi_target, delta_r, r_xi_target, r_xixi_target);
 
   /* partial derivative of the orthogonality condition with respect to primary Dofs defining
-   * slave point and master curve */
-  Core::LinAlg::Matrix<1, 3, T> orthogon_condition_partial_r_slave(
+   * source point and target curve */
+  Core::LinAlg::Matrix<1, 3, T> orthogon_condition_partial_r_source(
       Core::LinAlg::Initialization::zero);
 
-  calc_ptc_projection_orthogonality_condition_partial_deriv_cl_pos_slave(
-      orthogon_condition_partial_r_slave, r_xi_master);
+  calc_ptc_projection_orthogonality_condition_partial_deriv_cl_pos_source(
+      orthogon_condition_partial_r_source, r_xi_target);
 
-  Core::LinAlg::Matrix<1, 3, T> orthogon_condition_partial_r_master(
+  Core::LinAlg::Matrix<1, 3, T> orthogon_condition_partial_r_target(
       Core::LinAlg::Initialization::zero);
 
-  calc_ptc_projection_orthogonality_condition_partial_deriv_cl_pos_master(
-      orthogon_condition_partial_r_master, r_xi_master);
+  calc_ptc_projection_orthogonality_condition_partial_deriv_cl_pos_target(
+      orthogon_condition_partial_r_target, r_xi_target);
 
-  Core::LinAlg::Matrix<1, 3, T> orthogon_condition_partial_r_xi_master(
+  Core::LinAlg::Matrix<1, 3, T> orthogon_condition_partial_r_xi_target(
       Core::LinAlg::Initialization::zero);
 
-  calc_ptc_projection_orthogonality_condition_partial_deriv_cl_tangent_master(
-      orthogon_condition_partial_r_xi_master, delta_r);
+  calc_ptc_projection_orthogonality_condition_partial_deriv_cl_tangent_target(
+      orthogon_condition_partial_r_xi_target, delta_r);
 
 
   // finally compute the linearizations / directional derivatives
-  lin_xi_master_slaveDofs.clear();
-  lin_xi_master_masterDofs.clear();
+  lin_xi_target_sourceDofs.clear();
+  lin_xi_target_targetDofs.clear();
 
   for (unsigned int idim = 0; idim < 3; ++idim)
     for (unsigned int jdof = 0; jdof < dim1; ++jdof)
     {
-      lin_xi_master_slaveDofs(jdof) +=
-          orthogon_condition_partial_r_slave(idim) * N_slave(idim, jdof);
+      lin_xi_target_sourceDofs(jdof) +=
+          orthogon_condition_partial_r_source(idim) * N_source(idim, jdof);
     }
 
   for (unsigned int idim = 0; idim < 3; ++idim)
     for (unsigned int jdof = 0; jdof < dim2; ++jdof)
     {
-      lin_xi_master_masterDofs(jdof) +=
-          orthogon_condition_partial_r_master(idim) * N_master(idim, jdof) +
-          orthogon_condition_partial_r_xi_master(idim) * N_xi_master(idim, jdof);
+      lin_xi_target_targetDofs(jdof) +=
+          orthogon_condition_partial_r_target(idim) * N_target(idim, jdof) +
+          orthogon_condition_partial_r_xi_target(idim) * N_xi_target(idim, jdof);
     }
 
-  lin_xi_master_slaveDofs.scale(-1.0 / orthogon_condition_partial_xi_master);
-  lin_xi_master_masterDofs.scale(-1.0 / orthogon_condition_partial_xi_master);
+  lin_xi_target_sourceDofs.scale(-1.0 / orthogon_condition_partial_xi_target);
+  lin_xi_target_targetDofs.scale(-1.0 / orthogon_condition_partial_xi_target);
 }
 
 /*-----------------------------------------------------------------------------------------------*
  *-----------------------------------------------------------------------------------------------*/
 template <typename T>
-void BeamInteraction::Geo::calc_point_to_curve_projection_parameter_coord_master_partial_derivs(
-    Core::LinAlg::Matrix<1, 3, T>& xi_master_partial_r_slave,
-    Core::LinAlg::Matrix<1, 3, T>& xi_master_partial_r_master,
-    Core::LinAlg::Matrix<1, 3, T>& xi_master_partial_r_xi_master,
-    const Core::LinAlg::Matrix<3, 1, T>& delta_r, const Core::LinAlg::Matrix<3, 1, T>& r_xi_master,
-    const Core::LinAlg::Matrix<3, 1, T>& r_xixi_master)
+void BeamInteraction::Geo::calc_point_to_curve_projection_parameter_coord_target_partial_derivs(
+    Core::LinAlg::Matrix<1, 3, T>& xi_target_partial_r_source,
+    Core::LinAlg::Matrix<1, 3, T>& xi_target_partial_r_target,
+    Core::LinAlg::Matrix<1, 3, T>& xi_target_partial_r_xi_target,
+    const Core::LinAlg::Matrix<3, 1, T>& delta_r, const Core::LinAlg::Matrix<3, 1, T>& r_xi_target,
+    const Core::LinAlg::Matrix<3, 1, T>& r_xixi_target)
 {
   /* partial derivative of the orthogonality condition with respect to parameter coordinate on
-   * master xi_master */
-  T orthogon_condition_partial_xi_master = 0.0;
+   * target xi_target */
+  T orthogon_condition_partial_xi_target = 0.0;
 
-  calc_ptc_projection_orthogonality_condition_partial_deriv_parameter_coord_master(
-      orthogon_condition_partial_xi_master, delta_r, r_xi_master, r_xixi_master);
+  calc_ptc_projection_orthogonality_condition_partial_deriv_parameter_coord_target(
+      orthogon_condition_partial_xi_target, delta_r, r_xi_target, r_xixi_target);
 
   /* partial derivative of the orthogonality condition with respect to primary Dofs defining
-   * slave point and master curve */
-  Core::LinAlg::Matrix<1, 3, T> orthogon_condition_partial_r_slave(
+   * source point and target curve */
+  Core::LinAlg::Matrix<1, 3, T> orthogon_condition_partial_r_source(
       Core::LinAlg::Initialization::zero);
 
-  calc_ptc_projection_orthogonality_condition_partial_deriv_cl_pos_slave(
-      orthogon_condition_partial_r_slave, r_xi_master);
+  calc_ptc_projection_orthogonality_condition_partial_deriv_cl_pos_source(
+      orthogon_condition_partial_r_source, r_xi_target);
 
-  Core::LinAlg::Matrix<1, 3, T> orthogon_condition_partial_r_master(
+  Core::LinAlg::Matrix<1, 3, T> orthogon_condition_partial_r_target(
       Core::LinAlg::Initialization::zero);
 
-  calc_ptc_projection_orthogonality_condition_partial_deriv_cl_pos_master(
-      orthogon_condition_partial_r_master, r_xi_master);
+  calc_ptc_projection_orthogonality_condition_partial_deriv_cl_pos_target(
+      orthogon_condition_partial_r_target, r_xi_target);
 
-  Core::LinAlg::Matrix<1, 3, T> orthogon_condition_partial_r_xi_master(
+  Core::LinAlg::Matrix<1, 3, T> orthogon_condition_partial_r_xi_target(
       Core::LinAlg::Initialization::zero);
 
-  calc_ptc_projection_orthogonality_condition_partial_deriv_cl_tangent_master(
-      orthogon_condition_partial_r_xi_master, delta_r);
+  calc_ptc_projection_orthogonality_condition_partial_deriv_cl_tangent_target(
+      orthogon_condition_partial_r_xi_target, delta_r);
 
   // finally compute the partial/directional derivatives
-  xi_master_partial_r_slave.update(
-      -1.0 / orthogon_condition_partial_xi_master, orthogon_condition_partial_r_slave);
+  xi_target_partial_r_source.update(
+      -1.0 / orthogon_condition_partial_xi_target, orthogon_condition_partial_r_source);
 
-  xi_master_partial_r_master.update(
-      -1.0 / orthogon_condition_partial_xi_master, orthogon_condition_partial_r_master);
+  xi_target_partial_r_target.update(
+      -1.0 / orthogon_condition_partial_xi_target, orthogon_condition_partial_r_target);
 
-  xi_master_partial_r_xi_master.update(
-      -1.0 / orthogon_condition_partial_xi_master, orthogon_condition_partial_r_xi_master);
+  xi_target_partial_r_xi_target.update(
+      -1.0 / orthogon_condition_partial_xi_target, orthogon_condition_partial_r_xi_target);
 }
 
 /*-----------------------------------------------------------------------------------------------*
  *-----------------------------------------------------------------------------------------------*/
 template <typename T>
-void BeamInteraction::Geo::calc_point_to_curve_projection_parameter_coord_master_partial2nd_derivs(
-    Core::LinAlg::Matrix<3, 3, T>& xi_master_partial_r_slave_partial_r_slave,
-    Core::LinAlg::Matrix<3, 3, T>& xi_master_partial_r_slave_partial_r_master,
-    Core::LinAlg::Matrix<3, 3, T>& xi_master_partial_r_slave_partial_r_xi_master,
-    Core::LinAlg::Matrix<3, 3, T>& xi_master_partial_r_slave_partial_r_xixi_master,
-    Core::LinAlg::Matrix<3, 3, T>& xi_master_partial_r_master_partial_r_slave,
-    Core::LinAlg::Matrix<3, 3, T>& xi_master_partial_r_master_partial_r_master,
-    Core::LinAlg::Matrix<3, 3, T>& xi_master_partial_r_master_partial_r_xi_master,
-    Core::LinAlg::Matrix<3, 3, T>& xi_master_partial_r_master_partial_r_xixi_master,
-    Core::LinAlg::Matrix<3, 3, T>& xi_master_partial_r_xi_master_partial_r_slave,
-    Core::LinAlg::Matrix<3, 3, T>& xi_master_partial_r_xi_master_partial_r_master,
-    Core::LinAlg::Matrix<3, 3, T>& xi_master_partial_r_xi_master_partial_r_xi_master,
-    Core::LinAlg::Matrix<3, 3, T>& xi_master_partial_r_xi_master_partial_r_xixi_master,
-    Core::LinAlg::Matrix<3, 3, T>& xi_master_partial_r_xixi_master_partial_r_slave,
-    Core::LinAlg::Matrix<3, 3, T>& xi_master_partial_r_xixi_master_partial_r_master,
-    Core::LinAlg::Matrix<3, 3, T>& xi_master_partial_r_xixi_master_partial_r_xi_master,
-    const Core::LinAlg::Matrix<1, 3, T>& xi_master_partial_r_slave,
-    const Core::LinAlg::Matrix<1, 3, T>& xi_master_partial_r_master,
-    const Core::LinAlg::Matrix<1, 3, T>& xi_master_partial_r_xi_master,
-    const Core::LinAlg::Matrix<3, 3, T>& delta_r_deriv_r_slave,
-    const Core::LinAlg::Matrix<3, 3, T>& delta_r_deriv_r_master,
-    const Core::LinAlg::Matrix<3, 3, T>& delta_r_deriv_r_xi_master,
-    const Core::LinAlg::Matrix<3, 1, T>& delta_r, const Core::LinAlg::Matrix<3, 1, T>& r_xi_master,
-    const Core::LinAlg::Matrix<3, 1, T>& r_xixi_master,
-    const Core::LinAlg::Matrix<3, 1, T>& r_xixixi_master)
+void BeamInteraction::Geo::calc_point_to_curve_projection_parameter_coord_target_partial2nd_derivs(
+    Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_source_partial_r_source,
+    Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_source_partial_r_target,
+    Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_source_partial_r_xi_target,
+    Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_source_partial_r_xixi_target,
+    Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_target_partial_r_source,
+    Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_target_partial_r_target,
+    Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_target_partial_r_xi_target,
+    Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_target_partial_r_xixi_target,
+    Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_xi_target_partial_r_source,
+    Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_xi_target_partial_r_target,
+    Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_xi_target_partial_r_xi_target,
+    Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_xi_target_partial_r_xixi_target,
+    Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_xixi_target_partial_r_source,
+    Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_xixi_target_partial_r_target,
+    Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_xixi_target_partial_r_xi_target,
+    const Core::LinAlg::Matrix<1, 3, T>& xi_target_partial_r_source,
+    const Core::LinAlg::Matrix<1, 3, T>& xi_target_partial_r_target,
+    const Core::LinAlg::Matrix<1, 3, T>& xi_target_partial_r_xi_target,
+    const Core::LinAlg::Matrix<3, 3, T>& delta_r_deriv_r_source,
+    const Core::LinAlg::Matrix<3, 3, T>& delta_r_deriv_r_target,
+    const Core::LinAlg::Matrix<3, 3, T>& delta_r_deriv_r_xi_target,
+    const Core::LinAlg::Matrix<3, 1, T>& delta_r, const Core::LinAlg::Matrix<3, 1, T>& r_xi_target,
+    const Core::LinAlg::Matrix<3, 1, T>& r_xixi_target,
+    const Core::LinAlg::Matrix<3, 1, T>& r_xixixi_target)
 {
   //  Fixme: the (out) variables should be called (...)_partial_(...)_deriv_(...) !
 
   /* partial derivative of the orthogonality condition with respect to parameter coordinate on
-   * master xi_master */
-  T orthogon_condition_partial_xi_master = 0.0;
+   * target xi_target */
+  T orthogon_condition_partial_xi_target = 0.0;
 
-  calc_ptc_projection_orthogonality_condition_partial_deriv_parameter_coord_master(
-      orthogon_condition_partial_xi_master, delta_r, r_xi_master, r_xixi_master);
+  calc_ptc_projection_orthogonality_condition_partial_deriv_parameter_coord_target(
+      orthogon_condition_partial_xi_target, delta_r, r_xi_target, r_xixi_target);
 
-  T orthogon_condition_partial_xi_master_inverse = 1.0 / orthogon_condition_partial_xi_master;
+  T orthogon_condition_partial_xi_target_inverse = 1.0 / orthogon_condition_partial_xi_target;
 
-  // Note: 1) do (partial) derivs w.r.t. [r_master(xi_master_c)], [r_xi_master(xi_master_c)] and
-  //          [r_xixi_master(xi_master_c)],
-  // 2) add the contributions from xi_master_partial_(...) according to the chain rule,
+  // Note: 1) do (partial) derivs w.r.t. [r_target(xi_target_c)], [r_xi_target(xi_target_c)] and
+  //          [r_xixi_target(xi_target_c)],
+  // 2) add the contributions from xi_target_partial_(...) according to the chain rule,
   // 3) add the terms including delta_r_deriv_(...) since these already
-  //    contain the contributions from xi_master_partial_(...) according to the chain rule
-  // 4) add the contributions from linearization of (variation of r_master) and linearization of
-  //    (variation of r_xi_master) according to the chain rule
+  //    contain the contributions from xi_target_partial_(...) according to the chain rule
+  // 4) add the contributions from linearization of (variation of r_target) and linearization of
+  //    (variation of r_xi_target) according to the chain rule
 
 
   Core::LinAlg::Matrix<3, 3, T> unit_matrix(Core::LinAlg::Initialization::zero);
   for (unsigned int i = 0; i < 3; ++i) unit_matrix(i, i) = 1.0;
 
-  Core::LinAlg::Matrix<3, 3, T> r_xi_master_tensorproduct_r_xi_master(
+  Core::LinAlg::Matrix<3, 3, T> r_xi_target_tensorproduct_r_xi_target(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, T> r_xi_master_tensorproduct_r_xixi_master(
+  Core::LinAlg::Matrix<3, 3, T> r_xi_target_tensorproduct_r_xixi_target(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, T> r_xi_master_tensorproduct_delta_r(
+  Core::LinAlg::Matrix<3, 3, T> r_xi_target_tensorproduct_delta_r(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, T> delta_r_tensorproduct_r_xixi_master(
+  Core::LinAlg::Matrix<3, 3, T> delta_r_tensorproduct_r_xixi_target(
       Core::LinAlg::Initialization::zero);
   Core::LinAlg::Matrix<3, 3, T> delta_r_tensorproduct_delta_r(Core::LinAlg::Initialization::zero);
 
   for (unsigned int irow = 0; irow < 3; ++irow)
     for (unsigned int icol = 0; icol < 3; ++icol)
     {
-      r_xi_master_tensorproduct_r_xi_master(irow, icol) = r_xi_master(irow) * r_xi_master(icol);
-      r_xi_master_tensorproduct_r_xixi_master(irow, icol) = r_xi_master(irow) * r_xixi_master(icol);
-      r_xi_master_tensorproduct_delta_r(irow, icol) = r_xi_master(irow) * delta_r(icol);
-      delta_r_tensorproduct_r_xixi_master(irow, icol) = delta_r(irow) * r_xixi_master(icol);
+      r_xi_target_tensorproduct_r_xi_target(irow, icol) = r_xi_target(irow) * r_xi_target(icol);
+      r_xi_target_tensorproduct_r_xixi_target(irow, icol) = r_xi_target(irow) * r_xixi_target(icol);
+      r_xi_target_tensorproduct_delta_r(irow, icol) = r_xi_target(irow) * delta_r(icol);
+      delta_r_tensorproduct_r_xixi_target(irow, icol) = delta_r(irow) * r_xixi_target(icol);
       delta_r_tensorproduct_delta_r(irow, icol) = delta_r(irow) * delta_r(icol);
     }
 
   // 1)
-  xi_master_partial_r_slave_partial_r_xi_master.update(
-      -2.0 * orthogon_condition_partial_xi_master_inverse *
-          orthogon_condition_partial_xi_master_inverse,
-      r_xi_master_tensorproduct_r_xi_master);
+  xi_target_partial_r_source_partial_r_xi_target.update(
+      -2.0 * orthogon_condition_partial_xi_target_inverse *
+          orthogon_condition_partial_xi_target_inverse,
+      r_xi_target_tensorproduct_r_xi_target);
 
-  xi_master_partial_r_slave_partial_r_xi_master.update(
-      -1.0 * orthogon_condition_partial_xi_master_inverse, unit_matrix, 1.0);
+  xi_target_partial_r_source_partial_r_xi_target.update(
+      -1.0 * orthogon_condition_partial_xi_target_inverse, unit_matrix, 1.0);
 
-  xi_master_partial_r_master_partial_r_xi_master.update(
-      -1.0, xi_master_partial_r_slave_partial_r_xi_master);
-
-
-  xi_master_partial_r_slave_partial_r_xixi_master.update(
-      orthogon_condition_partial_xi_master_inverse * orthogon_condition_partial_xi_master_inverse,
-      r_xi_master_tensorproduct_delta_r);
-
-  xi_master_partial_r_master_partial_r_xixi_master.update(
-      -1.0, xi_master_partial_r_slave_partial_r_xixi_master);
+  xi_target_partial_r_target_partial_r_xi_target.update(
+      -1.0, xi_target_partial_r_source_partial_r_xi_target);
 
 
-  xi_master_partial_r_xi_master_partial_r_xi_master.update_t(
-      -2.0 * orthogon_condition_partial_xi_master_inverse *
-          orthogon_condition_partial_xi_master_inverse,
-      r_xi_master_tensorproduct_delta_r);
+  xi_target_partial_r_source_partial_r_xixi_target.update(
+      orthogon_condition_partial_xi_target_inverse * orthogon_condition_partial_xi_target_inverse,
+      r_xi_target_tensorproduct_delta_r);
 
-  xi_master_partial_r_xi_master_partial_r_xixi_master.update(
-      orthogon_condition_partial_xi_master_inverse * orthogon_condition_partial_xi_master_inverse,
+  xi_target_partial_r_target_partial_r_xixi_target.update(
+      -1.0, xi_target_partial_r_source_partial_r_xixi_target);
+
+
+  xi_target_partial_r_xi_target_partial_r_xi_target.update_t(
+      -2.0 * orthogon_condition_partial_xi_target_inverse *
+          orthogon_condition_partial_xi_target_inverse,
+      r_xi_target_tensorproduct_delta_r);
+
+  xi_target_partial_r_xi_target_partial_r_xixi_target.update(
+      orthogon_condition_partial_xi_target_inverse * orthogon_condition_partial_xi_target_inverse,
       delta_r_tensorproduct_delta_r);
 
 
   // 2)
-  // add contributions from linearization of master parameter coordinate xi_master
-  // to [.]_deriv_r_xi_master expressions (according to chain rule)
+  // add contributions from linearization of target parameter coordinate xi_target
+  // to [.]_deriv_r_xi_target expressions (according to chain rule)
   Core::LinAlg::Matrix<3, 1, T> tmp_vec2;
-  tmp_vec2.multiply(xi_master_partial_r_slave_partial_r_xi_master, r_xixi_master);
+  tmp_vec2.multiply(xi_target_partial_r_source_partial_r_xi_target, r_xixi_target);
 
   for (unsigned int irow = 0; irow < 3; ++irow)
   {
     for (unsigned int icol = 0; icol < 3; ++icol)
     {
-      xi_master_partial_r_slave_partial_r_slave(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_slave(icol);
+      xi_target_partial_r_source_partial_r_source(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_source(icol);
 
-      xi_master_partial_r_slave_partial_r_master(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_master(icol);
+      xi_target_partial_r_source_partial_r_target(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_target(icol);
 
-      xi_master_partial_r_slave_partial_r_xi_master(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_xi_master(icol);
+      xi_target_partial_r_source_partial_r_xi_target(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_xi_target(icol);
     }
   }
 
-  tmp_vec2.multiply(xi_master_partial_r_master_partial_r_xi_master, r_xixi_master);
+  tmp_vec2.multiply(xi_target_partial_r_target_partial_r_xi_target, r_xixi_target);
 
   for (unsigned int irow = 0; irow < 3; ++irow)
   {
     for (unsigned int icol = 0; icol < 3; ++icol)
     {
-      xi_master_partial_r_master_partial_r_slave(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_slave(icol);
+      xi_target_partial_r_target_partial_r_source(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_source(icol);
 
-      xi_master_partial_r_master_partial_r_master(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_master(icol);
+      xi_target_partial_r_target_partial_r_target(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_target(icol);
 
-      xi_master_partial_r_master_partial_r_xi_master(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_xi_master(icol);
+      xi_target_partial_r_target_partial_r_xi_target(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_xi_target(icol);
     }
   }
 
-  tmp_vec2.multiply(xi_master_partial_r_xi_master_partial_r_xi_master, r_xixi_master);
+  tmp_vec2.multiply(xi_target_partial_r_xi_target_partial_r_xi_target, r_xixi_target);
 
   for (unsigned int irow = 0; irow < 3; ++irow)
   {
     for (unsigned int icol = 0; icol < 3; ++icol)
     {
-      xi_master_partial_r_xi_master_partial_r_slave(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_slave(icol);
+      xi_target_partial_r_xi_target_partial_r_source(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_source(icol);
 
-      xi_master_partial_r_xi_master_partial_r_master(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_master(icol);
+      xi_target_partial_r_xi_target_partial_r_target(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_target(icol);
 
-      xi_master_partial_r_xi_master_partial_r_xi_master(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_xi_master(icol);
+      xi_target_partial_r_xi_target_partial_r_xi_target(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_xi_target(icol);
     }
   }
 
 
-  // add contributions from linearization of master parameter coordinate xi_master
-  // to [.]_deriv_r_xixi_master expressions (according to chain rule)
-  tmp_vec2.multiply(xi_master_partial_r_slave_partial_r_xixi_master, r_xixixi_master);
+  // add contributions from linearization of target parameter coordinate xi_target
+  // to [.]_deriv_r_xixi_target expressions (according to chain rule)
+  tmp_vec2.multiply(xi_target_partial_r_source_partial_r_xixi_target, r_xixixi_target);
 
   for (unsigned int irow = 0; irow < 3; ++irow)
   {
     for (unsigned int icol = 0; icol < 3; ++icol)
     {
-      xi_master_partial_r_slave_partial_r_slave(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_slave(icol);
+      xi_target_partial_r_source_partial_r_source(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_source(icol);
 
-      xi_master_partial_r_slave_partial_r_master(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_master(icol);
+      xi_target_partial_r_source_partial_r_target(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_target(icol);
 
-      xi_master_partial_r_slave_partial_r_xi_master(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_xi_master(icol);
+      xi_target_partial_r_source_partial_r_xi_target(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_xi_target(icol);
     }
   }
 
-  tmp_vec2.multiply(xi_master_partial_r_master_partial_r_xixi_master, r_xixixi_master);
+  tmp_vec2.multiply(xi_target_partial_r_target_partial_r_xixi_target, r_xixixi_target);
 
   for (unsigned int irow = 0; irow < 3; ++irow)
   {
     for (unsigned int icol = 0; icol < 3; ++icol)
     {
-      xi_master_partial_r_master_partial_r_slave(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_slave(icol);
+      xi_target_partial_r_target_partial_r_source(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_source(icol);
 
-      xi_master_partial_r_master_partial_r_master(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_master(icol);
+      xi_target_partial_r_target_partial_r_target(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_target(icol);
 
-      xi_master_partial_r_master_partial_r_xi_master(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_xi_master(icol);
+      xi_target_partial_r_target_partial_r_xi_target(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_xi_target(icol);
     }
   }
 
-  tmp_vec2.multiply(xi_master_partial_r_xi_master_partial_r_xixi_master, r_xixixi_master);
+  tmp_vec2.multiply(xi_target_partial_r_xi_target_partial_r_xixi_target, r_xixixi_target);
 
   for (unsigned int irow = 0; irow < 3; ++irow)
   {
     for (unsigned int icol = 0; icol < 3; ++icol)
     {
-      xi_master_partial_r_xi_master_partial_r_slave(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_slave(icol);
+      xi_target_partial_r_xi_target_partial_r_source(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_source(icol);
 
-      xi_master_partial_r_xi_master_partial_r_master(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_master(icol);
+      xi_target_partial_r_xi_target_partial_r_target(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_target(icol);
 
-      xi_master_partial_r_xi_master_partial_r_xi_master(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_xi_master(icol);
+      xi_target_partial_r_xi_target_partial_r_xi_target(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_xi_target(icol);
     }
   }
 
 
   // 3)
-  xi_master_partial_r_xi_master_partial_r_slave.update(
-      -1.0 * orthogon_condition_partial_xi_master_inverse, delta_r_deriv_r_slave, 1.0);
+  xi_target_partial_r_xi_target_partial_r_source.update(
+      -1.0 * orthogon_condition_partial_xi_target_inverse, delta_r_deriv_r_source, 1.0);
 
-  xi_master_partial_r_xi_master_partial_r_master.update(
-      -1.0 * orthogon_condition_partial_xi_master_inverse, delta_r_deriv_r_master, 1.0);
+  xi_target_partial_r_xi_target_partial_r_target.update(
+      -1.0 * orthogon_condition_partial_xi_target_inverse, delta_r_deriv_r_target, 1.0);
 
-  xi_master_partial_r_xi_master_partial_r_xi_master.update(
-      -1.0 * orthogon_condition_partial_xi_master_inverse, delta_r_deriv_r_xi_master, 1.0);
-
-
-  xi_master_partial_r_slave_partial_r_slave.multiply(
-      orthogon_condition_partial_xi_master_inverse * orthogon_condition_partial_xi_master_inverse,
-      r_xi_master_tensorproduct_r_xixi_master, delta_r_deriv_r_slave, 1.0);
-
-  xi_master_partial_r_slave_partial_r_master.multiply(
-      orthogon_condition_partial_xi_master_inverse * orthogon_condition_partial_xi_master_inverse,
-      r_xi_master_tensorproduct_r_xixi_master, delta_r_deriv_r_master, 1.0);
-
-  xi_master_partial_r_slave_partial_r_xi_master.multiply(
-      orthogon_condition_partial_xi_master_inverse * orthogon_condition_partial_xi_master_inverse,
-      r_xi_master_tensorproduct_r_xixi_master, delta_r_deriv_r_xi_master, 1.0);
+  xi_target_partial_r_xi_target_partial_r_xi_target.update(
+      -1.0 * orthogon_condition_partial_xi_target_inverse, delta_r_deriv_r_xi_target, 1.0);
 
 
-  xi_master_partial_r_master_partial_r_slave.multiply(
-      -1.0 * orthogon_condition_partial_xi_master_inverse *
-          orthogon_condition_partial_xi_master_inverse,
-      r_xi_master_tensorproduct_r_xixi_master, delta_r_deriv_r_slave, 1.0);
+  xi_target_partial_r_source_partial_r_source.multiply(
+      orthogon_condition_partial_xi_target_inverse * orthogon_condition_partial_xi_target_inverse,
+      r_xi_target_tensorproduct_r_xixi_target, delta_r_deriv_r_source, 1.0);
 
-  xi_master_partial_r_master_partial_r_master.multiply(
-      -1.0 * orthogon_condition_partial_xi_master_inverse *
-          orthogon_condition_partial_xi_master_inverse,
-      r_xi_master_tensorproduct_r_xixi_master, delta_r_deriv_r_master, 1.0);
+  xi_target_partial_r_source_partial_r_target.multiply(
+      orthogon_condition_partial_xi_target_inverse * orthogon_condition_partial_xi_target_inverse,
+      r_xi_target_tensorproduct_r_xixi_target, delta_r_deriv_r_target, 1.0);
 
-  xi_master_partial_r_master_partial_r_xi_master.multiply(
-      -1.0 * orthogon_condition_partial_xi_master_inverse *
-          orthogon_condition_partial_xi_master_inverse,
-      r_xi_master_tensorproduct_r_xixi_master, delta_r_deriv_r_xi_master, 1.0);
+  xi_target_partial_r_source_partial_r_xi_target.multiply(
+      orthogon_condition_partial_xi_target_inverse * orthogon_condition_partial_xi_target_inverse,
+      r_xi_target_tensorproduct_r_xixi_target, delta_r_deriv_r_xi_target, 1.0);
 
 
-  xi_master_partial_r_xi_master_partial_r_slave.multiply(
-      orthogon_condition_partial_xi_master_inverse * orthogon_condition_partial_xi_master_inverse,
-      delta_r_tensorproduct_r_xixi_master, delta_r_deriv_r_slave, 1.0);
+  xi_target_partial_r_target_partial_r_source.multiply(
+      -1.0 * orthogon_condition_partial_xi_target_inverse *
+          orthogon_condition_partial_xi_target_inverse,
+      r_xi_target_tensorproduct_r_xixi_target, delta_r_deriv_r_source, 1.0);
 
-  xi_master_partial_r_xi_master_partial_r_master.multiply(
-      orthogon_condition_partial_xi_master_inverse * orthogon_condition_partial_xi_master_inverse,
-      delta_r_tensorproduct_r_xixi_master, delta_r_deriv_r_master, 1.0);
+  xi_target_partial_r_target_partial_r_target.multiply(
+      -1.0 * orthogon_condition_partial_xi_target_inverse *
+          orthogon_condition_partial_xi_target_inverse,
+      r_xi_target_tensorproduct_r_xixi_target, delta_r_deriv_r_target, 1.0);
 
-  xi_master_partial_r_xi_master_partial_r_xi_master.multiply(
-      orthogon_condition_partial_xi_master_inverse * orthogon_condition_partial_xi_master_inverse,
-      delta_r_tensorproduct_r_xixi_master, delta_r_deriv_r_xi_master, 1.0);
+  xi_target_partial_r_target_partial_r_xi_target.multiply(
+      -1.0 * orthogon_condition_partial_xi_target_inverse *
+          orthogon_condition_partial_xi_target_inverse,
+      r_xi_target_tensorproduct_r_xixi_target, delta_r_deriv_r_xi_target, 1.0);
+
+
+  xi_target_partial_r_xi_target_partial_r_source.multiply(
+      orthogon_condition_partial_xi_target_inverse * orthogon_condition_partial_xi_target_inverse,
+      delta_r_tensorproduct_r_xixi_target, delta_r_deriv_r_source, 1.0);
+
+  xi_target_partial_r_xi_target_partial_r_target.multiply(
+      orthogon_condition_partial_xi_target_inverse * orthogon_condition_partial_xi_target_inverse,
+      delta_r_tensorproduct_r_xixi_target, delta_r_deriv_r_target, 1.0);
+
+  xi_target_partial_r_xi_target_partial_r_xi_target.multiply(
+      orthogon_condition_partial_xi_target_inverse * orthogon_condition_partial_xi_target_inverse,
+      delta_r_tensorproduct_r_xixi_target, delta_r_deriv_r_xi_target, 1.0);
 
 
   // 4)
@@ -564,17 +564,17 @@ void BeamInteraction::Geo::calc_point_to_curve_projection_parameter_coord_master
   {
     for (unsigned int icol = 0; icol < 3; ++icol)
     {
-      xi_master_partial_r_xi_master_partial_r_slave(irow, icol) +=
-          orthogon_condition_partial_xi_master_inverse * r_xi_master(irow) *
-          xi_master_partial_r_slave(icol);
+      xi_target_partial_r_xi_target_partial_r_source(irow, icol) +=
+          orthogon_condition_partial_xi_target_inverse * r_xi_target(irow) *
+          xi_target_partial_r_source(icol);
 
-      xi_master_partial_r_xi_master_partial_r_master(irow, icol) +=
-          orthogon_condition_partial_xi_master_inverse * r_xi_master(irow) *
-          xi_master_partial_r_master(icol);
+      xi_target_partial_r_xi_target_partial_r_target(irow, icol) +=
+          orthogon_condition_partial_xi_target_inverse * r_xi_target(irow) *
+          xi_target_partial_r_target(icol);
 
-      xi_master_partial_r_xi_master_partial_r_xi_master(irow, icol) +=
-          orthogon_condition_partial_xi_master_inverse * r_xi_master(irow) *
-          xi_master_partial_r_xi_master(icol);
+      xi_target_partial_r_xi_target_partial_r_xi_target(irow, icol) +=
+          orthogon_condition_partial_xi_target_inverse * r_xi_target(irow) *
+          xi_target_partial_r_xi_target(icol);
     }
   }
 
@@ -582,17 +582,17 @@ void BeamInteraction::Geo::calc_point_to_curve_projection_parameter_coord_master
   {
     for (unsigned int icol = 0; icol < 3; ++icol)
     {
-      xi_master_partial_r_xixi_master_partial_r_slave(irow, icol) -=
-          orthogon_condition_partial_xi_master_inverse * delta_r(irow) *
-          xi_master_partial_r_slave(icol);
+      xi_target_partial_r_xixi_target_partial_r_source(irow, icol) -=
+          orthogon_condition_partial_xi_target_inverse * delta_r(irow) *
+          xi_target_partial_r_source(icol);
 
-      xi_master_partial_r_xixi_master_partial_r_master(irow, icol) -=
-          orthogon_condition_partial_xi_master_inverse * delta_r(irow) *
-          xi_master_partial_r_master(icol);
+      xi_target_partial_r_xixi_target_partial_r_target(irow, icol) -=
+          orthogon_condition_partial_xi_target_inverse * delta_r(irow) *
+          xi_target_partial_r_target(icol);
 
-      xi_master_partial_r_xixi_master_partial_r_xi_master(irow, icol) -=
-          orthogon_condition_partial_xi_master_inverse * delta_r(irow) *
-          xi_master_partial_r_xi_master(icol);
+      xi_target_partial_r_xixi_target_partial_r_xi_target(irow, icol) -=
+          orthogon_condition_partial_xi_target_inverse * delta_r(irow) *
+          xi_target_partial_r_xi_target(icol);
     }
   }
 }
@@ -601,14 +601,14 @@ void BeamInteraction::Geo::calc_point_to_curve_projection_parameter_coord_master
  *-----------------------------------------------------------------------------------------------*/
 template <typename T>
 void BeamInteraction::Geo::
-    calc_ptc_projection_orthogonality_condition_partial_deriv_parameter_coord_master(
-        T& orthogon_condition_partial_xi_master, const Core::LinAlg::Matrix<3, 1, T>& delta_r,
-        const Core::LinAlg::Matrix<3, 1, T>& r_xi_master,
-        const Core::LinAlg::Matrix<3, 1, T>& r_xixi_master)
+    calc_ptc_projection_orthogonality_condition_partial_deriv_parameter_coord_target(
+        T& orthogon_condition_partial_xi_target, const Core::LinAlg::Matrix<3, 1, T>& delta_r,
+        const Core::LinAlg::Matrix<3, 1, T>& r_xi_target,
+        const Core::LinAlg::Matrix<3, 1, T>& r_xixi_target)
 {
-  orthogon_condition_partial_xi_master = -r_xi_master.dot(r_xi_master) + delta_r.dot(r_xixi_master);
+  orthogon_condition_partial_xi_target = -r_xi_target.dot(r_xi_target) + delta_r.dot(r_xixi_target);
 
-  if (std::abs(Core::FADUtils::cast_to_double(orthogon_condition_partial_xi_master)) <
+  if (std::abs(Core::FADUtils::cast_to_double(orthogon_condition_partial_xi_target)) <
       POINT_TO_CURVE_PROJECTION_NONUNIQUE_MINIMAL_DISTANCE_TOLERANCE)
     FOUR_C_THROW(
         "Linearization of point to line projection is zero, i.e. the minimal distance "
@@ -618,32 +618,32 @@ void BeamInteraction::Geo::
 /*-----------------------------------------------------------------------------------------------*
  *-----------------------------------------------------------------------------------------------*/
 template <typename T>
-void BeamInteraction::Geo::calc_ptc_projection_orthogonality_condition_partial_deriv_cl_pos_slave(
-    Core::LinAlg::Matrix<1, 3, T>& orthogon_condition_partial_r_slave,
-    const Core::LinAlg::Matrix<3, 1, T>& r_xi_master)
+void BeamInteraction::Geo::calc_ptc_projection_orthogonality_condition_partial_deriv_cl_pos_source(
+    Core::LinAlg::Matrix<1, 3, T>& orthogon_condition_partial_r_source,
+    const Core::LinAlg::Matrix<3, 1, T>& r_xi_target)
 {
-  orthogon_condition_partial_r_slave.update_t(r_xi_master);
+  orthogon_condition_partial_r_source.update_t(r_xi_target);
 }
 
 /*-----------------------------------------------------------------------------------------------*
  *-----------------------------------------------------------------------------------------------*/
 template <typename T>
-void BeamInteraction::Geo::calc_ptc_projection_orthogonality_condition_partial_deriv_cl_pos_master(
-    Core::LinAlg::Matrix<1, 3, T>& orthogon_condition_partial_r_master,
-    const Core::LinAlg::Matrix<3, 1, T>& r_xi_master)
+void BeamInteraction::Geo::calc_ptc_projection_orthogonality_condition_partial_deriv_cl_pos_target(
+    Core::LinAlg::Matrix<1, 3, T>& orthogon_condition_partial_r_target,
+    const Core::LinAlg::Matrix<3, 1, T>& r_xi_target)
 {
-  orthogon_condition_partial_r_master.update_t(-1.0, r_xi_master);
+  orthogon_condition_partial_r_target.update_t(-1.0, r_xi_target);
 }
 
 /*-----------------------------------------------------------------------------------------------*
  *-----------------------------------------------------------------------------------------------*/
 template <typename T>
 void BeamInteraction::Geo::
-    calc_ptc_projection_orthogonality_condition_partial_deriv_cl_tangent_master(
-        Core::LinAlg::Matrix<1, 3, T>& orthogon_condition_partial_r_xi_master,
+    calc_ptc_projection_orthogonality_condition_partial_deriv_cl_tangent_target(
+        Core::LinAlg::Matrix<1, 3, T>& orthogon_condition_partial_r_xi_target,
         const Core::LinAlg::Matrix<3, 1, T>& delta_r)
 {
-  orthogon_condition_partial_r_xi_master.update_t(delta_r);
+  orthogon_condition_partial_r_xi_target.update_t(delta_r);
 }
 
 /*-----------------------------------------------------------------------------------------------*
@@ -714,37 +714,37 @@ template bool BeamInteraction::Geo::point_to_curve_projection<2, 2, Sacado::Fad:
     const Core::FE::CellType&, double);
 
 template void
-BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coord_master<2, 1,
+BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coord_target<2, 1,
     double>(Core::LinAlg::Matrix<1, 6, double>&, Core::LinAlg::Matrix<1, 6, double>&,
     const Core::LinAlg::Matrix<3, 1, double>&, const Core::LinAlg::Matrix<3, 1, double>&,
     const Core::LinAlg::Matrix<3, 1, double>&, const Core::LinAlg::Matrix<3, 6, double>&,
     const Core::LinAlg::Matrix<3, 6, double>&, const Core::LinAlg::Matrix<3, 6, double>&);
 template void
-BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coord_master<3, 1,
+BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coord_target<3, 1,
     double>(Core::LinAlg::Matrix<1, 9, double>&, Core::LinAlg::Matrix<1, 9, double>&,
     const Core::LinAlg::Matrix<3, 1, double>&, const Core::LinAlg::Matrix<3, 1, double>&,
     const Core::LinAlg::Matrix<3, 1, double>&, const Core::LinAlg::Matrix<3, 9, double>&,
     const Core::LinAlg::Matrix<3, 9, double>&, const Core::LinAlg::Matrix<3, 9, double>&);
 template void
-BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coord_master<4, 1,
+BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coord_target<4, 1,
     double>(Core::LinAlg::Matrix<1, 12, double>&, Core::LinAlg::Matrix<1, 12, double>&,
     const Core::LinAlg::Matrix<3, 1, double>&, const Core::LinAlg::Matrix<3, 1, double>&,
     const Core::LinAlg::Matrix<3, 1, double>&, const Core::LinAlg::Matrix<3, 12, double>&,
     const Core::LinAlg::Matrix<3, 12, double>&, const Core::LinAlg::Matrix<3, 12, double>&);
 template void
-BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coord_master<5, 1,
+BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coord_target<5, 1,
     double>(Core::LinAlg::Matrix<1, 15, double>&, Core::LinAlg::Matrix<1, 15, double>&,
     const Core::LinAlg::Matrix<3, 1, double>&, const Core::LinAlg::Matrix<3, 1, double>&,
     const Core::LinAlg::Matrix<3, 1, double>&, const Core::LinAlg::Matrix<3, 15, double>&,
     const Core::LinAlg::Matrix<3, 15, double>&, const Core::LinAlg::Matrix<3, 15, double>&);
 template void
-BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coord_master<2, 2,
+BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coord_target<2, 2,
     double>(Core::LinAlg::Matrix<1, 12, double>&, Core::LinAlg::Matrix<1, 12, double>&,
     const Core::LinAlg::Matrix<3, 1, double>&, const Core::LinAlg::Matrix<3, 1, double>&,
     const Core::LinAlg::Matrix<3, 1, double>&, const Core::LinAlg::Matrix<3, 12, double>&,
     const Core::LinAlg::Matrix<3, 12, double>&, const Core::LinAlg::Matrix<3, 12, double>&);
 template void
-BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coord_master<2, 1,
+BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coord_target<2, 1,
     Sacado::Fad::DFad<double>>(Core::LinAlg::Matrix<1, 6, Sacado::Fad::DFad<double>>&,
     Core::LinAlg::Matrix<1, 6, Sacado::Fad::DFad<double>>&,
     const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
@@ -754,7 +754,7 @@ BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coo
     const Core::LinAlg::Matrix<3, 6, Sacado::Fad::DFad<double>>&,
     const Core::LinAlg::Matrix<3, 6, Sacado::Fad::DFad<double>>&);
 template void
-BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coord_master<3, 1,
+BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coord_target<3, 1,
     Sacado::Fad::DFad<double>>(Core::LinAlg::Matrix<1, 9, Sacado::Fad::DFad<double>>&,
     Core::LinAlg::Matrix<1, 9, Sacado::Fad::DFad<double>>&,
     const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
@@ -764,7 +764,7 @@ BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coo
     const Core::LinAlg::Matrix<3, 9, Sacado::Fad::DFad<double>>&,
     const Core::LinAlg::Matrix<3, 9, Sacado::Fad::DFad<double>>&);
 template void
-BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coord_master<4, 1,
+BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coord_target<4, 1,
     Sacado::Fad::DFad<double>>(Core::LinAlg::Matrix<1, 12, Sacado::Fad::DFad<double>>&,
     Core::LinAlg::Matrix<1, 12, Sacado::Fad::DFad<double>>&,
     const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
@@ -774,7 +774,7 @@ BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coo
     const Core::LinAlg::Matrix<3, 12, Sacado::Fad::DFad<double>>&,
     const Core::LinAlg::Matrix<3, 12, Sacado::Fad::DFad<double>>&);
 template void
-BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coord_master<5, 1,
+BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coord_target<5, 1,
     Sacado::Fad::DFad<double>>(Core::LinAlg::Matrix<1, 15, Sacado::Fad::DFad<double>>&,
     Core::LinAlg::Matrix<1, 15, Sacado::Fad::DFad<double>>&,
     const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
@@ -784,7 +784,7 @@ BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coo
     const Core::LinAlg::Matrix<3, 15, Sacado::Fad::DFad<double>>&,
     const Core::LinAlg::Matrix<3, 15, Sacado::Fad::DFad<double>>&);
 template void
-BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coord_master<2, 2,
+BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coord_target<2, 2,
     Sacado::Fad::DFad<double>>(Core::LinAlg::Matrix<1, 12, Sacado::Fad::DFad<double>>&,
     Core::LinAlg::Matrix<1, 12, Sacado::Fad::DFad<double>>&,
     const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
@@ -795,12 +795,12 @@ BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coo
     const Core::LinAlg::Matrix<3, 12, Sacado::Fad::DFad<double>>&);
 
 template void
-BeamInteraction::Geo::calc_point_to_curve_projection_parameter_coord_master_partial_derivs<double>(
+BeamInteraction::Geo::calc_point_to_curve_projection_parameter_coord_target_partial_derivs<double>(
     Core::LinAlg::Matrix<1, 3, double>&, Core::LinAlg::Matrix<1, 3, double>&,
     Core::LinAlg::Matrix<1, 3, double>&, const Core::LinAlg::Matrix<3, 1, double>&,
     const Core::LinAlg::Matrix<3, 1, double>&, const Core::LinAlg::Matrix<3, 1, double>&);
 template void BeamInteraction::Geo::
-    calc_point_to_curve_projection_parameter_coord_master_partial_derivs<Sacado::Fad::DFad<double>>(
+    calc_point_to_curve_projection_parameter_coord_target_partial_derivs<Sacado::Fad::DFad<double>>(
         Core::LinAlg::Matrix<1, 3, Sacado::Fad::DFad<double>>&,
         Core::LinAlg::Matrix<1, 3, Sacado::Fad::DFad<double>>&,
         Core::LinAlg::Matrix<1, 3, Sacado::Fad::DFad<double>>&,
@@ -809,7 +809,7 @@ template void BeamInteraction::Geo::
         const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&);
 
 template void BeamInteraction::Geo::
-    calc_point_to_curve_projection_parameter_coord_master_partial2nd_derivs<double>(
+    calc_point_to_curve_projection_parameter_coord_target_partial2nd_derivs<double>(
         Core::LinAlg::Matrix<3, 3, double>&, Core::LinAlg::Matrix<3, 3, double>&,
         Core::LinAlg::Matrix<3, 3, double>&, Core::LinAlg::Matrix<3, 3, double>&,
         Core::LinAlg::Matrix<3, 3, double>&, Core::LinAlg::Matrix<3, 3, double>&,
@@ -824,7 +824,7 @@ template void BeamInteraction::Geo::
         const Core::LinAlg::Matrix<3, 1, double>&, const Core::LinAlg::Matrix<3, 1, double>&,
         const Core::LinAlg::Matrix<3, 1, double>&);
 template void
-BeamInteraction::Geo::calc_point_to_curve_projection_parameter_coord_master_partial2nd_derivs<
+BeamInteraction::Geo::calc_point_to_curve_projection_parameter_coord_target_partial2nd_derivs<
     Sacado::Fad::DFad<double>>(Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
     Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
     Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,

--- a/src/beaminteraction/src/4C_beaminteraction_geometry_utils.hpp
+++ b/src/beaminteraction/src/4C_beaminteraction_geometry_utils.hpp
@@ -35,11 +35,11 @@ namespace BeamInteraction
      *
      */
     template <unsigned int numnodes, unsigned int numnodalvalues, typename T>
-    bool point_to_curve_projection(Core::LinAlg::Matrix<3, 1, T> const& r_slave, T& xi_master,
-        double const& xi_master_initial_guess,
+    bool point_to_curve_projection(Core::LinAlg::Matrix<3, 1, T> const& r_source, T& xi_target,
+        double const& xi_target_initial_guess,
         const Core::LinAlg::Matrix<3 * numnodes * numnodalvalues, 1, T>&
-            master_centerline_dof_values,
-        const Core::FE::CellType& master_distype, double master_ele_ref_length);
+            target_centerline_dof_values,
+        const Core::FE::CellType& target_distype, double target_ele_ref_length);
 
     /** \brief evaluates residual of orthogonality condition for so-called unilateral closest-point
      *         projection, i.e. a point-to-curve projection
@@ -48,7 +48,7 @@ namespace BeamInteraction
     template <typename T>
     void evaluate_point_to_curve_orthogonality_condition(T& f,
         const Core::LinAlg::Matrix<3, 1, T>& delta_r, const double norm_delta_r,
-        const Core::LinAlg::Matrix<3, 1, T>& r_xi_master);
+        const Core::LinAlg::Matrix<3, 1, T>& r_xi_target);
 
     /** \brief evaluates Jacobian of orthogonality condition for so-called unilateral closest-point
      *         projection, i.e. a point-to-curve projection
@@ -57,111 +57,111 @@ namespace BeamInteraction
     template <typename T>
     bool evaluate_linearization_point_to_curve_orthogonality_condition(T& df,
         const Core::LinAlg::Matrix<3, 1, T>& delta_r, const double norm_delta_r,
-        const Core::LinAlg::Matrix<3, 1, T>& r_xi_master,
-        const Core::LinAlg::Matrix<3, 1, T>& r_xixi_master);
+        const Core::LinAlg::Matrix<3, 1, T>& r_xi_target,
+        const Core::LinAlg::Matrix<3, 1, T>& r_xixi_target);
 
-    /** \brief compute linearization of parameter coordinate on master if determined by a
+    /** \brief compute linearization of parameter coordinate on target if determined by a
      *         point-to-curve projection
      *
      */
     template <unsigned int numnodes, unsigned int numnodalvalues, typename T>
-    void calc_linearization_point_to_curve_projection_parameter_coord_master(
-        Core::LinAlg::Matrix<1, 3 * numnodes * numnodalvalues, T>& lin_xi_master_slaveDofs,
-        Core::LinAlg::Matrix<1, 3 * numnodes * numnodalvalues, T>& lin_xi_master_masterDofs,
+    void calc_linearization_point_to_curve_projection_parameter_coord_target(
+        Core::LinAlg::Matrix<1, 3 * numnodes * numnodalvalues, T>& lin_xi_target_sourceDofs,
+        Core::LinAlg::Matrix<1, 3 * numnodes * numnodalvalues, T>& lin_xi_target_targetDofs,
         const Core::LinAlg::Matrix<3, 1, T>& delta_r,
-        const Core::LinAlg::Matrix<3, 1, T>& r_xi_master,
-        const Core::LinAlg::Matrix<3, 1, T>& r_xixi_master,
-        const Core::LinAlg::Matrix<3, 3 * numnodes * numnodalvalues, double>& N_slave,
-        const Core::LinAlg::Matrix<3, 3 * numnodes * numnodalvalues, T>& N_master,
-        const Core::LinAlg::Matrix<3, 3 * numnodes * numnodalvalues, T>& N_xi_master);
+        const Core::LinAlg::Matrix<3, 1, T>& r_xi_target,
+        const Core::LinAlg::Matrix<3, 1, T>& r_xixi_target,
+        const Core::LinAlg::Matrix<3, 3 * numnodes * numnodalvalues, double>& N_source,
+        const Core::LinAlg::Matrix<3, 3 * numnodes * numnodalvalues, T>& N_target,
+        const Core::LinAlg::Matrix<3, 3 * numnodes * numnodalvalues, T>& N_xi_target);
 
     /** \brief point-to-curve projection:
-     *         partial derivatives of the parameter coordinate on master xi_master with respect to
-     *         centerline position of slave point, master point and centerline tangent of master
+     *         partial derivatives of the parameter coordinate on target xi_target with respect to
+     *         centerline position of source point, target point and centerline tangent of target
      *
      */
     template <typename T>
-    void calc_point_to_curve_projection_parameter_coord_master_partial_derivs(
-        Core::LinAlg::Matrix<1, 3, T>& xi_master_partial_r_slave,
-        Core::LinAlg::Matrix<1, 3, T>& xi_master_partial_r_master,
-        Core::LinAlg::Matrix<1, 3, T>& xi_master_partial_r_xi_master,
+    void calc_point_to_curve_projection_parameter_coord_target_partial_derivs(
+        Core::LinAlg::Matrix<1, 3, T>& xi_target_partial_r_source,
+        Core::LinAlg::Matrix<1, 3, T>& xi_target_partial_r_target,
+        Core::LinAlg::Matrix<1, 3, T>& xi_target_partial_r_xi_target,
         const Core::LinAlg::Matrix<3, 1, T>& delta_r,
-        const Core::LinAlg::Matrix<3, 1, T>& r_xi_master,
-        const Core::LinAlg::Matrix<3, 1, T>& r_xixi_master);
+        const Core::LinAlg::Matrix<3, 1, T>& r_xi_target,
+        const Core::LinAlg::Matrix<3, 1, T>& r_xixi_target);
 
     /** \brief point-to-curve projection:
-     *         partial second derivatives of the parameter coordinate on master xi_master with
-     *         respect to centerline position of slave point, master point and centerline tangent of
-     *         master
+     *         partial second derivatives of the parameter coordinate on target xi_target with
+     *         respect to centerline position of source point, target point and centerline tangent
+     * of target
      *
      */
     template <typename T>
-    void calc_point_to_curve_projection_parameter_coord_master_partial2nd_derivs(
-        Core::LinAlg::Matrix<3, 3, T>& xi_master_partial_r_slave_partial_r_slave,
-        Core::LinAlg::Matrix<3, 3, T>& xi_master_partial_r_slave_partial_r_master,
-        Core::LinAlg::Matrix<3, 3, T>& xi_master_partial_r_slave_partial_r_xi_master,
-        Core::LinAlg::Matrix<3, 3, T>& xi_master_partial_r_slave_partial_r_xixi_master,
-        Core::LinAlg::Matrix<3, 3, T>& xi_master_partial_r_master_partial_r_slave,
-        Core::LinAlg::Matrix<3, 3, T>& xi_master_partial_r_master_partial_r_master,
-        Core::LinAlg::Matrix<3, 3, T>& xi_master_partial_r_master_partial_r_xi_master,
-        Core::LinAlg::Matrix<3, 3, T>& xi_master_partial_r_master_partial_r_xixi_master,
-        Core::LinAlg::Matrix<3, 3, T>& xi_master_partial_r_xi_master_partial_r_slave,
-        Core::LinAlg::Matrix<3, 3, T>& xi_master_partial_r_xi_master_partial_r_master,
-        Core::LinAlg::Matrix<3, 3, T>& xi_master_partial_r_xi_master_partial_r_xi_master,
-        Core::LinAlg::Matrix<3, 3, T>& xi_master_partial_r_xi_master_partial_r_xixi_master,
-        Core::LinAlg::Matrix<3, 3, T>& xi_master_partial_r_xixi_master_partial_r_slave,
-        Core::LinAlg::Matrix<3, 3, T>& xi_master_partial_r_xixi_master_partial_r_master,
-        Core::LinAlg::Matrix<3, 3, T>& xi_master_partial_r_xixi_master_partial_r_xi_master,
-        const Core::LinAlg::Matrix<1, 3, T>& xi_master_partial_r_slave,
-        const Core::LinAlg::Matrix<1, 3, T>& xi_master_partial_r_master,
-        const Core::LinAlg::Matrix<1, 3, T>& xi_master_partial_r_xi_master,
-        const Core::LinAlg::Matrix<3, 3, T>& delta_r_deriv_r_slave,
-        const Core::LinAlg::Matrix<3, 3, T>& delta_r_deriv_r_master,
-        const Core::LinAlg::Matrix<3, 3, T>& delta_r_deriv_r_xi_master,
+    void calc_point_to_curve_projection_parameter_coord_target_partial2nd_derivs(
+        Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_source_partial_r_source,
+        Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_source_partial_r_target,
+        Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_source_partial_r_xi_target,
+        Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_source_partial_r_xixi_target,
+        Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_target_partial_r_source,
+        Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_target_partial_r_target,
+        Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_target_partial_r_xi_target,
+        Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_target_partial_r_xixi_target,
+        Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_xi_target_partial_r_source,
+        Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_xi_target_partial_r_target,
+        Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_xi_target_partial_r_xi_target,
+        Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_xi_target_partial_r_xixi_target,
+        Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_xixi_target_partial_r_source,
+        Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_xixi_target_partial_r_target,
+        Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_xixi_target_partial_r_xi_target,
+        const Core::LinAlg::Matrix<1, 3, T>& xi_target_partial_r_source,
+        const Core::LinAlg::Matrix<1, 3, T>& xi_target_partial_r_target,
+        const Core::LinAlg::Matrix<1, 3, T>& xi_target_partial_r_xi_target,
+        const Core::LinAlg::Matrix<3, 3, T>& delta_r_deriv_r_source,
+        const Core::LinAlg::Matrix<3, 3, T>& delta_r_deriv_r_target,
+        const Core::LinAlg::Matrix<3, 3, T>& delta_r_deriv_r_xi_target,
         const Core::LinAlg::Matrix<3, 1, T>& delta_r,
-        const Core::LinAlg::Matrix<3, 1, T>& r_xi_master,
-        const Core::LinAlg::Matrix<3, 1, T>& r_xixi_master,
-        const Core::LinAlg::Matrix<3, 1, T>& r_xixixi_master);
+        const Core::LinAlg::Matrix<3, 1, T>& r_xi_target,
+        const Core::LinAlg::Matrix<3, 1, T>& r_xixi_target,
+        const Core::LinAlg::Matrix<3, 1, T>& r_xixixi_target);
 
     /** \brief point-to-curve projection:
      *         partial derivative of the orthogonality condition with respect to parameter
-     * coordinate on master xi_master
+     * coordinate on target xi_target
      *
      */
     template <typename T>
-    void calc_ptc_projection_orthogonality_condition_partial_deriv_parameter_coord_master(
-        T& orthogon_condition_partial_xi_master, const Core::LinAlg::Matrix<3, 1, T>& delta_r,
-        const Core::LinAlg::Matrix<3, 1, T>& r_xi_master,
-        const Core::LinAlg::Matrix<3, 1, T>& r_xixi_master);
+    void calc_ptc_projection_orthogonality_condition_partial_deriv_parameter_coord_target(
+        T& orthogon_condition_partial_xi_target, const Core::LinAlg::Matrix<3, 1, T>& delta_r,
+        const Core::LinAlg::Matrix<3, 1, T>& r_xi_target,
+        const Core::LinAlg::Matrix<3, 1, T>& r_xixi_target);
 
     /** \brief point-to-curve projection:
      *         partial derivative of the orthogonality condition with respect to centerline position
-     *         on slave
+     *         on source
      *
      */
     template <typename T>
-    void calc_ptc_projection_orthogonality_condition_partial_deriv_cl_pos_slave(
-        Core::LinAlg::Matrix<1, 3, T>& orthogon_condition_partial_r_slave,
-        const Core::LinAlg::Matrix<3, 1, T>& r_xi_master);
+    void calc_ptc_projection_orthogonality_condition_partial_deriv_cl_pos_source(
+        Core::LinAlg::Matrix<1, 3, T>& orthogon_condition_partial_r_source,
+        const Core::LinAlg::Matrix<3, 1, T>& r_xi_target);
 
     /** \brief point-to-curve projection:
      *         partial derivative of the orthogonality condition with respect to centerline position
-     *         on master
+     *         on target
      *
      */
     template <typename T>
-    void calc_ptc_projection_orthogonality_condition_partial_deriv_cl_pos_master(
-        Core::LinAlg::Matrix<1, 3, T>& orthogon_condition_partial_r_master,
-        const Core::LinAlg::Matrix<3, 1, T>& r_xi_master);
+    void calc_ptc_projection_orthogonality_condition_partial_deriv_cl_pos_target(
+        Core::LinAlg::Matrix<1, 3, T>& orthogon_condition_partial_r_target,
+        const Core::LinAlg::Matrix<3, 1, T>& r_xi_target);
 
     /** \brief point-to-curve projection:
      *         partial derivative of the orthogonality condition with respect to centerline tangent
-     *         on master
+     *         on target
      *
      */
     template <typename T>
-    void calc_ptc_projection_orthogonality_condition_partial_deriv_cl_tangent_master(
-        Core::LinAlg::Matrix<1, 3, T>& orthogon_condition_partial_r_xi_master,
+    void calc_ptc_projection_orthogonality_condition_partial_deriv_cl_tangent_target(
+        Core::LinAlg::Matrix<1, 3, T>& orthogon_condition_partial_r_xi_target,
         const Core::LinAlg::Matrix<3, 1, T>& delta_r);
 
     /** \brief calculate angle enclosed by two vectors a and b

--- a/src/beaminteraction/src/contact/beam_to_beam/4C_beaminteraction_contact_beam_to_beam_pair.cpp
+++ b/src/beaminteraction/src/contact/beam_to_beam/4C_beaminteraction_contact_beam_to_beam_pair.cpp
@@ -79,7 +79,7 @@ void BeamInteraction::BeamToBeamContactPair<numnodes, numnodalvalues>::setup()
   maxactivegap_ = get_max_active_dist();
 
   // In case we want to apply a segment-based integration at the endpoints of the physical beam (in
-  // order to avoid strong discontinuities in the integrand) we have to check, if a master beam
+  // order to avoid strong discontinuities in the integrand) we have to check, if a target beam
   // element node coincides with a beams endpoint!
   bool determine_neighbors = false;
   if (params()->beam_to_beam_contact_params()->end_point_penalty()) determine_neighbors = true;
@@ -169,8 +169,8 @@ void BeamInteraction::BeamToBeamContactPair<numnodes, numnodalvalues>::setup()
 
   if (l2 + 1.0e-8 < l1 / intintervals)
     FOUR_C_THROW(
-        "Length of second (master) beam has to be larger than length of one integration interval "
-        "on first (slave) beam!");
+        "Length of second (target) beam has to be larger than length of one integration interval "
+        "on first (source) beam!");
 
   if (gausspoints.nquad > 10) FOUR_C_THROW("So far, not more than 10 Gauss points are allowed!");
 
@@ -605,15 +605,15 @@ void BeamInteraction::BeamToBeamContactPair<numnodes, numnodalvalues>::get_activ
     std::vector<std::pair<double, double>> curintsegpairs;
     int size = inversepairs.size();
 
-    // All segment pairs for which the segment on the slave beam 1 intersects with the considered
+    // All segment pairs for which the segment on the source beam 1 intersects with the considered
     // integration interval are filtered out and stored in the vector curintsegpairs. These pairs
     // are relevant for the integration procedure on the current interval.
     for (int k = 0; k < size; k++)
     {
       double eta1_segleft = (inversepairs[size - 1 - k]).first;
       double eta1_segright = eta1_segleft + l1;
-      // Since the vector inversepairs is sorted with respect to the location of the slave segment
-      // (the slave segment with the lowest bounding parameter coordinates eta1_segleft and
+      // Since the vector inversepairs is sorted with respect to the location of the source segment
+      // (the source segment with the lowest bounding parameter coordinates eta1_segleft and
       // eta1_segright lie on the last position of the vector inversepairs), it is sufficient to
       // start with the last element and leave the k-loop as soon as we have found the first segment
       // pair without intersection. This procedure only works, if we delete a segment pair as soon
@@ -624,7 +624,7 @@ void BeamInteraction::BeamToBeamContactPair<numnodes, numnodalvalues>::get_activ
         // store relevant pairs in new vector
         curintsegpairs.push_back(inversepairs[size - 1 - k]);
 
-        //(*) In case eta1_segright (the largest parameter coordinate lying within the slave
+        //(*) In case eta1_segright (the largest parameter coordinate lying within the source
         // segment) is smaller than eta1_max(the upper bound of the integration interval), the
         // considered segment will not be relevant for the next integration interval at i+1 and can
         // be deleted.
@@ -650,12 +650,12 @@ void BeamInteraction::BeamToBeamContactPair<numnodes, numnodalvalues>::get_activ
         // integration points in parameter space and weights
         const double xi = gausspoints.qxg[numgp][0];
 
-        // Get Gauss point coordinate at slave element
-        double eta1_slave = 0.0;
+        // Get Gauss point coordinate at source element
+        double eta1_source = 0.0;
 
         // standard case of equidistant intervals
         // map from segment coordinate xi to element coordinate eta
-        eta1_slave = eta1_min + (1.0 + xi) / intintervals;
+        eta1_source = eta1_min + (1.0 + xi) / intintervals;
 
 
         for (int k = 0; k < (int)curintsegpairs.size(); k++)
@@ -666,30 +666,30 @@ void BeamInteraction::BeamToBeamContactPair<numnodes, numnodalvalues>::get_activ
           // TODO: This procedure can also be made more efficient by deleting all segments of
           // curintsegpairs which are not relevant for the following Gauss points anymore (see
           // intersection of integration intervals and segment pairs)
-          if (BeamInteraction::within_interval(eta1_slave, eta1_segleft, eta1_segright))
+          if (BeamInteraction::within_interval(eta1_source, eta1_segleft, eta1_segright))
           {
             double eta2_segleft = (curintsegpairs[k]).second;
-            double eta2_master = 0.0;
+            double eta2_target = 0.0;
             bool pairactive = false;
 
             double gap_dummy = 0.0;
             double alpha_dummy = 0.0;
 
-            bool solutionwithinsegment = point_to_line_projection(eta1_slave, eta2_segleft, l2,
-                eta2_master, gap_dummy, alpha_dummy, pairactive, true);
+            bool solutionwithinsegment = point_to_line_projection(eta1_source, eta2_segleft, l2,
+                eta2_target, gap_dummy, alpha_dummy, pairactive, true);
 
             if (solutionwithinsegment)
             {
               if (pairactive)
               {
-                TYPE eta1 = eta1_slave;
-                TYPE eta2 = eta2_master;
-                int leftpoint_id1 = BeamInteraction::get_segment_id(eta1_slave, numseg1_);
-                int leftpoint_id2 = BeamInteraction::get_segment_id(eta2_master, numseg2_);
+                TYPE eta1 = eta1_source;
+                TYPE eta2 = eta2_target;
+                int leftpoint_id1 = BeamInteraction::get_segment_id(eta1_source, numseg1_);
+                int leftpoint_id2 = BeamInteraction::get_segment_id(eta2_target, numseg2_);
                 std::pair<TYPE, TYPE> closestpoint(std::make_pair(eta1, eta2));
                 std::pair<int, int> integration_ids = std::make_pair(numgp, interval);
                 std::pair<int, int> leftpoint_ids = std::make_pair(leftpoint_id1, leftpoint_id2);
-                TYPE jacobi = get_jacobi_at_xi(element1(), eta1_slave) * jacobi_interval;
+                TYPE jacobi = get_jacobi_at_xi(element1(), eta1_source) * jacobi_interval;
 
                 const double parallel_pp =
                     params()->beam_to_beam_contact_params()->beam_to_beam_line_penalty_param();
@@ -704,7 +704,7 @@ void BeamInteraction::BeamToBeamContactPair<numnodes, numnodalvalues>::get_activ
                         closestpoint, leftpoint_ids, integration_ids, parallel_pp, jacobi));
               }
               // We can leave the k-loop as soon as we have found a valid projection for the given
-              // Gauss point eta1_slave
+              // Gauss point eta1_source
               break;
             }
           }
@@ -2318,7 +2318,7 @@ bool BeamInteraction::BeamToBeamContactPair<numnodes, numnodalvalues>::closest_p
  *----------------------------------------------------------------------*/
 template <unsigned int numnodes, unsigned int numnodalvalues>
 bool BeamInteraction::BeamToBeamContactPair<numnodes, numnodalvalues>::point_to_line_projection(
-    double& eta1_slave, double& eta_left2, double& l2, double& eta2_master, double& gap,
+    double& eta1_source, double& eta_left2, double& l2, double& eta2_target, double& gap,
     double& alpha, bool& pairactive, bool smallanglepair, bool invertpairs,
     bool orthogonalprojection)
 {
@@ -2384,7 +2384,7 @@ bool BeamInteraction::BeamToBeamContactPair<numnodes, numnodalvalues>::point_to_
     double residual0 = 0.0;
     int iter = 0;
 
-    TYPE eta1 = eta1_slave;
+    TYPE eta1 = eta1_source;
     TYPE eta2 = startingpoints[numstartpoint];
     double eta2_old = Core::FADUtils::cast_to_double(eta2);
 
@@ -2418,9 +2418,9 @@ bool BeamInteraction::BeamToBeamContactPair<numnodes, numnodalvalues>::point_to_
       if (inversion_possible)
       {
         // In the case of ENDPOINTPENALTY it can be necessary to make an
-        // invere projection (from the master beam onto the slave beam). In this case, the local
+        // inverse projection (from the target beam onto the source beam). In this case, the local
         // variables (e.g. r1, r1_xi...) inside point_to_line_projection() with index 1 represent
-        // the master beam which has the global index 2. In order to get the right nodal positions
+        // the target beam which has the global index 2. In order to get the right nodal positions
         // ele2pos_ for the local variables r1, r1_xi, r1_xixi, we have to invert the arguments of
         // the function call compute_coords_and_derivs()!
         if (!invertpairs)
@@ -2558,7 +2558,7 @@ bool BeamInteraction::BeamToBeamContactPair<numnodes, numnodalvalues>::point_to_
 
       eta2_old = Core::FADUtils::cast_to_double(eta2);
 
-      // update master element coordinate of contact point
+      // update target element coordinate of contact point
       eta2 += -f / df;
 
 #ifdef FADCHECKS
@@ -2652,7 +2652,7 @@ bool BeamInteraction::BeamToBeamContactPair<numnodes, numnodalvalues>::point_to_
         }
         if (check_contact_status(gap_test) and relevant_angle) pairactive = true;
 
-        eta2_master = Core::FADUtils::cast_to_double(eta2);
+        eta2_target = Core::FADUtils::cast_to_double(eta2);
 
         // Here, we perform an additional security check: If a unique CCP solution exists, the
         // Newton scheme should find it with the first starting point. Otherwise, the problem may be
@@ -2687,7 +2687,7 @@ void BeamInteraction::BeamToBeamContactPair<numnodes,
     double& l1, double& l2, double& eta1_min, double& eta2_min, double& g_min, double& alpha_g_min,
     bool& pointtolinesolfound)
 {
-  // Calculate initial length of slave element
+  // Calculate initial length of source element
   Core::LinAlg::Matrix<3, 1, double> lengthvec1(Core::LinAlg::Initialization::zero);
   for (int i = 0; i < 3; i++)
   {
@@ -2697,7 +2697,7 @@ void BeamInteraction::BeamToBeamContactPair<numnodes,
   double length1 = lengthvec1.norm2();
 
   int n = 1;
-  // subdivide the slave segment by n+1 test points until the distance between the
+  // subdivide the source segment by n+1 test points until the distance between the
   // test points is smaller than half of the cross-section radius
   while (l1 / 2 * length1 / n > r2_ / 2)
   {
@@ -2709,15 +2709,15 @@ void BeamInteraction::BeamToBeamContactPair<numnodes,
 
   for (int i = 0; i < n + 1; i++)
   {
-    double eta1_slave = eta_left1 + i * l1 / n;
+    double eta1_source = eta_left1 + i * l1 / n;
     double eta2_segleft = eta_left2;
-    double eta2_master = 0.0;
+    double eta2_target = 0.0;
     bool pairactive = false;
     double gap = 0.0;
     double alpha = 0.0;
 
     bool solutionwithinsegment = point_to_line_projection(
-        eta1_slave, eta2_segleft, l2, eta2_master, gap, alpha, pairactive, true);
+        eta1_source, eta2_segleft, l2, eta2_target, gap, alpha, pairactive, true);
 
     if (solutionwithinsegment)
     {
@@ -2726,8 +2726,8 @@ void BeamInteraction::BeamToBeamContactPair<numnodes,
       {
         g_min = gap;
         alpha_g_min = alpha;
-        eta1_closestpoint = eta1_slave;
-        eta2_closestpoint = eta2_master;
+        eta1_closestpoint = eta1_source;
+        eta2_closestpoint = eta2_target;
       }  // search also for the second-smallest gap
     }
   }
@@ -2737,15 +2737,15 @@ void BeamInteraction::BeamToBeamContactPair<numnodes,
   // if we have a boundary minimum on the left, we also investigate the left neighbor point
   if (fabs(eta1_closestpoint - eta_left1) < 1.0e-10)
   {
-    double eta1_slave = eta_left1 - l1 / n;
+    double eta1_source = eta_left1 - l1 / n;
     double eta2_segleft = eta_left2;
-    double eta2_master = 0.0;
+    double eta2_target = 0.0;
     bool pairactive = false;
     double gap = 0.0;
     double alpha = 0.0;
 
     bool solutionwithinsegment = point_to_line_projection(
-        eta1_slave, eta2_segleft, l2, eta2_master, gap, alpha, pairactive, true);
+        eta1_source, eta2_segleft, l2, eta2_target, gap, alpha, pairactive, true);
 
     if (solutionwithinsegment)
     {
@@ -2754,8 +2754,8 @@ void BeamInteraction::BeamToBeamContactPair<numnodes,
         cp_at_right_neighbor = true;
         g_min = gap;
         alpha_g_min = alpha;
-        eta1_closestpoint = eta1_slave;
-        eta2_closestpoint = eta2_master;
+        eta1_closestpoint = eta1_source;
+        eta2_closestpoint = eta2_target;
       }  // search also for the second-smallest gap
     }
   }
@@ -2763,15 +2763,15 @@ void BeamInteraction::BeamToBeamContactPair<numnodes,
   // if we have a boundary minimum on the right, we also investigate the right neighbor point
   if (fabs(eta1_closestpoint - (eta_left1 + l1)) < 1.0e-10)
   {
-    double eta1_slave = eta_left1 + (n + 1) * l1 / n;
+    double eta1_source = eta_left1 + (n + 1) * l1 / n;
     double eta2_segleft = eta_left2;
-    double eta2_master = 0.0;
+    double eta2_target = 0.0;
     bool pairactive = false;
     double gap = 0.0;
     double alpha = 0.0;
 
     bool solutionwithinsegment = point_to_line_projection(
-        eta1_slave, eta2_segleft, l2, eta2_master, gap, alpha, pairactive, true);
+        eta1_source, eta2_segleft, l2, eta2_target, gap, alpha, pairactive, true);
 
     if (solutionwithinsegment)
     {
@@ -2784,8 +2784,8 @@ void BeamInteraction::BeamToBeamContactPair<numnodes,
 
         g_min = gap;
         alpha_g_min = alpha;
-        eta1_closestpoint = eta1_slave;
-        eta2_closestpoint = eta2_master;
+        eta1_closestpoint = eta1_source;
+        eta2_closestpoint = eta2_target;
       }  // search also for the second-smallest gap
     }
   }
@@ -4270,8 +4270,8 @@ bool BeamInteraction::BeamToBeamContactPair<numnodes,
     }
   }
 
-  // check, if df=0: This can happen e.g. when the master beam 2 describes a circle geometry and the
-  // projectiong slave point coincides with the cetern of the circle
+  // check, if df=0: This can happen e.g. when the target beam 2 describes a circle geometry and the
+  // projectiong source point coincides with the cetern of the circle
 
   if (fabs(Core::FADUtils::cast_to_double(df)) < COLLINEARTOL)
     return false;

--- a/src/beaminteraction/src/contact/beam_to_beam/4C_beaminteraction_contact_beam_to_beam_pair.hpp
+++ b/src/beaminteraction/src/contact/beam_to_beam/4C_beaminteraction_contact_beam_to_beam_pair.hpp
@@ -191,11 +191,11 @@ namespace BeamInteraction
     //! bound for search of small angle contact segment pairs
     double deltasmallangle_;
 
-    //! Indicates if the left / right node of the slave element 1 coincides with the endpoint of the
-    //! physical beam (true) or not (false)
+    //! Indicates if the left / right node of the source element 1 coincides with the endpoint of
+    //! the physical beam (true) or not (false)
     std::pair<bool, bool> boundarynode1_;
 
-    //! Indicates if the left / right node of the master element 2 coincides with the endpoint of
+    //! Indicates if the left / right node of the target element 2 coincides with the endpoint of
     //! the physical beam (true) or not (false)
     std::pair<bool, bool> boundarynode2_;
 
@@ -281,10 +281,10 @@ namespace BeamInteraction
         int segid1, int segid2);
 
     /*!
-    \brief Find closest point eta2_master on a line for a given slave point eta1_slave
+    \brief Find closest point eta2_target on a line for a given source point eta1_source
     */
-    bool point_to_line_projection(double& eta1_slave, double& eta_left2, double& l2,
-        double& eta2_master, double& gap, double& alpha, bool& pairactive, bool smallanglepair,
+    bool point_to_line_projection(double& eta1_source, double& eta_left2, double& l2,
+        double& eta2_target, double& gap, double& alpha, bool& pairactive, bool smallanglepair,
         bool invertpairs = false, bool orthogonalprojection = false);
 
     /*!

--- a/src/beaminteraction/src/potential/4C_beaminteraction_potential_geometry_utils.cpp
+++ b/src/beaminteraction/src/potential/4C_beaminteraction_potential_geometry_utils.cpp
@@ -5,7 +5,7 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
-#include "4C_beaminteraction_geometry_utils.hpp"
+#include "4C_beaminteraction_potential_geometry_utils.hpp"
 
 #include "4C_beam3_spatial_discretization_utils.hpp"
 #include "4C_io_pstream.hpp"
@@ -18,8 +18,9 @@ FOUR_C_NAMESPACE_OPEN
 /*-----------------------------------------------------------------------------------------------*
  *-----------------------------------------------------------------------------------------------*/
 template <unsigned int numnodes, unsigned int numnodalvalues, typename T>
-bool BeamInteraction::Geo::point_to_curve_projection(Core::LinAlg::Matrix<3, 1, T> const& r_source,
-    T& xi_target, double const& xi_target_initial_guess,
+bool BeamInteraction::Potential::Geo::point_to_curve_projection(
+    Core::LinAlg::Matrix<3, 1, T> const& r_source, T& xi_target,
+    double const& xi_target_initial_guess,
     const Core::LinAlg::Matrix<3 * numnodes * numnodalvalues, 1, T>& target_centerline_dof_values,
     const Core::FE::CellType& target_distype, double target_ele_ref_length)
 {
@@ -138,7 +139,7 @@ bool BeamInteraction::Geo::point_to_curve_projection(Core::LinAlg::Matrix<3, 1, 
 /*-----------------------------------------------------------------------------------------------*
  *-----------------------------------------------------------------------------------------------*/
 template <typename T>
-void BeamInteraction::Geo::evaluate_point_to_curve_orthogonality_condition(T& f,
+void BeamInteraction::Potential::Geo::evaluate_point_to_curve_orthogonality_condition(T& f,
     const Core::LinAlg::Matrix<3, 1, T>& delta_r, const double norm_delta_r,
     const Core::LinAlg::Matrix<3, 1, T>& r_xi_target)
 {
@@ -155,8 +156,8 @@ void BeamInteraction::Geo::evaluate_point_to_curve_orthogonality_condition(T& f,
 /*-----------------------------------------------------------------------------------------------*
  *-----------------------------------------------------------------------------------------------*/
 template <typename T>
-bool BeamInteraction::Geo::evaluate_linearization_point_to_curve_orthogonality_condition(T& df,
-    const Core::LinAlg::Matrix<3, 1, T>& delta_r, const double norm_delta_r,
+bool BeamInteraction::Potential::Geo::evaluate_linearization_point_to_curve_orthogonality_condition(
+    T& df, const Core::LinAlg::Matrix<3, 1, T>& delta_r, const double norm_delta_r,
     const Core::LinAlg::Matrix<3, 1, T>& r_xi_target,
     const Core::LinAlg::Matrix<3, 1, T>& r_xixi_target)
 {
@@ -182,14 +183,16 @@ bool BeamInteraction::Geo::evaluate_linearization_point_to_curve_orthogonality_c
 /*-----------------------------------------------------------------------------------------------*
  *-----------------------------------------------------------------------------------------------*/
 template <unsigned int numnodes, unsigned int numnodalvalues, typename T>
-void BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coord_target(
-    Core::LinAlg::Matrix<1, 3 * numnodes * numnodalvalues, T>& lin_xi_target_sourceDofs,
-    Core::LinAlg::Matrix<1, 3 * numnodes * numnodalvalues, T>& lin_xi_target_targetDofs,
-    const Core::LinAlg::Matrix<3, 1, T>& delta_r, const Core::LinAlg::Matrix<3, 1, T>& r_xi_target,
-    const Core::LinAlg::Matrix<3, 1, T>& r_xixi_target,
-    const Core::LinAlg::Matrix<3, 3 * numnodes * numnodalvalues, double>& N_source,
-    const Core::LinAlg::Matrix<3, 3 * numnodes * numnodalvalues, T>& N_target,
-    const Core::LinAlg::Matrix<3, 3 * numnodes * numnodalvalues, T>& N_xi_target)
+void BeamInteraction::Potential::Geo::
+    calc_linearization_point_to_curve_projection_parameter_coord_target(
+        Core::LinAlg::Matrix<1, 3 * numnodes * numnodalvalues, T>& lin_xi_target_sourceDofs,
+        Core::LinAlg::Matrix<1, 3 * numnodes * numnodalvalues, T>& lin_xi_target_targetDofs,
+        const Core::LinAlg::Matrix<3, 1, T>& delta_r,
+        const Core::LinAlg::Matrix<3, 1, T>& r_xi_target,
+        const Core::LinAlg::Matrix<3, 1, T>& r_xixi_target,
+        const Core::LinAlg::Matrix<3, 3 * numnodes * numnodalvalues, double>& N_source,
+        const Core::LinAlg::Matrix<3, 3 * numnodes * numnodalvalues, T>& N_target,
+        const Core::LinAlg::Matrix<3, 3 * numnodes * numnodalvalues, T>& N_xi_target)
 {
   const unsigned int dim1 = 3 * numnodes * numnodalvalues;
   const unsigned int dim2 = 3 * numnodes * numnodalvalues;
@@ -248,12 +251,14 @@ void BeamInteraction::Geo::calc_linearization_point_to_curve_projection_paramete
 /*-----------------------------------------------------------------------------------------------*
  *-----------------------------------------------------------------------------------------------*/
 template <typename T>
-void BeamInteraction::Geo::calc_point_to_curve_projection_parameter_coord_target_partial_derivs(
-    Core::LinAlg::Matrix<1, 3, T>& xi_target_partial_r_source,
-    Core::LinAlg::Matrix<1, 3, T>& xi_target_partial_r_target,
-    Core::LinAlg::Matrix<1, 3, T>& xi_target_partial_r_xi_target,
-    const Core::LinAlg::Matrix<3, 1, T>& delta_r, const Core::LinAlg::Matrix<3, 1, T>& r_xi_target,
-    const Core::LinAlg::Matrix<3, 1, T>& r_xixi_target)
+void BeamInteraction::Potential::Geo::
+    calc_point_to_curve_projection_parameter_coord_target_partial_derivs(
+        Core::LinAlg::Matrix<1, 3, T>& xi_target_partial_r_source,
+        Core::LinAlg::Matrix<1, 3, T>& xi_target_partial_r_target,
+        Core::LinAlg::Matrix<1, 3, T>& xi_target_partial_r_xi_target,
+        const Core::LinAlg::Matrix<3, 1, T>& delta_r,
+        const Core::LinAlg::Matrix<3, 1, T>& r_xi_target,
+        const Core::LinAlg::Matrix<3, 1, T>& r_xixi_target)
 {
   /* partial derivative of the orthogonality condition with respect to parameter coordinate on
    * target xi_target */
@@ -296,31 +301,33 @@ void BeamInteraction::Geo::calc_point_to_curve_projection_parameter_coord_target
 /*-----------------------------------------------------------------------------------------------*
  *-----------------------------------------------------------------------------------------------*/
 template <typename T>
-void BeamInteraction::Geo::calc_point_to_curve_projection_parameter_coord_target_partial2nd_derivs(
-    Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_source_partial_r_source,
-    Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_source_partial_r_target,
-    Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_source_partial_r_xi_target,
-    Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_source_partial_r_xixi_target,
-    Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_target_partial_r_source,
-    Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_target_partial_r_target,
-    Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_target_partial_r_xi_target,
-    Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_target_partial_r_xixi_target,
-    Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_xi_target_partial_r_source,
-    Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_xi_target_partial_r_target,
-    Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_xi_target_partial_r_xi_target,
-    Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_xi_target_partial_r_xixi_target,
-    Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_xixi_target_partial_r_source,
-    Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_xixi_target_partial_r_target,
-    Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_xixi_target_partial_r_xi_target,
-    const Core::LinAlg::Matrix<1, 3, T>& xi_target_partial_r_source,
-    const Core::LinAlg::Matrix<1, 3, T>& xi_target_partial_r_target,
-    const Core::LinAlg::Matrix<1, 3, T>& xi_target_partial_r_xi_target,
-    const Core::LinAlg::Matrix<3, 3, T>& delta_r_deriv_r_source,
-    const Core::LinAlg::Matrix<3, 3, T>& delta_r_deriv_r_target,
-    const Core::LinAlg::Matrix<3, 3, T>& delta_r_deriv_r_xi_target,
-    const Core::LinAlg::Matrix<3, 1, T>& delta_r, const Core::LinAlg::Matrix<3, 1, T>& r_xi_target,
-    const Core::LinAlg::Matrix<3, 1, T>& r_xixi_target,
-    const Core::LinAlg::Matrix<3, 1, T>& r_xixixi_target)
+void BeamInteraction::Potential::Geo::
+    calc_point_to_curve_projection_parameter_coord_target_partial2nd_derivs(
+        Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_source_partial_r_source,
+        Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_source_partial_r_target,
+        Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_source_partial_r_xi_target,
+        Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_source_partial_r_xixi_target,
+        Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_target_partial_r_source,
+        Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_target_partial_r_target,
+        Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_target_partial_r_xi_target,
+        Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_target_partial_r_xixi_target,
+        Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_xi_target_partial_r_source,
+        Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_xi_target_partial_r_target,
+        Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_xi_target_partial_r_xi_target,
+        Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_xi_target_partial_r_xixi_target,
+        Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_xixi_target_partial_r_source,
+        Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_xixi_target_partial_r_target,
+        Core::LinAlg::Matrix<3, 3, T>& xi_target_partial_r_xixi_target_partial_r_xi_target,
+        const Core::LinAlg::Matrix<1, 3, T>& xi_target_partial_r_source,
+        const Core::LinAlg::Matrix<1, 3, T>& xi_target_partial_r_target,
+        const Core::LinAlg::Matrix<1, 3, T>& xi_target_partial_r_xi_target,
+        const Core::LinAlg::Matrix<3, 3, T>& delta_r_deriv_r_source,
+        const Core::LinAlg::Matrix<3, 3, T>& delta_r_deriv_r_target,
+        const Core::LinAlg::Matrix<3, 3, T>& delta_r_deriv_r_xi_target,
+        const Core::LinAlg::Matrix<3, 1, T>& delta_r,
+        const Core::LinAlg::Matrix<3, 1, T>& r_xi_target,
+        const Core::LinAlg::Matrix<3, 1, T>& r_xixi_target,
+        const Core::LinAlg::Matrix<3, 1, T>& r_xixixi_target)
 {
   //  Fixme: the (out) variables should be called (...)_partial_(...)_deriv_(...) !
 
@@ -600,7 +607,7 @@ void BeamInteraction::Geo::calc_point_to_curve_projection_parameter_coord_target
 /*-----------------------------------------------------------------------------------------------*
  *-----------------------------------------------------------------------------------------------*/
 template <typename T>
-void BeamInteraction::Geo::
+void BeamInteraction::Potential::Geo::
     calc_ptc_projection_orthogonality_condition_partial_deriv_parameter_coord_target(
         T& orthogon_condition_partial_xi_target, const Core::LinAlg::Matrix<3, 1, T>& delta_r,
         const Core::LinAlg::Matrix<3, 1, T>& r_xi_target,
@@ -618,9 +625,10 @@ void BeamInteraction::Geo::
 /*-----------------------------------------------------------------------------------------------*
  *-----------------------------------------------------------------------------------------------*/
 template <typename T>
-void BeamInteraction::Geo::calc_ptc_projection_orthogonality_condition_partial_deriv_cl_pos_source(
-    Core::LinAlg::Matrix<1, 3, T>& orthogon_condition_partial_r_source,
-    const Core::LinAlg::Matrix<3, 1, T>& r_xi_target)
+void BeamInteraction::Potential::Geo::
+    calc_ptc_projection_orthogonality_condition_partial_deriv_cl_pos_source(
+        Core::LinAlg::Matrix<1, 3, T>& orthogon_condition_partial_r_source,
+        const Core::LinAlg::Matrix<3, 1, T>& r_xi_target)
 {
   orthogon_condition_partial_r_source.update_t(r_xi_target);
 }
@@ -628,9 +636,10 @@ void BeamInteraction::Geo::calc_ptc_projection_orthogonality_condition_partial_d
 /*-----------------------------------------------------------------------------------------------*
  *-----------------------------------------------------------------------------------------------*/
 template <typename T>
-void BeamInteraction::Geo::calc_ptc_projection_orthogonality_condition_partial_deriv_cl_pos_target(
-    Core::LinAlg::Matrix<1, 3, T>& orthogon_condition_partial_r_target,
-    const Core::LinAlg::Matrix<3, 1, T>& r_xi_target)
+void BeamInteraction::Potential::Geo::
+    calc_ptc_projection_orthogonality_condition_partial_deriv_cl_pos_target(
+        Core::LinAlg::Matrix<1, 3, T>& orthogon_condition_partial_r_target,
+        const Core::LinAlg::Matrix<3, 1, T>& r_xi_target)
 {
   orthogon_condition_partial_r_target.update_t(-1.0, r_xi_target);
 }
@@ -638,7 +647,7 @@ void BeamInteraction::Geo::calc_ptc_projection_orthogonality_condition_partial_d
 /*-----------------------------------------------------------------------------------------------*
  *-----------------------------------------------------------------------------------------------*/
 template <typename T>
-void BeamInteraction::Geo::
+void BeamInteraction::Potential::Geo::
     calc_ptc_projection_orthogonality_condition_partial_deriv_cl_tangent_target(
         Core::LinAlg::Matrix<1, 3, T>& orthogon_condition_partial_r_xi_target,
         const Core::LinAlg::Matrix<3, 1, T>& delta_r)
@@ -649,7 +658,7 @@ void BeamInteraction::Geo::
 /*-----------------------------------------------------------------------------------------------*
  *-----------------------------------------------------------------------------------------------*/
 template <typename T>
-void BeamInteraction::Geo::calc_enclosed_angle(T& angle, T& cosine_angle,
+void BeamInteraction::Potential::Geo::calc_enclosed_angle(T& angle, T& cosine_angle,
     const Core::LinAlg::Matrix<3, 1, T>& a, const Core::LinAlg::Matrix<3, 1, T>& b)
 {
   if (Core::FADUtils::vector_norm(a) < 1.0e-12 or Core::FADUtils::vector_norm(b) < 1.0e-12)
@@ -677,129 +686,134 @@ void BeamInteraction::Geo::calc_enclosed_angle(T& angle, T& cosine_angle,
 
 
 // explicit template instantiations
-template bool BeamInteraction::Geo::point_to_curve_projection<2, 1, double>(
+template bool BeamInteraction::Potential::Geo::point_to_curve_projection<2, 1, double>(
     Core::LinAlg::Matrix<3, 1, double> const&, double&, double const&,
     const Core::LinAlg::Matrix<6, 1, double>&, const Core::FE::CellType&, double);
-template bool BeamInteraction::Geo::point_to_curve_projection<3, 1, double>(
+template bool BeamInteraction::Potential::Geo::point_to_curve_projection<3, 1, double>(
     Core::LinAlg::Matrix<3, 1, double> const&, double&, double const&,
     const Core::LinAlg::Matrix<9, 1, double>&, const Core::FE::CellType&, double);
-template bool BeamInteraction::Geo::point_to_curve_projection<4, 1, double>(
+template bool BeamInteraction::Potential::Geo::point_to_curve_projection<4, 1, double>(
     Core::LinAlg::Matrix<3, 1, double> const&, double&, double const&,
     const Core::LinAlg::Matrix<12, 1, double>&, const Core::FE::CellType&, double);
-template bool BeamInteraction::Geo::point_to_curve_projection<5, 1, double>(
+template bool BeamInteraction::Potential::Geo::point_to_curve_projection<5, 1, double>(
     Core::LinAlg::Matrix<3, 1, double> const&, double&, double const&,
     const Core::LinAlg::Matrix<15, 1, double>&, const Core::FE::CellType&, double);
-template bool BeamInteraction::Geo::point_to_curve_projection<2, 2, double>(
+template bool BeamInteraction::Potential::Geo::point_to_curve_projection<2, 2, double>(
     Core::LinAlg::Matrix<3, 1, double> const&, double&, double const&,
     const Core::LinAlg::Matrix<12, 1, double>&, const Core::FE::CellType&, double);
-template bool BeamInteraction::Geo::point_to_curve_projection<2, 1, Sacado::Fad::DFad<double>>(
+template bool
+BeamInteraction::Potential::Geo::point_to_curve_projection<2, 1, Sacado::Fad::DFad<double>>(
     Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>> const&, Sacado::Fad::DFad<double>&,
     double const&, const Core::LinAlg::Matrix<6, 1, Sacado::Fad::DFad<double>>&,
     const Core::FE::CellType&, double);
-template bool BeamInteraction::Geo::point_to_curve_projection<3, 1, Sacado::Fad::DFad<double>>(
+template bool
+BeamInteraction::Potential::Geo::point_to_curve_projection<3, 1, Sacado::Fad::DFad<double>>(
     Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>> const&, Sacado::Fad::DFad<double>&,
     double const&, const Core::LinAlg::Matrix<9, 1, Sacado::Fad::DFad<double>>&,
     const Core::FE::CellType&, double);
-template bool BeamInteraction::Geo::point_to_curve_projection<4, 1, Sacado::Fad::DFad<double>>(
+template bool
+BeamInteraction::Potential::Geo::point_to_curve_projection<4, 1, Sacado::Fad::DFad<double>>(
     Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>> const&, Sacado::Fad::DFad<double>&,
     double const&, const Core::LinAlg::Matrix<12, 1, Sacado::Fad::DFad<double>>&,
     const Core::FE::CellType&, double);
-template bool BeamInteraction::Geo::point_to_curve_projection<5, 1, Sacado::Fad::DFad<double>>(
+template bool
+BeamInteraction::Potential::Geo::point_to_curve_projection<5, 1, Sacado::Fad::DFad<double>>(
     Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>> const&, Sacado::Fad::DFad<double>&,
     double const&, const Core::LinAlg::Matrix<15, 1, Sacado::Fad::DFad<double>>&,
     const Core::FE::CellType&, double);
-template bool BeamInteraction::Geo::point_to_curve_projection<2, 2, Sacado::Fad::DFad<double>>(
+template bool
+BeamInteraction::Potential::Geo::point_to_curve_projection<2, 2, Sacado::Fad::DFad<double>>(
     Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>> const&, Sacado::Fad::DFad<double>&,
     double const&, const Core::LinAlg::Matrix<12, 1, Sacado::Fad::DFad<double>>&,
     const Core::FE::CellType&, double);
 
-template void
-BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coord_target<2, 1,
-    double>(Core::LinAlg::Matrix<1, 6, double>&, Core::LinAlg::Matrix<1, 6, double>&,
-    const Core::LinAlg::Matrix<3, 1, double>&, const Core::LinAlg::Matrix<3, 1, double>&,
-    const Core::LinAlg::Matrix<3, 1, double>&, const Core::LinAlg::Matrix<3, 6, double>&,
-    const Core::LinAlg::Matrix<3, 6, double>&, const Core::LinAlg::Matrix<3, 6, double>&);
-template void
-BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coord_target<3, 1,
-    double>(Core::LinAlg::Matrix<1, 9, double>&, Core::LinAlg::Matrix<1, 9, double>&,
-    const Core::LinAlg::Matrix<3, 1, double>&, const Core::LinAlg::Matrix<3, 1, double>&,
-    const Core::LinAlg::Matrix<3, 1, double>&, const Core::LinAlg::Matrix<3, 9, double>&,
-    const Core::LinAlg::Matrix<3, 9, double>&, const Core::LinAlg::Matrix<3, 9, double>&);
-template void
-BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coord_target<4, 1,
-    double>(Core::LinAlg::Matrix<1, 12, double>&, Core::LinAlg::Matrix<1, 12, double>&,
-    const Core::LinAlg::Matrix<3, 1, double>&, const Core::LinAlg::Matrix<3, 1, double>&,
-    const Core::LinAlg::Matrix<3, 1, double>&, const Core::LinAlg::Matrix<3, 12, double>&,
-    const Core::LinAlg::Matrix<3, 12, double>&, const Core::LinAlg::Matrix<3, 12, double>&);
-template void
-BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coord_target<5, 1,
-    double>(Core::LinAlg::Matrix<1, 15, double>&, Core::LinAlg::Matrix<1, 15, double>&,
-    const Core::LinAlg::Matrix<3, 1, double>&, const Core::LinAlg::Matrix<3, 1, double>&,
-    const Core::LinAlg::Matrix<3, 1, double>&, const Core::LinAlg::Matrix<3, 15, double>&,
-    const Core::LinAlg::Matrix<3, 15, double>&, const Core::LinAlg::Matrix<3, 15, double>&);
-template void
-BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coord_target<2, 2,
-    double>(Core::LinAlg::Matrix<1, 12, double>&, Core::LinAlg::Matrix<1, 12, double>&,
-    const Core::LinAlg::Matrix<3, 1, double>&, const Core::LinAlg::Matrix<3, 1, double>&,
-    const Core::LinAlg::Matrix<3, 1, double>&, const Core::LinAlg::Matrix<3, 12, double>&,
-    const Core::LinAlg::Matrix<3, 12, double>&, const Core::LinAlg::Matrix<3, 12, double>&);
-template void
-BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coord_target<2, 1,
-    Sacado::Fad::DFad<double>>(Core::LinAlg::Matrix<1, 6, Sacado::Fad::DFad<double>>&,
-    Core::LinAlg::Matrix<1, 6, Sacado::Fad::DFad<double>>&,
-    const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
-    const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
-    const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
-    const Core::LinAlg::Matrix<3, 6, double>&,
-    const Core::LinAlg::Matrix<3, 6, Sacado::Fad::DFad<double>>&,
-    const Core::LinAlg::Matrix<3, 6, Sacado::Fad::DFad<double>>&);
-template void
-BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coord_target<3, 1,
-    Sacado::Fad::DFad<double>>(Core::LinAlg::Matrix<1, 9, Sacado::Fad::DFad<double>>&,
-    Core::LinAlg::Matrix<1, 9, Sacado::Fad::DFad<double>>&,
-    const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
-    const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
-    const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
-    const Core::LinAlg::Matrix<3, 9, double>&,
-    const Core::LinAlg::Matrix<3, 9, Sacado::Fad::DFad<double>>&,
-    const Core::LinAlg::Matrix<3, 9, Sacado::Fad::DFad<double>>&);
-template void
-BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coord_target<4, 1,
-    Sacado::Fad::DFad<double>>(Core::LinAlg::Matrix<1, 12, Sacado::Fad::DFad<double>>&,
-    Core::LinAlg::Matrix<1, 12, Sacado::Fad::DFad<double>>&,
-    const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
-    const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
-    const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
-    const Core::LinAlg::Matrix<3, 12, double>&,
-    const Core::LinAlg::Matrix<3, 12, Sacado::Fad::DFad<double>>&,
-    const Core::LinAlg::Matrix<3, 12, Sacado::Fad::DFad<double>>&);
-template void
-BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coord_target<5, 1,
-    Sacado::Fad::DFad<double>>(Core::LinAlg::Matrix<1, 15, Sacado::Fad::DFad<double>>&,
-    Core::LinAlg::Matrix<1, 15, Sacado::Fad::DFad<double>>&,
-    const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
-    const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
-    const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
-    const Core::LinAlg::Matrix<3, 15, double>&,
-    const Core::LinAlg::Matrix<3, 15, Sacado::Fad::DFad<double>>&,
-    const Core::LinAlg::Matrix<3, 15, Sacado::Fad::DFad<double>>&);
-template void
-BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coord_target<2, 2,
-    Sacado::Fad::DFad<double>>(Core::LinAlg::Matrix<1, 12, Sacado::Fad::DFad<double>>&,
-    Core::LinAlg::Matrix<1, 12, Sacado::Fad::DFad<double>>&,
-    const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
-    const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
-    const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
-    const Core::LinAlg::Matrix<3, 12, double>&,
-    const Core::LinAlg::Matrix<3, 12, Sacado::Fad::DFad<double>>&,
-    const Core::LinAlg::Matrix<3, 12, Sacado::Fad::DFad<double>>&);
+template void BeamInteraction::Potential::Geo::
+    calc_linearization_point_to_curve_projection_parameter_coord_target<2, 1, double>(
+        Core::LinAlg::Matrix<1, 6, double>&, Core::LinAlg::Matrix<1, 6, double>&,
+        const Core::LinAlg::Matrix<3, 1, double>&, const Core::LinAlg::Matrix<3, 1, double>&,
+        const Core::LinAlg::Matrix<3, 1, double>&, const Core::LinAlg::Matrix<3, 6, double>&,
+        const Core::LinAlg::Matrix<3, 6, double>&, const Core::LinAlg::Matrix<3, 6, double>&);
+template void BeamInteraction::Potential::Geo::
+    calc_linearization_point_to_curve_projection_parameter_coord_target<3, 1, double>(
+        Core::LinAlg::Matrix<1, 9, double>&, Core::LinAlg::Matrix<1, 9, double>&,
+        const Core::LinAlg::Matrix<3, 1, double>&, const Core::LinAlg::Matrix<3, 1, double>&,
+        const Core::LinAlg::Matrix<3, 1, double>&, const Core::LinAlg::Matrix<3, 9, double>&,
+        const Core::LinAlg::Matrix<3, 9, double>&, const Core::LinAlg::Matrix<3, 9, double>&);
+template void BeamInteraction::Potential::Geo::
+    calc_linearization_point_to_curve_projection_parameter_coord_target<4, 1, double>(
+        Core::LinAlg::Matrix<1, 12, double>&, Core::LinAlg::Matrix<1, 12, double>&,
+        const Core::LinAlg::Matrix<3, 1, double>&, const Core::LinAlg::Matrix<3, 1, double>&,
+        const Core::LinAlg::Matrix<3, 1, double>&, const Core::LinAlg::Matrix<3, 12, double>&,
+        const Core::LinAlg::Matrix<3, 12, double>&, const Core::LinAlg::Matrix<3, 12, double>&);
+template void BeamInteraction::Potential::Geo::
+    calc_linearization_point_to_curve_projection_parameter_coord_target<5, 1, double>(
+        Core::LinAlg::Matrix<1, 15, double>&, Core::LinAlg::Matrix<1, 15, double>&,
+        const Core::LinAlg::Matrix<3, 1, double>&, const Core::LinAlg::Matrix<3, 1, double>&,
+        const Core::LinAlg::Matrix<3, 1, double>&, const Core::LinAlg::Matrix<3, 15, double>&,
+        const Core::LinAlg::Matrix<3, 15, double>&, const Core::LinAlg::Matrix<3, 15, double>&);
+template void BeamInteraction::Potential::Geo::
+    calc_linearization_point_to_curve_projection_parameter_coord_target<2, 2, double>(
+        Core::LinAlg::Matrix<1, 12, double>&, Core::LinAlg::Matrix<1, 12, double>&,
+        const Core::LinAlg::Matrix<3, 1, double>&, const Core::LinAlg::Matrix<3, 1, double>&,
+        const Core::LinAlg::Matrix<3, 1, double>&, const Core::LinAlg::Matrix<3, 12, double>&,
+        const Core::LinAlg::Matrix<3, 12, double>&, const Core::LinAlg::Matrix<3, 12, double>&);
+template void BeamInteraction::Potential::Geo::
+    calc_linearization_point_to_curve_projection_parameter_coord_target<2, 1,
+        Sacado::Fad::DFad<double>>(Core::LinAlg::Matrix<1, 6, Sacado::Fad::DFad<double>>&,
+        Core::LinAlg::Matrix<1, 6, Sacado::Fad::DFad<double>>&,
+        const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
+        const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
+        const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
+        const Core::LinAlg::Matrix<3, 6, double>&,
+        const Core::LinAlg::Matrix<3, 6, Sacado::Fad::DFad<double>>&,
+        const Core::LinAlg::Matrix<3, 6, Sacado::Fad::DFad<double>>&);
+template void BeamInteraction::Potential::Geo::
+    calc_linearization_point_to_curve_projection_parameter_coord_target<3, 1,
+        Sacado::Fad::DFad<double>>(Core::LinAlg::Matrix<1, 9, Sacado::Fad::DFad<double>>&,
+        Core::LinAlg::Matrix<1, 9, Sacado::Fad::DFad<double>>&,
+        const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
+        const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
+        const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
+        const Core::LinAlg::Matrix<3, 9, double>&,
+        const Core::LinAlg::Matrix<3, 9, Sacado::Fad::DFad<double>>&,
+        const Core::LinAlg::Matrix<3, 9, Sacado::Fad::DFad<double>>&);
+template void BeamInteraction::Potential::Geo::
+    calc_linearization_point_to_curve_projection_parameter_coord_target<4, 1,
+        Sacado::Fad::DFad<double>>(Core::LinAlg::Matrix<1, 12, Sacado::Fad::DFad<double>>&,
+        Core::LinAlg::Matrix<1, 12, Sacado::Fad::DFad<double>>&,
+        const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
+        const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
+        const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
+        const Core::LinAlg::Matrix<3, 12, double>&,
+        const Core::LinAlg::Matrix<3, 12, Sacado::Fad::DFad<double>>&,
+        const Core::LinAlg::Matrix<3, 12, Sacado::Fad::DFad<double>>&);
+template void BeamInteraction::Potential::Geo::
+    calc_linearization_point_to_curve_projection_parameter_coord_target<5, 1,
+        Sacado::Fad::DFad<double>>(Core::LinAlg::Matrix<1, 15, Sacado::Fad::DFad<double>>&,
+        Core::LinAlg::Matrix<1, 15, Sacado::Fad::DFad<double>>&,
+        const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
+        const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
+        const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
+        const Core::LinAlg::Matrix<3, 15, double>&,
+        const Core::LinAlg::Matrix<3, 15, Sacado::Fad::DFad<double>>&,
+        const Core::LinAlg::Matrix<3, 15, Sacado::Fad::DFad<double>>&);
+template void BeamInteraction::Potential::Geo::
+    calc_linearization_point_to_curve_projection_parameter_coord_target<2, 2,
+        Sacado::Fad::DFad<double>>(Core::LinAlg::Matrix<1, 12, Sacado::Fad::DFad<double>>&,
+        Core::LinAlg::Matrix<1, 12, Sacado::Fad::DFad<double>>&,
+        const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
+        const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
+        const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
+        const Core::LinAlg::Matrix<3, 12, double>&,
+        const Core::LinAlg::Matrix<3, 12, Sacado::Fad::DFad<double>>&,
+        const Core::LinAlg::Matrix<3, 12, Sacado::Fad::DFad<double>>&);
 
-template void
-BeamInteraction::Geo::calc_point_to_curve_projection_parameter_coord_target_partial_derivs<double>(
-    Core::LinAlg::Matrix<1, 3, double>&, Core::LinAlg::Matrix<1, 3, double>&,
-    Core::LinAlg::Matrix<1, 3, double>&, const Core::LinAlg::Matrix<3, 1, double>&,
-    const Core::LinAlg::Matrix<3, 1, double>&, const Core::LinAlg::Matrix<3, 1, double>&);
-template void BeamInteraction::Geo::
+template void BeamInteraction::Potential::Geo::
+    calc_point_to_curve_projection_parameter_coord_target_partial_derivs<double>(
+        Core::LinAlg::Matrix<1, 3, double>&, Core::LinAlg::Matrix<1, 3, double>&,
+        Core::LinAlg::Matrix<1, 3, double>&, const Core::LinAlg::Matrix<3, 1, double>&,
+        const Core::LinAlg::Matrix<3, 1, double>&, const Core::LinAlg::Matrix<3, 1, double>&);
+template void BeamInteraction::Potential::Geo::
     calc_point_to_curve_projection_parameter_coord_target_partial_derivs<Sacado::Fad::DFad<double>>(
         Core::LinAlg::Matrix<1, 3, Sacado::Fad::DFad<double>>&,
         Core::LinAlg::Matrix<1, 3, Sacado::Fad::DFad<double>>&,
@@ -808,7 +822,7 @@ template void BeamInteraction::Geo::
         const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
         const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&);
 
-template void BeamInteraction::Geo::
+template void BeamInteraction::Potential::Geo::
     calc_point_to_curve_projection_parameter_coord_target_partial2nd_derivs<double>(
         Core::LinAlg::Matrix<3, 3, double>&, Core::LinAlg::Matrix<3, 3, double>&,
         Core::LinAlg::Matrix<3, 3, double>&, Core::LinAlg::Matrix<3, 3, double>&,
@@ -823,37 +837,37 @@ template void BeamInteraction::Geo::
         const Core::LinAlg::Matrix<3, 3, double>&, const Core::LinAlg::Matrix<3, 1, double>&,
         const Core::LinAlg::Matrix<3, 1, double>&, const Core::LinAlg::Matrix<3, 1, double>&,
         const Core::LinAlg::Matrix<3, 1, double>&);
-template void
-BeamInteraction::Geo::calc_point_to_curve_projection_parameter_coord_target_partial2nd_derivs<
-    Sacado::Fad::DFad<double>>(Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
-    Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
-    Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
-    Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
-    Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
-    Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
-    Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
-    Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
-    Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
-    Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
-    Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
-    Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
-    Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
-    Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
-    Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
-    const Core::LinAlg::Matrix<1, 3, Sacado::Fad::DFad<double>>&,
-    const Core::LinAlg::Matrix<1, 3, Sacado::Fad::DFad<double>>&,
-    const Core::LinAlg::Matrix<1, 3, Sacado::Fad::DFad<double>>&,
-    const Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
-    const Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
-    const Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
-    const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
-    const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
-    const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
-    const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&);
+template void BeamInteraction::Potential::Geo::
+    calc_point_to_curve_projection_parameter_coord_target_partial2nd_derivs<
+        Sacado::Fad::DFad<double>>(Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
+        Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
+        Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
+        Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
+        Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
+        Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
+        Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
+        Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
+        Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
+        Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
+        Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
+        Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
+        Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
+        Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
+        Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
+        const Core::LinAlg::Matrix<1, 3, Sacado::Fad::DFad<double>>&,
+        const Core::LinAlg::Matrix<1, 3, Sacado::Fad::DFad<double>>&,
+        const Core::LinAlg::Matrix<1, 3, Sacado::Fad::DFad<double>>&,
+        const Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
+        const Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
+        const Core::LinAlg::Matrix<3, 3, Sacado::Fad::DFad<double>>&,
+        const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
+        const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
+        const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
+        const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&);
 
-template void BeamInteraction::Geo::calc_enclosed_angle<double>(double&, double&,
+template void BeamInteraction::Potential::Geo::calc_enclosed_angle<double>(double&, double&,
     const Core::LinAlg::Matrix<3, 1, double>&, const Core::LinAlg::Matrix<3, 1, double>&);
-template void BeamInteraction::Geo::calc_enclosed_angle<Sacado::Fad::DFad<double>>(
+template void BeamInteraction::Potential::Geo::calc_enclosed_angle<Sacado::Fad::DFad<double>>(
     Sacado::Fad::DFad<double>&, Sacado::Fad::DFad<double>&,
     const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&,
     const Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>>&);

--- a/src/beaminteraction/src/potential/4C_beaminteraction_potential_geometry_utils.hpp
+++ b/src/beaminteraction/src/potential/4C_beaminteraction_potential_geometry_utils.hpp
@@ -5,8 +5,8 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
-#ifndef FOUR_C_BEAMINTERACTION_GEOMETRY_UTILS_HPP
-#define FOUR_C_BEAMINTERACTION_GEOMETRY_UTILS_HPP
+#ifndef FOUR_C_BEAMINTERACTION_POTENTIAL_GEOMETRY_UTILS_HPP
+#define FOUR_C_BEAMINTERACTION_POTENTIAL_GEOMETRY_UTILS_HPP
 
 #include "4C_config.hpp"
 
@@ -16,7 +16,7 @@
 FOUR_C_NAMESPACE_OPEN
 
 
-namespace BeamInteraction
+namespace BeamInteraction::Potential
 {
   namespace Geo
   {
@@ -172,7 +172,7 @@ namespace BeamInteraction
         const Core::LinAlg::Matrix<3, 1, T>& b);
 
   }  // namespace Geo
-}  // namespace BeamInteraction
+}  // namespace BeamInteraction::Potential
 
 FOUR_C_NAMESPACE_CLOSE
 

--- a/src/beaminteraction/src/potential/4C_beaminteraction_potential_input.cpp
+++ b/src/beaminteraction/src/potential/4C_beaminteraction_potential_input.cpp
@@ -72,15 +72,15 @@ Core::IO::InputSpec BeamInteraction::Potential::valid_parameters()
                   .default_value = false,
                   .store = in_struct(&BeamPotentialParameters::automatic_differentiation)}),
 
-          parameter<MasterSlaveChoice>("choice_master_slave",
+          parameter<SourceTargetChoice>("choice_source_target",
               {.description =
-                      "Rule to which the role of master and slave is assigned to beam elements",
-                  .default_value = MasterSlaveChoice::smaller_eleGID_is_slave,
-                  .store = in_struct(&BeamPotentialParameters::choice_master_slave)}),
+                      "Rule to which the role of target and source is assigned to beam elements",
+                  .default_value = SourceTargetChoice::smaller_eleGID_is_source,
+                  .store = in_struct(&BeamPotentialParameters::choice_source_target)}),
 
           parameter<std::optional<double>>("potential_reduction_length",
               {.description =
-                      "Length in which the potential is reduced to 0 at master beam end points "
+                      "Length in which the potential is reduced to 0 at target beam end points "
                       "(only applicable for 'single_length_specific_small_separations' strategy).",
                   .validator = null_or(positive<double>()),
                   .store = in_struct(&BeamPotentialParameters::potential_reduction_length)}),
@@ -133,7 +133,7 @@ Core::IO::InputSpec BeamInteraction::Potential::valid_parameters()
                   parameter<bool>("write_uids",
                       {.description =
                               "Write out the unique ID's for each visualization point,i.e., "
-                              "master and slave beam element global ID (uid_0_beam_1_gid, "
+                              "source and target beam element global ID (uid_0_beam_1_gid, "
                               "uid_1_beam_2_gid) and local Gauss point ID (uid_2_gp_id)",
                           .default_value = false,
                           .store = in_struct(&BeamPotentialVisualizationParameters::write_uids)}),

--- a/src/beaminteraction/src/potential/4C_beaminteraction_potential_input.hpp
+++ b/src/beaminteraction/src/potential/4C_beaminteraction_potential_input.hpp
@@ -45,10 +45,10 @@ namespace BeamInteraction::Potential
                                                       ///< approach
   };
 
-  enum class MasterSlaveChoice
+  enum class SourceTargetChoice
   {
-    smaller_eleGID_is_slave,
-    higher_eleGID_is_slave,
+    smaller_eleGID_is_source,
+    higher_eleGID_is_source,
   };
 
 
@@ -90,7 +90,7 @@ namespace BeamInteraction::Potential
     int n_integration_segments{};
     int n_gauss_points{};
     bool automatic_differentiation = false;
-    MasterSlaveChoice choice_master_slave{};
+    SourceTargetChoice choice_source_target{};
     std::optional<double> potential_reduction_length{};
     BeamPotentialVisualizationParameters runtime_output_params{};
 

--- a/src/beaminteraction/src/potential/4C_beaminteraction_potential_pair_beam_to_beam.cpp
+++ b/src/beaminteraction/src/potential/4C_beaminteraction_potential_pair_beam_to_beam.cpp
@@ -60,11 +60,11 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::setu
   ele1pos_.clear();
   ele2pos_.clear();
 
-  /* take care of how to assign the role of master and slave (only applicable to
+  /* take care of how to assign the role of target and source (only applicable to
    * "SingleLengthSpecific" approach). Immediately before this setup(), the element with smaller GID
-   * has been assigned as element1_, i.e., slave. */
-  if (params()->choice_master_slave ==
-      BeamInteraction::Potential::MasterSlaveChoice::higher_eleGID_is_slave)
+   * has been assigned as element1_, i.e., source. */
+  if (params()->choice_source_target ==
+      BeamInteraction::Potential::SourceTargetChoice::higher_eleGID_is_source)
   {
     // interchange order, i.e., role of elements
     Core::Elements::Element const* tmp_ele_ptr = element1();
@@ -177,18 +177,18 @@ bool BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::eval
 
       if (params()->two_half_pass)
       {
-        exchange_master_slave_allocation_for_two_half_pass();
+        exchange_source_target_allocation_for_two_half_pass();
 
         // evaluate switched pair contribution a second time for two-half-pass approach
         // interaction potential is averaged
         // Note: the residual vectors and stiffness matrices need to be switched to correctly
-        // account for the changed master/slave role
+        // account for the changed target/source role
         evaluate_fpotand_stiffpot_single_length_specific_small_sep_approx(
             force_pot2, force_pot1, stiffmat22, stiffmat21, stiffmat12, stiffmat11);
 
-        // revert to original master/slave allocation (necessary for next evaluation within same
+        // revert to original target/source allocation (necessary for next evaluation within same
         // time step)
-        exchange_master_slave_allocation_for_two_half_pass();
+        exchange_source_target_allocation_for_two_half_pass();
       }
       break;
     }
@@ -1126,7 +1126,7 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
   // get potential reduction length
   const std::optional<double> potential_reduction_length = params()->potential_reduction_length;
 
-  // get length from current master beam element to beam edge
+  // get length from current target beam element to beam edge
   double length_prior_left = 0.0;
   double length_prior_right = 0.0;
 
@@ -1140,21 +1140,21 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
              length_prior_right) < 0.0))
     {
       FOUR_C_THROW(
-          "ERROR: Master beam endpoint reduction strategy would interfere on current master beam "
+          "ERROR: Target beam endpoint reduction strategy would interfere on current target beam "
           "element! Potential reduction would overlap due to too small prior element lengths on "
           "both sides");
     }
   }
 
-  /* parameter coordinate of the closest point on the master beam,
+  /* parameter coordinate of the closest point on the target beam,
    * determined via point-to-curve projection */
-  T xi_master = 0.0;
+  T xi_target = 0.0;
 
   // prepare differentiation via FAD if desired
-  /* xi_master is used as additional, auxiliary primary Dof
-   * since there is no closed-form expression for how xi_master depends on the 'real' primary Dofs.
+  /* xi_target is used as additional, auxiliary primary Dof
+   * since there is no closed-form expression for how xi_target depends on the 'real' primary Dofs.
    * It is determined iteratively via point-to-curve projection */
-  set_automatic_differentiation_variables_if_required(ele1pos_, ele2pos_, xi_master);
+  set_automatic_differentiation_variables_if_required(ele1pos_, ele2pos_, xi_target);
 
 
   // number of integration segments per element
@@ -1176,7 +1176,7 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
   double rho1rho2_JacFac_GaussWeight = 0.0;
 
   const unsigned int num_initial_values = 9;
-  const std::array<double, num_initial_values> xi_master_initial_guess_values = {
+  const std::array<double, num_initial_values> xi_target_initial_guess_values = {
       0.0, -1.0, 1.0, -0.5, 0.5, -0.75, -0.25, 0.25, 0.75};
 
   unsigned int iter_projection = 0;
@@ -1184,50 +1184,50 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
   // vectors for shape functions and their derivatives
   // Attention: these are individual shape function values, NOT shape function matrices
   // values at all Gauss points are stored in advance (more efficient espec. for many segments)
-  std::vector<Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double>> N_i_slave(
+  std::vector<Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double>> N_i_source(
       numgp_persegment);  // = N1_i
-  std::vector<Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double>> N_i_xi_slave(
+  std::vector<Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double>> N_i_xi_source(
       numgp_persegment);  // = N1_i,xi
 
-  Core::LinAlg::Matrix<1, numnodes * numnodalvalues, T> N_i_master(
+  Core::LinAlg::Matrix<1, numnodes * numnodalvalues, T> N_i_target(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<1, numnodes * numnodalvalues, T> N_i_xi_master(
+  Core::LinAlg::Matrix<1, numnodes * numnodalvalues, T> N_i_xi_target(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<1, numnodes * numnodalvalues, T> N_i_xixi_master(
+  Core::LinAlg::Matrix<1, numnodes * numnodalvalues, T> N_i_xixi_target(
       Core::LinAlg::Initialization::zero);
 
   // assembled shape function matrices: Todo maybe avoid these matrices
-  Core::LinAlg::Matrix<3, 3 * numnodes * numnodalvalues, double> N_slave(
+  Core::LinAlg::Matrix<3, 3 * numnodes * numnodalvalues, double> N_source(
       Core::LinAlg::Initialization::zero);
 
-  Core::LinAlg::Matrix<3, 3 * numnodes * numnodalvalues, T> N_master(
+  Core::LinAlg::Matrix<3, 3 * numnodes * numnodalvalues, T> N_target(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3 * numnodes * numnodalvalues, T> N_xi_master(
+  Core::LinAlg::Matrix<3, 3 * numnodes * numnodalvalues, T> N_xi_target(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3 * numnodes * numnodalvalues, T> N_xixi_master(
+  Core::LinAlg::Matrix<3, 3 * numnodes * numnodalvalues, T> N_xixi_target(
       Core::LinAlg::Initialization::zero);
 
 
-  // coords and derivatives of the slave Gauss point and projected point on master element
-  Core::LinAlg::Matrix<3, 1, T> r_slave(
-      Core::LinAlg::Initialization::zero);  // centerline position vector on slave
-  Core::LinAlg::Matrix<3, 1, T> r_xi_slave(
-      Core::LinAlg::Initialization::zero);  // centerline tangent vector on slave
-  Core::LinAlg::Matrix<3, 1, T> t_slave(
-      Core::LinAlg::Initialization::zero);  // unit centerline tangent vector on slave
-  Core::LinAlg::Matrix<3, 1, T> r_master(
-      Core::LinAlg::Initialization::zero);  // centerline position vector on master
-  Core::LinAlg::Matrix<3, 1, T> r_xi_master(
-      Core::LinAlg::Initialization::zero);  // centerline tangent vector on master
-  Core::LinAlg::Matrix<3, 1, T> r_xixi_master(
-      Core::LinAlg::Initialization::zero);  // 2nd deriv of master curve
-  Core::LinAlg::Matrix<3, 1, T> t_master(
-      Core::LinAlg::Initialization::zero);  // unit centerline tangent vector on master
+  // coords and derivatives of the source Gauss point and projected point on target element
+  Core::LinAlg::Matrix<3, 1, T> r_source(
+      Core::LinAlg::Initialization::zero);  // centerline position vector on source
+  Core::LinAlg::Matrix<3, 1, T> r_xi_source(
+      Core::LinAlg::Initialization::zero);  // centerline tangent vector on source
+  Core::LinAlg::Matrix<3, 1, T> t_source(
+      Core::LinAlg::Initialization::zero);  // unit centerline tangent vector on source
+  Core::LinAlg::Matrix<3, 1, T> r_target(
+      Core::LinAlg::Initialization::zero);  // centerline position vector on target
+  Core::LinAlg::Matrix<3, 1, T> r_xi_target(
+      Core::LinAlg::Initialization::zero);  // centerline tangent vector on target
+  Core::LinAlg::Matrix<3, 1, T> r_xixi_target(
+      Core::LinAlg::Initialization::zero);  // 2nd deriv of target curve
+  Core::LinAlg::Matrix<3, 1, T> t_target(
+      Core::LinAlg::Initialization::zero);  // unit centerline tangent vector on target
 
-  T norm_r_xi_slave = 0.0;
-  T norm_r_xi_master = 0.0;
+  T norm_r_xi_source = 0.0;
+  T norm_r_xi_target = 0.0;
 
-  Core::LinAlg::Matrix<3, 1, T> dist_ul(Core::LinAlg::Initialization::zero);  // = r_slave-r_master
+  Core::LinAlg::Matrix<3, 1, T> dist_ul(Core::LinAlg::Initialization::zero);  // = r_source-r_target
   T norm_dist_ul = 0.0;
 
   T alpha = 0.0;      // mutual angle of tangent vectors
@@ -1235,23 +1235,23 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
 
   T interaction_potential_GP = 0.0;
 
-  // components from variation of parameter coordinate on master beam
-  Core::LinAlg::Matrix<1, 3, T> xi_master_partial_r_slave(Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<1, 3, T> xi_master_partial_r_master(Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<1, 3, T> xi_master_partial_r_xi_master(Core::LinAlg::Initialization::zero);
+  // components from variation of parameter coordinate on target beam
+  Core::LinAlg::Matrix<1, 3, T> xi_target_partial_r_source(Core::LinAlg::Initialization::zero);
+  Core::LinAlg::Matrix<1, 3, T> xi_target_partial_r_target(Core::LinAlg::Initialization::zero);
+  Core::LinAlg::Matrix<1, 3, T> xi_target_partial_r_xi_target(Core::LinAlg::Initialization::zero);
 
 
-  // linearization of parameter coordinate on master resulting from point-to-curve projection
-  Core::LinAlg::Matrix<1, 3 * numnodes * numnodalvalues, T> lin_xi_master_slaveDofs(
+  // linearization of parameter coordinate on target resulting from point-to-curve projection
+  Core::LinAlg::Matrix<1, 3 * numnodes * numnodalvalues, T> lin_xi_source_targetDofs(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<1, 3 * numnodes * numnodalvalues, T> lin_xi_master_masterDofs(
+  Core::LinAlg::Matrix<1, 3 * numnodes * numnodalvalues, T> lin_xi_target_targetDofs(
       Core::LinAlg::Initialization::zero);
 
   /* contribution of one Gauss point (required for automatic differentiation with contributions
-   * from xi_master) */
-  Core::LinAlg::Matrix<3 * numnodes * numnodalvalues, 1, T> force_pot_slave_GP(
+   * from xi_target) */
+  Core::LinAlg::Matrix<3 * numnodes * numnodalvalues, 1, T> force_pot_source_GP(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3 * numnodes * numnodalvalues, 1, T> force_pot_master_GP(
+  Core::LinAlg::Matrix<3 * numnodes * numnodalvalues, 1, T> force_pot_target_GP(
       Core::LinAlg::Initialization::zero);
 
   // evaluate charge/particle densities from DLINE charge condition specified in input file
@@ -1322,13 +1322,13 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
     double jacobifactor_segment =
         0.5 * (integration_segment_upper_limit - integration_segment_lower_limit);
 
-    // Evaluate shape functions at Gauss points of slave element and store values
+    // Evaluate shape functions at Gauss points of source element and store values
     Discret::Utils::Beam::evaluate_shape_functions_and_derivs_all_gps<numnodes, numnodalvalues>(
-        gausspoints, N_i_slave, N_i_xi_slave, beam_element1()->shape(), ele1length_,
+        gausspoints, N_i_source, N_i_xi_source, beam_element1()->shape(), ele1length_,
         integration_segment_lower_limit, integration_segment_upper_limit);
 
     // loop over gauss points of element 1
-    // so far, element 1 is always treated as the slave element!
+    // so far, element 1 is always treated as the source element!
     for (int igp = 0; igp < numgp_persegment; ++igp)
     {
       // add zero-initialized visualization data for this Gauss point
@@ -1349,28 +1349,28 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
                         (1.0 + xi_GP_tilde) * integration_segment_upper_limit);
 
 
-      // compute coord vector and tangent vector on slave side
-      compute_centerline_position(r_slave, N_i_slave[igp], ele1pos_);
-      compute_centerline_tangent(r_xi_slave, N_i_xi_slave[igp], ele1pos_);
+      // compute coord vector and tangent vector on source side
+      compute_centerline_position(r_source, N_i_source[igp], ele1pos_);
+      compute_centerline_tangent(r_xi_source, N_i_xi_source[igp], ele1pos_);
 
-      norm_r_xi_slave = Core::FADUtils::vector_norm(r_xi_slave);
+      norm_r_xi_source = Core::FADUtils::vector_norm(r_xi_source);
 
-      t_slave.update(1.0 / norm_r_xi_slave, r_xi_slave);
+      t_source.update(1.0 / norm_r_xi_source, r_xi_source);
 
       // store for visualization
-      centerline_coords_gp_1_.back() = Core::FADUtils::cast_to_double<T, 3, 1>(r_slave);
+      centerline_coords_gp_1_.back() = Core::FADUtils::cast_to_double<T, 3, 1>(r_source);
 
       rho1rho2_JacFac_GaussWeight = rho1 * rho2 * jacobifactor_segment *
                                     beam_element1()->get_jacobi_fac_at_xi(xi_GP) *
                                     gausspoints.qwgt[igp];
 
       /* point-to-curve projection, i.e. 'unilateral' closest-point projection
-       * to determine point on master beam (i.e. parameter coordinate xi_master) */
+       * to determine point on target beam (i.e. parameter coordinate xi_target) */
       iter_projection = 0;
 
       while (iter_projection < num_initial_values and
              (not BeamInteraction::Geo::point_to_curve_projection<numnodes, numnodalvalues, T>(
-                 r_slave, xi_master, xi_master_initial_guess_values[iter_projection], ele2pos_,
+                 r_source, xi_target, xi_target_initial_guess_values[iter_projection], ele2pos_,
                  element2()->shape(), ele2length_)))
       {
         iter_projection++;
@@ -1379,7 +1379,7 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
       if (iter_projection == num_initial_values)
       {
         std::cout << "\nWARNING: Point-to-Curve Projection ultimately failed at "
-                     "xi_slave="
+                     "xi_source="
                   << xi_GP << " of ele pair " << element1()->id() << " & " << element2()->id()
                   << "\nFallback strategy: Assume invalid projection and skip this GP..."
                   << std::endl;
@@ -1387,38 +1387,38 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
       }
 
       // Todo: specify tolerance value in a more central place
-      if (Core::FADUtils::norm(xi_master) > 1.0 + 1.0e-10)
+      if (Core::FADUtils::norm(xi_target) > 1.0 + 1.0e-10)
       {
         continue;
       }
       // ensure no end node is utilized to prevent a possible doubled potential contribution
-      else if (Core::FADUtils::norm(xi_master) >= 1.0 - 1.0e-10)
+      else if (Core::FADUtils::norm(xi_target) >= 1.0 - 1.0e-10)
       {
         FOUR_C_THROW(
-            "Point-to-curve projection yields xi_master= {}. This is a critical case "
+            "Point-to-curve projection yields xi_target= {}. This is a critical case "
             "since it is very close to the element boundary!",
-            Core::FADUtils::cast_to_double(xi_master));
+            Core::FADUtils::cast_to_double(xi_target));
       }
 
       Discret::Utils::Beam::evaluate_shape_functions_and_derivs_and2nd_derivs_at_xi<numnodes,
-          numnodalvalues>(xi_master, N_i_master, N_i_xi_master, N_i_xixi_master,
+          numnodalvalues>(xi_target, N_i_target, N_i_xi_target, N_i_xixi_target,
           beam_element2()->shape(), ele2length_);
 
-      // compute coord vector and tangent vector on master side
-      compute_centerline_position(r_master, N_i_master, ele2pos_);
-      compute_centerline_tangent(r_xi_master, N_i_xi_master, ele2pos_);
-      compute_centerline_tangent(r_xixi_master, N_i_xixi_master, ele2pos_);
+      // compute coord vector and tangent vector on target side
+      compute_centerline_position(r_target, N_i_target, ele2pos_);
+      compute_centerline_tangent(r_xi_target, N_i_xi_target, ele2pos_);
+      compute_centerline_tangent(r_xixi_target, N_i_xixi_target, ele2pos_);
 
 
-      norm_r_xi_master = Core::FADUtils::vector_norm(r_xi_master);
+      norm_r_xi_target = Core::FADUtils::vector_norm(r_xi_target);
 
-      t_master.update(1.0 / norm_r_xi_master, r_xi_master);
+      t_target.update(1.0 / norm_r_xi_target, r_xi_target);
 
       // store for visualization
-      centerline_coords_gp_2_.back() = Core::FADUtils::cast_to_double<T, 3, 1>(r_master);
+      centerline_coords_gp_2_.back() = Core::FADUtils::cast_to_double<T, 3, 1>(r_target);
 
       // distance vector between unilateral closest points
-      dist_ul.update(1.0, r_slave, -1.0, r_master);
+      dist_ul.update(1.0, r_source, -1.0, r_target);
 
       norm_dist_ul = Core::FADUtils::vector_norm(dist_ul);
 
@@ -1436,7 +1436,7 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
       }
 
       // mutual angle of tangent vectors at unilateral closest points
-      BeamInteraction::Geo::calc_enclosed_angle(alpha, cos_alpha, r_xi_slave, r_xi_master);
+      BeamInteraction::Geo::calc_enclosed_angle(alpha, cos_alpha, r_xi_source, r_xi_target);
 
       if (alpha < 0.0 or alpha > std::numbers::pi / 2)
         FOUR_C_THROW("alpha={}, should be in [0,pi/2]", Core::FADUtils::cast_to_double(alpha));
@@ -1444,20 +1444,20 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
       // Todo: maybe avoid this assembly of shape fcns into matrices
       // Fixme: at least, do this only in case of FAD-based linearization
       Discret::Utils::Beam::assemble_shape_functions<numnodes, numnodalvalues>(
-          N_i_slave[igp], N_slave);
+          N_i_source[igp], N_source);
 
       Discret::Utils::Beam::assemble_shape_functions_and_derivs_and2nd_derivs<numnodes,
           numnodalvalues>(
-          N_i_master, N_i_xi_master, N_i_xixi_master, N_master, N_xi_master, N_xixi_master);
+          N_i_target, N_i_xi_target, N_i_xixi_target, N_target, N_xi_target, N_xixi_target);
 
-      BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coord_master<
-          numnodes, numnodalvalues>(lin_xi_master_slaveDofs, lin_xi_master_masterDofs, dist_ul,
-          r_xi_master, r_xixi_master, N_slave, N_master, N_xixi_master);
+      BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coord_target<
+          numnodes, numnodalvalues>(lin_xi_source_targetDofs, lin_xi_target_targetDofs, dist_ul,
+          r_xi_target, r_xixi_target, N_source, N_target, N_xixi_target);
 
 
-      BeamInteraction::Geo::calc_point_to_curve_projection_parameter_coord_master_partial_derivs(
-          xi_master_partial_r_slave, xi_master_partial_r_master, xi_master_partial_r_xi_master,
-          dist_ul, r_xi_master, r_xixi_master);
+      BeamInteraction::Geo::calc_point_to_curve_projection_parameter_coord_target_partial_derivs(
+          xi_target_partial_r_source, xi_target_partial_r_target, xi_target_partial_r_xi_target,
+          dist_ul, r_xi_target, r_xixi_target);
 
 
       // evaluate all quantities which depend on the applied disk-cylinder potential law
@@ -1466,13 +1466,13 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
       if (params()->strategy ==
           BeamInteraction::Potential::Strategy::single_length_specific_small_separations)
       {
-        if (not evaluate_full_disk_cylinder_potential(interaction_potential_GP, force_pot_slave_GP,
-                force_pot_master_GP, r_slave, r_xi_slave, t_slave, r_master, r_xi_master,
-                r_xixi_master, t_master, alpha, cos_alpha, dist_ul, xi_master_partial_r_slave,
-                xi_master_partial_r_master, xi_master_partial_r_xi_master,
+        if (not evaluate_full_disk_cylinder_potential(interaction_potential_GP, force_pot_source_GP,
+                force_pot_target_GP, r_source, r_xi_source, t_source, r_target, r_xi_target,
+                r_xixi_target, t_target, alpha, cos_alpha, dist_ul, xi_target_partial_r_source,
+                xi_target_partial_r_target, xi_target_partial_r_xi_target,
                 prefactor_visualization_data, forces_pot_gp_1_.back(), forces_pot_gp_2_.back(),
                 moments_pot_gp_1_.back(), moments_pot_gp_2_.back(), rho1rho2_JacFac_GaussWeight,
-                N_i_slave[igp], N_i_xi_slave[igp], N_i_master, N_i_xi_master))
+                N_i_source[igp], N_i_xi_source[igp], N_i_target, N_i_xi_target))
           continue;
       }
       // reduced, simpler variant of the disk-cylinder interaction potential
@@ -1480,12 +1480,12 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
                                          single_length_specific_small_separations_simple)
       {
         if (not evaluate_simple_disk_cylinder_potential(dist_ul, norm_dist_ul, alpha, cos_alpha,
-                r_slave, r_xi_slave, norm_r_xi_slave, t_slave, r_master, r_xi_master,
-                norm_r_xi_master, r_xixi_master, t_master, xi_master, xi_master_partial_r_slave,
-                xi_master_partial_r_master, xi_master_partial_r_xi_master,
+                r_source, r_xi_source, norm_r_xi_source, t_source, r_target, r_xi_target,
+                norm_r_xi_target, r_xixi_target, t_target, xi_target, xi_target_partial_r_source,
+                xi_target_partial_r_target, xi_target_partial_r_xi_target,
                 potential_reduction_length, length_prior_right, length_prior_left,
-                interaction_potential_GP, N_i_slave[igp], N_i_xi_slave[igp], N_i_master,
-                N_i_xi_master, N_i_xixi_master, force_pot_slave_GP, force_pot_master_GP,
+                interaction_potential_GP, N_i_source[igp], N_i_xi_source[igp], N_i_target,
+                N_i_xi_target, N_i_xixi_target, force_pot_source_GP, force_pot_target_GP,
                 prefactor_visualization_data, rho1rho2_JacFac_GaussWeight, forces_pot_gp_1_.back(),
                 forces_pot_gp_2_.back(), moments_pot_gp_1_.back(), moments_pot_gp_2_.back(),
                 stiffmat11, stiffmat12, stiffmat21, stiffmat22))
@@ -1493,19 +1493,19 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
       }
 
       // apply constant prefactor
-      force_pot_slave_GP.scale(prefactor);
-      force_pot_master_GP.scale(prefactor);
+      force_pot_source_GP.scale(prefactor);
+      force_pot_target_GP.scale(prefactor);
 
       // sum contributions from all Gauss points
-      force_pot1.update(1.0, force_pot_slave_GP, 1.0);
-      force_pot2.update(1.0, force_pot_master_GP, 1.0);
+      force_pot1.update(1.0, force_pot_source_GP, 1.0);
+      force_pot2.update(1.0, force_pot_target_GP, 1.0);
 
       if (stiffmat11 != nullptr and stiffmat12 != nullptr and stiffmat21 != nullptr and
           stiffmat22 != nullptr)
       {
-        add_stiffmat_contributions_xi_master_automatic_differentiation_if_required(
-            force_pot_slave_GP, force_pot_master_GP, lin_xi_master_slaveDofs,
-            lin_xi_master_masterDofs, *stiffmat11, *stiffmat12, *stiffmat21, *stiffmat22);
+        add_stiffmat_contributions_xi_target_automatic_differentiation_if_required(
+            force_pot_source_GP, force_pot_target_GP, lin_xi_source_targetDofs,
+            lin_xi_target_targetDofs, *stiffmat11, *stiffmat12, *stiffmat21, *stiffmat22);
       }
 
       // do this scaling down here, because the value without the prefactors is meant to be used
@@ -1536,28 +1536,28 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
 template <unsigned int numnodes, unsigned int numnodalvalues, typename T>
 void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
     evaluate_stiffpot_analytic_contributions_single_length_specific_small_sep_approx_simple(
-        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_slave,
-        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_xi_slave,
-        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_master,
-        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_xi_master,
-        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_xixi_master,
-        double const& xi_master, Core::LinAlg::Matrix<3, 1, double> const& r_xi_slave,
-        Core::LinAlg::Matrix<3, 1, double> const& r_xi_master,
-        Core::LinAlg::Matrix<3, 1, double> const& r_xixi_master, double const& norm_dist_ul,
+        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_source,
+        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_xi_source,
+        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_target,
+        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_xi_target,
+        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_xixi_target,
+        double const& xi_target, Core::LinAlg::Matrix<3, 1, double> const& r_xi_source,
+        Core::LinAlg::Matrix<3, 1, double> const& r_xi_target,
+        Core::LinAlg::Matrix<3, 1, double> const& r_xixi_target, double const& norm_dist_ul,
         Core::LinAlg::Matrix<3, 1, double> const& normal_ul, double const& pot_red_fac,
-        double const& pot_red_fac_deriv_xi_master, double const& pot_red_fac_2ndderiv_xi_master,
+        double const& pot_red_fac_deriv_xi_target, double const& pot_red_fac_2ndderiv_xi_target,
         double const& pot_ia, double const& pot_ia_deriv_gap_ul,
         double const& pot_ia_deriv_cos_alpha, double const& pot_ia_2ndderiv_gap_ul,
         double const& pot_ia_deriv_gap_ul_deriv_cos_alpha, double const& pot_ia_2ndderiv_cos_alpha,
-        Core::LinAlg::Matrix<3, 1, double> const& gap_ul_deriv_r_slave,
-        Core::LinAlg::Matrix<3, 1, double> const& gap_ul_deriv_r_master,
-        Core::LinAlg::Matrix<3, 1, double> const& cos_alpha_deriv_r_slave,
-        Core::LinAlg::Matrix<3, 1, double> const& cos_alpha_deriv_r_master,
-        Core::LinAlg::Matrix<3, 1, double> const& cos_alpha_deriv_r_xi_slave,
-        Core::LinAlg::Matrix<3, 1, double> const& cos_alpha_deriv_r_xi_master,
-        Core::LinAlg::Matrix<1, 3, double> const& xi_master_partial_r_slave,
-        Core::LinAlg::Matrix<1, 3, double> const& xi_master_partial_r_master,
-        Core::LinAlg::Matrix<1, 3, double> const& xi_master_partial_r_xi_master,
+        Core::LinAlg::Matrix<3, 1, double> const& gap_ul_deriv_r_source,
+        Core::LinAlg::Matrix<3, 1, double> const& gap_ul_deriv_r_target,
+        Core::LinAlg::Matrix<3, 1, double> const& cos_alpha_deriv_r_source,
+        Core::LinAlg::Matrix<3, 1, double> const& cos_alpha_deriv_r_target,
+        Core::LinAlg::Matrix<3, 1, double> const& cos_alpha_deriv_r_xi_source,
+        Core::LinAlg::Matrix<3, 1, double> const& cos_alpha_deriv_r_xi_target,
+        Core::LinAlg::Matrix<1, 3, double> const& xi_target_partial_r_source,
+        Core::LinAlg::Matrix<1, 3, double> const& xi_target_partial_r_target,
+        Core::LinAlg::Matrix<1, 3, double> const& xi_target_partial_r_xi_target,
         Core::LinAlg::SerialDenseMatrix& stiffmat11, Core::LinAlg::SerialDenseMatrix& stiffmat12,
         Core::LinAlg::SerialDenseMatrix& stiffmat21,
         Core::LinAlg::SerialDenseMatrix& stiffmat22) const
@@ -1570,21 +1570,21 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
   Core::LinAlg::Matrix<3, 3, double> unit_matrix(Core::LinAlg::Initialization::zero);
   for (unsigned int i = 0; i < 3; ++i) unit_matrix(i, i) = 1.0;
 
-  Core::LinAlg::Matrix<3, 3, double> dist_ul_deriv_r_slave(unit_matrix);
-  Core::LinAlg::Matrix<3, 3, double> dist_ul_deriv_r_master(unit_matrix);
-  dist_ul_deriv_r_master.scale(-1.0);
-  Core::LinAlg::Matrix<3, 3, double> dist_ul_deriv_r_xi_master(Core::LinAlg::Initialization::zero);
+  Core::LinAlg::Matrix<3, 3, double> dist_ul_deriv_r_source(unit_matrix);
+  Core::LinAlg::Matrix<3, 3, double> dist_ul_deriv_r_target(unit_matrix);
+  dist_ul_deriv_r_target.scale(-1.0);
+  Core::LinAlg::Matrix<3, 3, double> dist_ul_deriv_r_xi_target(Core::LinAlg::Initialization::zero);
 
   for (unsigned int irow = 0; irow < 3; ++irow)
   {
     for (unsigned int icol = 0; icol < 3; ++icol)
     {
-      dist_ul_deriv_r_slave(irow, icol) -= r_xi_master(irow) * xi_master_partial_r_slave(icol);
+      dist_ul_deriv_r_source(irow, icol) -= r_xi_target(irow) * xi_target_partial_r_source(icol);
 
-      dist_ul_deriv_r_master(irow, icol) -= r_xi_master(irow) * xi_master_partial_r_master(icol);
+      dist_ul_deriv_r_target(irow, icol) -= r_xi_target(irow) * xi_target_partial_r_target(icol);
 
-      dist_ul_deriv_r_xi_master(irow, icol) -=
-          r_xi_master(irow) * xi_master_partial_r_xi_master(icol);
+      dist_ul_deriv_r_xi_target(irow, icol) -=
+          r_xi_target(irow) * xi_target_partial_r_xi_target(icol);
     }
   }
 
@@ -1601,226 +1601,230 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
 
 
   // second derivatives of the unilateral gap
-  Core::LinAlg::Matrix<3, 3, double> gap_ul_deriv_r_slave_deriv_r_slave(
+  Core::LinAlg::Matrix<3, 3, double> gap_ul_deriv_r_source_deriv_r_source(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> gap_ul_deriv_r_slave_deriv_r_master(
+  Core::LinAlg::Matrix<3, 3, double> gap_ul_deriv_r_source_deriv_r_target(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> gap_ul_deriv_r_slave_deriv_r_xi_master(
-      Core::LinAlg::Initialization::zero);
-
-  Core::LinAlg::Matrix<3, 3, double> gap_ul_deriv_r_master_deriv_r_slave(
-      Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> gap_ul_deriv_r_master_deriv_r_master(
-      Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> gap_ul_deriv_r_master_deriv_r_xi_master(
+  Core::LinAlg::Matrix<3, 3, double> gap_ul_deriv_r_source_deriv_r_xi_target(
       Core::LinAlg::Initialization::zero);
 
+  Core::LinAlg::Matrix<3, 3, double> gap_ul_deriv_r_target_deriv_r_source(
+      Core::LinAlg::Initialization::zero);
+  Core::LinAlg::Matrix<3, 3, double> gap_ul_deriv_r_target_deriv_r_target(
+      Core::LinAlg::Initialization::zero);
+  Core::LinAlg::Matrix<3, 3, double> gap_ul_deriv_r_target_deriv_r_xi_target(
+      Core::LinAlg::Initialization::zero);
 
-  gap_ul_deriv_r_slave_deriv_r_slave.multiply(1.0, normal_ul_deriv_dist_ul, dist_ul_deriv_r_slave);
-  gap_ul_deriv_r_slave_deriv_r_master.multiply(
-      1.0, normal_ul_deriv_dist_ul, dist_ul_deriv_r_master);
-  gap_ul_deriv_r_slave_deriv_r_xi_master.multiply(
-      1.0, normal_ul_deriv_dist_ul, dist_ul_deriv_r_xi_master);
 
-  gap_ul_deriv_r_master_deriv_r_slave.multiply(
-      -1.0, normal_ul_deriv_dist_ul, dist_ul_deriv_r_slave);
-  gap_ul_deriv_r_master_deriv_r_master.multiply(
-      -1.0, normal_ul_deriv_dist_ul, dist_ul_deriv_r_master);
-  gap_ul_deriv_r_master_deriv_r_xi_master.multiply(
-      -1.0, normal_ul_deriv_dist_ul, dist_ul_deriv_r_xi_master);
+  gap_ul_deriv_r_source_deriv_r_source.multiply(
+      1.0, normal_ul_deriv_dist_ul, dist_ul_deriv_r_source);
+  gap_ul_deriv_r_source_deriv_r_target.multiply(
+      1.0, normal_ul_deriv_dist_ul, dist_ul_deriv_r_target);
+  gap_ul_deriv_r_source_deriv_r_xi_target.multiply(
+      1.0, normal_ul_deriv_dist_ul, dist_ul_deriv_r_xi_target);
 
-  // add contributions from linearization of (variation of r_master) according to the chain
+  gap_ul_deriv_r_target_deriv_r_source.multiply(
+      -1.0, normal_ul_deriv_dist_ul, dist_ul_deriv_r_source);
+  gap_ul_deriv_r_target_deriv_r_target.multiply(
+      -1.0, normal_ul_deriv_dist_ul, dist_ul_deriv_r_target);
+  gap_ul_deriv_r_target_deriv_r_xi_target.multiply(
+      -1.0, normal_ul_deriv_dist_ul, dist_ul_deriv_r_xi_target);
+
+  // add contributions from linearization of (variation of r_target) according to the chain
   // rule
-  Core::LinAlg::Matrix<3, 3, double> gap_ul_deriv_r_xi_master_deriv_r_slave(
+  Core::LinAlg::Matrix<3, 3, double> gap_ul_deriv_r_xi_target_deriv_r_source(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> gap_ul_deriv_r_xi_master_deriv_r_master(
+  Core::LinAlg::Matrix<3, 3, double> gap_ul_deriv_r_xi_target_deriv_r_target(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> gap_ul_deriv_r_xi_master_deriv_r_xi_master(
+  Core::LinAlg::Matrix<3, 3, double> gap_ul_deriv_r_xi_target_deriv_r_xi_target(
       Core::LinAlg::Initialization::zero);
 
   for (unsigned int irow = 0; irow < 3; ++irow)
   {
     for (unsigned int icol = 0; icol < 3; ++icol)
     {
-      gap_ul_deriv_r_xi_master_deriv_r_slave(irow, icol) -=
-          normal_ul(irow) * xi_master_partial_r_slave(icol);
+      gap_ul_deriv_r_xi_target_deriv_r_source(irow, icol) -=
+          normal_ul(irow) * xi_target_partial_r_source(icol);
 
-      gap_ul_deriv_r_xi_master_deriv_r_master(irow, icol) -=
-          normal_ul(irow) * xi_master_partial_r_master(icol);
+      gap_ul_deriv_r_xi_target_deriv_r_target(irow, icol) -=
+          normal_ul(irow) * xi_target_partial_r_target(icol);
 
-      gap_ul_deriv_r_xi_master_deriv_r_xi_master(irow, icol) -=
-          normal_ul(irow) * xi_master_partial_r_xi_master(icol);
+      gap_ul_deriv_r_xi_target_deriv_r_xi_target(irow, icol) -=
+          normal_ul(irow) * xi_target_partial_r_xi_target(icol);
     }
   }
 
 
   // second derivatives of cos(alpha)
-  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_slave_deriv_r_slave(
+  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_source_deriv_r_source(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_slave_deriv_r_xi_slave(
+  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_source_deriv_r_xi_source(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_slave_deriv_r_master(
+  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_source_deriv_r_target(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_slave_deriv_r_xi_master(
+  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_source_deriv_r_xi_target(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_slave_deriv_r_xixi_master(
-      Core::LinAlg::Initialization::zero);
-
-  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_xi_slave_deriv_r_slave(
-      Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_xi_slave_deriv_r_xi_slave(
-      Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_xi_slave_deriv_r_master(
-      Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_xi_slave_deriv_r_xi_master(
+  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_source_deriv_r_xixi_target(
       Core::LinAlg::Initialization::zero);
 
-  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_master_deriv_r_slave(
+  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_xi_source_deriv_r_source(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_master_deriv_r_xi_slave(
+  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_xi_source_deriv_r_xi_source(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_master_deriv_r_master(
+  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_xi_source_deriv_r_target(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_master_deriv_r_xi_master(
-      Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_master_deriv_r_xixi_master(
+  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_xi_source_deriv_r_xi_target(
       Core::LinAlg::Initialization::zero);
 
-  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_xi_master_deriv_r_slave(
+  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_target_deriv_r_source(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_xi_master_deriv_r_xi_slave(
+  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_target_deriv_r_xi_source(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_xi_master_deriv_r_master(
+  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_target_deriv_r_target(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_xi_master_deriv_r_xi_master(
+  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_target_deriv_r_xi_target(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_xi_master_deriv_r_xixi_master(
+  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_target_deriv_r_xixi_target(
+      Core::LinAlg::Initialization::zero);
+
+  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_xi_target_deriv_r_source(
+      Core::LinAlg::Initialization::zero);
+  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_xi_target_deriv_r_xi_source(
+      Core::LinAlg::Initialization::zero);
+  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_xi_target_deriv_r_target(
+      Core::LinAlg::Initialization::zero);
+  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_xi_target_deriv_r_xi_target(
+      Core::LinAlg::Initialization::zero);
+  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_xi_target_deriv_r_xixi_target(
       Core::LinAlg::Initialization::zero);
 
 
   // auxiliary and intermediate quantities required for second derivatives of cos(alpha)
 
-  double norm_r_xi_slave_inverse = 1.0 / Core::FADUtils::vector_norm(r_xi_slave);
-  double norm_r_xi_master_inverse = 1.0 / Core::FADUtils::vector_norm(r_xi_master);
+  double norm_r_xi_source_inverse = 1.0 / Core::FADUtils::vector_norm(r_xi_source);
+  double norm_r_xi_target_inverse = 1.0 / Core::FADUtils::vector_norm(r_xi_target);
 
-  Core::LinAlg::Matrix<3, 1, double> t_slave(Core::LinAlg::Initialization::zero);
-  t_slave.update(norm_r_xi_slave_inverse, r_xi_slave);
-  Core::LinAlg::Matrix<3, 1, double> t_master(Core::LinAlg::Initialization::zero);
-  t_master.update(norm_r_xi_master_inverse, r_xi_master);
+  Core::LinAlg::Matrix<3, 1, double> t_source(Core::LinAlg::Initialization::zero);
+  t_source.update(norm_r_xi_source_inverse, r_xi_source);
+  Core::LinAlg::Matrix<3, 1, double> t_target(Core::LinAlg::Initialization::zero);
+  t_target.update(norm_r_xi_target_inverse, r_xi_target);
 
-  double t_slave_dot_t_master = t_slave.dot(t_master);
-  double signum_tangentsscalarproduct = Core::FADUtils::signum(t_slave_dot_t_master);
+  double t_source_dot_t_target = t_source.dot(t_target);
+  double signum_tangentsscalarproduct = Core::FADUtils::signum(t_source_dot_t_target);
 
-  Core::LinAlg::Matrix<3, 3, double> t_slave_tensorproduct_t_slave(
+  Core::LinAlg::Matrix<3, 3, double> t_source_tensorproduct_t_source(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> t_slave_tensorproduct_t_master(
+  Core::LinAlg::Matrix<3, 3, double> t_source_tensorproduct_t_target(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> t_master_tensorproduct_t_master(
+  Core::LinAlg::Matrix<3, 3, double> t_target_tensorproduct_t_target(
       Core::LinAlg::Initialization::zero);
 
   for (unsigned int i = 0; i < 3; ++i)
     for (unsigned int j = 0; j < 3; ++j)
     {
-      t_slave_tensorproduct_t_slave(i, j) = t_slave(i) * t_slave(j);
-      t_slave_tensorproduct_t_master(i, j) = t_slave(i) * t_master(j);
-      t_master_tensorproduct_t_master(i, j) = t_master(i) * t_master(j);
+      t_source_tensorproduct_t_source(i, j) = t_source(i) * t_source(j);
+      t_source_tensorproduct_t_target(i, j) = t_source(i) * t_target(j);
+      t_target_tensorproduct_t_target(i, j) = t_target(i) * t_target(j);
     }
 
-  Core::LinAlg::Matrix<3, 3, double> t_slave_partial_r_xi_slave(Core::LinAlg::Initialization::zero);
-  t_slave_partial_r_xi_slave.update(norm_r_xi_slave_inverse, unit_matrix,
-      -1.0 * norm_r_xi_slave_inverse, t_slave_tensorproduct_t_slave);
-
-  Core::LinAlg::Matrix<3, 3, double> t_master_partial_r_xi_master(
+  Core::LinAlg::Matrix<3, 3, double> t_source_partial_r_xi_source(
       Core::LinAlg::Initialization::zero);
-  t_master_partial_r_xi_master.update(norm_r_xi_master_inverse, unit_matrix,
-      -1.0 * norm_r_xi_master_inverse, t_master_tensorproduct_t_master);
+  t_source_partial_r_xi_source.update(norm_r_xi_source_inverse, unit_matrix,
+      -1.0 * norm_r_xi_source_inverse, t_source_tensorproduct_t_source);
 
-
-  Core::LinAlg::Matrix<3, 1, double> t_slave_partial_r_xi_slave_mult_t_master(
+  Core::LinAlg::Matrix<3, 3, double> t_target_partial_r_xi_target(
       Core::LinAlg::Initialization::zero);
-  t_slave_partial_r_xi_slave_mult_t_master.multiply(t_slave_partial_r_xi_slave, t_master);
+  t_target_partial_r_xi_target.update(norm_r_xi_target_inverse, unit_matrix,
+      -1.0 * norm_r_xi_target_inverse, t_target_tensorproduct_t_target);
+
+
+  Core::LinAlg::Matrix<3, 1, double> t_source_partial_r_xi_source_mult_t_target(
+      Core::LinAlg::Initialization::zero);
+  t_source_partial_r_xi_source_mult_t_target.multiply(t_source_partial_r_xi_source, t_target);
 
   for (unsigned int i = 0; i < 3; ++i)
     for (unsigned int j = 0; j < 3; ++j)
-      cos_alpha_deriv_r_xi_slave_deriv_r_xi_slave(i, j) -=
-          norm_r_xi_slave_inverse * t_slave_partial_r_xi_slave_mult_t_master(i) * t_slave(j);
+      cos_alpha_deriv_r_xi_source_deriv_r_xi_source(i, j) -=
+          norm_r_xi_source_inverse * t_source_partial_r_xi_source_mult_t_target(i) * t_source(j);
 
-  cos_alpha_deriv_r_xi_slave_deriv_r_xi_slave.update(
-      -1.0 * norm_r_xi_slave_inverse * t_slave_dot_t_master, t_slave_partial_r_xi_slave, 1.0);
+  cos_alpha_deriv_r_xi_source_deriv_r_xi_source.update(
+      -1.0 * norm_r_xi_source_inverse * t_source_dot_t_target, t_source_partial_r_xi_source, 1.0);
 
   Core::LinAlg::Matrix<3, 3, double> tmp_mat(Core::LinAlg::Initialization::zero);
-  tmp_mat.multiply(t_slave_tensorproduct_t_master, t_slave_partial_r_xi_slave);
-  cos_alpha_deriv_r_xi_slave_deriv_r_xi_slave.update(-1.0 * norm_r_xi_slave_inverse, tmp_mat, 1.0);
+  tmp_mat.multiply(t_source_tensorproduct_t_target, t_source_partial_r_xi_source);
+  cos_alpha_deriv_r_xi_source_deriv_r_xi_source.update(
+      -1.0 * norm_r_xi_source_inverse, tmp_mat, 1.0);
 
 
-  cos_alpha_deriv_r_xi_slave_deriv_r_xi_master.update(
-      norm_r_xi_slave_inverse, t_master_partial_r_xi_master, 1.0);
+  cos_alpha_deriv_r_xi_source_deriv_r_xi_target.update(
+      norm_r_xi_source_inverse, t_target_partial_r_xi_target, 1.0);
 
-  tmp_mat.multiply(t_slave_tensorproduct_t_slave, t_master_partial_r_xi_master);
-  cos_alpha_deriv_r_xi_slave_deriv_r_xi_master.update(-1.0 * norm_r_xi_slave_inverse, tmp_mat, 1.0);
+  tmp_mat.multiply(t_source_tensorproduct_t_source, t_target_partial_r_xi_target);
+  cos_alpha_deriv_r_xi_source_deriv_r_xi_target.update(
+      -1.0 * norm_r_xi_source_inverse, tmp_mat, 1.0);
 
 
 
-  Core::LinAlg::Matrix<3, 1, double> t_master_partial_r_xi_master_mult_t_slave(
+  Core::LinAlg::Matrix<3, 1, double> t_target_partial_r_xi_target_mult_t_source(
       Core::LinAlg::Initialization::zero);
-  t_master_partial_r_xi_master_mult_t_slave.multiply(t_master_partial_r_xi_master, t_slave);
+  t_target_partial_r_xi_target_mult_t_source.multiply(t_target_partial_r_xi_target, t_source);
 
   for (unsigned int i = 0; i < 3; ++i)
     for (unsigned int j = 0; j < 3; ++j)
-      cos_alpha_deriv_r_xi_master_deriv_r_xi_master(i, j) -=
-          norm_r_xi_master_inverse * t_master_partial_r_xi_master_mult_t_slave(i) * t_master(j);
+      cos_alpha_deriv_r_xi_target_deriv_r_xi_target(i, j) -=
+          norm_r_xi_target_inverse * t_target_partial_r_xi_target_mult_t_source(i) * t_target(j);
 
-  cos_alpha_deriv_r_xi_master_deriv_r_xi_master.update(
-      -1.0 * norm_r_xi_master_inverse * t_slave_dot_t_master, t_master_partial_r_xi_master, 1.0);
+  cos_alpha_deriv_r_xi_target_deriv_r_xi_target.update(
+      -1.0 * norm_r_xi_target_inverse * t_source_dot_t_target, t_target_partial_r_xi_target, 1.0);
 
   tmp_mat.clear();
-  tmp_mat.multiply_tn(t_slave_tensorproduct_t_master, t_master_partial_r_xi_master);
-  cos_alpha_deriv_r_xi_master_deriv_r_xi_master.update(
-      -1.0 * norm_r_xi_master_inverse, tmp_mat, 1.0);
+  tmp_mat.multiply_tn(t_source_tensorproduct_t_target, t_target_partial_r_xi_target);
+  cos_alpha_deriv_r_xi_target_deriv_r_xi_target.update(
+      -1.0 * norm_r_xi_target_inverse, tmp_mat, 1.0);
 
 
-  cos_alpha_deriv_r_xi_master_deriv_r_xi_slave.update(
-      norm_r_xi_master_inverse, t_slave_partial_r_xi_slave, 1.0);
+  cos_alpha_deriv_r_xi_target_deriv_r_xi_source.update(
+      norm_r_xi_target_inverse, t_source_partial_r_xi_source, 1.0);
 
-  tmp_mat.multiply(t_master_tensorproduct_t_master, t_slave_partial_r_xi_slave);
-  cos_alpha_deriv_r_xi_master_deriv_r_xi_slave.update(
-      -1.0 * norm_r_xi_master_inverse, tmp_mat, 1.0);
+  tmp_mat.multiply(t_target_tensorproduct_t_target, t_source_partial_r_xi_source);
+  cos_alpha_deriv_r_xi_target_deriv_r_xi_source.update(
+      -1.0 * norm_r_xi_target_inverse, tmp_mat, 1.0);
 
 
-  // add contributions from variation of master parameter coordinate xi_master
-  // to [.]_deriv_r_xi_master_[.] expressions (according to chain rule)
+  // add contributions from variation of target parameter coordinate xi_target
+  // to [.]_deriv_r_xi_target_[.] expressions (according to chain rule)
   Core::LinAlg::Matrix<1, 3, double> tmp_vec;
-  tmp_vec.multiply_tn(r_xixi_master, cos_alpha_deriv_r_xi_master_deriv_r_xi_slave);
+  tmp_vec.multiply_tn(r_xixi_target, cos_alpha_deriv_r_xi_target_deriv_r_xi_source);
 
   for (unsigned int irow = 0; irow < 3; ++irow)
   {
     for (unsigned int icol = 0; icol < 3; ++icol)
     {
-      cos_alpha_deriv_r_slave_deriv_r_xi_slave(irow, icol) +=
-          xi_master_partial_r_slave(irow) * tmp_vec(icol);
+      cos_alpha_deriv_r_source_deriv_r_xi_source(irow, icol) +=
+          xi_target_partial_r_source(irow) * tmp_vec(icol);
 
-      cos_alpha_deriv_r_master_deriv_r_xi_slave(irow, icol) +=
-          xi_master_partial_r_master(irow) * tmp_vec(icol);
+      cos_alpha_deriv_r_target_deriv_r_xi_source(irow, icol) +=
+          xi_target_partial_r_target(irow) * tmp_vec(icol);
 
-      cos_alpha_deriv_r_xi_master_deriv_r_xi_slave(irow, icol) +=
-          xi_master_partial_r_xi_master(irow) * tmp_vec(icol);
+      cos_alpha_deriv_r_xi_target_deriv_r_xi_source(irow, icol) +=
+          xi_target_partial_r_xi_target(irow) * tmp_vec(icol);
     }
   }
 
-  tmp_vec.multiply_tn(r_xixi_master, cos_alpha_deriv_r_xi_master_deriv_r_xi_master);
+  tmp_vec.multiply_tn(r_xixi_target, cos_alpha_deriv_r_xi_target_deriv_r_xi_target);
 
   for (unsigned int irow = 0; irow < 3; ++irow)
   {
     for (unsigned int icol = 0; icol < 3; ++icol)
     {
-      cos_alpha_deriv_r_slave_deriv_r_xi_master(irow, icol) +=
-          xi_master_partial_r_slave(irow) * tmp_vec(icol);
+      cos_alpha_deriv_r_source_deriv_r_xi_target(irow, icol) +=
+          xi_target_partial_r_source(irow) * tmp_vec(icol);
 
-      cos_alpha_deriv_r_master_deriv_r_xi_master(irow, icol) +=
-          xi_master_partial_r_master(irow) * tmp_vec(icol);
+      cos_alpha_deriv_r_target_deriv_r_xi_target(irow, icol) +=
+          xi_target_partial_r_target(irow) * tmp_vec(icol);
 
-      cos_alpha_deriv_r_xi_master_deriv_r_xi_master(irow, icol) +=
-          xi_master_partial_r_xi_master(irow) * tmp_vec(icol);
+      cos_alpha_deriv_r_xi_target_deriv_r_xi_target(irow, icol) +=
+          xi_target_partial_r_xi_target(irow) * tmp_vec(icol);
     }
   }
 
@@ -1829,311 +1833,312 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
   {
     for (unsigned int icol = 0; icol < 3; ++icol)
     {
-      cos_alpha_deriv_r_slave_deriv_r_xixi_master(irow, icol) +=
-          xi_master_partial_r_slave(irow) * t_master_partial_r_xi_master_mult_t_slave(icol);
+      cos_alpha_deriv_r_source_deriv_r_xixi_target(irow, icol) +=
+          xi_target_partial_r_source(irow) * t_target_partial_r_xi_target_mult_t_source(icol);
 
-      cos_alpha_deriv_r_master_deriv_r_xixi_master(irow, icol) +=
-          xi_master_partial_r_master(irow) * t_master_partial_r_xi_master_mult_t_slave(icol);
+      cos_alpha_deriv_r_target_deriv_r_xixi_target(irow, icol) +=
+          xi_target_partial_r_target(irow) * t_target_partial_r_xi_target_mult_t_source(icol);
 
-      cos_alpha_deriv_r_xi_master_deriv_r_xixi_master(irow, icol) +=
-          xi_master_partial_r_xi_master(irow) * t_master_partial_r_xi_master_mult_t_slave(icol);
+      cos_alpha_deriv_r_xi_target_deriv_r_xixi_target(irow, icol) +=
+          xi_target_partial_r_xi_target(irow) * t_target_partial_r_xi_target_mult_t_source(icol);
     }
   }
 
 
-  // add contributions from linearization of master parameter coordinate xi_master
-  // to [.]_deriv_r_xi_master expressions (according to chain rule)
+  // add contributions from linearization of target parameter coordinate xi_target
+  // to [.]_deriv_r_xi_target expressions (according to chain rule)
   Core::LinAlg::Matrix<3, 1, double> tmp_vec2;
-  tmp_vec2.multiply(cos_alpha_deriv_r_slave_deriv_r_xi_master, r_xixi_master);
+  tmp_vec2.multiply(cos_alpha_deriv_r_source_deriv_r_xi_target, r_xixi_target);
 
   for (unsigned int irow = 0; irow < 3; ++irow)
   {
     for (unsigned int icol = 0; icol < 3; ++icol)
     {
-      cos_alpha_deriv_r_slave_deriv_r_slave(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_slave(icol);
+      cos_alpha_deriv_r_source_deriv_r_source(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_source(icol);
 
-      cos_alpha_deriv_r_slave_deriv_r_master(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_master(icol);
+      cos_alpha_deriv_r_source_deriv_r_target(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_target(icol);
 
-      cos_alpha_deriv_r_slave_deriv_r_xi_master(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_xi_master(icol);
+      cos_alpha_deriv_r_source_deriv_r_xi_target(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_xi_target(icol);
     }
   }
 
 
-  tmp_vec2.multiply(cos_alpha_deriv_r_xi_slave_deriv_r_xi_master, r_xixi_master);
+  tmp_vec2.multiply(cos_alpha_deriv_r_xi_source_deriv_r_xi_target, r_xixi_target);
 
   for (unsigned int irow = 0; irow < 3; ++irow)
   {
     for (unsigned int icol = 0; icol < 3; ++icol)
     {
-      cos_alpha_deriv_r_xi_slave_deriv_r_slave(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_slave(icol);
+      cos_alpha_deriv_r_xi_source_deriv_r_source(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_source(icol);
 
-      cos_alpha_deriv_r_xi_slave_deriv_r_master(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_master(icol);
+      cos_alpha_deriv_r_xi_source_deriv_r_target(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_target(icol);
 
-      cos_alpha_deriv_r_xi_slave_deriv_r_xi_master(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_xi_master(icol);
+      cos_alpha_deriv_r_xi_source_deriv_r_xi_target(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_xi_target(icol);
     }
   }
 
 
-  tmp_vec2.multiply(cos_alpha_deriv_r_master_deriv_r_xi_master, r_xixi_master);
+  tmp_vec2.multiply(cos_alpha_deriv_r_target_deriv_r_xi_target, r_xixi_target);
 
   for (unsigned int irow = 0; irow < 3; ++irow)
   {
     for (unsigned int icol = 0; icol < 3; ++icol)
     {
-      cos_alpha_deriv_r_master_deriv_r_slave(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_slave(icol);
+      cos_alpha_deriv_r_target_deriv_r_source(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_source(icol);
 
-      cos_alpha_deriv_r_master_deriv_r_master(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_master(icol);
+      cos_alpha_deriv_r_target_deriv_r_target(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_target(icol);
 
-      cos_alpha_deriv_r_master_deriv_r_xi_master(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_xi_master(icol);
+      cos_alpha_deriv_r_target_deriv_r_xi_target(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_xi_target(icol);
     }
   }
 
 
-  tmp_vec2.multiply(cos_alpha_deriv_r_xi_master_deriv_r_xi_master, r_xixi_master);
+  tmp_vec2.multiply(cos_alpha_deriv_r_xi_target_deriv_r_xi_target, r_xixi_target);
 
   for (unsigned int irow = 0; irow < 3; ++irow)
   {
     for (unsigned int icol = 0; icol < 3; ++icol)
     {
-      cos_alpha_deriv_r_xi_master_deriv_r_slave(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_slave(icol);
+      cos_alpha_deriv_r_xi_target_deriv_r_source(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_source(icol);
 
-      cos_alpha_deriv_r_xi_master_deriv_r_master(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_master(icol);
+      cos_alpha_deriv_r_xi_target_deriv_r_target(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_target(icol);
 
-      cos_alpha_deriv_r_xi_master_deriv_r_xi_master(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_xi_master(icol);
+      cos_alpha_deriv_r_xi_target_deriv_r_xi_target(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_xi_target(icol);
     }
   }
 
 
-  // add contributions from linearization of master parameter coordinate xi_master
-  // also to [.]_deriv_r_xixi_master expressions (according to chain rule)
-  Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> N_i_xixixi_master(
+  // add contributions from linearization of target parameter coordinate xi_target
+  // also to [.]_deriv_r_xixi_target expressions (according to chain rule)
+  Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> N_i_xixixi_target(
       Core::LinAlg::Initialization::zero);
 
   Discret::Utils::Beam::evaluate_shape_function3rd_derivs_at_xi<numnodes, numnodalvalues>(
-      xi_master, N_i_xixixi_master, beam_element2()->shape(), ele2length_);
+      xi_target, N_i_xixixi_target, beam_element2()->shape(), ele2length_);
 
-  Core::LinAlg::Matrix<3, 1, double> r_xixixi_master(Core::LinAlg::Initialization::zero);
+  Core::LinAlg::Matrix<3, 1, double> r_xixixi_target(Core::LinAlg::Initialization::zero);
 
   Discret::Utils::Beam::calc_interpolation<numnodes, numnodalvalues, 3>(
-      Core::FADUtils::cast_to_double(ele2pos_), N_i_xixixi_master, r_xixixi_master);
+      Core::FADUtils::cast_to_double(ele2pos_), N_i_xixixi_target, r_xixixi_target);
 
-  tmp_vec2.multiply(cos_alpha_deriv_r_slave_deriv_r_xixi_master, r_xixixi_master);
-
-  for (unsigned int irow = 0; irow < 3; ++irow)
-  {
-    for (unsigned int icol = 0; icol < 3; ++icol)
-    {
-      cos_alpha_deriv_r_slave_deriv_r_slave(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_slave(icol);
-
-      cos_alpha_deriv_r_slave_deriv_r_master(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_master(icol);
-
-      cos_alpha_deriv_r_slave_deriv_r_xi_master(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_xi_master(icol);
-    }
-  }
-
-  tmp_vec2.multiply(cos_alpha_deriv_r_master_deriv_r_xixi_master, r_xixixi_master);
+  tmp_vec2.multiply(cos_alpha_deriv_r_source_deriv_r_xixi_target, r_xixixi_target);
 
   for (unsigned int irow = 0; irow < 3; ++irow)
   {
     for (unsigned int icol = 0; icol < 3; ++icol)
     {
-      cos_alpha_deriv_r_master_deriv_r_slave(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_slave(icol);
+      cos_alpha_deriv_r_source_deriv_r_source(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_source(icol);
 
-      cos_alpha_deriv_r_master_deriv_r_master(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_master(icol);
+      cos_alpha_deriv_r_source_deriv_r_target(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_target(icol);
 
-      cos_alpha_deriv_r_master_deriv_r_xi_master(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_xi_master(icol);
+      cos_alpha_deriv_r_source_deriv_r_xi_target(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_xi_target(icol);
     }
   }
 
-  tmp_vec2.multiply(cos_alpha_deriv_r_xi_master_deriv_r_xixi_master, r_xixixi_master);
+  tmp_vec2.multiply(cos_alpha_deriv_r_target_deriv_r_xixi_target, r_xixixi_target);
 
   for (unsigned int irow = 0; irow < 3; ++irow)
   {
     for (unsigned int icol = 0; icol < 3; ++icol)
     {
-      cos_alpha_deriv_r_xi_master_deriv_r_slave(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_slave(icol);
+      cos_alpha_deriv_r_target_deriv_r_source(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_source(icol);
 
-      cos_alpha_deriv_r_xi_master_deriv_r_master(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_master(icol);
+      cos_alpha_deriv_r_target_deriv_r_target(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_target(icol);
 
-      cos_alpha_deriv_r_xi_master_deriv_r_xi_master(irow, icol) +=
-          tmp_vec2(irow) * xi_master_partial_r_xi_master(icol);
+      cos_alpha_deriv_r_target_deriv_r_xi_target(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_xi_target(icol);
+    }
+  }
+
+  tmp_vec2.multiply(cos_alpha_deriv_r_xi_target_deriv_r_xixi_target, r_xixixi_target);
+
+  for (unsigned int irow = 0; irow < 3; ++irow)
+  {
+    for (unsigned int icol = 0; icol < 3; ++icol)
+    {
+      cos_alpha_deriv_r_xi_target_deriv_r_source(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_source(icol);
+
+      cos_alpha_deriv_r_xi_target_deriv_r_target(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_target(icol);
+
+      cos_alpha_deriv_r_xi_target_deriv_r_xi_target(irow, icol) +=
+          tmp_vec2(irow) * xi_target_partial_r_xi_target(icol);
     }
   }
 
 
-  // add contributions from linearization of (variation of r_xi_master) according to the chain
+  // add contributions from linearization of (variation of r_xi_target) according to the chain
   // rule
-  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_xixi_master_deriv_r_slave(
+  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_xixi_target_deriv_r_source(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_xixi_master_deriv_r_master(
+  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_xixi_target_deriv_r_target(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_xixi_master_deriv_r_xi_master(
+  Core::LinAlg::Matrix<3, 3, double> cos_alpha_deriv_r_xixi_target_deriv_r_xi_target(
       Core::LinAlg::Initialization::zero);
 
   for (unsigned int irow = 0; irow < 3; ++irow)
   {
     for (unsigned int icol = 0; icol < 3; ++icol)
     {
-      cos_alpha_deriv_r_xixi_master_deriv_r_slave(irow, icol) +=
-          t_master_partial_r_xi_master_mult_t_slave(irow) * xi_master_partial_r_slave(icol);
+      cos_alpha_deriv_r_xixi_target_deriv_r_source(irow, icol) +=
+          t_target_partial_r_xi_target_mult_t_source(irow) * xi_target_partial_r_source(icol);
 
-      cos_alpha_deriv_r_xixi_master_deriv_r_master(irow, icol) +=
-          t_master_partial_r_xi_master_mult_t_slave(irow) * xi_master_partial_r_master(icol);
+      cos_alpha_deriv_r_xixi_target_deriv_r_target(irow, icol) +=
+          t_target_partial_r_xi_target_mult_t_source(irow) * xi_target_partial_r_target(icol);
 
-      cos_alpha_deriv_r_xixi_master_deriv_r_xi_master(irow, icol) +=
-          t_master_partial_r_xi_master_mult_t_slave(irow) * xi_master_partial_r_xi_master(icol);
+      cos_alpha_deriv_r_xixi_target_deriv_r_xi_target(irow, icol) +=
+          t_target_partial_r_xi_target_mult_t_source(irow) * xi_target_partial_r_xi_target(icol);
     }
   }
 
 
-  // contributions from linarization of the (variation of master parameter coordinate xi_master)
-  Core::LinAlg::Matrix<3, 3, double> xi_master_partial_r_slave_partial_r_slave(
+  // contributions from linarization of the (variation of target parameter coordinate xi_target)
+  Core::LinAlg::Matrix<3, 3, double> xi_target_partial_r_source_partial_r_source(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> xi_master_partial_r_slave_partial_r_master(
+  Core::LinAlg::Matrix<3, 3, double> xi_target_partial_r_source_partial_r_target(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> xi_master_partial_r_slave_partial_r_xi_master(
+  Core::LinAlg::Matrix<3, 3, double> xi_target_partial_r_source_partial_r_xi_target(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> xi_master_partial_r_slave_partial_r_xixi_master(
+  Core::LinAlg::Matrix<3, 3, double> xi_target_partial_r_source_partial_r_xixi_target(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> xi_master_partial_r_master_partial_r_slave(
+  Core::LinAlg::Matrix<3, 3, double> xi_target_partial_r_target_partial_r_source(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> xi_master_partial_r_master_partial_r_master(
+  Core::LinAlg::Matrix<3, 3, double> xi_target_partial_r_target_partial_r_target(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> xi_master_partial_r_master_partial_r_xi_master(
+  Core::LinAlg::Matrix<3, 3, double> xi_target_partial_r_target_partial_r_xi_target(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> xi_master_partial_r_master_partial_r_xixi_master(
+  Core::LinAlg::Matrix<3, 3, double> xi_target_partial_r_target_partial_r_xixi_target(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> xi_master_partial_r_xi_master_partial_r_slave(
+  Core::LinAlg::Matrix<3, 3, double> xi_target_partial_r_xi_target_partial_r_source(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> xi_master_partial_r_xi_master_partial_r_master(
+  Core::LinAlg::Matrix<3, 3, double> xi_target_partial_r_xi_target_partial_r_target(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> xi_master_partial_r_xi_master_partial_r_xi_master(
+  Core::LinAlg::Matrix<3, 3, double> xi_target_partial_r_xi_target_partial_r_xi_target(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> xi_master_partial_r_xi_master_partial_r_xixi_master(
+  Core::LinAlg::Matrix<3, 3, double> xi_target_partial_r_xi_target_partial_r_xixi_target(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> xi_master_partial_r_xixi_master_partial_r_slave(
+  Core::LinAlg::Matrix<3, 3, double> xi_target_partial_r_xixi_target_partial_r_source(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> xi_master_partial_r_xixi_master_partial_r_master(
+  Core::LinAlg::Matrix<3, 3, double> xi_target_partial_r_xixi_target_partial_r_target(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 3, double> xi_master_partial_r_xixi_master_partial_r_xi_master(
+  Core::LinAlg::Matrix<3, 3, double> xi_target_partial_r_xixi_target_partial_r_xi_target(
       Core::LinAlg::Initialization::zero);
 
   Core::LinAlg::Matrix<3, 1, double> dist_ul(Core::LinAlg::Initialization::zero);
   dist_ul.update(norm_dist_ul, normal_ul);
 
-  BeamInteraction::Geo::calc_point_to_curve_projection_parameter_coord_master_partial2nd_derivs(
-      xi_master_partial_r_slave_partial_r_slave, xi_master_partial_r_slave_partial_r_master,
-      xi_master_partial_r_slave_partial_r_xi_master,
-      xi_master_partial_r_slave_partial_r_xixi_master, xi_master_partial_r_master_partial_r_slave,
-      xi_master_partial_r_master_partial_r_master, xi_master_partial_r_master_partial_r_xi_master,
-      xi_master_partial_r_master_partial_r_xixi_master,
-      xi_master_partial_r_xi_master_partial_r_slave, xi_master_partial_r_xi_master_partial_r_master,
-      xi_master_partial_r_xi_master_partial_r_xi_master,
-      xi_master_partial_r_xi_master_partial_r_xixi_master,
-      xi_master_partial_r_xixi_master_partial_r_slave,
-      xi_master_partial_r_xixi_master_partial_r_master,
-      xi_master_partial_r_xixi_master_partial_r_xi_master, xi_master_partial_r_slave,
-      xi_master_partial_r_master, xi_master_partial_r_xi_master, dist_ul_deriv_r_slave,
-      dist_ul_deriv_r_master, dist_ul_deriv_r_xi_master, dist_ul, r_xi_master, r_xixi_master,
-      r_xixixi_master);
+  BeamInteraction::Geo::calc_point_to_curve_projection_parameter_coord_target_partial2nd_derivs(
+      xi_target_partial_r_source_partial_r_source, xi_target_partial_r_source_partial_r_target,
+      xi_target_partial_r_source_partial_r_xi_target,
+      xi_target_partial_r_source_partial_r_xixi_target, xi_target_partial_r_target_partial_r_source,
+      xi_target_partial_r_target_partial_r_target, xi_target_partial_r_target_partial_r_xi_target,
+      xi_target_partial_r_target_partial_r_xixi_target,
+      xi_target_partial_r_xi_target_partial_r_source,
+      xi_target_partial_r_xi_target_partial_r_target,
+      xi_target_partial_r_xi_target_partial_r_xi_target,
+      xi_target_partial_r_xi_target_partial_r_xixi_target,
+      xi_target_partial_r_xixi_target_partial_r_source,
+      xi_target_partial_r_xixi_target_partial_r_target,
+      xi_target_partial_r_xixi_target_partial_r_xi_target, xi_target_partial_r_source,
+      xi_target_partial_r_target, xi_target_partial_r_xi_target, dist_ul_deriv_r_source,
+      dist_ul_deriv_r_target, dist_ul_deriv_r_xi_target, dist_ul, r_xi_target, r_xixi_target,
+      r_xixixi_target);
 
-  double r_xixi_master_dot_v2 = r_xixi_master.dot(t_master_partial_r_xi_master_mult_t_slave);
+  double r_xixi_target_dot_v2 = r_xixi_target.dot(t_target_partial_r_xi_target_mult_t_source);
 
-  cos_alpha_deriv_r_slave_deriv_r_slave.update(
-      r_xixi_master_dot_v2, xi_master_partial_r_slave_partial_r_slave, 1.0);
+  cos_alpha_deriv_r_source_deriv_r_source.update(
+      r_xixi_target_dot_v2, xi_target_partial_r_source_partial_r_source, 1.0);
 
-  cos_alpha_deriv_r_slave_deriv_r_master.update(
-      r_xixi_master_dot_v2, xi_master_partial_r_slave_partial_r_master, 1.0);
+  cos_alpha_deriv_r_source_deriv_r_target.update(
+      r_xixi_target_dot_v2, xi_target_partial_r_source_partial_r_target, 1.0);
 
-  cos_alpha_deriv_r_slave_deriv_r_xi_master.update(
-      r_xixi_master_dot_v2, xi_master_partial_r_slave_partial_r_xi_master, 1.0);
+  cos_alpha_deriv_r_source_deriv_r_xi_target.update(
+      r_xixi_target_dot_v2, xi_target_partial_r_source_partial_r_xi_target, 1.0);
 
-  cos_alpha_deriv_r_slave_deriv_r_xixi_master.update(
-      r_xixi_master_dot_v2, xi_master_partial_r_slave_partial_r_xixi_master, 1.0);
-
-
-  cos_alpha_deriv_r_master_deriv_r_slave.update(
-      r_xixi_master_dot_v2, xi_master_partial_r_master_partial_r_slave, 1.0);
-
-  cos_alpha_deriv_r_master_deriv_r_master.update(
-      r_xixi_master_dot_v2, xi_master_partial_r_master_partial_r_master, 1.0);
-
-  cos_alpha_deriv_r_master_deriv_r_xi_master.update(
-      r_xixi_master_dot_v2, xi_master_partial_r_master_partial_r_xi_master, 1.0);
-
-  cos_alpha_deriv_r_master_deriv_r_xixi_master.update(
-      r_xixi_master_dot_v2, xi_master_partial_r_master_partial_r_xixi_master, 1.0);
+  cos_alpha_deriv_r_source_deriv_r_xixi_target.update(
+      r_xixi_target_dot_v2, xi_target_partial_r_source_partial_r_xixi_target, 1.0);
 
 
-  cos_alpha_deriv_r_xi_master_deriv_r_slave.update(
-      r_xixi_master_dot_v2, xi_master_partial_r_xi_master_partial_r_slave, 1.0);
+  cos_alpha_deriv_r_target_deriv_r_source.update(
+      r_xixi_target_dot_v2, xi_target_partial_r_target_partial_r_source, 1.0);
 
-  cos_alpha_deriv_r_xi_master_deriv_r_master.update(
-      r_xixi_master_dot_v2, xi_master_partial_r_xi_master_partial_r_master, 1.0);
+  cos_alpha_deriv_r_target_deriv_r_target.update(
+      r_xixi_target_dot_v2, xi_target_partial_r_target_partial_r_target, 1.0);
 
-  cos_alpha_deriv_r_xi_master_deriv_r_xi_master.update(
-      r_xixi_master_dot_v2, xi_master_partial_r_xi_master_partial_r_xi_master, 1.0);
+  cos_alpha_deriv_r_target_deriv_r_xi_target.update(
+      r_xixi_target_dot_v2, xi_target_partial_r_target_partial_r_xi_target, 1.0);
 
-  cos_alpha_deriv_r_xi_master_deriv_r_xixi_master.update(
-      r_xixi_master_dot_v2, xi_master_partial_r_xi_master_partial_r_xixi_master, 1.0);
-
-
-  cos_alpha_deriv_r_xixi_master_deriv_r_slave.update(
-      r_xixi_master_dot_v2, xi_master_partial_r_xixi_master_partial_r_slave, 1.0);
-
-  cos_alpha_deriv_r_xixi_master_deriv_r_master.update(
-      r_xixi_master_dot_v2, xi_master_partial_r_xixi_master_partial_r_master, 1.0);
-
-  cos_alpha_deriv_r_xixi_master_deriv_r_xi_master.update(
-      r_xixi_master_dot_v2, xi_master_partial_r_xixi_master_partial_r_xi_master, 1.0);
+  cos_alpha_deriv_r_target_deriv_r_xixi_target.update(
+      r_xixi_target_dot_v2, xi_target_partial_r_target_partial_r_xixi_target, 1.0);
 
 
-  cos_alpha_deriv_r_slave_deriv_r_slave.scale(signum_tangentsscalarproduct);
-  cos_alpha_deriv_r_slave_deriv_r_xi_slave.scale(signum_tangentsscalarproduct);
-  cos_alpha_deriv_r_slave_deriv_r_master.scale(signum_tangentsscalarproduct);
-  cos_alpha_deriv_r_slave_deriv_r_xi_master.scale(signum_tangentsscalarproduct);
-  cos_alpha_deriv_r_slave_deriv_r_xixi_master.scale(signum_tangentsscalarproduct);
+  cos_alpha_deriv_r_xi_target_deriv_r_source.update(
+      r_xixi_target_dot_v2, xi_target_partial_r_xi_target_partial_r_source, 1.0);
 
-  cos_alpha_deriv_r_xi_slave_deriv_r_slave.scale(signum_tangentsscalarproduct);
-  cos_alpha_deriv_r_xi_slave_deriv_r_xi_slave.scale(signum_tangentsscalarproduct);
-  cos_alpha_deriv_r_xi_slave_deriv_r_master.scale(signum_tangentsscalarproduct);
-  cos_alpha_deriv_r_xi_slave_deriv_r_xi_master.scale(signum_tangentsscalarproduct);
+  cos_alpha_deriv_r_xi_target_deriv_r_target.update(
+      r_xixi_target_dot_v2, xi_target_partial_r_xi_target_partial_r_target, 1.0);
 
-  cos_alpha_deriv_r_master_deriv_r_slave.scale(signum_tangentsscalarproduct);
-  cos_alpha_deriv_r_master_deriv_r_xi_slave.scale(signum_tangentsscalarproduct);
-  cos_alpha_deriv_r_master_deriv_r_master.scale(signum_tangentsscalarproduct);
-  cos_alpha_deriv_r_master_deriv_r_xi_master.scale(signum_tangentsscalarproduct);
-  cos_alpha_deriv_r_master_deriv_r_xixi_master.scale(signum_tangentsscalarproduct);
+  cos_alpha_deriv_r_xi_target_deriv_r_xi_target.update(
+      r_xixi_target_dot_v2, xi_target_partial_r_xi_target_partial_r_xi_target, 1.0);
 
-  cos_alpha_deriv_r_xi_master_deriv_r_slave.scale(signum_tangentsscalarproduct);
-  cos_alpha_deriv_r_xi_master_deriv_r_xi_slave.scale(signum_tangentsscalarproduct);
-  cos_alpha_deriv_r_xi_master_deriv_r_master.scale(signum_tangentsscalarproduct);
-  cos_alpha_deriv_r_xi_master_deriv_r_xi_master.scale(signum_tangentsscalarproduct);
-  cos_alpha_deriv_r_xi_master_deriv_r_xixi_master.scale(signum_tangentsscalarproduct);
+  cos_alpha_deriv_r_xi_target_deriv_r_xixi_target.update(
+      r_xixi_target_dot_v2, xi_target_partial_r_xi_target_partial_r_xixi_target, 1.0);
 
-  cos_alpha_deriv_r_xixi_master_deriv_r_slave.scale(signum_tangentsscalarproduct);
-  cos_alpha_deriv_r_xixi_master_deriv_r_master.scale(signum_tangentsscalarproduct);
-  cos_alpha_deriv_r_xixi_master_deriv_r_xi_master.scale(signum_tangentsscalarproduct);
+
+  cos_alpha_deriv_r_xixi_target_deriv_r_source.update(
+      r_xixi_target_dot_v2, xi_target_partial_r_xixi_target_partial_r_source, 1.0);
+
+  cos_alpha_deriv_r_xixi_target_deriv_r_target.update(
+      r_xixi_target_dot_v2, xi_target_partial_r_xixi_target_partial_r_target, 1.0);
+
+  cos_alpha_deriv_r_xixi_target_deriv_r_xi_target.update(
+      r_xixi_target_dot_v2, xi_target_partial_r_xixi_target_partial_r_xi_target, 1.0);
+
+
+  cos_alpha_deriv_r_source_deriv_r_source.scale(signum_tangentsscalarproduct);
+  cos_alpha_deriv_r_source_deriv_r_xi_source.scale(signum_tangentsscalarproduct);
+  cos_alpha_deriv_r_source_deriv_r_target.scale(signum_tangentsscalarproduct);
+  cos_alpha_deriv_r_source_deriv_r_xi_target.scale(signum_tangentsscalarproduct);
+  cos_alpha_deriv_r_source_deriv_r_xixi_target.scale(signum_tangentsscalarproduct);
+
+  cos_alpha_deriv_r_xi_source_deriv_r_source.scale(signum_tangentsscalarproduct);
+  cos_alpha_deriv_r_xi_source_deriv_r_xi_source.scale(signum_tangentsscalarproduct);
+  cos_alpha_deriv_r_xi_source_deriv_r_target.scale(signum_tangentsscalarproduct);
+  cos_alpha_deriv_r_xi_source_deriv_r_xi_target.scale(signum_tangentsscalarproduct);
+
+  cos_alpha_deriv_r_target_deriv_r_source.scale(signum_tangentsscalarproduct);
+  cos_alpha_deriv_r_target_deriv_r_xi_source.scale(signum_tangentsscalarproduct);
+  cos_alpha_deriv_r_target_deriv_r_target.scale(signum_tangentsscalarproduct);
+  cos_alpha_deriv_r_target_deriv_r_xi_target.scale(signum_tangentsscalarproduct);
+  cos_alpha_deriv_r_target_deriv_r_xixi_target.scale(signum_tangentsscalarproduct);
+
+  cos_alpha_deriv_r_xi_target_deriv_r_source.scale(signum_tangentsscalarproduct);
+  cos_alpha_deriv_r_xi_target_deriv_r_xi_source.scale(signum_tangentsscalarproduct);
+  cos_alpha_deriv_r_xi_target_deriv_r_target.scale(signum_tangentsscalarproduct);
+  cos_alpha_deriv_r_xi_target_deriv_r_xi_target.scale(signum_tangentsscalarproduct);
+  cos_alpha_deriv_r_xi_target_deriv_r_xixi_target.scale(signum_tangentsscalarproduct);
+
+  cos_alpha_deriv_r_xixi_target_deriv_r_source.scale(signum_tangentsscalarproduct);
+  cos_alpha_deriv_r_xixi_target_deriv_r_target.scale(signum_tangentsscalarproduct);
+  cos_alpha_deriv_r_xixi_target_deriv_r_xi_target.scale(signum_tangentsscalarproduct);
 
 
   // assemble all pre-computed terms into the stiffness matrices
@@ -2147,331 +2152,332 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
       {
         for (unsigned int icolumndim = 0; icolumndim < num_spatial_dimensions; ++icolumndim)
         {
-          // variation of xi_master * linearization of (pot_red_fac_deriv_xi_master * pot_ia)
+          // variation of xi_target * linearization of (pot_red_fac_deriv_xi_target * pot_ia)
           stiffmat11(3 * irowdofperdim + irowdim, 3 * icolumndofperdim + icolumndim) +=
-              N_i_slave(irowdofperdim) * xi_master_partial_r_slave(irowdim) *
-              (pot_red_fac_2ndderiv_xi_master * xi_master_partial_r_slave(icolumndim) *
-                      N_i_slave(icolumndofperdim) * pot_ia +
-                  pot_red_fac_deriv_xi_master *
-                      (pot_ia_deriv_gap_ul * gap_ul_deriv_r_slave(icolumndim) *
-                              N_i_slave(icolumndofperdim) +
-                          pot_ia_deriv_cos_alpha * cos_alpha_deriv_r_slave(icolumndim) *
-                              N_i_slave(icolumndofperdim) +
-                          pot_ia_deriv_cos_alpha * cos_alpha_deriv_r_xi_slave(icolumndim) *
-                              N_i_xi_slave(icolumndofperdim)));
+              N_i_source(irowdofperdim) * xi_target_partial_r_source(irowdim) *
+              (pot_red_fac_2ndderiv_xi_target * xi_target_partial_r_source(icolumndim) *
+                      N_i_source(icolumndofperdim) * pot_ia +
+                  pot_red_fac_deriv_xi_target *
+                      (pot_ia_deriv_gap_ul * gap_ul_deriv_r_source(icolumndim) *
+                              N_i_source(icolumndofperdim) +
+                          pot_ia_deriv_cos_alpha * cos_alpha_deriv_r_source(icolumndim) *
+                              N_i_source(icolumndofperdim) +
+                          pot_ia_deriv_cos_alpha * cos_alpha_deriv_r_xi_source(icolumndim) *
+                              N_i_xi_source(icolumndofperdim)));
 
           stiffmat12(3 * irowdofperdim + irowdim, 3 * icolumndofperdim + icolumndim) +=
-              N_i_slave(irowdofperdim) * xi_master_partial_r_slave(irowdim) *
-              (pot_red_fac_2ndderiv_xi_master *
-                      (xi_master_partial_r_master(icolumndim) * N_i_master(icolumndofperdim) +
-                          xi_master_partial_r_xi_master(icolumndim) *
-                              N_i_xi_master(icolumndofperdim)) *
+              N_i_source(irowdofperdim) * xi_target_partial_r_source(irowdim) *
+              (pot_red_fac_2ndderiv_xi_target *
+                      (xi_target_partial_r_target(icolumndim) * N_i_target(icolumndofperdim) +
+                          xi_target_partial_r_xi_target(icolumndim) *
+                              N_i_xi_target(icolumndofperdim)) *
                       pot_ia +
-                  pot_red_fac_deriv_xi_master *
-                      (pot_ia_deriv_gap_ul * gap_ul_deriv_r_master(icolumndim) *
-                              N_i_master(icolumndofperdim) +
-                          pot_ia_deriv_cos_alpha * cos_alpha_deriv_r_master(icolumndim) *
-                              N_i_master(icolumndofperdim) +
-                          pot_ia_deriv_cos_alpha * cos_alpha_deriv_r_xi_master(icolumndim) *
-                              N_i_xi_master(icolumndofperdim)));
+                  pot_red_fac_deriv_xi_target *
+                      (pot_ia_deriv_gap_ul * gap_ul_deriv_r_target(icolumndim) *
+                              N_i_target(icolumndofperdim) +
+                          pot_ia_deriv_cos_alpha * cos_alpha_deriv_r_target(icolumndim) *
+                              N_i_target(icolumndofperdim) +
+                          pot_ia_deriv_cos_alpha * cos_alpha_deriv_r_xi_target(icolumndim) *
+                              N_i_xi_target(icolumndofperdim)));
 
           stiffmat21(3 * irowdofperdim + irowdim, 3 * icolumndofperdim + icolumndim) +=
-              (N_i_master(irowdofperdim) * xi_master_partial_r_master(irowdim) +
-                  N_i_xi_master(irowdofperdim) * xi_master_partial_r_xi_master(irowdim)) *
-              (pot_red_fac_2ndderiv_xi_master * xi_master_partial_r_slave(icolumndim) *
-                      N_i_slave(icolumndofperdim) * pot_ia +
-                  pot_red_fac_deriv_xi_master *
-                      (pot_ia_deriv_gap_ul * gap_ul_deriv_r_slave(icolumndim) *
-                              N_i_slave(icolumndofperdim) +
-                          pot_ia_deriv_cos_alpha * cos_alpha_deriv_r_slave(icolumndim) *
-                              N_i_slave(icolumndofperdim) +
-                          pot_ia_deriv_cos_alpha * cos_alpha_deriv_r_xi_slave(icolumndim) *
-                              N_i_xi_slave(icolumndofperdim)));
+              (N_i_target(irowdofperdim) * xi_target_partial_r_target(irowdim) +
+                  N_i_xi_target(irowdofperdim) * xi_target_partial_r_xi_target(irowdim)) *
+              (pot_red_fac_2ndderiv_xi_target * xi_target_partial_r_source(icolumndim) *
+                      N_i_source(icolumndofperdim) * pot_ia +
+                  pot_red_fac_deriv_xi_target *
+                      (pot_ia_deriv_gap_ul * gap_ul_deriv_r_source(icolumndim) *
+                              N_i_source(icolumndofperdim) +
+                          pot_ia_deriv_cos_alpha * cos_alpha_deriv_r_source(icolumndim) *
+                              N_i_source(icolumndofperdim) +
+                          pot_ia_deriv_cos_alpha * cos_alpha_deriv_r_xi_source(icolumndim) *
+                              N_i_xi_source(icolumndofperdim)));
 
           stiffmat22(3 * irowdofperdim + irowdim, 3 * icolumndofperdim + icolumndim) +=
-              (N_i_master(irowdofperdim) * xi_master_partial_r_master(irowdim) +
-                  N_i_xi_master(irowdofperdim) * xi_master_partial_r_xi_master(irowdim)) *
-              (pot_red_fac_2ndderiv_xi_master *
-                      (xi_master_partial_r_master(icolumndim) * N_i_master(icolumndofperdim) +
-                          xi_master_partial_r_xi_master(icolumndim) *
-                              N_i_xi_master(icolumndofperdim)) *
+              (N_i_target(irowdofperdim) * xi_target_partial_r_target(irowdim) +
+                  N_i_xi_target(irowdofperdim) * xi_target_partial_r_xi_target(irowdim)) *
+              (pot_red_fac_2ndderiv_xi_target *
+                      (xi_target_partial_r_target(icolumndim) * N_i_target(icolumndofperdim) +
+                          xi_target_partial_r_xi_target(icolumndim) *
+                              N_i_xi_target(icolumndofperdim)) *
                       pot_ia +
-                  pot_red_fac_deriv_xi_master *
-                      (pot_ia_deriv_gap_ul * gap_ul_deriv_r_master(icolumndim) *
-                              N_i_master(icolumndofperdim) +
-                          pot_ia_deriv_cos_alpha * cos_alpha_deriv_r_master(icolumndim) *
-                              N_i_master(icolumndofperdim) +
-                          pot_ia_deriv_cos_alpha * cos_alpha_deriv_r_xi_master(icolumndim) *
-                              N_i_xi_master(icolumndofperdim)));
+                  pot_red_fac_deriv_xi_target *
+                      (pot_ia_deriv_gap_ul * gap_ul_deriv_r_target(icolumndim) *
+                              N_i_target(icolumndofperdim) +
+                          pot_ia_deriv_cos_alpha * cos_alpha_deriv_r_target(icolumndim) *
+                              N_i_target(icolumndofperdim) +
+                          pot_ia_deriv_cos_alpha * cos_alpha_deriv_r_xi_target(icolumndim) *
+                              N_i_xi_target(icolumndofperdim)));
 
-          // linearization of the (variation of xi_master) * (pot_red_fac_deriv_xi_master * pot_ia)
+          // linearization of the (variation of xi_target) * (pot_red_fac_deriv_xi_target * pot_ia)
           stiffmat11(3 * irowdofperdim + irowdim, 3 * icolumndofperdim + icolumndim) +=
-              pot_red_fac_deriv_xi_master * pot_ia * N_i_slave(irowdofperdim) *
-              xi_master_partial_r_slave_partial_r_slave(irowdim, icolumndim) *
-              N_i_slave(icolumndofperdim);
+              pot_red_fac_deriv_xi_target * pot_ia * N_i_source(irowdofperdim) *
+              xi_target_partial_r_source_partial_r_source(irowdim, icolumndim) *
+              N_i_source(icolumndofperdim);
 
           stiffmat12(3 * irowdofperdim + irowdim, 3 * icolumndofperdim + icolumndim) +=
-              pot_red_fac_deriv_xi_master * pot_ia * N_i_slave(irowdofperdim) *
-              (xi_master_partial_r_slave_partial_r_master(irowdim, icolumndim) *
-                      N_i_master(icolumndofperdim) +
-                  xi_master_partial_r_slave_partial_r_xi_master(irowdim, icolumndim) *
-                      N_i_xi_master(icolumndofperdim) +
-                  xi_master_partial_r_slave_partial_r_xixi_master(irowdim, icolumndim) *
-                      N_i_xixi_master(icolumndofperdim));
+              pot_red_fac_deriv_xi_target * pot_ia * N_i_source(irowdofperdim) *
+              (xi_target_partial_r_source_partial_r_target(irowdim, icolumndim) *
+                      N_i_target(icolumndofperdim) +
+                  xi_target_partial_r_source_partial_r_xi_target(irowdim, icolumndim) *
+                      N_i_xi_target(icolumndofperdim) +
+                  xi_target_partial_r_source_partial_r_xixi_target(irowdim, icolumndim) *
+                      N_i_xixi_target(icolumndofperdim));
 
           stiffmat21(3 * irowdofperdim + irowdim, 3 * icolumndofperdim + icolumndim) +=
-              pot_red_fac_deriv_xi_master * pot_ia *
-              (N_i_master(irowdofperdim) *
-                      xi_master_partial_r_master_partial_r_slave(irowdim, icolumndim) *
-                      N_i_slave(icolumndofperdim) +
-                  N_i_xi_master(irowdofperdim) *
-                      xi_master_partial_r_xi_master_partial_r_slave(irowdim, icolumndim) *
-                      N_i_slave(icolumndofperdim) +
-                  N_i_xixi_master(irowdofperdim) *
-                      (xi_master_partial_r_xixi_master_partial_r_slave(irowdim, icolumndim) *
-                          N_i_slave(icolumndofperdim)));
+              pot_red_fac_deriv_xi_target * pot_ia *
+              (N_i_target(irowdofperdim) *
+                      xi_target_partial_r_target_partial_r_source(irowdim, icolumndim) *
+                      N_i_source(icolumndofperdim) +
+                  N_i_xi_target(irowdofperdim) *
+                      xi_target_partial_r_xi_target_partial_r_source(irowdim, icolumndim) *
+                      N_i_source(icolumndofperdim) +
+                  N_i_xixi_target(irowdofperdim) *
+                      (xi_target_partial_r_xixi_target_partial_r_source(irowdim, icolumndim) *
+                          N_i_source(icolumndofperdim)));
 
           stiffmat22(3 * irowdofperdim + irowdim, 3 * icolumndofperdim + icolumndim) +=
-              pot_red_fac_deriv_xi_master * pot_ia *
-              (N_i_master(irowdofperdim) *
-                      (xi_master_partial_r_master_partial_r_master(irowdim, icolumndim) *
-                              N_i_master(icolumndofperdim) +
-                          xi_master_partial_r_master_partial_r_xi_master(irowdim, icolumndim) *
-                              N_i_xi_master(icolumndofperdim) +
-                          xi_master_partial_r_master_partial_r_xixi_master(irowdim, icolumndim) *
-                              N_i_xixi_master(icolumndofperdim)) +
-                  N_i_xi_master(irowdofperdim) *
-                      (xi_master_partial_r_xi_master_partial_r_master(irowdim, icolumndim) *
-                              N_i_master(icolumndofperdim) +
-                          xi_master_partial_r_xi_master_partial_r_xi_master(irowdim, icolumndim) *
-                              N_i_xi_master(icolumndofperdim) +
-                          xi_master_partial_r_xi_master_partial_r_xixi_master(irowdim, icolumndim) *
-                              N_i_xixi_master(icolumndofperdim)) +
-                  N_i_xixi_master(irowdofperdim) *
-                      (xi_master_partial_r_xixi_master_partial_r_master(irowdim, icolumndim) *
-                              N_i_master(icolumndofperdim) +
-                          xi_master_partial_r_xixi_master_partial_r_xi_master(irowdim, icolumndim) *
-                              N_i_xi_master(icolumndofperdim)));
+              pot_red_fac_deriv_xi_target * pot_ia *
+              (N_i_target(irowdofperdim) *
+                      (xi_target_partial_r_target_partial_r_target(irowdim, icolumndim) *
+                              N_i_target(icolumndofperdim) +
+                          xi_target_partial_r_target_partial_r_xi_target(irowdim, icolumndim) *
+                              N_i_xi_target(icolumndofperdim) +
+                          xi_target_partial_r_target_partial_r_xixi_target(irowdim, icolumndim) *
+                              N_i_xixi_target(icolumndofperdim)) +
+                  N_i_xi_target(irowdofperdim) *
+                      (xi_target_partial_r_xi_target_partial_r_target(irowdim, icolumndim) *
+                              N_i_target(icolumndofperdim) +
+                          xi_target_partial_r_xi_target_partial_r_xi_target(irowdim, icolumndim) *
+                              N_i_xi_target(icolumndofperdim) +
+                          xi_target_partial_r_xi_target_partial_r_xixi_target(irowdim, icolumndim) *
+                              N_i_xixi_target(icolumndofperdim)) +
+                  N_i_xixi_target(irowdofperdim) *
+                      (xi_target_partial_r_xixi_target_partial_r_target(irowdim, icolumndim) *
+                              N_i_target(icolumndofperdim) +
+                          xi_target_partial_r_xixi_target_partial_r_xi_target(irowdim, icolumndim) *
+                              N_i_xi_target(icolumndofperdim)));
 
           // variation of gap_ul * linearization of (pot_red_fac * pot_ia_deriv_gap_ul)
           stiffmat11(3 * irowdofperdim + irowdim, 3 * icolumndofperdim + icolumndim) +=
-              N_i_slave(irowdofperdim) * gap_ul_deriv_r_slave(irowdim) *
-              (pot_red_fac_deriv_xi_master * xi_master_partial_r_slave(icolumndim) *
-                      N_i_slave(icolumndofperdim) * pot_ia_deriv_gap_ul +
+              N_i_source(irowdofperdim) * gap_ul_deriv_r_source(irowdim) *
+              (pot_red_fac_deriv_xi_target * xi_target_partial_r_source(icolumndim) *
+                      N_i_source(icolumndofperdim) * pot_ia_deriv_gap_ul +
                   pot_red_fac *
-                      (pot_ia_2ndderiv_gap_ul * gap_ul_deriv_r_slave(icolumndim) *
-                              N_i_slave(icolumndofperdim) +
+                      (pot_ia_2ndderiv_gap_ul * gap_ul_deriv_r_source(icolumndim) *
+                              N_i_source(icolumndofperdim) +
                           pot_ia_deriv_gap_ul_deriv_cos_alpha *
-                              cos_alpha_deriv_r_slave(icolumndim) * N_i_slave(icolumndofperdim) +
+                              cos_alpha_deriv_r_source(icolumndim) * N_i_source(icolumndofperdim) +
                           pot_ia_deriv_gap_ul_deriv_cos_alpha *
-                              cos_alpha_deriv_r_xi_slave(icolumndim) *
-                              N_i_xi_slave(icolumndofperdim)));
+                              cos_alpha_deriv_r_xi_source(icolumndim) *
+                              N_i_xi_source(icolumndofperdim)));
 
           stiffmat12(3 * irowdofperdim + irowdim, 3 * icolumndofperdim + icolumndim) +=
-              N_i_slave(irowdofperdim) * gap_ul_deriv_r_slave(irowdim) *
-              (pot_red_fac_deriv_xi_master *
-                      (xi_master_partial_r_master(icolumndim) * N_i_master(icolumndofperdim) +
-                          xi_master_partial_r_xi_master(icolumndim) *
-                              N_i_xi_master(icolumndofperdim)) *
+              N_i_source(irowdofperdim) * gap_ul_deriv_r_source(irowdim) *
+              (pot_red_fac_deriv_xi_target *
+                      (xi_target_partial_r_target(icolumndim) * N_i_target(icolumndofperdim) +
+                          xi_target_partial_r_xi_target(icolumndim) *
+                              N_i_xi_target(icolumndofperdim)) *
                       pot_ia_deriv_gap_ul +
                   pot_red_fac *
-                      (pot_ia_2ndderiv_gap_ul * gap_ul_deriv_r_master(icolumndim) *
-                              N_i_master(icolumndofperdim) +
+                      (pot_ia_2ndderiv_gap_ul * gap_ul_deriv_r_target(icolumndim) *
+                              N_i_target(icolumndofperdim) +
                           pot_ia_deriv_gap_ul_deriv_cos_alpha *
-                              cos_alpha_deriv_r_master(icolumndim) * N_i_master(icolumndofperdim) +
+                              cos_alpha_deriv_r_target(icolumndim) * N_i_target(icolumndofperdim) +
                           pot_ia_deriv_gap_ul_deriv_cos_alpha *
-                              cos_alpha_deriv_r_xi_master(icolumndim) *
-                              N_i_xi_master(icolumndofperdim)));
+                              cos_alpha_deriv_r_xi_target(icolumndim) *
+                              N_i_xi_target(icolumndofperdim)));
 
           stiffmat21(3 * irowdofperdim + irowdim, 3 * icolumndofperdim + icolumndim) +=
-              N_i_master(irowdofperdim) * gap_ul_deriv_r_master(irowdim) *
-              (pot_red_fac_deriv_xi_master * xi_master_partial_r_slave(icolumndim) *
-                      N_i_slave(icolumndofperdim) * pot_ia_deriv_gap_ul +
+              N_i_target(irowdofperdim) * gap_ul_deriv_r_target(irowdim) *
+              (pot_red_fac_deriv_xi_target * xi_target_partial_r_source(icolumndim) *
+                      N_i_source(icolumndofperdim) * pot_ia_deriv_gap_ul +
                   pot_red_fac *
-                      (pot_ia_2ndderiv_gap_ul * gap_ul_deriv_r_slave(icolumndim) *
-                              N_i_slave(icolumndofperdim) +
+                      (pot_ia_2ndderiv_gap_ul * gap_ul_deriv_r_source(icolumndim) *
+                              N_i_source(icolumndofperdim) +
                           pot_ia_deriv_gap_ul_deriv_cos_alpha *
-                              cos_alpha_deriv_r_slave(icolumndim) * N_i_slave(icolumndofperdim) +
+                              cos_alpha_deriv_r_source(icolumndim) * N_i_source(icolumndofperdim) +
                           pot_ia_deriv_gap_ul_deriv_cos_alpha *
-                              cos_alpha_deriv_r_xi_slave(icolumndim) *
-                              N_i_xi_slave(icolumndofperdim)));
+                              cos_alpha_deriv_r_xi_source(icolumndim) *
+                              N_i_xi_source(icolumndofperdim)));
 
           stiffmat22(3 * irowdofperdim + irowdim, 3 * icolumndofperdim + icolumndim) +=
-              N_i_master(irowdofperdim) * gap_ul_deriv_r_master(irowdim) *
-              (pot_red_fac_deriv_xi_master *
-                      (xi_master_partial_r_master(icolumndim) * N_i_master(icolumndofperdim) +
-                          xi_master_partial_r_xi_master(icolumndim) *
-                              N_i_xi_master(icolumndofperdim)) *
+              N_i_target(irowdofperdim) * gap_ul_deriv_r_target(irowdim) *
+              (pot_red_fac_deriv_xi_target *
+                      (xi_target_partial_r_target(icolumndim) * N_i_target(icolumndofperdim) +
+                          xi_target_partial_r_xi_target(icolumndim) *
+                              N_i_xi_target(icolumndofperdim)) *
                       pot_ia_deriv_gap_ul +
                   pot_red_fac *
-                      (pot_ia_2ndderiv_gap_ul * gap_ul_deriv_r_master(icolumndim) *
-                              N_i_master(icolumndofperdim) +
+                      (pot_ia_2ndderiv_gap_ul * gap_ul_deriv_r_target(icolumndim) *
+                              N_i_target(icolumndofperdim) +
                           pot_ia_deriv_gap_ul_deriv_cos_alpha *
-                              cos_alpha_deriv_r_master(icolumndim) * N_i_master(icolumndofperdim) +
+                              cos_alpha_deriv_r_target(icolumndim) * N_i_target(icolumndofperdim) +
                           pot_ia_deriv_gap_ul_deriv_cos_alpha *
-                              cos_alpha_deriv_r_xi_master(icolumndim) *
-                              N_i_xi_master(icolumndofperdim)));
+                              cos_alpha_deriv_r_xi_target(icolumndim) *
+                              N_i_xi_target(icolumndofperdim)));
 
           // linearization of the (variation of gap_ul) * (pot_red_fac * pot_ia_deriv_gap_ul)
           stiffmat11(3 * irowdofperdim + irowdim, 3 * icolumndofperdim + icolumndim) +=
-              pot_red_fac * pot_ia_deriv_gap_ul * N_i_slave(irowdofperdim) *
-              gap_ul_deriv_r_slave_deriv_r_slave(irowdim, icolumndim) * N_i_slave(icolumndofperdim);
+              pot_red_fac * pot_ia_deriv_gap_ul * N_i_source(irowdofperdim) *
+              gap_ul_deriv_r_source_deriv_r_source(irowdim, icolumndim) *
+              N_i_source(icolumndofperdim);
 
           stiffmat12(3 * irowdofperdim + irowdim, 3 * icolumndofperdim + icolumndim) +=
-              pot_red_fac * pot_ia_deriv_gap_ul * N_i_slave(irowdofperdim) *
-              (gap_ul_deriv_r_slave_deriv_r_master(irowdim, icolumndim) *
-                      N_i_master(icolumndofperdim) +
-                  gap_ul_deriv_r_slave_deriv_r_xi_master(irowdim, icolumndim) *
-                      N_i_xi_master(icolumndofperdim));
+              pot_red_fac * pot_ia_deriv_gap_ul * N_i_source(irowdofperdim) *
+              (gap_ul_deriv_r_source_deriv_r_target(irowdim, icolumndim) *
+                      N_i_target(icolumndofperdim) +
+                  gap_ul_deriv_r_source_deriv_r_xi_target(irowdim, icolumndim) *
+                      N_i_xi_target(icolumndofperdim));
 
           stiffmat21(3 * irowdofperdim + irowdim, 3 * icolumndofperdim + icolumndim) +=
               pot_red_fac * pot_ia_deriv_gap_ul *
-              (N_i_master(irowdofperdim) *
-                      gap_ul_deriv_r_master_deriv_r_slave(irowdim, icolumndim) +
-                  N_i_xi_master(irowdofperdim) *
-                      gap_ul_deriv_r_xi_master_deriv_r_slave(irowdim, icolumndim)) *
-              N_i_slave(icolumndofperdim);
+              (N_i_target(irowdofperdim) *
+                      gap_ul_deriv_r_target_deriv_r_source(irowdim, icolumndim) +
+                  N_i_xi_target(irowdofperdim) *
+                      gap_ul_deriv_r_xi_target_deriv_r_source(irowdim, icolumndim)) *
+              N_i_source(icolumndofperdim);
 
           stiffmat22(3 * irowdofperdim + irowdim, 3 * icolumndofperdim + icolumndim) +=
               pot_red_fac * pot_ia_deriv_gap_ul *
-              (N_i_master(irowdofperdim) *
-                      (gap_ul_deriv_r_master_deriv_r_master(irowdim, icolumndim) *
-                              N_i_master(icolumndofperdim) +
-                          gap_ul_deriv_r_master_deriv_r_xi_master(irowdim, icolumndim) *
-                              N_i_xi_master(icolumndofperdim)) +
-                  N_i_xi_master(irowdofperdim) *
-                      (gap_ul_deriv_r_xi_master_deriv_r_master(irowdim, icolumndim) *
-                              N_i_master(icolumndofperdim) +
-                          gap_ul_deriv_r_xi_master_deriv_r_xi_master(irowdim, icolumndim) *
-                              N_i_xi_master(icolumndofperdim)));
+              (N_i_target(irowdofperdim) *
+                      (gap_ul_deriv_r_target_deriv_r_target(irowdim, icolumndim) *
+                              N_i_target(icolumndofperdim) +
+                          gap_ul_deriv_r_target_deriv_r_xi_target(irowdim, icolumndim) *
+                              N_i_xi_target(icolumndofperdim)) +
+                  N_i_xi_target(irowdofperdim) *
+                      (gap_ul_deriv_r_xi_target_deriv_r_target(irowdim, icolumndim) *
+                              N_i_target(icolumndofperdim) +
+                          gap_ul_deriv_r_xi_target_deriv_r_xi_target(irowdim, icolumndim) *
+                              N_i_xi_target(icolumndofperdim)));
 
 
           // variation of cos_alpha * linearization of (pot_red_fac * pot_ia_deriv_cos_alpha)
           stiffmat11(3 * irowdofperdim + irowdim, 3 * icolumndofperdim + icolumndim) +=
-              (N_i_slave(irowdofperdim) * cos_alpha_deriv_r_slave(irowdim) +
-                  N_i_xi_slave(irowdofperdim) * cos_alpha_deriv_r_xi_slave(irowdim)) *
-              (pot_red_fac_deriv_xi_master * xi_master_partial_r_slave(icolumndim) *
-                      N_i_slave(icolumndofperdim) * pot_ia_deriv_cos_alpha +
+              (N_i_source(irowdofperdim) * cos_alpha_deriv_r_source(irowdim) +
+                  N_i_xi_source(irowdofperdim) * cos_alpha_deriv_r_xi_source(irowdim)) *
+              (pot_red_fac_deriv_xi_target * xi_target_partial_r_source(icolumndim) *
+                      N_i_source(icolumndofperdim) * pot_ia_deriv_cos_alpha +
                   pot_red_fac *
-                      (pot_ia_2ndderiv_cos_alpha * cos_alpha_deriv_r_slave(icolumndim) *
-                              N_i_slave(icolumndofperdim) +
-                          pot_ia_2ndderiv_cos_alpha * cos_alpha_deriv_r_xi_slave(icolumndim) *
-                              N_i_xi_slave(icolumndofperdim) +
-                          pot_ia_deriv_gap_ul_deriv_cos_alpha * gap_ul_deriv_r_slave(icolumndim) *
-                              N_i_slave(icolumndofperdim)));
+                      (pot_ia_2ndderiv_cos_alpha * cos_alpha_deriv_r_source(icolumndim) *
+                              N_i_source(icolumndofperdim) +
+                          pot_ia_2ndderiv_cos_alpha * cos_alpha_deriv_r_xi_source(icolumndim) *
+                              N_i_xi_source(icolumndofperdim) +
+                          pot_ia_deriv_gap_ul_deriv_cos_alpha * gap_ul_deriv_r_source(icolumndim) *
+                              N_i_source(icolumndofperdim)));
 
           stiffmat12(3 * irowdofperdim + irowdim, 3 * icolumndofperdim + icolumndim) +=
-              (N_i_slave(irowdofperdim) * cos_alpha_deriv_r_slave(irowdim) +
-                  N_i_xi_slave(irowdofperdim) * cos_alpha_deriv_r_xi_slave(irowdim)) *
-              (pot_red_fac_deriv_xi_master *
-                      (xi_master_partial_r_master(icolumndim) * N_i_master(icolumndofperdim) +
-                          xi_master_partial_r_xi_master(icolumndim) *
-                              N_i_xi_master(icolumndofperdim)) *
+              (N_i_source(irowdofperdim) * cos_alpha_deriv_r_source(irowdim) +
+                  N_i_xi_source(irowdofperdim) * cos_alpha_deriv_r_xi_source(irowdim)) *
+              (pot_red_fac_deriv_xi_target *
+                      (xi_target_partial_r_target(icolumndim) * N_i_target(icolumndofperdim) +
+                          xi_target_partial_r_xi_target(icolumndim) *
+                              N_i_xi_target(icolumndofperdim)) *
                       pot_ia_deriv_cos_alpha +
                   pot_red_fac *
-                      (pot_ia_2ndderiv_cos_alpha * cos_alpha_deriv_r_master(icolumndim) *
-                              N_i_master(icolumndofperdim) +
-                          pot_ia_2ndderiv_cos_alpha * cos_alpha_deriv_r_xi_master(icolumndim) *
-                              N_i_xi_master(icolumndofperdim) +
-                          pot_ia_deriv_gap_ul_deriv_cos_alpha * gap_ul_deriv_r_master(icolumndim) *
-                              N_i_master(icolumndofperdim)));
+                      (pot_ia_2ndderiv_cos_alpha * cos_alpha_deriv_r_target(icolumndim) *
+                              N_i_target(icolumndofperdim) +
+                          pot_ia_2ndderiv_cos_alpha * cos_alpha_deriv_r_xi_target(icolumndim) *
+                              N_i_xi_target(icolumndofperdim) +
+                          pot_ia_deriv_gap_ul_deriv_cos_alpha * gap_ul_deriv_r_target(icolumndim) *
+                              N_i_target(icolumndofperdim)));
 
           stiffmat21(3 * irowdofperdim + irowdim, 3 * icolumndofperdim + icolumndim) +=
-              (N_i_master(irowdofperdim) * cos_alpha_deriv_r_master(irowdim) +
-                  N_i_xi_master(irowdofperdim) * cos_alpha_deriv_r_xi_master(irowdim)) *
-              (pot_red_fac_deriv_xi_master * xi_master_partial_r_slave(icolumndim) *
-                      N_i_slave(icolumndofperdim) * pot_ia_deriv_cos_alpha +
+              (N_i_target(irowdofperdim) * cos_alpha_deriv_r_target(irowdim) +
+                  N_i_xi_target(irowdofperdim) * cos_alpha_deriv_r_xi_target(irowdim)) *
+              (pot_red_fac_deriv_xi_target * xi_target_partial_r_source(icolumndim) *
+                      N_i_source(icolumndofperdim) * pot_ia_deriv_cos_alpha +
                   pot_red_fac *
-                      (pot_ia_2ndderiv_cos_alpha * cos_alpha_deriv_r_slave(icolumndim) *
-                              N_i_slave(icolumndofperdim) +
-                          pot_ia_2ndderiv_cos_alpha * cos_alpha_deriv_r_xi_slave(icolumndim) *
-                              N_i_xi_slave(icolumndofperdim) +
-                          pot_ia_deriv_gap_ul_deriv_cos_alpha * gap_ul_deriv_r_slave(icolumndim) *
-                              N_i_slave(icolumndofperdim)));
+                      (pot_ia_2ndderiv_cos_alpha * cos_alpha_deriv_r_source(icolumndim) *
+                              N_i_source(icolumndofperdim) +
+                          pot_ia_2ndderiv_cos_alpha * cos_alpha_deriv_r_xi_source(icolumndim) *
+                              N_i_xi_source(icolumndofperdim) +
+                          pot_ia_deriv_gap_ul_deriv_cos_alpha * gap_ul_deriv_r_source(icolumndim) *
+                              N_i_source(icolumndofperdim)));
 
           stiffmat22(3 * irowdofperdim + irowdim, 3 * icolumndofperdim + icolumndim) +=
-              (N_i_master(irowdofperdim) * cos_alpha_deriv_r_master(irowdim) +
-                  N_i_xi_master(irowdofperdim) * cos_alpha_deriv_r_xi_master(irowdim)) *
-              (pot_red_fac_deriv_xi_master *
-                      (xi_master_partial_r_master(icolumndim) * N_i_master(icolumndofperdim) +
-                          xi_master_partial_r_xi_master(icolumndim) *
-                              N_i_xi_master(icolumndofperdim)) *
+              (N_i_target(irowdofperdim) * cos_alpha_deriv_r_target(irowdim) +
+                  N_i_xi_target(irowdofperdim) * cos_alpha_deriv_r_xi_target(irowdim)) *
+              (pot_red_fac_deriv_xi_target *
+                      (xi_target_partial_r_target(icolumndim) * N_i_target(icolumndofperdim) +
+                          xi_target_partial_r_xi_target(icolumndim) *
+                              N_i_xi_target(icolumndofperdim)) *
                       pot_ia_deriv_cos_alpha +
                   pot_red_fac *
-                      (pot_ia_2ndderiv_cos_alpha * cos_alpha_deriv_r_master(icolumndim) *
-                              N_i_master(icolumndofperdim) +
-                          pot_ia_2ndderiv_cos_alpha * cos_alpha_deriv_r_xi_master(icolumndim) *
-                              N_i_xi_master(icolumndofperdim) +
-                          pot_ia_deriv_gap_ul_deriv_cos_alpha * gap_ul_deriv_r_master(icolumndim) *
-                              N_i_master(icolumndofperdim)));
+                      (pot_ia_2ndderiv_cos_alpha * cos_alpha_deriv_r_target(icolumndim) *
+                              N_i_target(icolumndofperdim) +
+                          pot_ia_2ndderiv_cos_alpha * cos_alpha_deriv_r_xi_target(icolumndim) *
+                              N_i_xi_target(icolumndofperdim) +
+                          pot_ia_deriv_gap_ul_deriv_cos_alpha * gap_ul_deriv_r_target(icolumndim) *
+                              N_i_target(icolumndofperdim)));
 
 
           // linearization of the (variation of cos_alpha) * (pot_red_fac * pot_ia_deriv_cos_alpha)
           stiffmat11(3 * irowdofperdim + irowdim, 3 * icolumndofperdim + icolumndim) +=
               pot_red_fac * pot_ia_deriv_cos_alpha *
-              (N_i_slave(irowdofperdim) *
-                      (cos_alpha_deriv_r_slave_deriv_r_slave(irowdim, icolumndim) *
-                              N_i_slave(icolumndofperdim) +
-                          cos_alpha_deriv_r_slave_deriv_r_xi_slave(irowdim, icolumndim) *
-                              N_i_xi_slave(icolumndofperdim)) +
-                  N_i_xi_slave(irowdofperdim) *
-                      (cos_alpha_deriv_r_xi_slave_deriv_r_slave(irowdim, icolumndim) *
-                              N_i_slave(icolumndofperdim) +
-                          cos_alpha_deriv_r_xi_slave_deriv_r_xi_slave(irowdim, icolumndim) *
-                              N_i_xi_slave(icolumndofperdim)));
+              (N_i_source(irowdofperdim) *
+                      (cos_alpha_deriv_r_source_deriv_r_source(irowdim, icolumndim) *
+                              N_i_source(icolumndofperdim) +
+                          cos_alpha_deriv_r_source_deriv_r_xi_source(irowdim, icolumndim) *
+                              N_i_xi_source(icolumndofperdim)) +
+                  N_i_xi_source(irowdofperdim) *
+                      (cos_alpha_deriv_r_xi_source_deriv_r_source(irowdim, icolumndim) *
+                              N_i_source(icolumndofperdim) +
+                          cos_alpha_deriv_r_xi_source_deriv_r_xi_source(irowdim, icolumndim) *
+                              N_i_xi_source(icolumndofperdim)));
 
           stiffmat12(3 * irowdofperdim + irowdim, 3 * icolumndofperdim + icolumndim) +=
               pot_red_fac * pot_ia_deriv_cos_alpha *
-              (N_i_slave(irowdofperdim) *
-                      (cos_alpha_deriv_r_slave_deriv_r_master(irowdim, icolumndim) *
-                              N_i_master(icolumndofperdim) +
-                          cos_alpha_deriv_r_slave_deriv_r_xi_master(irowdim, icolumndim) *
-                              N_i_xi_master(icolumndofperdim) +
-                          cos_alpha_deriv_r_slave_deriv_r_xixi_master(irowdim, icolumndim) *
-                              N_i_xixi_master(icolumndofperdim)) +
-                  N_i_xi_slave(irowdofperdim) *
-                      (cos_alpha_deriv_r_xi_slave_deriv_r_master(irowdim, icolumndim) *
-                              N_i_master(icolumndofperdim) +
-                          cos_alpha_deriv_r_xi_slave_deriv_r_xi_master(irowdim, icolumndim) *
-                              N_i_xi_master(icolumndofperdim)));
+              (N_i_source(irowdofperdim) *
+                      (cos_alpha_deriv_r_source_deriv_r_target(irowdim, icolumndim) *
+                              N_i_target(icolumndofperdim) +
+                          cos_alpha_deriv_r_source_deriv_r_xi_target(irowdim, icolumndim) *
+                              N_i_xi_target(icolumndofperdim) +
+                          cos_alpha_deriv_r_source_deriv_r_xixi_target(irowdim, icolumndim) *
+                              N_i_xixi_target(icolumndofperdim)) +
+                  N_i_xi_source(irowdofperdim) *
+                      (cos_alpha_deriv_r_xi_source_deriv_r_target(irowdim, icolumndim) *
+                              N_i_target(icolumndofperdim) +
+                          cos_alpha_deriv_r_xi_source_deriv_r_xi_target(irowdim, icolumndim) *
+                              N_i_xi_target(icolumndofperdim)));
 
           stiffmat21(3 * irowdofperdim + irowdim, 3 * icolumndofperdim + icolumndim) +=
               pot_red_fac * pot_ia_deriv_cos_alpha *
-              (N_i_master(irowdofperdim) *
-                      (cos_alpha_deriv_r_master_deriv_r_slave(irowdim, icolumndim) *
-                              N_i_slave(icolumndofperdim) +
-                          cos_alpha_deriv_r_master_deriv_r_xi_slave(irowdim, icolumndim) *
-                              N_i_xi_slave(icolumndofperdim)) +
-                  N_i_xi_master(irowdofperdim) *
-                      (cos_alpha_deriv_r_xi_master_deriv_r_slave(irowdim, icolumndim) *
-                              N_i_slave(icolumndofperdim) +
-                          cos_alpha_deriv_r_xi_master_deriv_r_xi_slave(irowdim, icolumndim) *
-                              N_i_xi_slave(icolumndofperdim)) +
-                  N_i_xixi_master(irowdofperdim) *
-                      (cos_alpha_deriv_r_xixi_master_deriv_r_slave(irowdim, icolumndim) *
-                          N_i_slave(icolumndofperdim)));
+              (N_i_target(irowdofperdim) *
+                      (cos_alpha_deriv_r_target_deriv_r_source(irowdim, icolumndim) *
+                              N_i_source(icolumndofperdim) +
+                          cos_alpha_deriv_r_target_deriv_r_xi_source(irowdim, icolumndim) *
+                              N_i_xi_source(icolumndofperdim)) +
+                  N_i_xi_target(irowdofperdim) *
+                      (cos_alpha_deriv_r_xi_target_deriv_r_source(irowdim, icolumndim) *
+                              N_i_source(icolumndofperdim) +
+                          cos_alpha_deriv_r_xi_target_deriv_r_xi_source(irowdim, icolumndim) *
+                              N_i_xi_source(icolumndofperdim)) +
+                  N_i_xixi_target(irowdofperdim) *
+                      (cos_alpha_deriv_r_xixi_target_deriv_r_source(irowdim, icolumndim) *
+                          N_i_source(icolumndofperdim)));
 
           stiffmat22(3 * irowdofperdim + irowdim, 3 * icolumndofperdim + icolumndim) +=
               pot_red_fac * pot_ia_deriv_cos_alpha *
-              (N_i_master(irowdofperdim) *
-                      (cos_alpha_deriv_r_master_deriv_r_master(irowdim, icolumndim) *
-                              N_i_master(icolumndofperdim) +
-                          cos_alpha_deriv_r_master_deriv_r_xi_master(irowdim, icolumndim) *
-                              N_i_xi_master(icolumndofperdim) +
-                          cos_alpha_deriv_r_master_deriv_r_xixi_master(irowdim, icolumndim) *
-                              N_i_xixi_master(icolumndofperdim)) +
-                  N_i_xi_master(irowdofperdim) *
-                      (cos_alpha_deriv_r_xi_master_deriv_r_master(irowdim, icolumndim) *
-                              N_i_master(icolumndofperdim) +
-                          cos_alpha_deriv_r_xi_master_deriv_r_xi_master(irowdim, icolumndim) *
-                              N_i_xi_master(icolumndofperdim) +
-                          cos_alpha_deriv_r_xi_master_deriv_r_xixi_master(irowdim, icolumndim) *
-                              N_i_xixi_master(icolumndofperdim)) +
-                  N_i_xixi_master(irowdofperdim) *
-                      (cos_alpha_deriv_r_xixi_master_deriv_r_master(irowdim, icolumndim) *
-                              N_i_master(icolumndofperdim) +
-                          cos_alpha_deriv_r_xixi_master_deriv_r_xi_master(irowdim, icolumndim) *
-                              N_i_xi_master(icolumndofperdim)));
+              (N_i_target(irowdofperdim) *
+                      (cos_alpha_deriv_r_target_deriv_r_target(irowdim, icolumndim) *
+                              N_i_target(icolumndofperdim) +
+                          cos_alpha_deriv_r_target_deriv_r_xi_target(irowdim, icolumndim) *
+                              N_i_xi_target(icolumndofperdim) +
+                          cos_alpha_deriv_r_target_deriv_r_xixi_target(irowdim, icolumndim) *
+                              N_i_xixi_target(icolumndofperdim)) +
+                  N_i_xi_target(irowdofperdim) *
+                      (cos_alpha_deriv_r_xi_target_deriv_r_target(irowdim, icolumndim) *
+                              N_i_target(icolumndofperdim) +
+                          cos_alpha_deriv_r_xi_target_deriv_r_xi_target(irowdim, icolumndim) *
+                              N_i_xi_target(icolumndofperdim) +
+                          cos_alpha_deriv_r_xi_target_deriv_r_xixi_target(irowdim, icolumndim) *
+                              N_i_xixi_target(icolumndofperdim)) +
+                  N_i_xixi_target(irowdofperdim) *
+                      (cos_alpha_deriv_r_xixi_target_deriv_r_target(irowdim, icolumndim) *
+                              N_i_target(icolumndofperdim) +
+                          cos_alpha_deriv_r_xixi_target_deriv_r_xi_target(irowdim, icolumndim) *
+                              N_i_xi_target(icolumndofperdim)));
         }
       }
     }
@@ -2483,26 +2489,27 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
 template <unsigned int numnodes, unsigned int numnodalvalues, typename T>
 bool BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues,
     T>::evaluate_full_disk_cylinder_potential(T& interaction_potential_GP,
-    Core::LinAlg::Matrix<3 * numnodes * numnodalvalues, 1, T>& force_pot_slave_GP,
-    Core::LinAlg::Matrix<3 * numnodes * numnodalvalues, 1, T>& force_pot_master_GP,
-    Core::LinAlg::Matrix<3, 1, T> const& r_slave, Core::LinAlg::Matrix<3, 1, T> const& r_xi_slave,
-    Core::LinAlg::Matrix<3, 1, T> const& t1_slave, Core::LinAlg::Matrix<3, 1, T> const& r_master,
-    Core::LinAlg::Matrix<3, 1, T> const& r_xi_master,
-    Core::LinAlg::Matrix<3, 1, T> const& r_xixi_master,
-    Core::LinAlg::Matrix<3, 1, T> const& t1_master, T alpha, T cos_alpha,
+    Core::LinAlg::Matrix<3 * numnodes * numnodalvalues, 1, T>& force_pot_source_GP,
+    Core::LinAlg::Matrix<3 * numnodes * numnodalvalues, 1, T>& force_pot_target_GP,
+    Core::LinAlg::Matrix<3, 1, T> const& r_source, Core::LinAlg::Matrix<3, 1, T> const& r_xi_source,
+    Core::LinAlg::Matrix<3, 1, T> const& t1_source, Core::LinAlg::Matrix<3, 1, T> const& r_target,
+    Core::LinAlg::Matrix<3, 1, T> const& r_xi_target,
+    Core::LinAlg::Matrix<3, 1, T> const& r_xixi_target,
+    Core::LinAlg::Matrix<3, 1, T> const& t1_target, T alpha, T cos_alpha,
     Core::LinAlg::Matrix<3, 1, T> const& dist_ul,
-    Core::LinAlg::Matrix<1, 3, T> const& xi_master_partial_r_slave,
-    Core::LinAlg::Matrix<1, 3, T> const& xi_master_partial_r_master,
-    Core::LinAlg::Matrix<1, 3, T> const& xi_master_partial_r_xi_master,
-    double prefactor_visualization_data, Core::LinAlg::Matrix<3, 1, double>& vtk_force_pot_slave_GP,
-    Core::LinAlg::Matrix<3, 1, double>& vtk_force_pot_master_GP,
-    Core::LinAlg::Matrix<3, 1, double>& vtk_moment_pot_slave_GP,
-    Core::LinAlg::Matrix<3, 1, double>& vtk_moment_pot_master_GP,
+    Core::LinAlg::Matrix<1, 3, T> const& xi_target_partial_r_source,
+    Core::LinAlg::Matrix<1, 3, T> const& xi_target_partial_r_target,
+    Core::LinAlg::Matrix<1, 3, T> const& xi_target_partial_r_xi_target,
+    double prefactor_visualization_data,
+    Core::LinAlg::Matrix<3, 1, double>& vtk_force_pot_source_GP,
+    Core::LinAlg::Matrix<3, 1, double>& vtk_force_pot_target_GP,
+    Core::LinAlg::Matrix<3, 1, double>& vtk_moment_pot_source_GP,
+    Core::LinAlg::Matrix<3, 1, double>& vtk_moment_pot_target_GP,
     double rho1rho2_JacFac_GaussWeight,
-    Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_slave,
-    Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_xi_slave,
-    Core::LinAlg::Matrix<1, numnodes * numnodalvalues, T> const& N_i_master,
-    Core::LinAlg::Matrix<1, numnodes * numnodalvalues, T> const& N_i_xi_master)
+    Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_source,
+    Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_xi_source,
+    Core::LinAlg::Matrix<1, numnodes * numnodalvalues, T> const& N_i_target,
+    Core::LinAlg::Matrix<1, numnodes * numnodalvalues, T> const& N_i_xi_target)
 {
   // get regularization type and separation
   const BeamInteraction::Potential::RegularizationType regularization_type =
@@ -2517,7 +2524,7 @@ bool BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues,
       Core::LinAlg::Initialization::zero);  // normal vector at bilateral closest point
   T norm_normal_bl_tilde = 0.0;             // norm of vector defining bilateral normal vector
   T gap_bl = 0.0;                           // gap of bilateral closest point
-  T x = 0.0;  // distance between Gauss point and bilateral closest point on slave
+  T x = 0.0;  // distance between Gauss point and bilateral closest point on source
   Core::LinAlg::Matrix<3, 1, T> aux_plane_normal(
       Core::LinAlg::Initialization::zero);  // normal vector of auxiliary plane n*
 
@@ -2564,25 +2571,25 @@ bool BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues,
 
 
   // components from variation of bilateral gap
-  Core::LinAlg::Matrix<3, 1, T> gap_bl_partial_r_slave(Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 1, T> gap_bl_partial_r_master(Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 1, T> gap_bl_partial_r_xi_slave(Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 1, T> gap_bl_partial_r_xi_master(Core::LinAlg::Initialization::zero);
-  T gap_bl_partial_xi_master = 0.0;
+  Core::LinAlg::Matrix<3, 1, T> gap_bl_partial_r_source(Core::LinAlg::Initialization::zero);
+  Core::LinAlg::Matrix<3, 1, T> gap_bl_partial_r_target(Core::LinAlg::Initialization::zero);
+  Core::LinAlg::Matrix<3, 1, T> gap_bl_partial_r_xi_source(Core::LinAlg::Initialization::zero);
+  Core::LinAlg::Matrix<3, 1, T> gap_bl_partial_r_xi_target(Core::LinAlg::Initialization::zero);
+  T gap_bl_partial_xi_target = 0.0;
 
   // components from variation of cosine of enclosed angle
-  Core::LinAlg::Matrix<3, 1, T> cos_alpha_partial_r_xi_slave(Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 1, T> cos_alpha_partial_r_xi_master(Core::LinAlg::Initialization::zero);
-  T cos_alpha_partial_xi_master = 0.0;
+  Core::LinAlg::Matrix<3, 1, T> cos_alpha_partial_r_xi_source(Core::LinAlg::Initialization::zero);
+  Core::LinAlg::Matrix<3, 1, T> cos_alpha_partial_r_xi_target(Core::LinAlg::Initialization::zero);
+  T cos_alpha_partial_xi_target = 0.0;
 
-  // components from variation of distance from bilateral closest point on slave
-  Core::LinAlg::Matrix<3, 1, T> x_partial_r_slave(Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 1, T> x_partial_r_master(Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 1, T> x_partial_r_xi_slave(Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 1, T> x_partial_r_xi_master(Core::LinAlg::Initialization::zero);
+  // components from variation of distance from bilateral closest point on source
+  Core::LinAlg::Matrix<3, 1, T> x_partial_r_source(Core::LinAlg::Initialization::zero);
+  Core::LinAlg::Matrix<3, 1, T> x_partial_r_target(Core::LinAlg::Initialization::zero);
+  Core::LinAlg::Matrix<3, 1, T> x_partial_r_xi_source(Core::LinAlg::Initialization::zero);
+  Core::LinAlg::Matrix<3, 1, T> x_partial_r_xi_target(Core::LinAlg::Initialization::zero);
 
   Core::LinAlg::Matrix<3, 1, T> x_partial_aux_plane_normal(Core::LinAlg::Initialization::zero);
-  T x_partial_xi_master = 0.0;
+  T x_partial_xi_target = 0.0;
 
 
   // auxiliary variables
@@ -2608,17 +2615,17 @@ bool BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues,
   else
   {
     // normal vector at bilateral closest point Fixme
-    normal_bl.cross_product(r_xi_slave, r_xi_master);
+    normal_bl.cross_product(r_xi_source, r_xi_target);
     norm_normal_bl_tilde = Core::FADUtils::vector_norm(normal_bl);
     normal_bl.scale(1.0 / norm_normal_bl_tilde);
 
-    // distance between Gauss point and bilateral closest point on slave
-    aux_plane_normal.update(
-        r_xi_master.dot(r_xi_master), r_xi_slave, -1.0 * r_xi_master.dot(r_xi_slave), r_xi_master);
+    // distance between Gauss point and bilateral closest point on source
+    aux_plane_normal.update(r_xi_target.dot(r_xi_target), r_xi_source,
+        -1.0 * r_xi_target.dot(r_xi_source), r_xi_target);
 
-    x = Core::FADUtils::vector_norm(r_xi_slave) *
-        (r_master.dot(aux_plane_normal) - r_slave.dot(aux_plane_normal)) /
-        r_xi_slave.dot(aux_plane_normal);
+    x = Core::FADUtils::vector_norm(r_xi_source) *
+        (r_target.dot(aux_plane_normal) - r_source.dot(aux_plane_normal)) /
+        r_xi_source.dot(aux_plane_normal);
   }
 
   // gap of bilateral closest point (also valid for special case alpha=0)
@@ -2821,11 +2828,11 @@ bool BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues,
   // components from variation of bilateral gap
   T signum_dist_bl_tilde = Core::FADUtils::signum(dist_ul.dot(normal_bl));
 
-  gap_bl_partial_r_slave.update(signum_dist_bl_tilde, normal_bl);
-  gap_bl_partial_r_master.update(-1.0 * signum_dist_bl_tilde, normal_bl);
+  gap_bl_partial_r_source.update(signum_dist_bl_tilde, normal_bl);
+  gap_bl_partial_r_target.update(-1.0 * signum_dist_bl_tilde, normal_bl);
 
-  // Todo: check and remove: the following term should vanish since r_xi_master \perp normal_bl
-  gap_bl_partial_xi_master = -1.0 * signum_dist_bl_tilde * r_xi_master.dot(normal_bl);
+  // Todo: check and remove: the following term should vanish since r_xi_target \perp normal_bl
+  gap_bl_partial_xi_target = -1.0 * signum_dist_bl_tilde * r_xi_target.dot(normal_bl);
 
   v_mat_tmp.clear();
   for (unsigned int i = 0; i < 3; ++i)
@@ -2842,110 +2849,112 @@ bool BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues,
   {
     // Todo: check and remove: signum_dist_bl_tilde should always be +1.0 in this case!
 
-    gap_bl_partial_r_xi_slave.clear();
+    gap_bl_partial_r_xi_source.clear();
 
-    gap_bl_partial_r_slave.update(signum_dist_bl_tilde / norm_normal_bl_tilde, vec_tmp, 1.0);
+    gap_bl_partial_r_source.update(signum_dist_bl_tilde / norm_normal_bl_tilde, vec_tmp, 1.0);
 
-    gap_bl_partial_r_xi_master.clear();
+    gap_bl_partial_r_xi_target.clear();
 
-    gap_bl_partial_r_master.update(
+    gap_bl_partial_r_target.update(
         -1.0 * signum_dist_bl_tilde / norm_normal_bl_tilde, vec_tmp, 1.0);
 
     // Todo: check and remove: the following term should vanish
-    gap_bl_partial_xi_master -=
-        signum_dist_bl_tilde / norm_normal_bl_tilde * r_xi_master.dot(vec_tmp);
+    gap_bl_partial_xi_target -=
+        signum_dist_bl_tilde / norm_normal_bl_tilde * r_xi_target.dot(vec_tmp);
   }
   else
   {
-    gap_bl_partial_r_xi_slave.update(signum_dist_bl_tilde / norm_normal_bl_tilde,
-        Core::FADUtils::vector_product(r_xi_master, vec_tmp));
+    gap_bl_partial_r_xi_source.update(signum_dist_bl_tilde / norm_normal_bl_tilde,
+        Core::FADUtils::vector_product(r_xi_target, vec_tmp));
 
-    gap_bl_partial_r_xi_master.update(-1.0 * signum_dist_bl_tilde / norm_normal_bl_tilde,
-        Core::FADUtils::vector_product(r_xi_slave, vec_tmp));
+    gap_bl_partial_r_xi_target.update(-1.0 * signum_dist_bl_tilde / norm_normal_bl_tilde,
+        Core::FADUtils::vector_product(r_xi_source, vec_tmp));
 
-    gap_bl_partial_xi_master += r_xixi_master.dot(gap_bl_partial_r_xi_master);
+    gap_bl_partial_xi_target += r_xixi_target.dot(gap_bl_partial_r_xi_target);
   }
 
 
   // components from variation of cosine of enclosed angle
-  T signum_tangentsscalarproduct = Core::FADUtils::signum(r_xi_slave.dot(r_xi_master));
+  T signum_tangentsscalarproduct = Core::FADUtils::signum(r_xi_source.dot(r_xi_target));
 
   v_mat_tmp.clear();
   for (unsigned int i = 0; i < 3; ++i)
   {
     v_mat_tmp(i, i) += 1.0;
-    for (unsigned int j = 0; j < 3; ++j) v_mat_tmp(i, j) -= t1_slave(i) * t1_slave(j);
+    for (unsigned int j = 0; j < 3; ++j) v_mat_tmp(i, j) -= t1_source(i) * t1_source(j);
   }
 
-  cos_alpha_partial_r_xi_slave.multiply(
-      signum_tangentsscalarproduct / Core::FADUtils::vector_norm(r_xi_slave), v_mat_tmp, t1_master);
+  cos_alpha_partial_r_xi_source.multiply(
+      signum_tangentsscalarproduct / Core::FADUtils::vector_norm(r_xi_source), v_mat_tmp,
+      t1_target);
 
   v_mat_tmp.clear();
   for (unsigned int i = 0; i < 3; ++i)
   {
     v_mat_tmp(i, i) += 1.0;
-    for (unsigned int j = 0; j < 3; ++j) v_mat_tmp(i, j) -= t1_master(i) * t1_master(j);
+    for (unsigned int j = 0; j < 3; ++j) v_mat_tmp(i, j) -= t1_target(i) * t1_target(j);
   }
 
-  cos_alpha_partial_r_xi_master.multiply(
-      signum_tangentsscalarproduct / Core::FADUtils::vector_norm(r_xi_master), v_mat_tmp, t1_slave);
+  cos_alpha_partial_r_xi_target.multiply(
+      signum_tangentsscalarproduct / Core::FADUtils::vector_norm(r_xi_target), v_mat_tmp,
+      t1_source);
 
-  cos_alpha_partial_xi_master = r_xixi_master.dot(cos_alpha_partial_r_xi_master);
+  cos_alpha_partial_xi_target = r_xixi_target.dot(cos_alpha_partial_r_xi_target);
 
 
-  // components from variation of distance from bilateral closest point on slave
+  // components from variation of distance from bilateral closest point on source
   if (Core::FADUtils::cast_to_double(alpha) < BEAMSCOLINEARANGLETHRESHOLD)
   {
     /* set the following quantities to zero since they are not required in this case
      * because pot_ia_partial_x is zero anyway */
-    x_partial_r_slave.clear();
-    x_partial_r_master.clear();
-    x_partial_r_xi_slave.clear();
-    x_partial_r_xi_master.clear();
-    x_partial_xi_master = 0.0;
+    x_partial_r_source.clear();
+    x_partial_r_target.clear();
+    x_partial_r_xi_source.clear();
+    x_partial_r_xi_target.clear();
+    x_partial_xi_target = 0.0;
   }
   else
   {
-    x_partial_r_slave.update(-1.0 / t1_slave.dot(aux_plane_normal), aux_plane_normal);
-    x_partial_r_master.update(1.0 / t1_slave.dot(aux_plane_normal), aux_plane_normal);
+    x_partial_r_source.update(-1.0 / t1_source.dot(aux_plane_normal), aux_plane_normal);
+    x_partial_r_target.update(1.0 / t1_source.dot(aux_plane_normal), aux_plane_normal);
 
     v_mat_tmp.clear();
     for (unsigned int i = 0; i < 3; ++i)
     {
       v_mat_tmp(i, i) += 1.0;
-      for (unsigned int j = 0; j < 3; ++j) v_mat_tmp(i, j) -= t1_slave(i) * t1_slave(j);
+      for (unsigned int j = 0; j < 3; ++j) v_mat_tmp(i, j) -= t1_source(i) * t1_source(j);
     }
 
-    x_partial_r_xi_slave.multiply(1.0 / Core::FADUtils::vector_norm(r_xi_slave) *
-                                      dist_ul.dot(aux_plane_normal) /
-                                      std::pow(t1_slave.dot(aux_plane_normal), 2),
+    x_partial_r_xi_source.multiply(1.0 / Core::FADUtils::vector_norm(r_xi_source) *
+                                       dist_ul.dot(aux_plane_normal) /
+                                       std::pow(t1_source.dot(aux_plane_normal), 2),
         v_mat_tmp, aux_plane_normal);
 
-    x_partial_aux_plane_normal.update(-1.0 / t1_slave.dot(aux_plane_normal), dist_ul,
-        dist_ul.dot(aux_plane_normal) / std::pow(t1_slave.dot(aux_plane_normal), 2), t1_slave);
+    x_partial_aux_plane_normal.update(-1.0 / t1_source.dot(aux_plane_normal), dist_ul,
+        dist_ul.dot(aux_plane_normal) / std::pow(t1_source.dot(aux_plane_normal), 2), t1_source);
 
     v_mat_tmp.clear();
     for (unsigned int i = 0; i < 3; ++i)
-      for (unsigned int j = 0; j < 3; ++j) v_mat_tmp(i, j) += r_xi_master(i) * r_xi_master(j);
+      for (unsigned int j = 0; j < 3; ++j) v_mat_tmp(i, j) += r_xi_target(i) * r_xi_target(j);
 
-    x_partial_r_xi_slave.update(r_xi_master.dot(r_xi_master), x_partial_aux_plane_normal, 1.0);
+    x_partial_r_xi_source.update(r_xi_target.dot(r_xi_target), x_partial_aux_plane_normal, 1.0);
 
-    x_partial_r_xi_slave.multiply(-1.0, v_mat_tmp, x_partial_aux_plane_normal, 1.0);
+    x_partial_r_xi_source.multiply(-1.0, v_mat_tmp, x_partial_aux_plane_normal, 1.0);
 
 
-    x_partial_r_xi_master.update(-1.0 * r_xi_master.dot(r_xi_slave), x_partial_aux_plane_normal);
+    x_partial_r_xi_target.update(-1.0 * r_xi_target.dot(r_xi_source), x_partial_aux_plane_normal);
 
     v_mat_tmp.clear();
     for (unsigned int i = 0; i < 3; ++i)
       for (unsigned int j = 0; j < 3; ++j)
       {
-        v_mat_tmp(i, j) += 2.0 * r_xi_master(i) * r_xi_slave(j);
-        v_mat_tmp(i, j) -= 1.0 * r_xi_slave(i) * r_xi_master(j);
+        v_mat_tmp(i, j) += 2.0 * r_xi_target(i) * r_xi_source(j);
+        v_mat_tmp(i, j) -= 1.0 * r_xi_source(i) * r_xi_target(j);
       }
 
-    x_partial_r_xi_master.multiply(1.0, v_mat_tmp, x_partial_aux_plane_normal, 1.0);
+    x_partial_r_xi_target.multiply(1.0, v_mat_tmp, x_partial_aux_plane_normal, 1.0);
 
-    x_partial_xi_master = r_xixi_master.dot(x_partial_r_xi_master);
+    x_partial_xi_target = r_xixi_target.dot(x_partial_r_xi_target);
   }
 
 
@@ -2961,53 +2970,53 @@ bool BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues,
    * of the centerline is already a distributed force
    */
 
-  // distributed force on slave
-  vtk_force_pot_slave_GP.update(
+  // distributed force on source
+  vtk_force_pot_source_GP.update(
       prefactor_visualization_data * Core::FADUtils::cast_to_double(pot_ia_partial_gap_bl),
-      Core::FADUtils::cast_to_double<T, 3, 1>(gap_bl_partial_r_slave), 1.0);
+      Core::FADUtils::cast_to_double<T, 3, 1>(gap_bl_partial_r_source), 1.0);
 
-  vtk_force_pot_slave_GP.update_t(prefactor_visualization_data *
-                                      Core::FADUtils::cast_to_double(pot_ia_partial_gap_bl) *
-                                      Core::FADUtils::cast_to_double(gap_bl_partial_xi_master),
-      Core::FADUtils::cast_to_double<T, 1, 3>(xi_master_partial_r_slave), 1.0);
-
-  vtk_force_pot_slave_GP.update_t(prefactor_visualization_data *
-                                      Core::FADUtils::cast_to_double(pot_ia_partial_cos_alpha) *
-                                      Core::FADUtils::cast_to_double(cos_alpha_partial_xi_master),
-      Core::FADUtils::cast_to_double<T, 1, 3>(xi_master_partial_r_slave), 1.0);
-
-  vtk_force_pot_slave_GP.update(
-      prefactor_visualization_data * Core::FADUtils::cast_to_double(pot_ia_partial_x),
-      Core::FADUtils::cast_to_double<T, 3, 1>(x_partial_r_slave), 1.0);
-
-  vtk_force_pot_slave_GP.update_t(prefactor_visualization_data *
-                                      Core::FADUtils::cast_to_double(pot_ia_partial_x) *
-                                      Core::FADUtils::cast_to_double(x_partial_xi_master),
-      Core::FADUtils::cast_to_double<T, 1, 3>(xi_master_partial_r_slave), 1.0);
-
-  // distributed force on master
-  vtk_force_pot_master_GP.update(
-      prefactor_visualization_data * Core::FADUtils::cast_to_double(pot_ia_partial_gap_bl),
-      Core::FADUtils::cast_to_double<T, 3, 1>(gap_bl_partial_r_master), 1.0);
-
-  vtk_force_pot_master_GP.update_t(prefactor_visualization_data *
+  vtk_force_pot_source_GP.update_t(prefactor_visualization_data *
                                        Core::FADUtils::cast_to_double(pot_ia_partial_gap_bl) *
-                                       Core::FADUtils::cast_to_double(gap_bl_partial_xi_master),
-      Core::FADUtils::cast_to_double<T, 1, 3>(xi_master_partial_r_master), 1.0);
+                                       Core::FADUtils::cast_to_double(gap_bl_partial_xi_target),
+      Core::FADUtils::cast_to_double<T, 1, 3>(xi_target_partial_r_source), 1.0);
 
-  vtk_force_pot_master_GP.update_t(prefactor_visualization_data *
+  vtk_force_pot_source_GP.update_t(prefactor_visualization_data *
                                        Core::FADUtils::cast_to_double(pot_ia_partial_cos_alpha) *
-                                       Core::FADUtils::cast_to_double(cos_alpha_partial_xi_master),
-      Core::FADUtils::cast_to_double<T, 1, 3>(xi_master_partial_r_master), 1.0);
+                                       Core::FADUtils::cast_to_double(cos_alpha_partial_xi_target),
+      Core::FADUtils::cast_to_double<T, 1, 3>(xi_target_partial_r_source), 1.0);
 
-  vtk_force_pot_master_GP.update(
+  vtk_force_pot_source_GP.update(
       prefactor_visualization_data * Core::FADUtils::cast_to_double(pot_ia_partial_x),
-      Core::FADUtils::cast_to_double<T, 3, 1>(x_partial_r_master), 1.0);
+      Core::FADUtils::cast_to_double<T, 3, 1>(x_partial_r_source), 1.0);
 
-  vtk_force_pot_master_GP.update_t(prefactor_visualization_data *
+  vtk_force_pot_source_GP.update_t(prefactor_visualization_data *
                                        Core::FADUtils::cast_to_double(pot_ia_partial_x) *
-                                       Core::FADUtils::cast_to_double(x_partial_xi_master),
-      Core::FADUtils::cast_to_double<T, 1, 3>(xi_master_partial_r_master), 1.0);
+                                       Core::FADUtils::cast_to_double(x_partial_xi_target),
+      Core::FADUtils::cast_to_double<T, 1, 3>(xi_target_partial_r_source), 1.0);
+
+  // distributed force on target
+  vtk_force_pot_target_GP.update(
+      prefactor_visualization_data * Core::FADUtils::cast_to_double(pot_ia_partial_gap_bl),
+      Core::FADUtils::cast_to_double<T, 3, 1>(gap_bl_partial_r_target), 1.0);
+
+  vtk_force_pot_target_GP.update_t(prefactor_visualization_data *
+                                       Core::FADUtils::cast_to_double(pot_ia_partial_gap_bl) *
+                                       Core::FADUtils::cast_to_double(gap_bl_partial_xi_target),
+      Core::FADUtils::cast_to_double<T, 1, 3>(xi_target_partial_r_target), 1.0);
+
+  vtk_force_pot_target_GP.update_t(prefactor_visualization_data *
+                                       Core::FADUtils::cast_to_double(pot_ia_partial_cos_alpha) *
+                                       Core::FADUtils::cast_to_double(cos_alpha_partial_xi_target),
+      Core::FADUtils::cast_to_double<T, 1, 3>(xi_target_partial_r_target), 1.0);
+
+  vtk_force_pot_target_GP.update(
+      prefactor_visualization_data * Core::FADUtils::cast_to_double(pot_ia_partial_x),
+      Core::FADUtils::cast_to_double<T, 3, 1>(x_partial_r_target), 1.0);
+
+  vtk_force_pot_target_GP.update_t(prefactor_visualization_data *
+                                       Core::FADUtils::cast_to_double(pot_ia_partial_x) *
+                                       Core::FADUtils::cast_to_double(x_partial_xi_target),
+      Core::FADUtils::cast_to_double<T, 1, 3>(xi_target_partial_r_target), 1.0);
 
   /* note on distributed moment visualization
    * Contrary to the distributed force visualization, the distributed moment can not be directly
@@ -3040,45 +3049,45 @@ bool BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues,
   Core::LinAlg::Matrix<3, 1, double> m_pseudo(Core::LinAlg::Initialization::zero);
   Core::LinAlg::Matrix<3, 1, double> m(Core::LinAlg::Initialization::zero);
 
-  // distributed moment on slave
+  // distributed moment on source
   m_pseudo.update(Core::FADUtils::cast_to_double(pot_ia_partial_gap_bl),
-      Core::FADUtils::cast_to_double<T, 3, 1>(gap_bl_partial_r_xi_slave));
+      Core::FADUtils::cast_to_double<T, 3, 1>(gap_bl_partial_r_xi_source));
 
   m_pseudo.update(Core::FADUtils::cast_to_double(pot_ia_partial_cos_alpha),
-      Core::FADUtils::cast_to_double<T, 3, 1>(cos_alpha_partial_r_xi_slave), 1.0);
+      Core::FADUtils::cast_to_double<T, 3, 1>(cos_alpha_partial_r_xi_source), 1.0);
 
   m_pseudo.update(Core::FADUtils::cast_to_double(pot_ia_partial_x),
-      Core::FADUtils::cast_to_double<T, 3, 1>(x_partial_r_xi_slave), 1.0);
+      Core::FADUtils::cast_to_double<T, 3, 1>(x_partial_r_xi_source), 1.0);
 
-  m.cross_product(Core::FADUtils::cast_to_double<T, 3, 1>(r_xi_slave), m_pseudo);
+  m.cross_product(Core::FADUtils::cast_to_double<T, 3, 1>(r_xi_source), m_pseudo);
 
-  vtk_moment_pot_slave_GP.update(prefactor_visualization_data, m, 1.0);
+  vtk_moment_pot_source_GP.update(prefactor_visualization_data, m, 1.0);
 
-  // distributed moment on master
+  // distributed moment on target
   m_pseudo.update(Core::FADUtils::cast_to_double(pot_ia_partial_gap_bl),
-      Core::FADUtils::cast_to_double<T, 3, 1>(gap_bl_partial_r_xi_master));
+      Core::FADUtils::cast_to_double<T, 3, 1>(gap_bl_partial_r_xi_target));
 
   m_pseudo.update_t(Core::FADUtils::cast_to_double(pot_ia_partial_gap_bl) *
-                        Core::FADUtils::cast_to_double(gap_bl_partial_xi_master),
-      Core::FADUtils::cast_to_double<T, 1, 3>(xi_master_partial_r_xi_master), 1.0);
+                        Core::FADUtils::cast_to_double(gap_bl_partial_xi_target),
+      Core::FADUtils::cast_to_double<T, 1, 3>(xi_target_partial_r_xi_target), 1.0);
 
   m_pseudo.update(Core::FADUtils::cast_to_double(pot_ia_partial_cos_alpha),
-      Core::FADUtils::cast_to_double<T, 3, 1>(cos_alpha_partial_r_xi_master), 1.0);
+      Core::FADUtils::cast_to_double<T, 3, 1>(cos_alpha_partial_r_xi_target), 1.0);
 
   m_pseudo.update_t(Core::FADUtils::cast_to_double(pot_ia_partial_cos_alpha) *
-                        Core::FADUtils::cast_to_double(cos_alpha_partial_xi_master),
-      Core::FADUtils::cast_to_double<T, 1, 3>(xi_master_partial_r_xi_master), 1.0);
+                        Core::FADUtils::cast_to_double(cos_alpha_partial_xi_target),
+      Core::FADUtils::cast_to_double<T, 1, 3>(xi_target_partial_r_xi_target), 1.0);
 
   m_pseudo.update(Core::FADUtils::cast_to_double(pot_ia_partial_x),
-      Core::FADUtils::cast_to_double<T, 3, 1>(x_partial_r_xi_master), 1.0);
+      Core::FADUtils::cast_to_double<T, 3, 1>(x_partial_r_xi_target), 1.0);
 
   m_pseudo.update_t(Core::FADUtils::cast_to_double(pot_ia_partial_x) *
-                        Core::FADUtils::cast_to_double(x_partial_xi_master),
-      Core::FADUtils::cast_to_double<T, 1, 3>(xi_master_partial_r_xi_master), 1.0);
+                        Core::FADUtils::cast_to_double(x_partial_xi_target),
+      Core::FADUtils::cast_to_double<T, 1, 3>(xi_target_partial_r_xi_target), 1.0);
 
-  m.cross_product(Core::FADUtils::cast_to_double<T, 3, 1>(r_xi_master), m_pseudo);
+  m.cross_product(Core::FADUtils::cast_to_double<T, 3, 1>(r_xi_target), m_pseudo);
 
-  vtk_moment_pot_master_GP.update(prefactor_visualization_data, m, 1.0);
+  vtk_moment_pot_target_GP.update(prefactor_visualization_data, m, 1.0);
 
   // integration factor
   interaction_potential_GP *= rho1rho2_JacFac_GaussWeight;
@@ -3087,79 +3096,80 @@ bool BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues,
   pot_ia_partial_x *= rho1rho2_JacFac_GaussWeight;
 
   //********************************************************************
-  // calculate fpot1: force/residual vector on slave element
+  // calculate fpot1: force/residual vector on source element
   //********************************************************************
-  force_pot_slave_GP.clear();
+  force_pot_source_GP.clear();
   // sum up the contributions of all nodes (in all dimensions)
   for (unsigned int idofperdim = 0; idofperdim < (numnodes * numnodalvalues); ++idofperdim)
   {
     // loop over dimensions
     for (unsigned int jdim = 0; jdim < 3; ++jdim)
     {
-      force_pot_slave_GP(3 * idofperdim + jdim) +=
-          N_i_slave(idofperdim) * pot_ia_partial_gap_bl *
-          (gap_bl_partial_r_slave(jdim) +
-              gap_bl_partial_xi_master * xi_master_partial_r_slave(jdim));
+      force_pot_source_GP(3 * idofperdim + jdim) +=
+          N_i_source(idofperdim) * pot_ia_partial_gap_bl *
+          (gap_bl_partial_r_source(jdim) +
+              gap_bl_partial_xi_target * xi_target_partial_r_source(jdim));
 
-      force_pot_slave_GP(3 * idofperdim + jdim) +=
-          N_i_xi_slave(idofperdim) * pot_ia_partial_gap_bl * gap_bl_partial_r_xi_slave(jdim);
-
-
-      force_pot_slave_GP(3 * idofperdim + jdim) +=
-          N_i_slave(idofperdim) * pot_ia_partial_cos_alpha * cos_alpha_partial_xi_master *
-          xi_master_partial_r_slave(jdim);
-
-      force_pot_slave_GP(3 * idofperdim + jdim) +=
-          N_i_xi_slave(idofperdim) * pot_ia_partial_cos_alpha * cos_alpha_partial_r_xi_slave(jdim);
+      force_pot_source_GP(3 * idofperdim + jdim) +=
+          N_i_xi_source(idofperdim) * pot_ia_partial_gap_bl * gap_bl_partial_r_xi_source(jdim);
 
 
-      force_pot_slave_GP(3 * idofperdim + jdim) +=
-          N_i_slave(idofperdim) * pot_ia_partial_x *
-          (x_partial_r_slave(jdim) + x_partial_xi_master * xi_master_partial_r_slave(jdim));
+      force_pot_source_GP(3 * idofperdim + jdim) +=
+          N_i_source(idofperdim) * pot_ia_partial_cos_alpha * cos_alpha_partial_xi_target *
+          xi_target_partial_r_source(jdim);
 
-      force_pot_slave_GP(3 * idofperdim + jdim) +=
-          N_i_xi_slave(idofperdim) * pot_ia_partial_x * x_partial_r_xi_slave(jdim);
+      force_pot_source_GP(3 * idofperdim + jdim) += N_i_xi_source(idofperdim) *
+                                                    pot_ia_partial_cos_alpha *
+                                                    cos_alpha_partial_r_xi_source(jdim);
+
+
+      force_pot_source_GP(3 * idofperdim + jdim) +=
+          N_i_source(idofperdim) * pot_ia_partial_x *
+          (x_partial_r_source(jdim) + x_partial_xi_target * xi_target_partial_r_source(jdim));
+
+      force_pot_source_GP(3 * idofperdim + jdim) +=
+          N_i_xi_source(idofperdim) * pot_ia_partial_x * x_partial_r_xi_source(jdim);
     }
   }
 
   //********************************************************************
-  // calculate fpot2: force/residual vector on master element
+  // calculate fpot2: force/residual vector on target element
   //********************************************************************
-  force_pot_master_GP.clear();
+  force_pot_target_GP.clear();
   // sum up the contributions of all nodes (in all dimensions)
   for (unsigned int idofperdim = 0; idofperdim < (numnodes * numnodalvalues); ++idofperdim)
   {
     // loop over dimensions
     for (unsigned int jdim = 0; jdim < 3; ++jdim)
     {
-      force_pot_master_GP(3 * idofperdim + jdim) +=
-          N_i_master(idofperdim) * pot_ia_partial_gap_bl *
-          (gap_bl_partial_r_master(jdim) +
-              gap_bl_partial_xi_master * xi_master_partial_r_master(jdim));
+      force_pot_target_GP(3 * idofperdim + jdim) +=
+          N_i_target(idofperdim) * pot_ia_partial_gap_bl *
+          (gap_bl_partial_r_target(jdim) +
+              gap_bl_partial_xi_target * xi_target_partial_r_target(jdim));
 
-      force_pot_master_GP(3 * idofperdim + jdim) +=
-          N_i_xi_master(idofperdim) * pot_ia_partial_gap_bl *
-          (gap_bl_partial_r_xi_master(jdim) +
-              gap_bl_partial_xi_master * xi_master_partial_r_xi_master(jdim));
-
-
-      force_pot_master_GP(3 * idofperdim + jdim) +=
-          N_i_master(idofperdim) * pot_ia_partial_cos_alpha * cos_alpha_partial_xi_master *
-          xi_master_partial_r_master(jdim);
-
-      force_pot_master_GP(3 * idofperdim + jdim) +=
-          N_i_xi_master(idofperdim) * pot_ia_partial_cos_alpha *
-          (cos_alpha_partial_r_xi_master(jdim) +
-              cos_alpha_partial_xi_master * xi_master_partial_r_xi_master(jdim));
+      force_pot_target_GP(3 * idofperdim + jdim) +=
+          N_i_xi_target(idofperdim) * pot_ia_partial_gap_bl *
+          (gap_bl_partial_r_xi_target(jdim) +
+              gap_bl_partial_xi_target * xi_target_partial_r_xi_target(jdim));
 
 
-      force_pot_master_GP(3 * idofperdim + jdim) +=
-          N_i_master(idofperdim) * pot_ia_partial_x *
-          (x_partial_r_master(jdim) + x_partial_xi_master * xi_master_partial_r_master(jdim));
+      force_pot_target_GP(3 * idofperdim + jdim) +=
+          N_i_target(idofperdim) * pot_ia_partial_cos_alpha * cos_alpha_partial_xi_target *
+          xi_target_partial_r_target(jdim);
 
-      force_pot_master_GP(3 * idofperdim + jdim) +=
-          N_i_xi_master(idofperdim) * pot_ia_partial_x *
-          (x_partial_r_xi_master(jdim) + x_partial_xi_master * xi_master_partial_r_xi_master(jdim));
+      force_pot_target_GP(3 * idofperdim + jdim) +=
+          N_i_xi_target(idofperdim) * pot_ia_partial_cos_alpha *
+          (cos_alpha_partial_r_xi_target(jdim) +
+              cos_alpha_partial_xi_target * xi_target_partial_r_xi_target(jdim));
+
+
+      force_pot_target_GP(3 * idofperdim + jdim) +=
+          N_i_target(idofperdim) * pot_ia_partial_x *
+          (x_partial_r_target(jdim) + x_partial_xi_target * xi_target_partial_r_target(jdim));
+
+      force_pot_target_GP(3 * idofperdim + jdim) +=
+          N_i_xi_target(idofperdim) * pot_ia_partial_x *
+          (x_partial_r_xi_target(jdim) + x_partial_xi_target * xi_target_partial_r_xi_target(jdim));
     }
   }
 
@@ -3171,29 +3181,29 @@ bool BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues,
 template <unsigned int numnodes, unsigned int numnodalvalues, typename T>
 bool BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues,
     T>::evaluate_simple_disk_cylinder_potential(Core::LinAlg::Matrix<3, 1, T> const& dist_ul,
-    T norm_dist_ul, T alpha, T cos_alpha, Core::LinAlg::Matrix<3, 1, T> const& r_slave,
-    Core::LinAlg::Matrix<3, 1, T> const& r_xi_slave, T norm_r_xi_slave,
-    Core::LinAlg::Matrix<3, 1, T> const& t_slave, Core::LinAlg::Matrix<3, 1, T> const& r_master,
-    Core::LinAlg::Matrix<3, 1, T> const& r_xi_master, T norm_r_xi_master,
-    Core::LinAlg::Matrix<3, 1, T> const& r_xixi_master,
-    Core::LinAlg::Matrix<3, 1, T> const& t_master, T xi_master,
-    Core::LinAlg::Matrix<1, 3, T> const& xi_master_partial_r_slave,
-    Core::LinAlg::Matrix<1, 3, T> const& xi_master_partial_r_master,
-    Core::LinAlg::Matrix<1, 3, T> const& xi_master_partial_r_xi_master,
+    T norm_dist_ul, T alpha, T cos_alpha, Core::LinAlg::Matrix<3, 1, T> const& r_source,
+    Core::LinAlg::Matrix<3, 1, T> const& r_xi_source, T norm_r_xi_source,
+    Core::LinAlg::Matrix<3, 1, T> const& t_source, Core::LinAlg::Matrix<3, 1, T> const& r_target,
+    Core::LinAlg::Matrix<3, 1, T> const& r_xi_target, T norm_r_xi_target,
+    Core::LinAlg::Matrix<3, 1, T> const& r_xixi_target,
+    Core::LinAlg::Matrix<3, 1, T> const& t_target, T xi_target,
+    Core::LinAlg::Matrix<1, 3, T> const& xi_target_partial_r_source,
+    Core::LinAlg::Matrix<1, 3, T> const& xi_target_partial_r_target,
+    Core::LinAlg::Matrix<1, 3, T> const& xi_target_partial_r_xi_target,
     std::optional<double> potential_reduction_length, double length_prior_right,
     double length_prior_left, T& interaction_potential_GP,
-    Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_slave,
-    Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_xi_slave,
-    Core::LinAlg::Matrix<1, numnodes * numnodalvalues, T> const& N_i_master,
-    Core::LinAlg::Matrix<1, numnodes * numnodalvalues, T> const& N_i_xi_master,
-    Core::LinAlg::Matrix<1, numnodes * numnodalvalues, T> const& N_i_xixi_master,
-    Core::LinAlg::Matrix<3 * numnodes * numnodalvalues, 1, T>& force_pot_slave_GP,
-    Core::LinAlg::Matrix<3 * numnodes * numnodalvalues, 1, T>& force_pot_master_GP,
+    Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_source,
+    Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_xi_source,
+    Core::LinAlg::Matrix<1, numnodes * numnodalvalues, T> const& N_i_target,
+    Core::LinAlg::Matrix<1, numnodes * numnodalvalues, T> const& N_i_xi_target,
+    Core::LinAlg::Matrix<1, numnodes * numnodalvalues, T> const& N_i_xixi_target,
+    Core::LinAlg::Matrix<3 * numnodes * numnodalvalues, 1, T>& force_pot_source_GP,
+    Core::LinAlg::Matrix<3 * numnodes * numnodalvalues, 1, T>& force_pot_target_GP,
     double prefactor_visualization_data, double rho1rho2_JacFac_GaussWeight,
-    Core::LinAlg::Matrix<3, 1, double>& vtk_force_pot_slave_GP,
-    Core::LinAlg::Matrix<3, 1, double>& vtk_force_pot_master_GP,
-    Core::LinAlg::Matrix<3, 1, double>& vtk_moment_pot_slave_GP,
-    Core::LinAlg::Matrix<3, 1, double>& vtk_moment_pot_master_GP,
+    Core::LinAlg::Matrix<3, 1, double>& vtk_force_pot_source_GP,
+    Core::LinAlg::Matrix<3, 1, double>& vtk_force_pot_target_GP,
+    Core::LinAlg::Matrix<3, 1, double>& vtk_moment_pot_source_GP,
+    Core::LinAlg::Matrix<3, 1, double>& vtk_moment_pot_target_GP,
     Core::LinAlg::SerialDenseMatrix* stiffmat11, Core::LinAlg::SerialDenseMatrix* stiffmat12,
     Core::LinAlg::SerialDenseMatrix* stiffmat21, Core::LinAlg::SerialDenseMatrix* stiffmat22)
 {
@@ -3234,26 +3244,26 @@ bool BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues,
   // fourth derivative
   T pot_ia_2ndderiv_gap_ul_2ndderiv_cos_alpha_at_regsep = 0.0;
 
-  // derivatives of the potential reduction factor w.r.t. xi_master
+  // derivatives of the potential reduction factor w.r.t. xi_target
   T pot_red_fac_deriv_l_edge = 0.0;
   T pot_red_fac_2ndderiv_l_edge = 0.0;
-  T l_edge_deriv_xi_master = 0.0;
-  T pot_red_fac_deriv_xi_master = 0.0;
-  T pot_red_fac_2ndderiv_xi_master = 0.0;
+  T l_edge_deriv_xi_target = 0.0;
+  T pot_red_fac_deriv_xi_target = 0.0;
+  T pot_red_fac_2ndderiv_xi_target = 0.0;
 
   // components from variation of unilateral gap
-  Core::LinAlg::Matrix<3, 1, T> gap_ul_deriv_r_slave(Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 1, T> gap_ul_deriv_r_master(Core::LinAlg::Initialization::zero);
+  Core::LinAlg::Matrix<3, 1, T> gap_ul_deriv_r_source(Core::LinAlg::Initialization::zero);
+  Core::LinAlg::Matrix<3, 1, T> gap_ul_deriv_r_target(Core::LinAlg::Initialization::zero);
 
   // components from variation of cosine of enclosed angle
-  Core::LinAlg::Matrix<3, 1, T> cos_alpha_partial_r_xi_slave(Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 1, T> cos_alpha_partial_r_xi_master(Core::LinAlg::Initialization::zero);
-  T cos_alpha_partial_xi_master = 0.0;
+  Core::LinAlg::Matrix<3, 1, T> cos_alpha_partial_r_xi_source(Core::LinAlg::Initialization::zero);
+  Core::LinAlg::Matrix<3, 1, T> cos_alpha_partial_r_xi_target(Core::LinAlg::Initialization::zero);
+  T cos_alpha_partial_xi_target = 0.0;
 
-  Core::LinAlg::Matrix<3, 1, T> cos_alpha_deriv_r_slave(Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 1, T> cos_alpha_deriv_r_master(Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 1, T> cos_alpha_deriv_r_xi_slave(Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Matrix<3, 1, T> cos_alpha_deriv_r_xi_master(Core::LinAlg::Initialization::zero);
+  Core::LinAlg::Matrix<3, 1, T> cos_alpha_deriv_r_source(Core::LinAlg::Initialization::zero);
+  Core::LinAlg::Matrix<3, 1, T> cos_alpha_deriv_r_target(Core::LinAlg::Initialization::zero);
+  Core::LinAlg::Matrix<3, 1, T> cos_alpha_deriv_r_xi_source(Core::LinAlg::Initialization::zero);
+  Core::LinAlg::Matrix<3, 1, T> cos_alpha_deriv_r_xi_target(Core::LinAlg::Initialization::zero);
 
   // gap of unilateral closest points
   gap_ul = norm_dist_ul - radius1_ - radius2_;
@@ -3383,15 +3393,15 @@ bool BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues,
     }
   }
 
-  // determine potential reduction factor for master beam endpoint strategy
+  // determine potential reduction factor for target beam endpoint strategy
   if (potential_reduction_length.has_value())
   {
-    T left_length_to_edge = length_prior_left + ele2length_ * 0.5 * (1 + xi_master);
-    T right_length_to_edge = length_prior_right + ele2length_ * 0.5 * (1 - xi_master);
+    T left_length_to_edge = length_prior_left + ele2length_ * 0.5 * (1 + xi_target);
+    T right_length_to_edge = length_prior_right + ele2length_ * 0.5 * (1 - xi_target);
     T length_to_edge = -1.0;
     bool right_node = false;
 
-    // determine potential reduction factor (master beam can only consist of one element!)
+    // determine potential reduction factor (target beam can only consist of one element!)
     if (left_length_to_edge < potential_reduction_length.value())
     {
       potential_reduction_factor_GP = 0.5 - 0.5 * std::cos(std::numbers::pi * left_length_to_edge /
@@ -3417,54 +3427,54 @@ bool BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues,
           std::cos(std::numbers::pi * length_to_edge / potential_reduction_length.value());
     }
 
-    l_edge_deriv_xi_master = 0.5 * ele2length_;
+    l_edge_deriv_xi_target = 0.5 * ele2length_;
 
-    if (right_node) l_edge_deriv_xi_master *= -1.0;
+    if (right_node) l_edge_deriv_xi_target *= -1.0;
 
-    pot_red_fac_deriv_xi_master = pot_red_fac_deriv_l_edge * l_edge_deriv_xi_master;
-    pot_red_fac_2ndderiv_xi_master =
-        pot_red_fac_2ndderiv_l_edge * l_edge_deriv_xi_master * l_edge_deriv_xi_master;
+    pot_red_fac_deriv_xi_target = pot_red_fac_deriv_l_edge * l_edge_deriv_xi_target;
+    pot_red_fac_2ndderiv_xi_target =
+        pot_red_fac_2ndderiv_l_edge * l_edge_deriv_xi_target * l_edge_deriv_xi_target;
   }
 
   // compute components from variation of cosine of enclosed angle
-  signum_tangentsscalarproduct = Core::FADUtils::signum(r_xi_slave.dot(r_xi_master));
+  signum_tangentsscalarproduct = Core::FADUtils::signum(r_xi_source.dot(r_xi_target));
   // auxiliary variables
   Core::LinAlg::Matrix<3, 3, T> v_mat_tmp(Core::LinAlg::Initialization::zero);
 
   for (unsigned int i = 0; i < 3; ++i)
   {
     v_mat_tmp(i, i) += 1.0;
-    for (unsigned int j = 0; j < 3; ++j) v_mat_tmp(i, j) -= t_slave(i) * t_slave(j);
+    for (unsigned int j = 0; j < 3; ++j) v_mat_tmp(i, j) -= t_source(i) * t_source(j);
   }
 
-  cos_alpha_partial_r_xi_slave.multiply(
-      signum_tangentsscalarproduct / Core::FADUtils::vector_norm(r_xi_slave), v_mat_tmp, t_master);
+  cos_alpha_partial_r_xi_source.multiply(
+      signum_tangentsscalarproduct / Core::FADUtils::vector_norm(r_xi_source), v_mat_tmp, t_target);
 
   v_mat_tmp.clear();
   for (unsigned int i = 0; i < 3; ++i)
   {
     v_mat_tmp(i, i) += 1.0;
-    for (unsigned int j = 0; j < 3; ++j) v_mat_tmp(i, j) -= t_master(i) * t_master(j);
+    for (unsigned int j = 0; j < 3; ++j) v_mat_tmp(i, j) -= t_target(i) * t_target(j);
   }
 
-  cos_alpha_partial_r_xi_master.multiply(
-      signum_tangentsscalarproduct / Core::FADUtils::vector_norm(r_xi_master), v_mat_tmp, t_slave);
+  cos_alpha_partial_r_xi_target.multiply(
+      signum_tangentsscalarproduct / Core::FADUtils::vector_norm(r_xi_target), v_mat_tmp, t_source);
 
-  cos_alpha_partial_xi_master = r_xixi_master.dot(cos_alpha_partial_r_xi_master);
+  cos_alpha_partial_xi_target = r_xixi_target.dot(cos_alpha_partial_r_xi_target);
 
 
-  cos_alpha_deriv_r_slave.update_t(cos_alpha_partial_xi_master, xi_master_partial_r_slave);
-  cos_alpha_deriv_r_master.update_t(cos_alpha_partial_xi_master, xi_master_partial_r_master);
+  cos_alpha_deriv_r_source.update_t(cos_alpha_partial_xi_target, xi_target_partial_r_source);
+  cos_alpha_deriv_r_target.update_t(cos_alpha_partial_xi_target, xi_target_partial_r_target);
 
-  cos_alpha_deriv_r_xi_slave.update(cos_alpha_partial_r_xi_slave);
-  cos_alpha_deriv_r_xi_master.update(1.0, cos_alpha_partial_r_xi_master);
-  cos_alpha_deriv_r_xi_master.update_t(
-      cos_alpha_partial_xi_master, xi_master_partial_r_xi_master, 1.0);
+  cos_alpha_deriv_r_xi_source.update(cos_alpha_partial_r_xi_source);
+  cos_alpha_deriv_r_xi_target.update(1.0, cos_alpha_partial_r_xi_target);
+  cos_alpha_deriv_r_xi_target.update_t(
+      cos_alpha_partial_xi_target, xi_target_partial_r_xi_target, 1.0);
 
 
   // compute components from variation of the unilateral gap
-  gap_ul_deriv_r_slave.update(normal_ul);
-  gap_ul_deriv_r_master.update(-1.0, normal_ul);
+  gap_ul_deriv_r_source.update(normal_ul);
+  gap_ul_deriv_r_target.update(-1.0, normal_ul);
 
 
   /* store for visualization
@@ -3479,37 +3489,37 @@ bool BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues,
    * of the centerline is already a distributed force
    */
 
-  // distributed force on slave
-  vtk_force_pot_slave_GP.update_t(prefactor_visualization_data *
-                                      Core::FADUtils::cast_to_double(pot_red_fac_deriv_xi_master) *
-                                      Core::FADUtils::cast_to_double(interaction_potential_GP),
-      Core::FADUtils::cast_to_double<T, 1, 3>(xi_master_partial_r_slave), 1.0);
-
-  vtk_force_pot_slave_GP.update(prefactor_visualization_data *
-                                    Core::FADUtils::cast_to_double(potential_reduction_factor_GP) *
-                                    Core::FADUtils::cast_to_double(pot_ia_deriv_gap_ul),
-      Core::FADUtils::cast_to_double<T, 3, 1>(gap_ul_deriv_r_slave), 1.0);
-
-  vtk_force_pot_slave_GP.update(prefactor_visualization_data *
-                                    Core::FADUtils::cast_to_double(potential_reduction_factor_GP) *
-                                    Core::FADUtils::cast_to_double(pot_ia_deriv_cos_alpha),
-      Core::FADUtils::cast_to_double<T, 3, 1>(cos_alpha_deriv_r_slave), 1.0);
-
-  // distributed force on master
-  vtk_force_pot_master_GP.update_t(prefactor_visualization_data *
-                                       Core::FADUtils::cast_to_double(pot_red_fac_deriv_xi_master) *
+  // distributed force on source
+  vtk_force_pot_source_GP.update_t(prefactor_visualization_data *
+                                       Core::FADUtils::cast_to_double(pot_red_fac_deriv_xi_target) *
                                        Core::FADUtils::cast_to_double(interaction_potential_GP),
-      Core::FADUtils::cast_to_double<T, 1, 3>(xi_master_partial_r_master), 1.0);
+      Core::FADUtils::cast_to_double<T, 1, 3>(xi_target_partial_r_source), 1.0);
 
-  vtk_force_pot_master_GP.update(prefactor_visualization_data *
+  vtk_force_pot_source_GP.update(prefactor_visualization_data *
                                      Core::FADUtils::cast_to_double(potential_reduction_factor_GP) *
                                      Core::FADUtils::cast_to_double(pot_ia_deriv_gap_ul),
-      Core::FADUtils::cast_to_double<T, 3, 1>(gap_ul_deriv_r_master), 1.0);
+      Core::FADUtils::cast_to_double<T, 3, 1>(gap_ul_deriv_r_source), 1.0);
 
-  vtk_force_pot_master_GP.update(prefactor_visualization_data *
+  vtk_force_pot_source_GP.update(prefactor_visualization_data *
                                      Core::FADUtils::cast_to_double(potential_reduction_factor_GP) *
                                      Core::FADUtils::cast_to_double(pot_ia_deriv_cos_alpha),
-      Core::FADUtils::cast_to_double<T, 3, 1>(cos_alpha_deriv_r_master), 1.0);
+      Core::FADUtils::cast_to_double<T, 3, 1>(cos_alpha_deriv_r_source), 1.0);
+
+  // distributed force on target
+  vtk_force_pot_target_GP.update_t(prefactor_visualization_data *
+                                       Core::FADUtils::cast_to_double(pot_red_fac_deriv_xi_target) *
+                                       Core::FADUtils::cast_to_double(interaction_potential_GP),
+      Core::FADUtils::cast_to_double<T, 1, 3>(xi_target_partial_r_target), 1.0);
+
+  vtk_force_pot_target_GP.update(prefactor_visualization_data *
+                                     Core::FADUtils::cast_to_double(potential_reduction_factor_GP) *
+                                     Core::FADUtils::cast_to_double(pot_ia_deriv_gap_ul),
+      Core::FADUtils::cast_to_double<T, 3, 1>(gap_ul_deriv_r_target), 1.0);
+
+  vtk_force_pot_target_GP.update(prefactor_visualization_data *
+                                     Core::FADUtils::cast_to_double(potential_reduction_factor_GP) *
+                                     Core::FADUtils::cast_to_double(pot_ia_deriv_cos_alpha),
+      Core::FADUtils::cast_to_double<T, 3, 1>(cos_alpha_deriv_r_target), 1.0);
 
   /* note on distributed moment visualization
    * Contrary to the distributed force visualization, the distributed moment can not be directly
@@ -3542,28 +3552,28 @@ bool BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues,
   Core::LinAlg::Matrix<3, 1, double> m_pseudo(Core::LinAlg::Initialization::zero);
   Core::LinAlg::Matrix<3, 1, double> m(Core::LinAlg::Initialization::zero);
 
-  // distributed moment on slave
+  // distributed moment on source
   m_pseudo.update(Core::FADUtils::cast_to_double(potential_reduction_factor_GP) *
                       Core::FADUtils::cast_to_double(pot_ia_deriv_cos_alpha),
-      Core::FADUtils::cast_to_double<T, 3, 1>(cos_alpha_deriv_r_xi_slave));
+      Core::FADUtils::cast_to_double<T, 3, 1>(cos_alpha_deriv_r_xi_source));
 
-  m.cross_product(Core::FADUtils::cast_to_double<T, 3, 1>(r_xi_slave), m_pseudo);
+  m.cross_product(Core::FADUtils::cast_to_double<T, 3, 1>(r_xi_source), m_pseudo);
 
-  vtk_moment_pot_slave_GP.update(prefactor_visualization_data, m, 1.0);
+  vtk_moment_pot_source_GP.update(prefactor_visualization_data, m, 1.0);
 
 
-  // distributed moment on master
-  m_pseudo.update_t(Core::FADUtils::cast_to_double(pot_red_fac_deriv_xi_master) *
+  // distributed moment on target
+  m_pseudo.update_t(Core::FADUtils::cast_to_double(pot_red_fac_deriv_xi_target) *
                         Core::FADUtils::cast_to_double(interaction_potential_GP),
-      Core::FADUtils::cast_to_double<T, 1, 3>(xi_master_partial_r_xi_master));
+      Core::FADUtils::cast_to_double<T, 1, 3>(xi_target_partial_r_xi_target));
 
   m_pseudo.update(Core::FADUtils::cast_to_double(potential_reduction_factor_GP) *
                       Core::FADUtils::cast_to_double(pot_ia_deriv_cos_alpha),
-      Core::FADUtils::cast_to_double<T, 3, 1>(cos_alpha_deriv_r_xi_master), 1.0);
+      Core::FADUtils::cast_to_double<T, 3, 1>(cos_alpha_deriv_r_xi_target), 1.0);
 
-  m.cross_product(Core::FADUtils::cast_to_double<T, 3, 1>(r_xi_master), m_pseudo);
+  m.cross_product(Core::FADUtils::cast_to_double<T, 3, 1>(r_xi_target), m_pseudo);
 
-  vtk_moment_pot_master_GP.update(prefactor_visualization_data, m, 1.0);
+  vtk_moment_pot_target_GP.update(prefactor_visualization_data, m, 1.0);
 
 
   // now apply scalar integration factor
@@ -3579,10 +3589,10 @@ bool BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues,
 
 
   //********************************************************************
-  // calculate force/residual vector of slave and master element
+  // calculate force/residual vector of source and target element
   //********************************************************************
-  force_pot_slave_GP.clear();
-  force_pot_master_GP.clear();
+  force_pot_source_GP.clear();
+  force_pot_target_GP.clear();
 
   // sum up the contributions of all nodes (in all dimensions)
   for (unsigned int idofperdim = 0; idofperdim < (numnodes * numnodalvalues); ++idofperdim)
@@ -3590,50 +3600,50 @@ bool BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues,
     // loop over dimensions
     for (unsigned int jdim = 0; jdim < 3; ++jdim)
     {
-      // slave beam => axial pull-off force
-      force_pot_slave_GP(3 * idofperdim + jdim) +=
-          N_i_slave(idofperdim) * pot_red_fac_deriv_xi_master * interaction_potential_GP *
-          xi_master_partial_r_slave(jdim);
+      // source beam => axial pull-off force
+      force_pot_source_GP(3 * idofperdim + jdim) +=
+          N_i_source(idofperdim) * pot_red_fac_deriv_xi_target * interaction_potential_GP *
+          xi_target_partial_r_source(jdim);
 
-      // slave beam => radial (attractive / repulsive) force
-      force_pot_slave_GP(3 * idofperdim + jdim) += N_i_slave(idofperdim) *
-                                                   potential_reduction_factor_GP *
-                                                   pot_ia_deriv_gap_ul * gap_ul_deriv_r_slave(jdim);
+      // source beam => radial (attractive / repulsive) force
+      force_pot_source_GP(3 * idofperdim + jdim) +=
+          N_i_source(idofperdim) * potential_reduction_factor_GP * pot_ia_deriv_gap_ul *
+          gap_ul_deriv_r_source(jdim);
 
-      // slave beam => force arising from not parallel beams
-      force_pot_slave_GP(3 * idofperdim + jdim) +=
-          N_i_slave(idofperdim) * potential_reduction_factor_GP * pot_ia_deriv_cos_alpha *
-          cos_alpha_deriv_r_slave(jdim);
+      // source beam => force arising from not parallel beams
+      force_pot_source_GP(3 * idofperdim + jdim) +=
+          N_i_source(idofperdim) * potential_reduction_factor_GP * pot_ia_deriv_cos_alpha *
+          cos_alpha_deriv_r_source(jdim);
 
-      // slave beam => moment arising from not parallel beams
-      force_pot_slave_GP(3 * idofperdim + jdim) +=
-          N_i_xi_slave(idofperdim) * potential_reduction_factor_GP * pot_ia_deriv_cos_alpha *
-          cos_alpha_deriv_r_xi_slave(jdim);
+      // source beam => moment arising from not parallel beams
+      force_pot_source_GP(3 * idofperdim + jdim) +=
+          N_i_xi_source(idofperdim) * potential_reduction_factor_GP * pot_ia_deriv_cos_alpha *
+          cos_alpha_deriv_r_xi_source(jdim);
 
-      // master beam => axial pull-off force
-      force_pot_master_GP(3 * idofperdim + jdim) +=
-          N_i_master(idofperdim) * pot_red_fac_deriv_xi_master * interaction_potential_GP *
-          xi_master_partial_r_master(jdim);
+      // target beam => axial pull-off force
+      force_pot_target_GP(3 * idofperdim + jdim) +=
+          N_i_target(idofperdim) * pot_red_fac_deriv_xi_target * interaction_potential_GP *
+          xi_target_partial_r_target(jdim);
 
-      // master beam => end point moment
-      force_pot_master_GP(3 * idofperdim + jdim) +=
-          N_i_xi_master(idofperdim) * pot_red_fac_deriv_xi_master * interaction_potential_GP *
-          xi_master_partial_r_xi_master(jdim);
+      // target beam => end point moment
+      force_pot_target_GP(3 * idofperdim + jdim) +=
+          N_i_xi_target(idofperdim) * pot_red_fac_deriv_xi_target * interaction_potential_GP *
+          xi_target_partial_r_xi_target(jdim);
 
-      // master beam => radial (attractive / repulsive) force
-      force_pot_master_GP(3 * idofperdim + jdim) +=
-          N_i_master(idofperdim) * potential_reduction_factor_GP * pot_ia_deriv_gap_ul *
-          gap_ul_deriv_r_master(jdim);
+      // target beam => radial (attractive / repulsive) force
+      force_pot_target_GP(3 * idofperdim + jdim) +=
+          N_i_target(idofperdim) * potential_reduction_factor_GP * pot_ia_deriv_gap_ul *
+          gap_ul_deriv_r_target(jdim);
 
-      // master beam => force arising from not parallel beams
-      force_pot_master_GP(3 * idofperdim + jdim) +=
-          N_i_master(idofperdim) * potential_reduction_factor_GP * pot_ia_deriv_cos_alpha *
-          cos_alpha_deriv_r_master(jdim);
+      // target beam => force arising from not parallel beams
+      force_pot_target_GP(3 * idofperdim + jdim) +=
+          N_i_target(idofperdim) * potential_reduction_factor_GP * pot_ia_deriv_cos_alpha *
+          cos_alpha_deriv_r_target(jdim);
 
-      // master beam => moment due to not parallel beams
-      force_pot_master_GP(3 * idofperdim + jdim) +=
-          N_i_xi_master(idofperdim) * potential_reduction_factor_GP * pot_ia_deriv_cos_alpha *
-          cos_alpha_deriv_r_xi_master(jdim);
+      // target beam => moment due to not parallel beams
+      force_pot_target_GP(3 * idofperdim + jdim) +=
+          N_i_xi_target(idofperdim) * potential_reduction_factor_GP * pot_ia_deriv_cos_alpha *
+          cos_alpha_deriv_r_xi_target(jdim);
     }
   }
 
@@ -3642,15 +3652,15 @@ bool BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues,
   {
     // evaluate contributions to linearization based on analytical expression
     evaluate_stiffpot_analytic_contributions_single_length_specific_small_sep_approx_simple(
-        N_i_slave, N_i_xi_slave, N_i_master, N_i_xi_master, N_i_xixi_master, xi_master, r_xi_slave,
-        r_xi_master, r_xixi_master, norm_dist_ul, normal_ul, potential_reduction_factor_GP,
-        pot_red_fac_deriv_xi_master, pot_red_fac_2ndderiv_xi_master, interaction_potential_GP,
-        pot_ia_deriv_gap_ul, pot_ia_deriv_cos_alpha, pot_ia_2ndderiv_gap_ul,
-        pot_ia_deriv_gap_ul_deriv_cos_alpha, pot_ia_2ndderiv_cos_alpha, gap_ul_deriv_r_slave,
-        gap_ul_deriv_r_master, cos_alpha_deriv_r_slave, cos_alpha_deriv_r_master,
-        cos_alpha_deriv_r_xi_slave, cos_alpha_deriv_r_xi_master, xi_master_partial_r_slave,
-        xi_master_partial_r_master, xi_master_partial_r_xi_master, *stiffmat11, *stiffmat12,
-        *stiffmat21, *stiffmat22);
+        N_i_source, N_i_xi_source, N_i_target, N_i_xi_target, N_i_xixi_target, xi_target,
+        r_xi_source, r_xi_target, r_xixi_target, norm_dist_ul, normal_ul,
+        potential_reduction_factor_GP, pot_red_fac_deriv_xi_target, pot_red_fac_2ndderiv_xi_target,
+        interaction_potential_GP, pot_ia_deriv_gap_ul, pot_ia_deriv_cos_alpha,
+        pot_ia_2ndderiv_gap_ul, pot_ia_deriv_gap_ul_deriv_cos_alpha, pot_ia_2ndderiv_cos_alpha,
+        gap_ul_deriv_r_source, gap_ul_deriv_r_target, cos_alpha_deriv_r_source,
+        cos_alpha_deriv_r_target, cos_alpha_deriv_r_xi_source, cos_alpha_deriv_r_xi_target,
+        xi_target_partial_r_source, xi_target_partial_r_target, xi_target_partial_r_xi_target,
+        *stiffmat11, *stiffmat12, *stiffmat21, *stiffmat22);
   }
 
   // add potential reduction factor to interaction potential for correct energy output
@@ -3709,15 +3719,15 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
  *-----------------------------------------------------------------------------------------------*/
 template <unsigned int numnodes, unsigned int numnodalvalues, typename T>
 void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
-    add_stiffmat_contributions_xi_master_automatic_differentiation_if_required(
+    add_stiffmat_contributions_xi_target_automatic_differentiation_if_required(
         Core::LinAlg::Matrix<3 * numnodes * numnodalvalues, 1, Sacado::Fad::DFad<double>> const&
             force_pot1,
         Core::LinAlg::Matrix<3 * numnodes * numnodalvalues, 1, Sacado::Fad::DFad<double>> const&
             force_pot2,
         Core::LinAlg::Matrix<1, 3 * numnodes * numnodalvalues, Sacado::Fad::DFad<double>> const&
-            lin_xi_master_slaveDofs,
+            lin_xi_source_targetDofs,
         Core::LinAlg::Matrix<1, 3 * numnodes * numnodalvalues, Sacado::Fad::DFad<double>> const&
-            lin_xi_master_masterDofs,
+            lin_xi_target_targetDofs,
         Core::LinAlg::SerialDenseMatrix& stiffmat11, Core::LinAlg::SerialDenseMatrix& stiffmat12,
         Core::LinAlg::SerialDenseMatrix& stiffmat21,
         Core::LinAlg::SerialDenseMatrix& stiffmat22) const
@@ -3730,19 +3740,19 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
     {
       // d (Res_1) / d (d_1)
       stiffmat11(idof, jdof) += force_pot1(idof).dx(2 * dim) *
-                                Core::FADUtils::cast_to_double(lin_xi_master_slaveDofs(jdof));
+                                Core::FADUtils::cast_to_double(lin_xi_source_targetDofs(jdof));
 
       // d (Res_1) / d (d_2)
       stiffmat12(idof, jdof) += force_pot1(idof).dx(2 * dim) *
-                                Core::FADUtils::cast_to_double(lin_xi_master_masterDofs(jdof));
+                                Core::FADUtils::cast_to_double(lin_xi_target_targetDofs(jdof));
 
       // d (Res_2) / d (d_1)
       stiffmat21(idof, jdof) += force_pot2(idof).dx(2 * dim) *
-                                Core::FADUtils::cast_to_double(lin_xi_master_slaveDofs(jdof));
+                                Core::FADUtils::cast_to_double(lin_xi_source_targetDofs(jdof));
 
       // d (Res_2) / d (d_2)
       stiffmat22(idof, jdof) += force_pot2(idof).dx(2 * dim) *
-                                Core::FADUtils::cast_to_double(lin_xi_master_masterDofs(jdof));
+                                Core::FADUtils::cast_to_double(lin_xi_target_targetDofs(jdof));
     }
   }
 }
@@ -3757,9 +3767,9 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
         Sacado::Fad::DFad<double> const& interaction_potential,
         Sacado::Fad::DFad<double> const& potential_reduction_factor,
         Core::LinAlg::Matrix<1, 3 * numnodes * numnodalvalues, Sacado::Fad::DFad<double>> const&
-            lin_xi_master_slaveDofs,
+            lin_xi_source_targetDofs,
         Core::LinAlg::Matrix<1, 3 * numnodes * numnodalvalues, Sacado::Fad::DFad<double>> const&
-            lin_xi_master_masterDofs) const
+            lin_xi_target_targetDofs) const
 {
   const unsigned int dim = 3 * numnodalvalues * numnodes;
 
@@ -3767,11 +3777,11 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
   {
     force_pot1(idof) = (potential_reduction_factor * interaction_potential).dx(idof) +
                        (potential_reduction_factor * interaction_potential).dx(2 * dim) *
-                           Core::FADUtils::cast_to_double(lin_xi_master_slaveDofs(idof));
+                           Core::FADUtils::cast_to_double(lin_xi_source_targetDofs(idof));
 
     force_pot2(idof) = (potential_reduction_factor * interaction_potential).dx(dim + idof) +
                        (potential_reduction_factor * interaction_potential).dx(2 * dim) *
-                           Core::FADUtils::cast_to_double(lin_xi_master_masterDofs(idof));
+                           Core::FADUtils::cast_to_double(lin_xi_target_targetDofs(idof));
   }
 }
 
@@ -3787,9 +3797,9 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
         Sacado::Fad::DFad<double> const& interaction_potential,
         Sacado::Fad::DFad<double> const& potential_reduction_factor,
         Core::LinAlg::Matrix<1, 3 * numnodes * numnodalvalues, Sacado::Fad::DFad<double>> const&
-            lin_xi_master_slaveDofs,
+            lin_xi_source_targetDofs,
         Core::LinAlg::Matrix<1, 3 * numnodes * numnodalvalues, Sacado::Fad::DFad<double>> const&
-            lin_xi_master_masterDofs) const
+            lin_xi_target_targetDofs) const
 {
   const unsigned int dim = 3 * numnodalvalues * numnodes;
 
@@ -3797,11 +3807,11 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
   {
     force_pot1(idof) = (potential_reduction_factor * interaction_potential).dx(idof) +
                        (potential_reduction_factor * interaction_potential).dx(2 * dim) *
-                           lin_xi_master_slaveDofs(idof);
+                           lin_xi_source_targetDofs(idof);
 
     force_pot2(idof) = (potential_reduction_factor * interaction_potential).dx(dim + idof) +
                        (potential_reduction_factor * interaction_potential).dx(2 * dim) *
-                           lin_xi_master_masterDofs(idof);
+                           lin_xi_target_targetDofs(idof);
   }
 }
 
@@ -3904,7 +3914,7 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
             ele1centerlinedofvec,
         Core::LinAlg::Matrix<3 * numnodes * numnodalvalues, 1, Sacado::Fad::DFad<double>>&
             ele2centerlinedofvec,
-        Sacado::Fad::DFad<double>& xi_master)
+        Sacado::Fad::DFad<double>& xi_target)
 {
   // The 2*3*numnodes*numnodalvalues primary DoFs consist of all nodal positions and tangents
   for (unsigned int i = 0; i < 3 * numnodes * numnodalvalues; ++i)
@@ -3914,8 +3924,8 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
     ele2centerlinedofvec(i).diff(
         3 * numnodes * numnodalvalues + i, 2 * 3 * numnodes * numnodalvalues + 1);
 
-  // Additionally, we set the parameter coordinate on the master side xi_master as primary Dof
-  xi_master.diff(2 * 3 * numnodes * numnodalvalues, 2 * 3 * numnodes * numnodalvalues + 1);
+  // Additionally, we set the parameter coordinate on the target side xi_target as primary Dof
+  xi_target.diff(2 * 3 * numnodes * numnodalvalues, 2 * 3 * numnodes * numnodalvalues + 1);
 }
 
 /*-----------------------------------------------------------------------------------------------*
@@ -3985,7 +3995,7 @@ bool BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues,
 
 template <unsigned int numnodes, unsigned int numnodalvalues, typename T>
 void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues,
-    T>::exchange_master_slave_allocation_for_two_half_pass()
+    T>::exchange_source_target_allocation_for_two_half_pass()
 {
   // interchange elements (also swap base class pointers!)
   Core::Elements::Element const* tmp_ele = element1();

--- a/src/beaminteraction/src/potential/4C_beaminteraction_potential_pair_beam_to_beam.cpp
+++ b/src/beaminteraction/src/potential/4C_beaminteraction_potential_pair_beam_to_beam.cpp
@@ -9,7 +9,7 @@
 
 #include "4C_beam3_base.hpp"
 #include "4C_beam3_spatial_discretization_utils.hpp"
-#include "4C_beaminteraction_geometry_utils.hpp"
+#include "4C_beaminteraction_potential_geometry_utils.hpp"
 #include "4C_beaminteraction_potential_input.hpp"
 #include "4C_fem_general_largerotations.hpp"
 #include "4C_fem_general_utils_integration.hpp"
@@ -1368,10 +1368,11 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
        * to determine point on target beam (i.e. parameter coordinate xi_target) */
       iter_projection = 0;
 
-      while (iter_projection < num_initial_values and
-             (not BeamInteraction::Geo::point_to_curve_projection<numnodes, numnodalvalues, T>(
-                 r_source, xi_target, xi_target_initial_guess_values[iter_projection], ele2pos_,
-                 element2()->shape(), ele2length_)))
+      while (
+          iter_projection < num_initial_values and
+          (not BeamInteraction::Potential::Geo::point_to_curve_projection<numnodes, numnodalvalues,
+              T>(r_source, xi_target, xi_target_initial_guess_values[iter_projection], ele2pos_,
+              element2()->shape(), ele2length_)))
       {
         iter_projection++;
       }
@@ -1436,7 +1437,8 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
       }
 
       // mutual angle of tangent vectors at unilateral closest points
-      BeamInteraction::Geo::calc_enclosed_angle(alpha, cos_alpha, r_xi_source, r_xi_target);
+      BeamInteraction::Potential::Geo::calc_enclosed_angle(
+          alpha, cos_alpha, r_xi_source, r_xi_target);
 
       if (alpha < 0.0 or alpha > std::numbers::pi / 2)
         FOUR_C_THROW("alpha={}, should be in [0,pi/2]", Core::FADUtils::cast_to_double(alpha));
@@ -1450,14 +1452,16 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
           numnodalvalues>(
           N_i_target, N_i_xi_target, N_i_xixi_target, N_target, N_xi_target, N_xixi_target);
 
-      BeamInteraction::Geo::calc_linearization_point_to_curve_projection_parameter_coord_target<
-          numnodes, numnodalvalues>(lin_xi_source_targetDofs, lin_xi_target_targetDofs, dist_ul,
-          r_xi_target, r_xixi_target, N_source, N_target, N_xixi_target);
+      BeamInteraction::Potential::Geo::
+          calc_linearization_point_to_curve_projection_parameter_coord_target<numnodes,
+              numnodalvalues>(lin_xi_source_targetDofs, lin_xi_target_targetDofs, dist_ul,
+              r_xi_target, r_xixi_target, N_source, N_target, N_xixi_target);
 
 
-      BeamInteraction::Geo::calc_point_to_curve_projection_parameter_coord_target_partial_derivs(
-          xi_target_partial_r_source, xi_target_partial_r_target, xi_target_partial_r_xi_target,
-          dist_ul, r_xi_target, r_xixi_target);
+      BeamInteraction::Potential::Geo::
+          calc_point_to_curve_projection_parameter_coord_target_partial_derivs(
+              xi_target_partial_r_source, xi_target_partial_r_target, xi_target_partial_r_xi_target,
+              dist_ul, r_xi_target, r_xixi_target);
 
 
       // evaluate all quantities which depend on the applied disk-cylinder potential law
@@ -2045,22 +2049,24 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
   Core::LinAlg::Matrix<3, 1, double> dist_ul(Core::LinAlg::Initialization::zero);
   dist_ul.update(norm_dist_ul, normal_ul);
 
-  BeamInteraction::Geo::calc_point_to_curve_projection_parameter_coord_target_partial2nd_derivs(
-      xi_target_partial_r_source_partial_r_source, xi_target_partial_r_source_partial_r_target,
-      xi_target_partial_r_source_partial_r_xi_target,
-      xi_target_partial_r_source_partial_r_xixi_target, xi_target_partial_r_target_partial_r_source,
-      xi_target_partial_r_target_partial_r_target, xi_target_partial_r_target_partial_r_xi_target,
-      xi_target_partial_r_target_partial_r_xixi_target,
-      xi_target_partial_r_xi_target_partial_r_source,
-      xi_target_partial_r_xi_target_partial_r_target,
-      xi_target_partial_r_xi_target_partial_r_xi_target,
-      xi_target_partial_r_xi_target_partial_r_xixi_target,
-      xi_target_partial_r_xixi_target_partial_r_source,
-      xi_target_partial_r_xixi_target_partial_r_target,
-      xi_target_partial_r_xixi_target_partial_r_xi_target, xi_target_partial_r_source,
-      xi_target_partial_r_target, xi_target_partial_r_xi_target, dist_ul_deriv_r_source,
-      dist_ul_deriv_r_target, dist_ul_deriv_r_xi_target, dist_ul, r_xi_target, r_xixi_target,
-      r_xixixi_target);
+  BeamInteraction::Potential::Geo::
+      calc_point_to_curve_projection_parameter_coord_target_partial2nd_derivs(
+          xi_target_partial_r_source_partial_r_source, xi_target_partial_r_source_partial_r_target,
+          xi_target_partial_r_source_partial_r_xi_target,
+          xi_target_partial_r_source_partial_r_xixi_target,
+          xi_target_partial_r_target_partial_r_source, xi_target_partial_r_target_partial_r_target,
+          xi_target_partial_r_target_partial_r_xi_target,
+          xi_target_partial_r_target_partial_r_xixi_target,
+          xi_target_partial_r_xi_target_partial_r_source,
+          xi_target_partial_r_xi_target_partial_r_target,
+          xi_target_partial_r_xi_target_partial_r_xi_target,
+          xi_target_partial_r_xi_target_partial_r_xixi_target,
+          xi_target_partial_r_xixi_target_partial_r_source,
+          xi_target_partial_r_xixi_target_partial_r_target,
+          xi_target_partial_r_xixi_target_partial_r_xi_target, xi_target_partial_r_source,
+          xi_target_partial_r_target, xi_target_partial_r_xi_target, dist_ul_deriv_r_source,
+          dist_ul_deriv_r_target, dist_ul_deriv_r_xi_target, dist_ul, r_xi_target, r_xixi_target,
+          r_xixixi_target);
 
   double r_xixi_target_dot_v2 = r_xixi_target.dot(t_target_partial_r_xi_target_mult_t_source);
 

--- a/src/beaminteraction/src/potential/4C_beaminteraction_potential_pair_beam_to_beam.hpp
+++ b/src/beaminteraction/src/potential/4C_beaminteraction_potential_pair_beam_to_beam.hpp
@@ -244,55 +244,56 @@ namespace BeamInteraction
      *
      */
     bool evaluate_full_disk_cylinder_potential(T& interaction_potential_GP,
-        Core::LinAlg::Matrix<3 * numnodes * numnodalvalues, 1, T>& force_pot_slave_GP,
-        Core::LinAlg::Matrix<3 * numnodes * numnodalvalues, 1, T>& force_pot_master_GP,
-        Core::LinAlg::Matrix<3, 1, T> const& r_slave,
-        Core::LinAlg::Matrix<3, 1, T> const& r_xi_slave,
-        Core::LinAlg::Matrix<3, 1, T> const& t1_slave,
-        Core::LinAlg::Matrix<3, 1, T> const& r_master,
-        Core::LinAlg::Matrix<3, 1, T> const& r_xi_master,
-        Core::LinAlg::Matrix<3, 1, T> const& r_xixi_master,
-        Core::LinAlg::Matrix<3, 1, T> const& t1_master, T alpha, T cos_alpha,
+        Core::LinAlg::Matrix<3 * numnodes * numnodalvalues, 1, T>& force_pot_source_GP,
+        Core::LinAlg::Matrix<3 * numnodes * numnodalvalues, 1, T>& force_pot_target_GP,
+        Core::LinAlg::Matrix<3, 1, T> const& r_source,
+        Core::LinAlg::Matrix<3, 1, T> const& r_xi_source,
+        Core::LinAlg::Matrix<3, 1, T> const& t1_source,
+        Core::LinAlg::Matrix<3, 1, T> const& r_target,
+        Core::LinAlg::Matrix<3, 1, T> const& r_xi_target,
+        Core::LinAlg::Matrix<3, 1, T> const& r_xixi_target,
+        Core::LinAlg::Matrix<3, 1, T> const& t1_target, T alpha, T cos_alpha,
         Core::LinAlg::Matrix<3, 1, T> const& dist_ul,
-        Core::LinAlg::Matrix<1, 3, T> const& xi_master_partial_r_slave,
-        Core::LinAlg::Matrix<1, 3, T> const& xi_master_partial_r_master,
-        Core::LinAlg::Matrix<1, 3, T> const& xi_master_partial_r_xi_master,
+        Core::LinAlg::Matrix<1, 3, T> const& xi_target_partial_r_source,
+        Core::LinAlg::Matrix<1, 3, T> const& xi_target_partial_r_target,
+        Core::LinAlg::Matrix<1, 3, T> const& xi_target_partial_r_xi_target,
         double prefactor_visualization_data,
-        Core::LinAlg::Matrix<3, 1, double>& vtk_force_pot_slave_GP,
-        Core::LinAlg::Matrix<3, 1, double>& vtk_force_pot_master_GP,
-        Core::LinAlg::Matrix<3, 1, double>& vtk_moment_pot_slave_GP,
-        Core::LinAlg::Matrix<3, 1, double>& vtk_moment_pot_master_GP,
+        Core::LinAlg::Matrix<3, 1, double>& vtk_force_pot_source_GP,
+        Core::LinAlg::Matrix<3, 1, double>& vtk_force_pot_target_GP,
+        Core::LinAlg::Matrix<3, 1, double>& vtk_moment_pot_source_GP,
+        Core::LinAlg::Matrix<3, 1, double>& vtk_moment_pot_target_GP,
         double rho1rho2_JacFac_GaussWeight,
-        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_slave,
-        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_xi_slave,
-        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, T> const& N_i_master,
-        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, T> const& N_i_xi_master);
+        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_source,
+        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_xi_source,
+        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, T> const& N_i_target,
+        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, T> const& N_i_xi_target);
 
     /** \brief Evaluate all quantities for the simple disk-cylinder potential law */
     bool evaluate_simple_disk_cylinder_potential(Core::LinAlg::Matrix<3, 1, T> const& dist_ul,
-        T norm_dist_ul, T alpha, T cos_alpha, Core::LinAlg::Matrix<3, 1, T> const& r_slave,
-        Core::LinAlg::Matrix<3, 1, T> const& r_xi_slave, T norm_r_xi_slave,
-        Core::LinAlg::Matrix<3, 1, T> const& t_slave, Core::LinAlg::Matrix<3, 1, T> const& r_master,
-        Core::LinAlg::Matrix<3, 1, T> const& r_xi_master, T norm_r_xi_master,
-        Core::LinAlg::Matrix<3, 1, T> const& r_xixi_master,
-        Core::LinAlg::Matrix<3, 1, T> const& t_master, T xi_master,
-        Core::LinAlg::Matrix<1, 3, T> const& xi_master_partial_r_slave,
-        Core::LinAlg::Matrix<1, 3, T> const& xi_master_partial_r_master,
-        Core::LinAlg::Matrix<1, 3, T> const& xi_master_partial_r_xi_master,
+        T norm_dist_ul, T alpha, T cos_alpha, Core::LinAlg::Matrix<3, 1, T> const& r_source,
+        Core::LinAlg::Matrix<3, 1, T> const& r_xi_source, T norm_r_xi_source,
+        Core::LinAlg::Matrix<3, 1, T> const& t_source,
+        Core::LinAlg::Matrix<3, 1, T> const& r_target,
+        Core::LinAlg::Matrix<3, 1, T> const& r_xi_target, T norm_r_xi_target,
+        Core::LinAlg::Matrix<3, 1, T> const& r_xixi_target,
+        Core::LinAlg::Matrix<3, 1, T> const& t_target, T xi_target,
+        Core::LinAlg::Matrix<1, 3, T> const& xi_target_partial_r_source,
+        Core::LinAlg::Matrix<1, 3, T> const& xi_target_partial_r_target,
+        Core::LinAlg::Matrix<1, 3, T> const& xi_target_partial_r_xi_target,
         std::optional<double> potential_reduction_length, double length_prior_right,
         double length_prior_left, T& interaction_potential_GP,
-        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_slave,
-        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_xi_slave,
-        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, T> const& N_i_master,
-        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, T> const& N_i_xi_master,
-        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, T> const& N_i_xixi_master,
-        Core::LinAlg::Matrix<3 * numnodes * numnodalvalues, 1, T>& force_pot_slave_GP,
-        Core::LinAlg::Matrix<3 * numnodes * numnodalvalues, 1, T>& force_pot_master_GP,
+        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_source,
+        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_xi_source,
+        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, T> const& N_i_target,
+        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, T> const& N_i_xi_target,
+        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, T> const& N_i_xixi_target,
+        Core::LinAlg::Matrix<3 * numnodes * numnodalvalues, 1, T>& force_pot_source_GP,
+        Core::LinAlg::Matrix<3 * numnodes * numnodalvalues, 1, T>& force_pot_target_GP,
         double prefactor_visualization_data, double rho1rho2_JacFac_GaussWeight,
-        Core::LinAlg::Matrix<3, 1, double>& vtk_force_pot_slave_GP,
-        Core::LinAlg::Matrix<3, 1, double>& vtk_force_pot_master_GP,
-        Core::LinAlg::Matrix<3, 1, double>& vtk_moment_pot_slave_GP,
-        Core::LinAlg::Matrix<3, 1, double>& vtk_moment_pot_master_GP,
+        Core::LinAlg::Matrix<3, 1, double>& vtk_force_pot_source_GP,
+        Core::LinAlg::Matrix<3, 1, double>& vtk_force_pot_target_GP,
+        Core::LinAlg::Matrix<3, 1, double>& vtk_moment_pot_source_GP,
+        Core::LinAlg::Matrix<3, 1, double>& vtk_moment_pot_target_GP,
         Core::LinAlg::SerialDenseMatrix* stiffmat11, Core::LinAlg::SerialDenseMatrix* stiffmat12,
         Core::LinAlg::SerialDenseMatrix* stiffmat21, Core::LinAlg::SerialDenseMatrix* stiffmat22);
 
@@ -342,18 +343,18 @@ namespace BeamInteraction
         Core::LinAlg::SerialDenseMatrix& stiffmat21,
         Core::LinAlg::SerialDenseMatrix& stiffmat22) const;
 
-    /** \brief add contributions from linearization of parameter coordinate on master beam xi_master
+    /** \brief add contributions from linearization of parameter coordinate on target beam xi_target
      *         if determined via point-to-curve projection
      *         using automatic differentiation based on Sacado::Fad package
      *
      */
-    void add_stiffmat_contributions_xi_master_automatic_differentiation_if_required(
+    void add_stiffmat_contributions_xi_target_automatic_differentiation_if_required(
         Core::LinAlg::Matrix<3 * numnodes * numnodalvalues, 1, double> const& force_pot1,
         Core::LinAlg::Matrix<3 * numnodes * numnodalvalues, 1, double> const& force_pot2,
         Core::LinAlg::Matrix<1, 3 * numnodes * numnodalvalues, double> const&
-            lin_xi_master_slaveDofs,
+            lin_xi_source_targetDofs,
         Core::LinAlg::Matrix<1, 3 * numnodes * numnodalvalues, double> const&
-            lin_xi_master_masterDofs,
+            lin_xi_target_targetDofs,
         Core::LinAlg::SerialDenseMatrix& stiffmat11, Core::LinAlg::SerialDenseMatrix& stiffmat12,
         Core::LinAlg::SerialDenseMatrix& stiffmat21,
         Core::LinAlg::SerialDenseMatrix& stiffmat22) const
@@ -361,20 +362,20 @@ namespace BeamInteraction
       // this is a dummy since for type double, no automatic differentiation is required
     }
 
-    /** \brief add contributions from linearization of parameter coordinate on master beam xi_master
+    /** \brief add contributions from linearization of parameter coordinate on target beam xi_target
      *         if determined via point-to-curve projection
      *         using automatic differentiation based on Sacado::Fad package
      *
      */
-    void add_stiffmat_contributions_xi_master_automatic_differentiation_if_required(
+    void add_stiffmat_contributions_xi_target_automatic_differentiation_if_required(
         Core::LinAlg::Matrix<3 * numnodes * numnodalvalues, 1, Sacado::Fad::DFad<double>> const&
             force_pot1,
         Core::LinAlg::Matrix<3 * numnodes * numnodalvalues, 1, Sacado::Fad::DFad<double>> const&
             force_pot2,
         Core::LinAlg::Matrix<1, 3 * numnodes * numnodalvalues, Sacado::Fad::DFad<double>> const&
-            lin_xi_master_slaveDofs,
+            lin_xi_source_targetDofs,
         Core::LinAlg::Matrix<1, 3 * numnodes * numnodalvalues, Sacado::Fad::DFad<double>> const&
-            lin_xi_master_masterDofs,
+            lin_xi_target_targetDofs,
         Core::LinAlg::SerialDenseMatrix& stiffmat11, Core::LinAlg::SerialDenseMatrix& stiffmat12,
         Core::LinAlg::SerialDenseMatrix& stiffmat21,
         Core::LinAlg::SerialDenseMatrix& stiffmat22) const;
@@ -388,9 +389,9 @@ namespace BeamInteraction
         Sacado::Fad::DFad<double> const& interaction_potential,
         Sacado::Fad::DFad<double> const& potential_reduction_factor,
         Core::LinAlg::Matrix<1, 3 * numnodes * numnodalvalues, Sacado::Fad::DFad<double>> const&
-            lin_xi_master_slaveDofs,
+            lin_xi_source_targetDofs,
         Core::LinAlg::Matrix<1, 3 * numnodes * numnodalvalues, Sacado::Fad::DFad<double>> const&
-            lin_xi_master_masterDofs) const;
+            lin_xi_target_targetDofs) const;
 
     /** \brief compute discrete force vectors using automatic differentiation
      *
@@ -403,9 +404,9 @@ namespace BeamInteraction
         Sacado::Fad::DFad<double> const& interaction_potential,
         Sacado::Fad::DFad<double> const& potential_reduction_factor,
         Core::LinAlg::Matrix<1, 3 * numnodes * numnodalvalues, Sacado::Fad::DFad<double>> const&
-            lin_xi_master_slaveDofs,
+            lin_xi_source_targetDofs,
         Core::LinAlg::Matrix<1, 3 * numnodes * numnodalvalues, Sacado::Fad::DFad<double>> const&
-            lin_xi_master_masterDofs) const;
+            lin_xi_target_targetDofs) const;
 
     /** \brief compute discrete force vectors using automatic differentiation
      *
@@ -416,9 +417,9 @@ namespace BeamInteraction
         Core::LinAlg::Matrix<3 * numnodes * numnodalvalues, 1, double>& force_pot2,
         double const& interaction_potential, double const& potential_reduction_factor,
         Core::LinAlg::Matrix<1, 3 * numnodes * numnodalvalues, double> const&
-            lin_xi_master_slaveDofs,
+            lin_xi_source_targetDofs,
         Core::LinAlg::Matrix<1, 3 * numnodes * numnodalvalues, double> const&
-            lin_xi_master_masterDofs) const
+            lin_xi_target_targetDofs) const
     {
       // this is a dummy since for type double, no automatic differentiation is available
     }
@@ -429,28 +430,28 @@ namespace BeamInteraction
      *
      */
     void evaluate_stiffpot_analytic_contributions_single_length_specific_small_sep_approx_simple(
-        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_slave,
-        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_xi_slave,
-        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_master,
-        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_xi_master,
-        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_xixi_master,
-        double const& xi_master, Core::LinAlg::Matrix<3, 1, double> const& r_xi_slave,
-        Core::LinAlg::Matrix<3, 1, double> const& r_xi_master,
-        Core::LinAlg::Matrix<3, 1, double> const& r_xixi_master, double const& norm_dist_ul,
+        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_source,
+        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_xi_source,
+        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_target,
+        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_xi_target,
+        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_xixi_target,
+        double const& xi_target, Core::LinAlg::Matrix<3, 1, double> const& r_xi_source,
+        Core::LinAlg::Matrix<3, 1, double> const& r_xi_target,
+        Core::LinAlg::Matrix<3, 1, double> const& r_xixi_target, double const& norm_dist_ul,
         Core::LinAlg::Matrix<3, 1, double> const& normal_ul, double const& pot_red_fac,
-        double const& pot_red_fac_deriv_xi_master, double const& pot_red_fac_2ndderiv_xi_master,
+        double const& pot_red_fac_deriv_xi_target, double const& pot_red_fac_2ndderiv_xi_target,
         double const& pot_ia, double const& pot_ia_deriv_gap_ul,
         double const& pot_ia_deriv_cos_alpha, double const& pot_ia_2ndderiv_gap_ul,
         double const& pot_ia_deriv_gap_ul_deriv_cos_alpha, double const& pot_ia_2ndderiv_cos_alpha,
-        Core::LinAlg::Matrix<3, 1, double> const& gap_ul_deriv_r_slave,
-        Core::LinAlg::Matrix<3, 1, double> const& gap_ul_deriv_r_master,
-        Core::LinAlg::Matrix<3, 1, double> const& cos_alpha_deriv_r_slave,
-        Core::LinAlg::Matrix<3, 1, double> const& cos_alpha_deriv_r_master,
-        Core::LinAlg::Matrix<3, 1, double> const& cos_alpha_deriv_r_xi_slave,
-        Core::LinAlg::Matrix<3, 1, double> const& cos_alpha_deriv_r_xi_master,
-        Core::LinAlg::Matrix<1, 3, double> const& xi_master_partial_r_slave,
-        Core::LinAlg::Matrix<1, 3, double> const& xi_master_partial_r_master,
-        Core::LinAlg::Matrix<1, 3, double> const& xi_master_partial_r_xi_master,
+        Core::LinAlg::Matrix<3, 1, double> const& gap_ul_deriv_r_source,
+        Core::LinAlg::Matrix<3, 1, double> const& gap_ul_deriv_r_target,
+        Core::LinAlg::Matrix<3, 1, double> const& cos_alpha_deriv_r_source,
+        Core::LinAlg::Matrix<3, 1, double> const& cos_alpha_deriv_r_target,
+        Core::LinAlg::Matrix<3, 1, double> const& cos_alpha_deriv_r_xi_source,
+        Core::LinAlg::Matrix<3, 1, double> const& cos_alpha_deriv_r_xi_target,
+        Core::LinAlg::Matrix<1, 3, double> const& xi_target_partial_r_source,
+        Core::LinAlg::Matrix<1, 3, double> const& xi_target_partial_r_target,
+        Core::LinAlg::Matrix<1, 3, double> const& xi_target_partial_r_xi_target,
         Core::LinAlg::SerialDenseMatrix& stiffmat11, Core::LinAlg::SerialDenseMatrix& stiffmat12,
         Core::LinAlg::SerialDenseMatrix& stiffmat21,
         Core::LinAlg::SerialDenseMatrix& stiffmat22) const;
@@ -459,38 +460,38 @@ namespace BeamInteraction
      *
      */
     void evaluate_stiffpot_analytic_contributions_single_length_specific_small_sep_approx_simple(
-        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_slave,
-        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_xi_slave,
+        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_source,
+        Core::LinAlg::Matrix<1, numnodes * numnodalvalues, double> const& N_i_xi_source,
         Core::LinAlg::Matrix<1, numnodes * numnodalvalues, Sacado::Fad::DFad<double>> const&
-            N_i_master,
+            N_i_target,
         Core::LinAlg::Matrix<1, numnodes * numnodalvalues, Sacado::Fad::DFad<double>> const&
-            N_i_xi_master,
+            N_i_xi_target,
         Core::LinAlg::Matrix<1, numnodes * numnodalvalues, Sacado::Fad::DFad<double>> const&
-            N_i_xixi_master,
-        Sacado::Fad::DFad<double> const& xi_master,
-        Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>> const& r_xi_slave,
-        Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>> const& r_xi_master,
-        Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>> const& r_xixi_master,
+            N_i_xixi_target,
+        Sacado::Fad::DFad<double> const& xi_target,
+        Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>> const& r_xi_source,
+        Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>> const& r_xi_target,
+        Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>> const& r_xixi_target,
         Sacado::Fad::DFad<double> const& norm_dist_ul,
         Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>> const& normal_ul,
         Sacado::Fad::DFad<double> const& pot_red_fac,
-        Sacado::Fad::DFad<double> const& pot_red_fac_deriv_xi_master,
-        Sacado::Fad::DFad<double> const& pot_red_fac_2ndderiv_xi_master,
+        Sacado::Fad::DFad<double> const& pot_red_fac_deriv_xi_target,
+        Sacado::Fad::DFad<double> const& pot_red_fac_2ndderiv_xi_target,
         Sacado::Fad::DFad<double> const& pot_ia,
         Sacado::Fad::DFad<double> const& pot_ia_deriv_gap_ul,
         Sacado::Fad::DFad<double> const& pot_ia_deriv_cos_alpha,
         Sacado::Fad::DFad<double> const& pot_ia_2ndderiv_gap_ul,
         Sacado::Fad::DFad<double> const& pot_ia_deriv_gap_ul_deriv_cos_alpha,
         Sacado::Fad::DFad<double> const& pot_ia_2ndderiv_cos_alpha,
-        Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>> const& gap_ul_deriv_r_slave,
-        Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>> const& gap_ul_deriv_r_master,
-        Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>> const& cos_alpha_deriv_r_slave,
-        Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>> const& cos_alpha_deriv_r_master,
-        Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>> const& cos_alpha_deriv_r_xi_slave,
-        Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>> const& cos_alpha_deriv_r_xi_master,
-        Core::LinAlg::Matrix<1, 3, Sacado::Fad::DFad<double>> const& xi_master_partial_r_slave,
-        Core::LinAlg::Matrix<1, 3, Sacado::Fad::DFad<double>> const& xi_master_partial_r_master,
-        Core::LinAlg::Matrix<1, 3, Sacado::Fad::DFad<double>> const& xi_master_partial_r_xi_master,
+        Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>> const& gap_ul_deriv_r_source,
+        Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>> const& gap_ul_deriv_r_target,
+        Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>> const& cos_alpha_deriv_r_source,
+        Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>> const& cos_alpha_deriv_r_target,
+        Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>> const& cos_alpha_deriv_r_xi_source,
+        Core::LinAlg::Matrix<3, 1, Sacado::Fad::DFad<double>> const& cos_alpha_deriv_r_xi_target,
+        Core::LinAlg::Matrix<1, 3, Sacado::Fad::DFad<double>> const& xi_target_partial_r_source,
+        Core::LinAlg::Matrix<1, 3, Sacado::Fad::DFad<double>> const& xi_target_partial_r_target,
+        Core::LinAlg::Matrix<1, 3, Sacado::Fad::DFad<double>> const& xi_target_partial_r_xi_target,
         Core::LinAlg::SerialDenseMatrix& stiffmat11, Core::LinAlg::SerialDenseMatrix& stiffmat12,
         Core::LinAlg::SerialDenseMatrix& stiffmat21,
         Core::LinAlg::SerialDenseMatrix& stiffmat22) const
@@ -534,18 +535,18 @@ namespace BeamInteraction
         Core::LinAlg::Matrix<3 * numnodes * numnodalvalues, 1, Sacado::Fad::DFad<double>>&
             ele2centerlinedofvec);
 
-    /** \brief set primary variables including xi_master for FAD if required
+    /** \brief set primary variables including xi_target for FAD if required
      *
      */
     void set_automatic_differentiation_variables_if_required(
         Core::LinAlg::Matrix<3 * numnodes * numnodalvalues, 1, double>& ele1centerlinedofvec,
         Core::LinAlg::Matrix<3 * numnodes * numnodalvalues, 1, double>& ele2centerlinedofvec,
-        double& xi_master)
+        double& xi_target)
     {
       // do nothing in case of type double (analytic differentiation)
     }
 
-    /** \brief set primary variables including xi_master for FAD if required
+    /** \brief set primary variables including xi_target for FAD if required
      *
      */
     void set_automatic_differentiation_variables_if_required(
@@ -553,7 +554,7 @@ namespace BeamInteraction
             ele1centerlinedofvec,
         Core::LinAlg::Matrix<3 * numnodes * numnodalvalues, 1, Sacado::Fad::DFad<double>>&
             ele2centerlinedofvec,
-        Sacado::Fad::DFad<double>& xi_master);
+        Sacado::Fad::DFad<double>& xi_target);
 
     /** \brief estimate whether the elements' separation is much more than the cutoff distance
      *
@@ -565,13 +566,13 @@ namespace BeamInteraction
      */
     bool are_elements_much_more_separated_than_cutoff_distance();
 
-    /** \brief exchange master/slave allocation for the evaluation of the two-half-pass approach
+    /** \brief exchange target/source allocation for the evaluation of the two-half-pass approach
      *
      *   All private members need to be exchanged to allow reusing the function to evaluate the
      *   residual force vectors and stiffness matrices for the second half-pass.
      */
 
-    void exchange_master_slave_allocation_for_two_half_pass();
+    void exchange_source_target_allocation_for_two_half_pass();
 
     //@}
 

--- a/src/beaminteraction/src/potential/4C_beaminteraction_potential_submodel_evaluator.cpp
+++ b/src/beaminteraction/src/potential/4C_beaminteraction_potential_submodel_evaluator.cpp
@@ -1035,9 +1035,9 @@ void BeamInteraction::SubmodelEvaluator::BeamPotential::write_output_runtime_bea
   }
 
   /* Note: - each UID set is not unique due to the fact that each GP produces two force
-   *         vectors (one on the slave side, one on the master side)
+   *         vectors (one on the source side, one on the target side)
    *       - in case of the single length specific approach (SBIP) the uid for the GP refers
-   *         to the slave beam element */
+   *         to the source beam element */
   // get and prepare storage for uid_0_beam_1_gid values
   std::vector<int> uid_0_beam_1_gid;
   uid_0_beam_1_gid.reserve(num_row_points);
@@ -1108,7 +1108,7 @@ void BeamInteraction::SubmodelEvaluator::BeamPotential::write_output_runtime_bea
     for (unsigned int ipoint = 0; ipoint < num_interacting_points_per_element; ++ipoint)
     {
       // ignore point pairs with zero forces
-      /* (e.g. if no valid point-to-curve projection in master-slave approach or
+      /* (e.g. if no valid point-to-curve projection in source-target approach or
        * contribution is neglected on element pair level due to cutoff value) */
       if (potential_forces_ele1_this_pair[ipoint].norm2() < 1e-16 and
           potential_forces_ele2_this_pair[ipoint].norm2() < 1e-16 and

--- a/tests/input_files/beam3r_herm2line3_static_LJ_singlelengthspec_smallsepapprox_simple_regularization_linextpol_twocrossedbeams_pulloff_highereleGIDisslave.4C.yaml
+++ b/tests/input_files/beam3r_herm2line3_static_LJ_singlelengthspec_smallsepapprox_simple_regularization_linextpol_twocrossedbeams_pulloff_highereleGIDisslave.4C.yaml
@@ -50,7 +50,7 @@ beam_potential:
     separation: 0.0008
   n_integration_segments: 10
   n_gauss_points: 50
-  choice_master_slave: higher_eleGID_is_slave
+  choice_source_target: higher_eleGID_is_source
   runtime_output:
     interval_steps: 1
     force: true


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

Part of #1094

Renames the master/slave approach in beaminteraction to source/target

The changes are sorted into three commits:

- first commit renames everything in the potential framework (here slave => source, master => target made more sense because the GP sits on the "slave"/source element and gets projected onto the "master"/target element)
- second commit moves geometry utils from the general beaminteraction framework into the potential framework because it is just used there (same applies as in the potential regarding naming)
- third commit changes the nomenclature in the beam contact framework

@isteinbrecher @knarfnitram please check the second and third commit if it makes sense:)

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->

#1094 