### PR TITLE
Move s2i input from inpar to scatra

### DIFF
--- a/src/contact/src/4C_contact_nitsche_integrator_ssi.cpp
+++ b/src/contact/src/4C_contact_nitsche_integrator_ssi.cpp
@@ -369,7 +369,7 @@ void CONTACT::IntegratorNitscheSsi::integrate_ssi_interface_condition(Mortar::El
   // perform integration according to kinetic model
   switch (kinetic_model)
   {
-    case Inpar::S2I::kinetics_constperm:
+    case S2I::kinetics_constperm:
     {
       const double permeability = (*get_scatra_ele_parameter_boundary()->permeabilities())[0];
 
@@ -388,7 +388,7 @@ void CONTACT::IntegratorNitscheSsi::integrate_ssi_interface_condition(Mortar::El
 
       break;
     }
-    case Inpar::S2I::kinetics_linearperm:
+    case S2I::kinetics_linearperm:
     {
       const double permeability = (*get_scatra_ele_parameter_boundary()->permeabilities())[0];
 

--- a/src/contact/src/4C_contact_nitsche_integrator_ssi_elch.cpp
+++ b/src/contact/src/4C_contact_nitsche_integrator_ssi_elch.cpp
@@ -349,8 +349,8 @@ void CONTACT::IntegratorNitscheSsiElch::integrate_ssi_interface_condition(
   // perform integration dependent on scatra-scatra interface kinetic model
   switch (kinetic_model)
   {
-    case Inpar::S2I::kinetics_butlervolmer:
-    case Inpar::S2I::kinetics_butlervolmerreduced:
+    case S2I::kinetics_butlervolmer:
+    case S2I::kinetics_butlervolmerreduced:
     {
       // access material of parent element for ELCH simulations
       std::shared_ptr<const Mat::Electrode> electrode_material =
@@ -403,7 +403,7 @@ void CONTACT::IntegratorNitscheSsiElch::integrate_ssi_interface_condition(
                 electrode_conc, faraday, frt, detF);
 
         // Butler-Volmer exchange mass flux density
-        const double j0(kinetic_model == Inpar::S2I::kinetics_butlervolmerreduced
+        const double j0(kinetic_model == S2I::kinetics_butlervolmerreduced
                             ? kr
                             : kr * std::pow(electrolyte_conc, alphaa) *
                                   std::pow(cmax - electrode_conc, alphaa) *
@@ -481,7 +481,7 @@ void CONTACT::IntegratorNitscheSsiElch::integrate_ssi_interface_condition(
 
       break;
     }
-    case Inpar::S2I::kinetics_nointerfaceflux:
+    case S2I::kinetics_nointerfaceflux:
       break;
     default:
     {

--- a/src/contact/src/4C_contact_strategy_factory.cpp
+++ b/src/contact/src/4C_contact_strategy_factory.cpp
@@ -28,11 +28,11 @@
 #include "4C_contact_wear_interface.hpp"
 #include "4C_fem_discretization.hpp"
 #include "4C_global_data.hpp"
-#include "4C_inpar_s2i.hpp"
 #include "4C_io.hpp"
 #include "4C_io_pstream.hpp"
 #include "4C_linalg_utils_sparse_algebra_math.hpp"
 #include "4C_linear_solver_method.hpp"
+#include "4C_scatra_s2i_input.hpp"
 #include "4C_scatra_timint_meshtying_strategy_s2i.hpp"
 #include "4C_ssi_input.hpp"
 #include "4C_structure_new_timint_basedataglobalstate.hpp"
@@ -1938,8 +1938,8 @@ void CONTACT::STRATEGY::Factory::set_parameters_for_contact_condition(
       if (s2ikinetics_cond->parameters().get<int>("ConditionID") == conditiongroupid)
       {
         // only the source-side stores the parameters
-        if (s2ikinetics_cond->parameters().get<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE") ==
-            Inpar::S2I::side_source)
+        if (s2ikinetics_cond->parameters().get<S2I::InterfaceSides>("INTERFACE_SIDE") ==
+            S2I::side_source)
         {
           // fill the parameters from the s2i condition
           ScaTra::MeshtyingStrategyS2I::

--- a/src/global_legacy_module/4C_global_legacy_module_validconditions.cpp
+++ b/src/global_legacy_module/4C_global_legacy_module_validconditions.cpp
@@ -22,7 +22,6 @@
 #include "4C_fs3i_biofilm_fsi_input.hpp"
 #include "4C_fsi_input.hpp"
 #include "4C_inpar_fluid.hpp"
-#include "4C_inpar_s2i.hpp"
 #include "4C_inpar_structure.hpp"
 #include "4C_io_input_spec_builders.hpp"
 #include "4C_levelset_input.hpp"
@@ -32,6 +31,7 @@
 #include "4C_red_airways_input.hpp"
 #include "4C_scatra_cardiac_monodomain_input.hpp"
 #include "4C_scatra_input.hpp"
+#include "4C_scatra_s2i_input.hpp"
 #include "4C_ssi_input.hpp"
 #include "4C_ssti_input.hpp"
 #include "4C_sti_input.hpp"
@@ -828,7 +828,7 @@ std::vector<Core::Conditions::ConditionDefinition> Global::valid_conditions()
 
   // Finally, add the problem-specific conditions from the various modules
   Mortar::set_valid_conditions(condlist);
-  Inpar::S2I::set_valid_conditions(condlist);
+  S2I::set_valid_conditions(condlist);
   ScaTra::set_valid_conditions(condlist);
   ElCh::set_valid_conditions(condlist);
   Inpar::FLUID::set_valid_conditions(condlist);

--- a/src/global_legacy_module/4C_global_legacy_module_validparameters.cpp
+++ b/src/global_legacy_module/4C_global_legacy_module_validparameters.cpp
@@ -38,7 +38,6 @@
 #include "4C_inpar_IO_runtime_vtk_output_structure.hpp"
 #include "4C_inpar_IO_runtime_vtp_output_structure.hpp"
 #include "4C_inpar_plasticity.hpp"
-#include "4C_inpar_s2i.hpp"
 #include "4C_inpar_structure.hpp"
 #include "4C_io_gridgenerator.hpp"
 #include "4C_io_input_field.hpp"
@@ -63,6 +62,7 @@
 #include "4C_reduced_lung_input.hpp"
 #include "4C_scatra_cardiac_monodomain_input.hpp"
 #include "4C_scatra_input.hpp"
+#include "4C_scatra_s2i_input.hpp"
 #include "4C_solver_nonlin_nox_input.hpp"
 #include "4C_ssi_input.hpp"
 #include "4C_ssti_input.hpp"
@@ -330,7 +330,7 @@ std::vector<Core::IO::InputSpec> Global::valid_parameters()
   push_specs(specs, ElectroPhysiology::valid_parameters());
   push_specs(specs, STI::valid_parameters());
 
-  push_specs(specs, Inpar::S2I::valid_parameters());
+  push_specs(specs, S2I::valid_parameters());
   push_specs(specs, FS3I::valid_parameters());
   push_specs(specs, FSI::valid_parameters());
   push_specs(specs, PoroElast::valid_parameters());

--- a/src/scatra/4C_scatra_resulttest.cpp
+++ b/src/scatra/4C_scatra_resulttest.cpp
@@ -182,13 +182,13 @@ double ScaTra::ScaTraResultTest::result_node(
     std::shared_ptr<const Core::LinAlg::Vector<double>> s2igrowthvec(nullptr);
     switch (strategy->int_layer_growth_evaluation())
     {
-      case Inpar::S2I::growth_evaluation_monolithic:
+      case S2I::growth_evaluation_monolithic:
       {
         s2igrowthvec = strategy->growth_var_np();
         break;
       }
 
-      case Inpar::S2I::growth_evaluation_semi_implicit:
+      case S2I::growth_evaluation_semi_implicit:
       {
         s2igrowthvec = strategy->growth_var_n();
         break;

--- a/src/scatra/4C_scatra_s2i_input.cpp
+++ b/src/scatra/4C_scatra_s2i_input.cpp
@@ -5,7 +5,7 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
-#include "4C_inpar_s2i.hpp"
+#include "4C_scatra_s2i_input.hpp"
 
 #include "4C_fem_condition_definition.hpp"
 #include "4C_io_input_spec_builders.hpp"
@@ -14,7 +14,7 @@ FOUR_C_NAMESPACE_OPEN
 /*------------------------------------------------------------------------*
  | valid parameters for scatra-scatra interface coupling   fang 01/16 |
  *------------------------------------------------------------------------*/
-std::vector<Core::IO::InputSpec> Inpar::S2I::valid_parameters()
+std::vector<Core::IO::InputSpec> S2I::valid_parameters()
 {
   using namespace Core::IO::InputSpecBuilders;
 
@@ -115,7 +115,7 @@ std::vector<Core::IO::InputSpec> Inpar::S2I::valid_parameters()
 /*------------------------------------------------------------------------*
  | set valid conditions for scatra-scatra interface coupling   fang 01/16 |
  *------------------------------------------------------------------------*/
-void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDefinition>& condlist)
+void S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDefinition>& condlist)
 {
   using namespace Core::IO::InputSpecBuilders;
 
@@ -135,9 +135,9 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
     const auto make_s2imeshtying = [&condlist](Core::Conditions::ConditionDefinition& cond)
     {
       cond.add_component(parameter<int>("ConditionID"));
-      cond.add_component(deprecated_selection<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE",
-          {{"Undefined", Inpar::S2I::side_undefined}, {"Slave", Inpar::S2I::side_source},
-              {"Master", Inpar::S2I::side_master}},
+      cond.add_component(deprecated_selection<S2I::InterfaceSides>("INTERFACE_SIDE",
+          {{"Undefined", S2I::side_undefined}, {"Slave", S2I::side_source},
+              {"Master", S2I::side_master}},
           {.description = "interface side"}));
       cond.add_component(parameter<int>("S2I_KINETICS_ID"));
 
@@ -177,10 +177,10 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
       {
         // constant and linear permeability
         auto constlinperm = all_of({
-            deprecated_selection<Inpar::S2I::KineticModels>("KINETIC_MODEL",
+            deprecated_selection<S2I::KineticModels>("KINETIC_MODEL",
                 {
-                    {"ConstantPermeability", Inpar::S2I::kinetics_constperm},
-                    {"LinearPermeability", Inpar::S2I::kinetics_linearperm},
+                    {"ConstantPermeability", S2I::kinetics_constperm},
+                    {"LinearPermeability", S2I::kinetics_linearperm},
                 }),
             parameter<int>("NUMSCAL"),
             parameter<std::vector<double>>(
@@ -192,13 +192,13 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
 
       {
         auto butler_volmer = all_of({
-            deprecated_selection<Inpar::S2I::KineticModels>("KINETIC_MODEL",
+            deprecated_selection<S2I::KineticModels>("KINETIC_MODEL",
                 {
-                    {"Butler-Volmer", Inpar::S2I::kinetics_butlervolmer},
-                    {"Butler-Volmer_Linearized", Inpar::S2I::kinetics_butlervolmerlinearized},
-                    {"Butler-VolmerReduced", Inpar::S2I::kinetics_butlervolmerreduced},
+                    {"Butler-Volmer", S2I::kinetics_butlervolmer},
+                    {"Butler-Volmer_Linearized", S2I::kinetics_butlervolmerlinearized},
+                    {"Butler-VolmerReduced", S2I::kinetics_butlervolmerreduced},
                     {"Butler-VolmerReduced_Linearized",
-                        Inpar::S2I::kinetics_butlervolmerreducedlinearized},
+                        S2I::kinetics_butlervolmerreducedlinearized},
                 }),
             parameter<int>("NUMSCAL"),
             parameter<std::vector<int>>(
@@ -214,9 +214,9 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
 
       {
         auto butler_volmer_peltier = all_of({
-            deprecated_selection<Inpar::S2I::KineticModels>("KINETIC_MODEL",
+            deprecated_selection<S2I::KineticModels>("KINETIC_MODEL",
                 {
-                    {"Butler-Volmer-Peltier", Inpar::S2I::kinetics_butlervolmerpeltier},
+                    {"Butler-Volmer-Peltier", S2I::kinetics_butlervolmerpeltier},
                 }),
             parameter<int>("NUMSCAL"),
             parameter<std::vector<int>>(
@@ -234,10 +234,10 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
 
       {
         auto butler_volmer_reduced_capacitance = all_of({
-            deprecated_selection<Inpar::S2I::KineticModels>("KINETIC_MODEL",
+            deprecated_selection<S2I::KineticModels>("KINETIC_MODEL",
                 {
                     {"Butler-VolmerReduced_Capacitance",
-                        Inpar::S2I::kinetics_butlervolmerreducedcapacitance},
+                        S2I::kinetics_butlervolmerreducedcapacitance},
                 }),
             parameter<int>("NUMSCAL"),
             parameter<std::vector<int>>(
@@ -255,9 +255,9 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
 
       {
         auto butler_volmer_resistance = all_of({
-            deprecated_selection<Inpar::S2I::KineticModels>("KINETIC_MODEL",
+            deprecated_selection<S2I::KineticModels>("KINETIC_MODEL",
                 {
-                    {"Butler-Volmer_Resistance", Inpar::S2I::kinetics_butlervolmerresistance},
+                    {"Butler-Volmer_Resistance", S2I::kinetics_butlervolmerresistance},
                 }),
             parameter<int>("NUMSCAL"),
             parameter<std::vector<int>>(
@@ -276,10 +276,10 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
 
       {
         auto butler_volmer_reduced_with_resistance = all_of({
-            deprecated_selection<Inpar::S2I::KineticModels>("KINETIC_MODEL",
+            deprecated_selection<S2I::KineticModels>("KINETIC_MODEL",
                 {
                     {"Butler-VolmerReduced_Resistance",
-                        Inpar::S2I::kinetics_butlervolmerreducedresistance},
+                        S2I::kinetics_butlervolmerreducedresistance},
                 }),
             parameter<int>("NUMSCAL"),
             parameter<std::vector<int>>(
@@ -299,10 +299,10 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
 
       {
         auto butler_volmer_reduced_thermo = all_of({
-            deprecated_selection<Inpar::S2I::KineticModels>("KINETIC_MODEL",
+            deprecated_selection<S2I::KineticModels>("KINETIC_MODEL",
                 {
                     {"Butler-VolmerReduced_ThermoResistance",
-                        Inpar::S2I::kinetics_butlervolmerreducedthermoresistance},
+                        S2I::kinetics_butlervolmerreducedthermoresistance},
                 }),
             parameter<int>("NUMSCAL"),
             parameter<std::vector<int>>(
@@ -321,10 +321,9 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
 
       {
         auto constant_interface_resistance = all_of({
-            deprecated_selection<Inpar::S2I::KineticModels>("KINETIC_MODEL",
+            deprecated_selection<S2I::KineticModels>("KINETIC_MODEL",
                 {
-                    {"ConstantInterfaceResistance",
-                        Inpar::S2I::kinetics_constantinterfaceresistance},
+                    {"ConstantInterfaceResistance", S2I::kinetics_constantinterfaceresistance},
                 }),
             parameter<std::vector<int>>("ONOFF", {.size = 2}),
             parameter<double>("RESISTANCE"),
@@ -339,7 +338,7 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
         // no interface flux
         auto noflux = deprecated_selection<KineticModels>(
             "KINETIC_MODEL", {
-                                 {"NoInterfaceFlux", Inpar::S2I::kinetics_nointerfaceflux},
+                                 {"NoInterfaceFlux", S2I::kinetics_nointerfaceflux},
                              });
 
         kinetic_model_choices.emplace_back(std::move(noflux));
@@ -405,10 +404,10 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
         parameter<double>("CONDUCTIVITY"),
         deprecated_selection<RegularizationType>("REGTYPE",
             {
-                {"none", Inpar::S2I::regularization_none},
-                {"polynomial", Inpar::S2I::regularization_polynomial},
-                {"Hein", Inpar::S2I::regularization_hein},
-                {"trigonometrical", Inpar::S2I::regularization_trigonometrical},
+                {"none", S2I::regularization_none},
+                {"polynomial", S2I::regularization_polynomial},
+                {"Hein", S2I::regularization_hein},
+                {"trigonometrical", S2I::regularization_trigonometrical},
             }),
         parameter<double>("REGPAR"),
         parameter<double>("INITTHICKNESS"),
@@ -437,8 +436,8 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
         Core::Conditions::S2ISCLCoupling, true, Core::Conditions::geometry_type_surface);
 
     s2isclcond.add_component(deprecated_selection<InterfaceSides>("INTERFACE_SIDE",
-        {{"Undefined", Inpar::S2I::side_undefined}, {"Slave", Inpar::S2I::side_source},
-            {"Master", Inpar::S2I::side_master}},
+        {{"Undefined", S2I::side_undefined}, {"Slave", S2I::side_source},
+            {"Master", S2I::side_master}},
         {.description = "interface side"}));
 
     condlist.emplace_back(s2isclcond);

--- a/src/scatra/4C_scatra_s2i_input.hpp
+++ b/src/scatra/4C_scatra_s2i_input.hpp
@@ -5,8 +5,8 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
-#ifndef FOUR_C_INPAR_S2I_HPP
-#define FOUR_C_INPAR_S2I_HPP
+#ifndef FOUR_C_SCATRA_S2I_INPUT_HPP
+#define FOUR_C_SCATRA_S2I_INPUT_HPP
 
 #include "4C_config.hpp"
 
@@ -20,7 +20,7 @@ namespace Core::Conditions
 {
   class ConditionDefinition;
 }
-namespace Inpar::S2I
+namespace S2I
 {
   //! type of interface side
   enum InterfaceSides
@@ -100,7 +100,7 @@ namespace Inpar::S2I
 
   //! set valid conditions for scatra-scatra interface coupling
   void set_valid_conditions(std::vector<Core::Conditions::ConditionDefinition>& condlist);
-}  // namespace Inpar::S2I
+}  // namespace S2I
 
 FOUR_C_NAMESPACE_CLOSE
 

--- a/src/scatra/4C_scatra_timint_elch.cpp
+++ b/src/scatra/4C_scatra_timint_elch.cpp
@@ -887,10 +887,10 @@ void ScaTra::ScaTraTimIntElch::read_restart_problem_specific(
   for (auto* s2ikinetics_cond : s2ikinetics_conditions)
   {
     // only slave side has relevant information
-    if (s2ikinetics_cond->parameters().get<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE") ==
-            static_cast<int>(Inpar::S2I::side_source) and
-        s2ikinetics_cond->parameters().get<Inpar::S2I::KineticModels>("KINETIC_MODEL") ==
-            static_cast<int>(Inpar::S2I::kinetics_butlervolmerreducedcapacitance))
+    if (s2ikinetics_cond->parameters().get<S2I::InterfaceSides>("INTERFACE_SIDE") ==
+            static_cast<int>(S2I::side_source) and
+        s2ikinetics_cond->parameters().get<S2I::KineticModels>("KINETIC_MODEL") ==
+            static_cast<int>(S2I::kinetics_butlervolmerreducedcapacitance))
     {
       reader.read_vector(phidtnp_, "phidtnp");
       break;
@@ -1620,10 +1620,10 @@ void ScaTra::ScaTraTimIntElch::write_restart() const
   for (auto* s2ikinetics_cond : s2ikinetics_conditions)
   {
     // only slave side has relevant information
-    if (s2ikinetics_cond->parameters().get<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE") ==
-            static_cast<int>(Inpar::S2I::side_source) and
-        s2ikinetics_cond->parameters().get<Inpar::S2I::KineticModels>("KINETIC_MODEL") ==
-            static_cast<int>(Inpar::S2I::kinetics_butlervolmerreducedcapacitance))
+    if (s2ikinetics_cond->parameters().get<S2I::InterfaceSides>("INTERFACE_SIDE") ==
+            static_cast<int>(S2I::side_source) and
+        s2ikinetics_cond->parameters().get<S2I::KineticModels>("KINETIC_MODEL") ==
+            static_cast<int>(S2I::kinetics_butlervolmerreducedcapacitance))
     {
       output_->write_vector("phidtnp", phidtnp_);
       break;

--- a/src/scatra/4C_scatra_timint_elch_scl.cpp
+++ b/src/scatra/4C_scatra_timint_elch_scl.cpp
@@ -601,12 +601,12 @@ void ScaTra::ScaTraTimIntElchSCL::setup_coupling()
       // is this node owned by this proc?
       if (!Core::Communication::is_node_gid_on_this_proc(*discret_, coupling_node_gid)) continue;
 
-      switch (coupling_condition->parameters().get<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE"))
+      switch (coupling_condition->parameters().get<S2I::InterfaceSides>("INTERFACE_SIDE"))
       {
-        case Inpar::S2I::side_source:
+        case S2I::side_source:
           my_macro_slave_node_gids.emplace_back(coupling_node_gid);
           break;
-        case Inpar::S2I::side_master:
+        case S2I::side_master:
           my_macro_master_node_gids.emplace_back(coupling_node_gid);
           break;
         default:

--- a/src/scatra/4C_scatra_timint_implicit.cpp
+++ b/src/scatra/4C_scatra_timint_implicit.cpp
@@ -3340,11 +3340,11 @@ void ScaTra::ScaTraTimIntImpl::evaluate_macro_micro_coupling()
           // compute matrix and vector contributions according to kinetic model for current
           // macro-micro coupling condition
           const int kinetic_model =
-              condition->parameters().get<Inpar::S2I::KineticModels>("KINETIC_MODEL");
+              condition->parameters().get<S2I::KineticModels>("KINETIC_MODEL");
 
           switch (kinetic_model)
           {
-            case Inpar::S2I::kinetics_constperm:
+            case S2I::kinetics_constperm:
             {
               // access real vector of constant permeabilities
               const std::vector<double>* permeabilities =
@@ -3377,8 +3377,8 @@ void ScaTra::ScaTraTimIntImpl::evaluate_macro_micro_coupling()
               break;
             }
 
-            case Inpar::S2I::kinetics_butlervolmer:
-            case Inpar::S2I::kinetics_butlervolmerreduced:
+            case S2I::kinetics_butlervolmer:
+            case S2I::kinetics_butlervolmerreduced:
             {
               // access material of electrode
               std::shared_ptr<const Mat::Electrode> matelectrode =
@@ -3462,12 +3462,12 @@ void ScaTra::ScaTraTimIntImpl::evaluate_macro_micro_coupling()
               const double eta = phinp_macro_[2] - phinp_macro_[1] - epd;
 
               // Butler-Volmer exchange mass flux density
-              const double j0 =
-                  condition->parameters().get<Inpar::S2I::KineticModels>("KINETIC_MODEL") ==
-                          Inpar::S2I::kinetics_butlervolmerreduced
-                      ? kr
-                      : kr * std::pow(conc_el, alphaa) * std::pow(cmax - conc_ed, alphaa) *
-                            std::pow(conc_ed, alphac);
+              const double j0 = condition->parameters().get<S2I::KineticModels>("KINETIC_MODEL") ==
+                                        S2I::kinetics_butlervolmerreduced
+                                    ? kr
+                                    : kr * std::pow(conc_el, alphaa) *
+                                          std::pow(cmax - conc_ed, alphaa) *
+                                          std::pow(conc_ed, alphac);
 
               // exponential Butler-Volmer terms
               const double expterm1 = std::exp(alphaa * frt * eta);
@@ -3497,7 +3497,7 @@ void ScaTra::ScaTraTimIntImpl::evaluate_macro_micro_coupling()
 
               break;
             }
-            case Inpar::S2I::kinetics_nointerfaceflux:
+            case S2I::kinetics_nointerfaceflux:
               break;
 
             default:

--- a/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
+++ b/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
@@ -56,8 +56,8 @@ ScaTra::MeshtyingStrategyS2I::MeshtyingStrategyS2I(
       icoupmortar_(),
       imortarcells_(),
       imortarredistribution_(
-          Teuchos::getIntegralValue<Inpar::S2I::CouplingType>(parameters.sublist("S2I COUPLING"),
-              "COUPLINGTYPE") == Inpar::S2I::coupling_mortar_standard and
+          Teuchos::getIntegralValue<S2I::CouplingType>(parameters.sublist("S2I COUPLING"),
+              "COUPLINGTYPE") == S2I::coupling_mortar_standard and
           Teuchos::getIntegralValue<Mortar::ParallelRedist>(
               Global::Problem::instance()->mortar_coupling_params().sublist(
                   "PARALLEL REDISTRIBUTION"),
@@ -70,7 +70,7 @@ ScaTra::MeshtyingStrategyS2I::MeshtyingStrategyS2I(
       islavematrix_(nullptr),
       imastermatrix_(nullptr),
       imasterslavematrix_(nullptr),
-      couplingtype_(Teuchos::getIntegralValue<Inpar::S2I::CouplingType>(
+      couplingtype_(Teuchos::getIntegralValue<S2I::CouplingType>(
           parameters.sublist("S2I COUPLING"), "COUPLINGTYPE")),
       D_(nullptr),
       M_(nullptr),
@@ -89,11 +89,11 @@ ScaTra::MeshtyingStrategyS2I::MeshtyingStrategyS2I(
       islavephidtnp_(nullptr),
       imasterphidt_on_slave_side_np_(nullptr),
       imasterphi_on_slave_side_np_(nullptr),
-      lmside_(Teuchos::getIntegralValue<Inpar::S2I::InterfaceSides>(
+      lmside_(Teuchos::getIntegralValue<S2I::InterfaceSides>(
           parameters.sublist("S2I COUPLING"), "LMSIDE")),
       matrixtype_(Teuchos::getIntegralValue<Core::LinAlg::MatrixType>(parameters, "MATRIXTYPE")),
       ntsprojtol_(parameters.sublist("S2I COUPLING").get<double>("NTSPROJTOL")),
-      intlayergrowth_evaluation_(Teuchos::getIntegralValue<Inpar::S2I::GrowthEvaluation>(
+      intlayergrowth_evaluation_(Teuchos::getIntegralValue<S2I::GrowthEvaluation>(
           parameters.sublist("S2I COUPLING"), "INTLAYERGROWTH_EVALUATION")),
       intlayergrowth_convtol_(
           parameters.sublist("S2I COUPLING").get<double>("INTLAYERGROWTH_CONVTOL")),
@@ -135,13 +135,13 @@ void ScaTra::MeshtyingStrategyS2I::condense_mat_and_rhs(
 {
   switch (couplingtype_)
   {
-    case Inpar::S2I::coupling_mortar_condensed_bubnov:
+    case S2I::coupling_mortar_condensed_bubnov:
     {
       // extract global system matrix
       std::shared_ptr<Core::LinAlg::SparseMatrix> sparsematrix = scatratimint_->system_matrix();
       if (sparsematrix == nullptr) FOUR_C_THROW("System matrix is not a sparse matrix!");
 
-      if (lmside_ == Inpar::S2I::side_source)
+      if (lmside_ == S2I::side_source)
       {
         // initialize temporary matrix for slave-side rows of global system matrix
         Core::LinAlg::SparseMatrix sparsematrixrowsslave(*interfacemaps_->map(1), 81);
@@ -261,12 +261,12 @@ void ScaTra::MeshtyingStrategyS2I::condense_mat_and_rhs(
       break;
     }
 
-    case Inpar::S2I::coupling_matching_nodes:
-    case Inpar::S2I::coupling_mortar_standard:
-    case Inpar::S2I::coupling_mortar_saddlepoint_petrov:
-    case Inpar::S2I::coupling_mortar_saddlepoint_bubnov:
-    case Inpar::S2I::coupling_mortar_condensed_petrov:
-    case Inpar::S2I::coupling_nts_standard:
+    case S2I::coupling_matching_nodes:
+    case S2I::coupling_mortar_standard:
+    case S2I::coupling_mortar_saddlepoint_petrov:
+    case S2I::coupling_mortar_saddlepoint_bubnov:
+    case S2I::coupling_mortar_condensed_petrov:
+    case S2I::coupling_nts_standard:
     {
       // do nothing in these cases
       break;
@@ -298,7 +298,7 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
 
   switch (couplingtype_)
   {
-    case Inpar::S2I::coupling_matching_nodes:
+    case S2I::coupling_matching_nodes:
     {
       // create parameter list
       Teuchos::ParameterList condparams;
@@ -316,8 +316,8 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
       islaveresidual_->put_scalar(0.);
       for (auto kinetics_slave_cond : kinetics_conditions_meshtying_slaveside_)
       {
-        if (kinetics_slave_cond.second->parameters().get<Inpar::S2I::KineticModels>(
-                "KINETIC_MODEL") != static_cast<int>(Inpar::S2I::kinetics_nointerfaceflux) and
+        if (kinetics_slave_cond.second->parameters().get<S2I::KineticModels>("KINETIC_MODEL") !=
+                static_cast<int>(S2I::kinetics_nointerfaceflux) and
             kinetics_slave_cond.second->g_type() != Core::Conditions::geometry_type_point)
         {
           // collect condition specific data and store to scatra boundary parameter class
@@ -551,24 +551,24 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
       break;
     }
 
-    case Inpar::S2I::coupling_mortar_standard:
-    case Inpar::S2I::coupling_mortar_saddlepoint_petrov:
-    case Inpar::S2I::coupling_mortar_saddlepoint_bubnov:
-    case Inpar::S2I::coupling_mortar_condensed_petrov:
-    case Inpar::S2I::coupling_mortar_condensed_bubnov:
-    case Inpar::S2I::coupling_nts_standard:
+    case S2I::coupling_mortar_standard:
+    case S2I::coupling_mortar_saddlepoint_petrov:
+    case S2I::coupling_mortar_saddlepoint_bubnov:
+    case S2I::coupling_mortar_condensed_petrov:
+    case S2I::coupling_mortar_condensed_bubnov:
+    case S2I::coupling_nts_standard:
     {
       // initialize auxiliary system matrix and vector for slave side
-      if (couplingtype_ == Inpar::S2I::coupling_mortar_standard or
-          lmside_ == Inpar::S2I::side_source or couplingtype_ == Inpar::S2I::coupling_nts_standard)
+      if (couplingtype_ == S2I::coupling_mortar_standard or lmside_ == S2I::side_source or
+          couplingtype_ == S2I::coupling_nts_standard)
       {
         islavematrix_->zero();
         islaveresidual_->put_scalar(0.);
       }
 
       // initialize auxiliary system matrix and vector for master side
-      if (couplingtype_ == Inpar::S2I::coupling_mortar_standard or
-          lmside_ == Inpar::S2I::side_master or couplingtype_ == Inpar::S2I::coupling_nts_standard)
+      if (couplingtype_ == S2I::coupling_mortar_standard or lmside_ == S2I::side_master or
+          couplingtype_ == S2I::coupling_nts_standard)
       {
         imastermatrix_->zero();
         imasterresidual_->put_scalar(0.);
@@ -595,50 +595,47 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
         // collect condition specific data and store to scatra boundary parameter class
         set_condition_specific_scatra_parameters(*(kinetics_slave_cond.second));
 
-        if (couplingtype_ != Inpar::S2I::coupling_nts_standard)
+        if (couplingtype_ != S2I::coupling_nts_standard)
         {
           // set action
-          params.set<Inpar::S2I::EvaluationActions>("action", Inpar::S2I::evaluate_condition);
+          params.set<S2I::EvaluationActions>("action", S2I::evaluate_condition);
 
-          evaluate_mortar_cells(idiscret, params, islavematrix_, Inpar::S2I::side_source,
-              Inpar::S2I::side_source, islavematrix_, Inpar::S2I::side_source,
-              Inpar::S2I::side_master, imastermatrix_, Inpar::S2I::side_master,
-              Inpar::S2I::side_source, imastermatrix_, Inpar::S2I::side_master,
-              Inpar::S2I::side_master,
+          evaluate_mortar_cells(idiscret, params, islavematrix_, S2I::side_source, S2I::side_source,
+              islavematrix_, S2I::side_source, S2I::side_master, imastermatrix_, S2I::side_master,
+              S2I::side_source, imastermatrix_, S2I::side_master, S2I::side_master,
               islaveresidual_ != nullptr
                   ? Core::Utils::shared_ptr_from_ref(islaveresidual_->as_multi_vector())
                   : nullptr,
-              Inpar::S2I::side_source, imasterresidual_, Inpar::S2I::side_master);
+              S2I::side_source, imasterresidual_, S2I::side_master);
         }
 
         else
         {
           // set action
-          params.set<Inpar::S2I::EvaluationActions>("action", Inpar::S2I::evaluate_condition_nts);
+          params.set<S2I::EvaluationActions>("action", S2I::evaluate_condition_nts);
 
           // evaluate note-to-segment coupling at current interface
           evaluate_nts(*islavenodestomasterelements_[kinetics_slave_cond.first],
               *islavenodeslumpedareas_[kinetics_slave_cond.first],
               *islavenodesimpltypes_[kinetics_slave_cond.first], idiscret, params, islavematrix_,
-              Inpar::S2I::side_source, Inpar::S2I::side_source, islavematrix_,
-              Inpar::S2I::side_source, Inpar::S2I::side_master, imastermatrix_,
-              Inpar::S2I::side_master, Inpar::S2I::side_source, imastermatrix_,
-              Inpar::S2I::side_master, Inpar::S2I::side_master,
+              S2I::side_source, S2I::side_source, islavematrix_, S2I::side_source, S2I::side_master,
+              imastermatrix_, S2I::side_master, S2I::side_source, imastermatrix_, S2I::side_master,
+              S2I::side_master,
               islaveresidual_ != nullptr
                   ? Core::Utils::shared_ptr_from_ref(islaveresidual_->as_multi_vector())
                   : nullptr,
-              Inpar::S2I::side_source, imasterresidual_, Inpar::S2I::side_master);
+              S2I::side_source, imasterresidual_, S2I::side_master);
         }
       }
 
       // finalize auxiliary system matrix for slave side
-      if (couplingtype_ == Inpar::S2I::coupling_mortar_standard or
-          lmside_ == Inpar::S2I::side_source or couplingtype_ == Inpar::S2I::coupling_nts_standard)
+      if (couplingtype_ == S2I::coupling_mortar_standard or lmside_ == S2I::side_source or
+          couplingtype_ == S2I::coupling_nts_standard)
         islavematrix_->complete(*interfacemaps_->full_map(), *interfacemaps_->map(1));
 
       // finalize auxiliary system matrix and residual vector for master side
-      if (couplingtype_ == Inpar::S2I::coupling_mortar_standard or
-          lmside_ == Inpar::S2I::side_master or couplingtype_ == Inpar::S2I::coupling_nts_standard)
+      if (couplingtype_ == S2I::coupling_mortar_standard or lmside_ == S2I::side_master or
+          couplingtype_ == S2I::coupling_nts_standard)
       {
         imastermatrix_->complete(*interfacemaps_->full_map(), *interfacemaps_->map(2));
         imasterresidual_->complete(Core::LinAlg::CombineMode::add, true);
@@ -657,8 +654,8 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
           // assemble interface contributions into global system of equations
           switch (couplingtype_)
           {
-            case Inpar::S2I::coupling_mortar_standard:
-            case Inpar::S2I::coupling_nts_standard:
+            case S2I::coupling_mortar_standard:
+            case S2I::coupling_nts_standard:
             {
               const std::shared_ptr<const Core::LinAlg::SparseMatrix> islavematrix =
                   not imortarredistribution_
@@ -677,10 +674,10 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
               break;
             }
 
-            case Inpar::S2I::coupling_mortar_saddlepoint_petrov:
-            case Inpar::S2I::coupling_mortar_saddlepoint_bubnov:
+            case S2I::coupling_mortar_saddlepoint_petrov:
+            case S2I::coupling_mortar_saddlepoint_bubnov:
             {
-              if (lmside_ == Inpar::S2I::side_source)
+              if (lmside_ == S2I::side_source)
               {
                 // assemble slave-side interface contributions into global residual vector
                 Core::LinAlg::Vector<double> islaveresidual(*interfacemaps_->map(1));
@@ -722,9 +719,9 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
               break;
             }
 
-            case Inpar::S2I::coupling_mortar_condensed_petrov:
+            case S2I::coupling_mortar_condensed_petrov:
             {
-              if (lmside_ == Inpar::S2I::side_source)
+              if (lmside_ == S2I::side_source)
               {
                 Core::LinAlg::matrix_add(*islavematrix_, false, 1., *systemmatrix, 1.);
                 Core::LinAlg::matrix_add(*Core::LinAlg::matrix_multiply(
@@ -751,7 +748,7 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
               break;
             }
 
-            case Inpar::S2I::coupling_mortar_condensed_bubnov:
+            case S2I::coupling_mortar_condensed_bubnov:
             {
               // assemble interface contributions into global system of equations
               if (slaveonly_)
@@ -788,7 +785,7 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
           // assemble interface contributions into global system of equations
           switch (couplingtype_)
           {
-            case Inpar::S2I::coupling_mortar_standard:
+            case S2I::coupling_mortar_standard:
             {
               // split interface sparse matrices into block matrices
               const std::shared_ptr<const Core::LinAlg::SparseMatrix> islavematrix =
@@ -856,7 +853,7 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
   {
     switch (couplingtype_)
     {
-      case Inpar::S2I::coupling_matching_nodes:
+      case S2I::coupling_matching_nodes:
       {
         // create parameter list for elements
         Teuchos::ParameterList conditionparams;
@@ -971,7 +968,7 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
             *icoup_->source_to_target(*islaveresidual_), 2, *scatratimint_->residual(), -1.);
 
         // compute additional linearizations and residuals in case of monolithic evaluation approach
-        if (intlayergrowth_evaluation_ == Inpar::S2I::growth_evaluation_monolithic)
+        if (intlayergrowth_evaluation_ == S2I::growth_evaluation_monolithic)
         {
           // extract map associated with scalar transport degrees of freedom
           const Core::LinAlg::Map& dofrowmap_scatra =
@@ -1371,9 +1368,8 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_and_assemble_capacitive_contribution
   // evaluate scatra-scatra interface coupling
   for (auto kinetics_slave_cond_cap : kinetics_conditions_meshtying_slaveside_)
   {
-    if (kinetics_slave_cond_cap.second->parameters().get<Inpar::S2I::KineticModels>(
-            "KINETIC_MODEL") ==
-        static_cast<int>(Inpar::S2I::kinetics_butlervolmerreducedcapacitance))
+    if (kinetics_slave_cond_cap.second->parameters().get<S2I::KineticModels>("KINETIC_MODEL") ==
+        static_cast<int>(S2I::kinetics_butlervolmerreducedcapacitance))
     {
       // collect condition specific data and store to scatra boundary parameter class
       set_condition_specific_scatra_parameters(*kinetics_slave_cond_cap.second);
@@ -1541,21 +1537,17 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_mortar_element(const Core::FE::Discr
 void ScaTra::MeshtyingStrategyS2I::evaluate_mortar_cells(const Core::FE::Discretization& idiscret,
     const Teuchos::ParameterList& params,
     const std::shared_ptr<Core::LinAlg::SparseOperator>& systemmatrix1,
-    const Inpar::S2I::InterfaceSides matrix1_side_rows,
-    const Inpar::S2I::InterfaceSides matrix1_side_cols,
+    const S2I::InterfaceSides matrix1_side_rows, const S2I::InterfaceSides matrix1_side_cols,
     const std::shared_ptr<Core::LinAlg::SparseOperator>& systemmatrix2,
-    const Inpar::S2I::InterfaceSides matrix2_side_rows,
-    const Inpar::S2I::InterfaceSides matrix2_side_cols,
+    const S2I::InterfaceSides matrix2_side_rows, const S2I::InterfaceSides matrix2_side_cols,
     const std::shared_ptr<Core::LinAlg::SparseOperator>& systemmatrix3,
-    const Inpar::S2I::InterfaceSides matrix3_side_rows,
-    const Inpar::S2I::InterfaceSides matrix3_side_cols,
+    const S2I::InterfaceSides matrix3_side_rows, const S2I::InterfaceSides matrix3_side_cols,
     const std::shared_ptr<Core::LinAlg::SparseOperator>& systemmatrix4,
-    const Inpar::S2I::InterfaceSides matrix4_side_rows,
-    const Inpar::S2I::InterfaceSides matrix4_side_cols,
+    const S2I::InterfaceSides matrix4_side_rows, const S2I::InterfaceSides matrix4_side_cols,
     const std::shared_ptr<Core::LinAlg::MultiVector<double>>& systemvector1,
-    const Inpar::S2I::InterfaceSides vector1_side,
+    const S2I::InterfaceSides vector1_side,
     const std::shared_ptr<Core::LinAlg::FEVector<double>>& systemvector2,
-    const Inpar::S2I::InterfaceSides vector2_side) const
+    const S2I::InterfaceSides vector2_side) const
 {
   // instantiate assembly strategy for mortar integration cells
   ScaTra::MortarCellAssemblyStrategy strategy(systemmatrix1, matrix1_side_rows, matrix1_side_cols,
@@ -1633,21 +1625,17 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_nts(
     const Core::LinAlg::Vector<int>& islavenodesimpltypes, const Core::FE::Discretization& idiscret,
     const Teuchos::ParameterList& params,
     const std::shared_ptr<Core::LinAlg::SparseOperator>& systemmatrix1,
-    const Inpar::S2I::InterfaceSides matrix1_side_rows,
-    const Inpar::S2I::InterfaceSides matrix1_side_cols,
+    const S2I::InterfaceSides matrix1_side_rows, const S2I::InterfaceSides matrix1_side_cols,
     const std::shared_ptr<Core::LinAlg::SparseOperator>& systemmatrix2,
-    const Inpar::S2I::InterfaceSides matrix2_side_rows,
-    const Inpar::S2I::InterfaceSides matrix2_side_cols,
+    const S2I::InterfaceSides matrix2_side_rows, const S2I::InterfaceSides matrix2_side_cols,
     const std::shared_ptr<Core::LinAlg::SparseOperator>& systemmatrix3,
-    const Inpar::S2I::InterfaceSides matrix3_side_rows,
-    const Inpar::S2I::InterfaceSides matrix3_side_cols,
+    const S2I::InterfaceSides matrix3_side_rows, const S2I::InterfaceSides matrix3_side_cols,
     const std::shared_ptr<Core::LinAlg::SparseOperator>& systemmatrix4,
-    const Inpar::S2I::InterfaceSides matrix4_side_rows,
-    const Inpar::S2I::InterfaceSides matrix4_side_cols,
+    const S2I::InterfaceSides matrix4_side_rows, const S2I::InterfaceSides matrix4_side_cols,
     const std::shared_ptr<Core::LinAlg::MultiVector<double>>& systemvector1,
-    const Inpar::S2I::InterfaceSides vector1_side,
+    const S2I::InterfaceSides vector1_side,
     const std::shared_ptr<Core::LinAlg::FEVector<double>>& systemvector2,
-    const Inpar::S2I::InterfaceSides vector2_side) const
+    const S2I::InterfaceSides vector2_side) const
 {
   // instantiate assembly strategy for node-to-segment coupling
   ScaTra::MortarCellAssemblyStrategy strategy(systemmatrix1, matrix1_side_rows, matrix1_side_cols,
@@ -1708,21 +1696,17 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_mortar_elements(const Core::LinAlg::
     const Core::LinAlg::Vector<int>& ieleimpltypes, const Core::FE::Discretization& idiscret,
     const Teuchos::ParameterList& params,
     const std::shared_ptr<Core::LinAlg::SparseOperator>& systemmatrix1,
-    const Inpar::S2I::InterfaceSides matrix1_side_rows,
-    const Inpar::S2I::InterfaceSides matrix1_side_cols,
+    const S2I::InterfaceSides matrix1_side_rows, const S2I::InterfaceSides matrix1_side_cols,
     const std::shared_ptr<Core::LinAlg::SparseOperator>& systemmatrix2,
-    const Inpar::S2I::InterfaceSides matrix2_side_rows,
-    const Inpar::S2I::InterfaceSides matrix2_side_cols,
+    const S2I::InterfaceSides matrix2_side_rows, const S2I::InterfaceSides matrix2_side_cols,
     const std::shared_ptr<Core::LinAlg::SparseOperator>& systemmatrix3,
-    const Inpar::S2I::InterfaceSides matrix3_side_rows,
-    const Inpar::S2I::InterfaceSides matrix3_side_cols,
+    const S2I::InterfaceSides matrix3_side_rows, const S2I::InterfaceSides matrix3_side_cols,
     const std::shared_ptr<Core::LinAlg::SparseOperator>& systemmatrix4,
-    const Inpar::S2I::InterfaceSides matrix4_side_rows,
-    const Inpar::S2I::InterfaceSides matrix4_side_cols,
+    const S2I::InterfaceSides matrix4_side_rows, const S2I::InterfaceSides matrix4_side_cols,
     const std::shared_ptr<Core::LinAlg::MultiVector<double>>& systemvector1,
-    const Inpar::S2I::InterfaceSides vector1_side,
+    const S2I::InterfaceSides vector1_side,
     const std::shared_ptr<Core::LinAlg::FEVector<double>>& systemvector2,
-    const Inpar::S2I::InterfaceSides vector2_side) const
+    const S2I::InterfaceSides vector2_side) const
 {
   // instantiate assembly strategy for mortar elements
   ScaTra::MortarCellAssemblyStrategy strategy(systemmatrix1, matrix1_side_rows, matrix1_side_cols,
@@ -1761,8 +1745,8 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_mortar_elements(const Core::LinAlg::
  *--------------------------------------------------------------------------------------*/
 ScaTra::MortarCellInterface* ScaTra::MortarCellFactory::mortar_cell_calc(
     const ScaTra::ImplType& impltype, const Mortar::Element& slaveelement,
-    const Mortar::Element& masterelement, const Inpar::S2I::CouplingType& couplingtype,
-    const Inpar::S2I::InterfaceSides& lmside, const std::string& disname)
+    const Mortar::Element& masterelement, const S2I::CouplingType& couplingtype,
+    const S2I::InterfaceSides& lmside, const std::string& disname)
 {
   // extract number of slave-side degrees of freedom per node
   const int numdofpernode_slave = slaveelement.num_dof_per_node(*slaveelement.nodes()[0]);
@@ -1798,7 +1782,7 @@ ScaTra::MortarCellInterface* ScaTra::MortarCellFactory::mortar_cell_calc(
 template <Core::FE::CellType distype_s>
 ScaTra::MortarCellInterface* ScaTra::MortarCellFactory::mortar_cell_calc(
     const ScaTra::ImplType& impltype, const Mortar::Element& masterelement,
-    const Inpar::S2I::CouplingType& couplingtype, const Inpar::S2I::InterfaceSides& lmside,
+    const S2I::CouplingType& couplingtype, const S2I::InterfaceSides& lmside,
     const int& numdofpernode_slave, const std::string& disname)
 {
   // extract number of master-side degrees of freedom per node
@@ -1834,8 +1818,8 @@ ScaTra::MortarCellInterface* ScaTra::MortarCellFactory::mortar_cell_calc(
  *--------------------------------------------------------------------------------------*/
 template <Core::FE::CellType distype_s, Core::FE::CellType distype_m>
 ScaTra::MortarCellInterface* ScaTra::MortarCellFactory::mortar_cell_calc(
-    const ScaTra::ImplType& impltype, const Inpar::S2I::CouplingType& couplingtype,
-    const Inpar::S2I::InterfaceSides& lmside, const int& numdofpernode_slave,
+    const ScaTra::ImplType& impltype, const S2I::CouplingType& couplingtype,
+    const S2I::InterfaceSides& lmside, const int& numdofpernode_slave,
     const int& numdofpernode_master, const std::string& disname)
 {
   // return instance of evaluation class for mortar integration cell depending on physical
@@ -1884,8 +1868,8 @@ ScaTra::MortarCellInterface* ScaTra::MortarCellFactory::mortar_cell_calc(
  *------------------------------------------------------------------------*/
 void ScaTra::MeshtyingStrategyS2I::init_conv_check_strategy()
 {
-  if (couplingtype_ == Inpar::S2I::coupling_mortar_saddlepoint_petrov or
-      couplingtype_ == Inpar::S2I::coupling_mortar_saddlepoint_bubnov)
+  if (couplingtype_ == S2I::coupling_mortar_saddlepoint_petrov or
+      couplingtype_ == S2I::coupling_mortar_saddlepoint_bubnov)
   {
     convcheckstrategy_ = std::make_shared<ScaTra::ConvCheckStrategyS2ILM>(
         scatratimint_->scatra_parameter_list()->sublist("NONLINEAR"));
@@ -1917,7 +1901,7 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
     {
       const int s2ikinetics_cond_id = s2ikinetics_cond->parameters().get<int>("ConditionID");
       const int s2ikinetics_cond_interface_side =
-          s2ikinetics_cond->parameters().get<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE");
+          s2ikinetics_cond->parameters().get<S2I::InterfaceSides>("INTERFACE_SIDE");
 
       if (s2ikinetics_cond_id < 0)
         FOUR_C_THROW("Invalid condition ID {} for S2IKinetics Condition!", s2ikinetics_cond_id);
@@ -1926,13 +1910,13 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
       if (s2imeshtying_cond->parameters().get<int>("S2I_KINETICS_ID") != s2ikinetics_cond_id)
         continue;
       // only continue if sides match
-      if (s2imeshtying_cond->parameters().get<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE") !=
+      if (s2imeshtying_cond->parameters().get<S2I::InterfaceSides>("INTERFACE_SIDE") !=
           s2ikinetics_cond_interface_side)
         continue;
 
       switch (s2ikinetics_cond_interface_side)
       {
-        case Inpar::S2I::side_source:
+        case S2I::side_source:
         {
           if (kinetics_conditions_meshtying_slaveside_.find(s2ikinetics_cond_id) ==
               kinetics_conditions_meshtying_slaveside_.end())
@@ -1948,8 +1932,8 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
                 s2ikinetics_cond_id);
           }
 
-          if (s2ikinetics_cond->parameters().get<Inpar::S2I::KineticModels>("KINETIC_MODEL") ==
-              static_cast<int>(Inpar::S2I::kinetics_butlervolmerreducedcapacitance))
+          if (s2ikinetics_cond->parameters().get<S2I::KineticModels>("KINETIC_MODEL") ==
+              static_cast<int>(S2I::kinetics_butlervolmerreducedcapacitance))
           {
             has_capacitive_contributions_ = true;
 
@@ -1972,7 +1956,7 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
           break;
         }
 
-        case Inpar::S2I::side_master:
+        case S2I::side_master:
         {
           if (master_conditions_.find(s2ikinetics_cond_id) == master_conditions_.end())
           {
@@ -2002,7 +1986,7 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
   {
     // setup scatra-scatra interface coupling for interfaces with pairwise overlapping interface
     // nodes
-    case Inpar::S2I::coupling_matching_nodes:
+    case S2I::coupling_matching_nodes:
     {
       // overwrite IDs of master-side scatra-scatra interface coupling conditions with the value -1
       // to prevent them from being evaluated when calling evaluate_condition on the discretization
@@ -2042,8 +2026,8 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
                    scatratimint_->num_dof_per_node_in_condition(*kinetics_condition))
             FOUR_C_THROW("all S2I conditions must have the same number of dof per node");
 
-          if (kinetics_condition->parameters().get<Inpar::S2I::KineticModels>("KINETIC_MODEL") !=
-              static_cast<int>(Inpar::S2I::kinetics_nointerfaceflux))
+          if (kinetics_condition->parameters().get<S2I::KineticModels>("KINETIC_MODEL") !=
+              static_cast<int>(S2I::kinetics_nointerfaceflux))
           {
             Core::Communication::add_owned_node_gid_from_list(*scatratimint_->discretization(),
                 *kinetics_condition->get_nodes(), islavenodegidvec);
@@ -2081,8 +2065,8 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
                    scatratimint_->num_dof_per_node_in_condition(*kinetics_condition))
             FOUR_C_THROW("all S2I conditions must have the same number of dof per node");
 
-          if (kinetics_condition->parameters().get<Inpar::S2I::KineticModels>("KINETIC_MODEL") !=
-              static_cast<int>(Inpar::S2I::kinetics_nointerfaceflux))
+          if (kinetics_condition->parameters().get<S2I::KineticModels>("KINETIC_MODEL") !=
+              static_cast<int>(S2I::kinetics_nointerfaceflux))
           {
             Core::Communication::add_owned_node_gid_from_list(*scatratimint_->discretization(),
                 *kinetics_condition->get_nodes(), islavenodegidset);
@@ -2149,15 +2133,15 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
     }
 
     // setup scatra-scatra interface coupling for interfaces with non-overlapping interface nodes
-    case Inpar::S2I::coupling_mortar_standard:
-    case Inpar::S2I::coupling_mortar_saddlepoint_petrov:
-    case Inpar::S2I::coupling_mortar_saddlepoint_bubnov:
-    case Inpar::S2I::coupling_mortar_condensed_petrov:
-    case Inpar::S2I::coupling_mortar_condensed_bubnov:
-    case Inpar::S2I::coupling_nts_standard:
+    case S2I::coupling_mortar_standard:
+    case S2I::coupling_mortar_saddlepoint_petrov:
+    case S2I::coupling_mortar_saddlepoint_bubnov:
+    case S2I::coupling_mortar_condensed_petrov:
+    case S2I::coupling_mortar_condensed_bubnov:
+    case S2I::coupling_nts_standard:
     {
       // safety checks
-      if (imortarredistribution_ and couplingtype_ != Inpar::S2I::coupling_mortar_standard)
+      if (imortarredistribution_ and couplingtype_ != S2I::coupling_mortar_standard)
       {
         FOUR_C_THROW(
             "Parallel redistribution only implemented for scatra-scatra interface coupling based "
@@ -2237,7 +2221,7 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
         // extract mortar discretization
         const Core::FE::Discretization& idiscret = interface.discret();
 
-        if (couplingtype_ != Inpar::S2I::coupling_nts_standard)
+        if (couplingtype_ != S2I::coupling_nts_standard)
         {
           // provide each slave-side mortar element with material of corresponding parent element
           for (int iele = 0; iele < interface.source_col_elements()->num_my_elements(); ++iele)
@@ -2441,23 +2425,21 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
           Teuchos::ParameterList eleparams;
 
           // set action for slave-side elements
-          eleparams.set<Inpar::S2I::EvaluationActions>(
-              "action", Inpar::S2I::evaluate_nodal_area_fractions);
+          eleparams.set<S2I::EvaluationActions>("action", S2I::evaluate_nodal_area_fractions);
 
           // compute vector for lumped interface area fractions associated with slave-side nodes
           const Core::LinAlg::Map& dofrowmap_slave = *interface.source_row_dofs();
           std::shared_ptr<Core::LinAlg::Vector<double>> islavenodeslumpedareas_dofvector =
               std::make_shared<Core::LinAlg::Vector<double>>(dofrowmap_slave);
           evaluate_mortar_elements(elecolmap_slave, islaveelementsimpltypes, idiscret, eleparams,
-              nullptr, Inpar::S2I::side_undefined, Inpar::S2I::side_undefined, nullptr,
-              Inpar::S2I::side_undefined, Inpar::S2I::side_undefined, nullptr,
-              Inpar::S2I::side_undefined, Inpar::S2I::side_undefined, nullptr,
-              Inpar::S2I::side_undefined, Inpar::S2I::side_undefined,
+              nullptr, S2I::side_undefined, S2I::side_undefined, nullptr, S2I::side_undefined,
+              S2I::side_undefined, nullptr, S2I::side_undefined, S2I::side_undefined, nullptr,
+              S2I::side_undefined, S2I::side_undefined,
               islavenodeslumpedareas_dofvector != nullptr
                   ? Core::Utils::shared_ptr_from_ref(
                         islavenodeslumpedareas_dofvector->as_multi_vector())
                   : nullptr,
-              Inpar::S2I::side_source, nullptr, Inpar::S2I::side_undefined);
+              S2I::side_source, nullptr, S2I::side_undefined);
 
           // transform map of result vector
           std::shared_ptr<Core::LinAlg::Vector<double>>& islavenodeslumpedareas =
@@ -2497,8 +2479,8 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
           *(scatratimint_->discretization()->dof_row_map()), imaps);
       interfacemaps_->check_for_valid_map_extractor();
 
-      if (couplingtype_ == Inpar::S2I::coupling_mortar_standard or
-          lmside_ == Inpar::S2I::side_source or couplingtype_ == Inpar::S2I::coupling_nts_standard)
+      if (couplingtype_ == S2I::coupling_mortar_standard or lmside_ == S2I::side_source or
+          couplingtype_ == S2I::coupling_nts_standard)
       {
         // initialize auxiliary system matrix for slave side
         islavematrix_ = std::make_shared<Core::LinAlg::SparseMatrix>(*interfacemaps_->map(1), 81);
@@ -2507,8 +2489,8 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
         islaveresidual_ = std::make_shared<Core::LinAlg::Vector<double>>(*interfacemaps_->map(1));
       }
 
-      if (couplingtype_ == Inpar::S2I::coupling_mortar_standard or
-          lmside_ == Inpar::S2I::side_master or couplingtype_ == Inpar::S2I::coupling_nts_standard)
+      if (couplingtype_ == S2I::coupling_mortar_standard or lmside_ == S2I::side_master or
+          couplingtype_ == S2I::coupling_nts_standard)
       {
         // initialize auxiliary system matrix for master side
         imastermatrix_ = std::make_shared<Core::LinAlg::SparseMatrix>(
@@ -2521,17 +2503,17 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
 
       switch (couplingtype_)
       {
-        case Inpar::S2I::coupling_mortar_saddlepoint_petrov:
-        case Inpar::S2I::coupling_mortar_saddlepoint_bubnov:
-        case Inpar::S2I::coupling_mortar_condensed_petrov:
-        case Inpar::S2I::coupling_mortar_condensed_bubnov:
+        case S2I::coupling_mortar_saddlepoint_petrov:
+        case S2I::coupling_mortar_saddlepoint_bubnov:
+        case S2I::coupling_mortar_condensed_petrov:
+        case S2I::coupling_mortar_condensed_bubnov:
         {
-          if (lmside_ == Inpar::S2I::side_source)
+          if (lmside_ == S2I::side_source)
           {
             D_ = std::make_shared<Core::LinAlg::SparseMatrix>(*interfacemaps_->map(1), 81);
             M_ = std::make_shared<Core::LinAlg::SparseMatrix>(*interfacemaps_->map(1), 81);
-            if (couplingtype_ == Inpar::S2I::coupling_mortar_saddlepoint_bubnov or
-                couplingtype_ == Inpar::S2I::coupling_mortar_condensed_bubnov)
+            if (couplingtype_ == S2I::coupling_mortar_saddlepoint_bubnov or
+                couplingtype_ == S2I::coupling_mortar_condensed_bubnov)
               E_ = std::make_shared<Core::LinAlg::SparseMatrix>(*interfacemaps_->map(1), 81);
           }
           else
@@ -2540,8 +2522,8 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
                 *interfacemaps_->map(2), 81, true, false, Core::LinAlg::SparseMatrix::FE_MATRIX);
             M_ = std::make_shared<Core::LinAlg::SparseMatrix>(
                 *interfacemaps_->map(2), 81, true, false, Core::LinAlg::SparseMatrix::FE_MATRIX);
-            if (couplingtype_ == Inpar::S2I::coupling_mortar_saddlepoint_bubnov or
-                couplingtype_ == Inpar::S2I::coupling_mortar_condensed_bubnov)
+            if (couplingtype_ == S2I::coupling_mortar_saddlepoint_bubnov or
+                couplingtype_ == S2I::coupling_mortar_condensed_bubnov)
               E_ = std::make_shared<Core::LinAlg::SparseMatrix>(
                   *interfacemaps_->map(2), 81, true, false, Core::LinAlg::SparseMatrix::FE_MATRIX);
           }
@@ -2556,48 +2538,38 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
             params.set<const Core::Conditions::Condition*>("condition", kinetics_slave_cond.second);
 
             // set action
-            params.set<Inpar::S2I::EvaluationActions>(
-                "action", Inpar::S2I::evaluate_mortar_matrices);
+            params.set<S2I::EvaluationActions>("action", S2I::evaluate_mortar_matrices);
 
             // evaluate mortar integration cells at current interface
             evaluate_mortar_cells(icoupmortar_[kinetics_slave_cond.first]->interface()->discret(),
-                params, D_,
-                lmside_ == Inpar::S2I::side_source ? Inpar::S2I::side_source
-                                                   : Inpar::S2I::side_master,
-                lmside_ == Inpar::S2I::side_source ? Inpar::S2I::side_source
-                                                   : Inpar::S2I::side_master,
-                M_,
-                lmside_ == Inpar::S2I::side_source ? Inpar::S2I::side_source
-                                                   : Inpar::S2I::side_master,
-                lmside_ == Inpar::S2I::side_source ? Inpar::S2I::side_master
-                                                   : Inpar::S2I::side_source,
-                E_,
-                lmside_ == Inpar::S2I::side_source ? Inpar::S2I::side_source
-                                                   : Inpar::S2I::side_master,
-                lmside_ == Inpar::S2I::side_source ? Inpar::S2I::side_source
-                                                   : Inpar::S2I::side_master,
-                nullptr, Inpar::S2I::side_undefined, Inpar::S2I::side_undefined, nullptr,
-                Inpar::S2I::side_undefined, nullptr, Inpar::S2I::side_undefined);
+                params, D_, lmside_ == S2I::side_source ? S2I::side_source : S2I::side_master,
+                lmside_ == S2I::side_source ? S2I::side_source : S2I::side_master, M_,
+                lmside_ == S2I::side_source ? S2I::side_source : S2I::side_master,
+                lmside_ == S2I::side_source ? S2I::side_master : S2I::side_source, E_,
+                lmside_ == S2I::side_source ? S2I::side_source : S2I::side_master,
+                lmside_ == S2I::side_source ? S2I::side_source : S2I::side_master, nullptr,
+                S2I::side_undefined, S2I::side_undefined, nullptr, S2I::side_undefined, nullptr,
+                S2I::side_undefined);
           }
 
           // finalize mortar matrices D, M, and E
           D_->complete();
-          if (lmside_ == Inpar::S2I::side_source)
+          if (lmside_ == S2I::side_source)
             M_->complete(*interfacemaps_->map(2), *interfacemaps_->map(1));
           else
             M_->complete(*interfacemaps_->map(1), *interfacemaps_->map(2));
-          if (couplingtype_ == Inpar::S2I::coupling_mortar_saddlepoint_bubnov or
-              couplingtype_ == Inpar::S2I::coupling_mortar_condensed_bubnov)
+          if (couplingtype_ == S2I::coupling_mortar_saddlepoint_bubnov or
+              couplingtype_ == S2I::coupling_mortar_condensed_bubnov)
             E_->complete();
 
           switch (couplingtype_)
           {
-            case Inpar::S2I::coupling_mortar_condensed_petrov:
-            case Inpar::S2I::coupling_mortar_condensed_bubnov:
+            case S2I::coupling_mortar_condensed_petrov:
+            case S2I::coupling_mortar_condensed_bubnov:
             {
               // set up mortar projector P
               std::shared_ptr<Core::LinAlg::Vector<double>> D_diag(nullptr);
-              if (lmside_ == Inpar::S2I::side_source)
+              if (lmside_ == S2I::side_source)
                 D_diag = std::make_shared<Core::LinAlg::Vector<double>>(*interfacemaps_->map(1));
               else
                 D_diag = std::make_shared<Core::LinAlg::Vector<double>>(*interfacemaps_->map(2));
@@ -2614,7 +2586,7 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
                 M_ = nullptr;
               }
 
-              if (couplingtype_ == Inpar::S2I::coupling_mortar_condensed_bubnov)
+              if (couplingtype_ == S2I::coupling_mortar_condensed_bubnov)
               {
                 // set up mortar projector Q
                 Q_ = std::make_shared<Core::LinAlg::SparseMatrix>(*E_);
@@ -2627,8 +2599,8 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
               break;
             }
 
-            case Inpar::S2I::coupling_mortar_saddlepoint_petrov:
-            case Inpar::S2I::coupling_mortar_saddlepoint_bubnov:
+            case S2I::coupling_mortar_saddlepoint_petrov:
+            case S2I::coupling_mortar_saddlepoint_bubnov:
             {
               // determine number of Lagrange multiplier dofs owned by each processor
               MPI_Comm comm(scatratimint_->discretization()->get_comm());
@@ -2636,7 +2608,7 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
               const int mypid(Core::Communication::my_mpi_rank(comm));
               std::vector<int> localnumlmdof(numproc, 0);
               std::vector<int> globalnumlmdof(numproc, 0);
-              if (lmside_ == Inpar::S2I::side_source)
+              if (lmside_ == S2I::side_source)
                 localnumlmdof[mypid] = interfacemaps_->map(1)->num_my_elements();
               else
                 localnumlmdof[mypid] = interfacemaps_->map(2)->num_my_elements();
@@ -2676,7 +2648,7 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
               D_ = Core::LinAlg::matrix_row_transform_gids(*D_, *lmdofrowmap);
               M_ = Core::LinAlg::matrix_row_transform_gids(*M_, *lmdofrowmap);
 
-              if (couplingtype_ == Inpar::S2I::coupling_mortar_saddlepoint_petrov)
+              if (couplingtype_ == S2I::coupling_mortar_saddlepoint_petrov)
               {
                 // transform domain map of mortar matrix D from slave-side dofrowmap to Lagrange
                 // multiplier dofrowmap and store transformed matrix as mortar matrix E
@@ -2764,8 +2736,8 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
     // perform setup depending on evaluation method
     switch (intlayergrowth_evaluation_)
     {
-      case Inpar::S2I::growth_evaluation_monolithic:
-      case Inpar::S2I::growth_evaluation_semi_implicit:
+      case S2I::growth_evaluation_monolithic:
+      case S2I::growth_evaluation_semi_implicit:
       {
         // extract map associated with scatra-scatra interface layer thicknesses
         const std::shared_ptr<const Core::LinAlg::Map>& dofrowmap_growth =
@@ -2775,7 +2747,7 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
         growthn_ = std::make_shared<Core::LinAlg::Vector<double>>(*dofrowmap_growth, true);
 
         // additional initializations for monolithic solution approach
-        if (intlayergrowth_evaluation_ == Inpar::S2I::growth_evaluation_monolithic)
+        if (intlayergrowth_evaluation_ == S2I::growth_evaluation_monolithic)
         {
           // initialize extended map extractor
           const Core::LinAlg::Map* const dofrowmap_scatra =
@@ -2911,7 +2883,7 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
         }  // loop over all nodes
 
         // copy initial state
-        if (intlayergrowth_evaluation_ == Inpar::S2I::growth_evaluation_monolithic)
+        if (intlayergrowth_evaluation_ == S2I::growth_evaluation_monolithic)
           growthnp_->update(1., *growthn_, 0.);
 
         break;
@@ -2931,7 +2903,7 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
   auto equilibration_method =
       std::vector<Core::LinAlg::EquilibrationMethod>(1, scatratimint_->equilibration_method());
   equilibration_ = Core::LinAlg::build_equilibration(matrixtype_, equilibration_method,
-      (intlayergrowth_evaluation_ == Inpar::S2I::growth_evaluation_monolithic
+      (intlayergrowth_evaluation_ == S2I::growth_evaluation_monolithic
               ? extendedmaps_->full_map()
               : std::make_shared<const Core::LinAlg::Map>(
                     *scatratimint_->discretization()->dof_row_map())));
@@ -2942,7 +2914,7 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
 void ScaTra::MeshtyingStrategyS2I::compute_time_derivative() const
 {
   // only relevant for monolithic evaluation of scatra-scatra interface layer growth
-  if (intlayergrowth_evaluation_ == Inpar::S2I::growth_evaluation_monolithic)
+  if (intlayergrowth_evaluation_ == S2I::growth_evaluation_monolithic)
   {
     // compute inverse time factor 1./(theta*dt)
     const double timefac_inverse =
@@ -2959,7 +2931,7 @@ void ScaTra::MeshtyingStrategyS2I::compute_time_derivative() const
 void ScaTra::MeshtyingStrategyS2I::update() const
 {
   // only relevant for monolithic evaluation of scatra-scatra interface layer growth
-  if (intlayergrowth_evaluation_ == Inpar::S2I::growth_evaluation_monolithic)
+  if (intlayergrowth_evaluation_ == S2I::growth_evaluation_monolithic)
   {
     // update state vectors
     growthn_->update(1., *growthnp_, 0.);
@@ -3013,14 +2985,14 @@ void ScaTra::MeshtyingStrategyS2I::write_s2_i_kinetics_specific_scatra_parameter
     case Core::Conditions::ConditionType::S2IKinetics:
     {
       const int kineticmodel =
-          s2ikinetics_cond.parameters().get<Inpar::S2I::KineticModels>("KINETIC_MODEL");
+          s2ikinetics_cond.parameters().get<S2I::KineticModels>("KINETIC_MODEL");
       s2icouplingparameters.set("KINETIC_MODEL", kineticmodel);
 
       // set the kinetic model specific parameters
       switch (kineticmodel)
       {
-        case Inpar::S2I::kinetics_constperm:
-        case Inpar::S2I::kinetics_linearperm:
+        case S2I::kinetics_constperm:
+        case S2I::kinetics_linearperm:
         {
           s2icouplingparameters.set<int>(
               "NUMSCAL", s2ikinetics_cond.parameters().get<int>("NUMSCAL"));
@@ -3031,7 +3003,7 @@ void ScaTra::MeshtyingStrategyS2I::write_s2_i_kinetics_specific_scatra_parameter
           break;
         }
 
-        case Inpar::S2I::kinetics_constantinterfaceresistance:
+        case S2I::kinetics_constantinterfaceresistance:
         {
           s2icouplingparameters.set<double>(
               "RESISTANCE", s2ikinetics_cond.parameters().get<double>("RESISTANCE"));
@@ -3044,21 +3016,21 @@ void ScaTra::MeshtyingStrategyS2I::write_s2_i_kinetics_specific_scatra_parameter
           break;
         }
 
-        case Inpar::S2I::kinetics_nointerfaceflux:
+        case S2I::kinetics_nointerfaceflux:
         {
           // do nothing
           break;
         }
 
-        case Inpar::S2I::kinetics_butlervolmer:
-        case Inpar::S2I::kinetics_butlervolmerlinearized:
-        case Inpar::S2I::kinetics_butlervolmerreduced:
-        case Inpar::S2I::kinetics_butlervolmerreducedcapacitance:
-        case Inpar::S2I::kinetics_butlervolmerreducedlinearized:
-        case Inpar::S2I::kinetics_butlervolmerpeltier:
-        case Inpar::S2I::kinetics_butlervolmerresistance:
-        case Inpar::S2I::kinetics_butlervolmerreducedthermoresistance:
-        case Inpar::S2I::kinetics_butlervolmerreducedresistance:
+        case S2I::kinetics_butlervolmer:
+        case S2I::kinetics_butlervolmerlinearized:
+        case S2I::kinetics_butlervolmerreduced:
+        case S2I::kinetics_butlervolmerreducedcapacitance:
+        case S2I::kinetics_butlervolmerreducedlinearized:
+        case S2I::kinetics_butlervolmerpeltier:
+        case S2I::kinetics_butlervolmerresistance:
+        case S2I::kinetics_butlervolmerreducedthermoresistance:
+        case S2I::kinetics_butlervolmerreducedresistance:
         {
           s2icouplingparameters.set<int>(
               "NUMSCAL", s2ikinetics_cond.parameters().get<int>("NUMSCAL"));
@@ -3075,16 +3047,16 @@ void ScaTra::MeshtyingStrategyS2I::write_s2_i_kinetics_specific_scatra_parameter
           s2icouplingparameters.set<bool>(
               "IS_PSEUDO_CONTACT", s2ikinetics_cond.parameters().get<bool>("IS_PSEUDO_CONTACT"));
 
-          if (kineticmodel == Inpar::S2I::kinetics_butlervolmerreducedcapacitance)
+          if (kineticmodel == S2I::kinetics_butlervolmerreducedcapacitance)
             s2icouplingparameters.set<double>(
                 "CAPACITANCE", s2ikinetics_cond.parameters().get<double>("CAPACITANCE"));
 
-          if (kineticmodel == Inpar::S2I::kinetics_butlervolmerpeltier)
+          if (kineticmodel == S2I::kinetics_butlervolmerpeltier)
             s2icouplingparameters.set<double>(
                 "PELTIER", s2ikinetics_cond.parameters().get<double>("PELTIER"));
 
-          if (kineticmodel == Inpar::S2I::kinetics_butlervolmerresistance or
-              kineticmodel == Inpar::S2I::kinetics_butlervolmerreducedresistance)
+          if (kineticmodel == S2I::kinetics_butlervolmerresistance or
+              kineticmodel == S2I::kinetics_butlervolmerreducedresistance)
           {
             s2icouplingparameters.set<double>(
                 "RESISTANCE", s2ikinetics_cond.parameters().get<double>("RESISTANCE"));
@@ -3094,7 +3066,7 @@ void ScaTra::MeshtyingStrategyS2I::write_s2_i_kinetics_specific_scatra_parameter
                 s2ikinetics_cond.parameters().get<int>("ITEMAX_IMPLBUTLERVOLMER"));
           }
 
-          if (kineticmodel == Inpar::S2I::kinetics_butlervolmerreducedthermoresistance)
+          if (kineticmodel == S2I::kinetics_butlervolmerreducedthermoresistance)
           {
             s2icouplingparameters.set<double>(
                 "THERMOPERM", s2ikinetics_cond.parameters().get<double>("THERMOPERM"));
@@ -3115,13 +3087,13 @@ void ScaTra::MeshtyingStrategyS2I::write_s2_i_kinetics_specific_scatra_parameter
     case Core::Conditions::ConditionType::S2IKineticsGrowth:
     {
       const int kineticmodel =
-          s2ikinetics_cond.parameters().get<Inpar::S2I::GrowthKineticModels>("KINETIC_MODEL");
+          s2ikinetics_cond.parameters().get<S2I::GrowthKineticModels>("KINETIC_MODEL");
       s2icouplingparameters.set("KINETIC_MODEL", kineticmodel);
 
       // set the kinetic model specific parameters
       switch (kineticmodel)
       {
-        case Inpar::S2I::growth_kinetics_butlervolmer:
+        case S2I::growth_kinetics_butlervolmer:
         {
           s2icouplingparameters.set<int>(
               "NUMSCAL", s2ikinetics_cond.parameters().get<int>("NUMSCAL"));
@@ -3141,8 +3113,8 @@ void ScaTra::MeshtyingStrategyS2I::write_s2_i_kinetics_specific_scatra_parameter
               "MOLMASS", s2ikinetics_cond.parameters().get<double>("MOLMASS"));
           s2icouplingparameters.set<double>(
               "REGPAR", s2ikinetics_cond.parameters().get<double>("REGPAR"));
-          s2icouplingparameters.set("REGTYPE",
-              s2ikinetics_cond.parameters().get<Inpar::S2I::RegularizationType>("REGTYPE"));
+          s2icouplingparameters.set(
+              "REGTYPE", s2ikinetics_cond.parameters().get<S2I::RegularizationType>("REGTYPE"));
           s2icouplingparameters.set<double>(
               "CONDUCTIVITY", s2ikinetics_cond.parameters().get<double>("CONDUCTIVITY"));
           break;
@@ -3168,7 +3140,7 @@ void ScaTra::MeshtyingStrategyS2I::write_s2_i_kinetics_specific_scatra_parameter
 void ScaTra::MeshtyingStrategyS2I::set_old_part_of_rhs() const
 {
   // only relevant for monolithic evaluation of scatra-scatra interface layer growth
-  if (intlayergrowth_evaluation_ == Inpar::S2I::growth_evaluation_monolithic)
+  if (intlayergrowth_evaluation_ == S2I::growth_evaluation_monolithic)
   {
     // compute factor dt*(1-theta)
     const double factor = scatratimint_->dt() -
@@ -3185,13 +3157,13 @@ void ScaTra::MeshtyingStrategyS2I::write_restart() const
 {
   // only relevant for monolithic or semi-implicit evaluation of scatra-scatra interface layer
   // growth
-  if (intlayergrowth_evaluation_ == Inpar::S2I::growth_evaluation_monolithic or
-      intlayergrowth_evaluation_ == Inpar::S2I::growth_evaluation_semi_implicit)
+  if (intlayergrowth_evaluation_ == S2I::growth_evaluation_monolithic or
+      intlayergrowth_evaluation_ == S2I::growth_evaluation_semi_implicit)
   {
     // output state vector of discrete scatra-scatra interface layer thicknesses
     scatratimint_->disc_writer()->write_vector("growthn", growthn_);
 
-    if (intlayergrowth_evaluation_ == Inpar::S2I::growth_evaluation_monolithic)
+    if (intlayergrowth_evaluation_ == S2I::growth_evaluation_monolithic)
     {
       // output state vector of time derivatives of discrete scatra-scatra interface layer
       // thicknesses
@@ -3207,8 +3179,8 @@ void ScaTra::MeshtyingStrategyS2I::read_restart(
 {
   // only relevant for monolithic or semi-implicit evaluation of scatra-scatra interface layer
   // growth
-  if (intlayergrowth_evaluation_ == Inpar::S2I::growth_evaluation_monolithic or
-      intlayergrowth_evaluation_ == Inpar::S2I::growth_evaluation_semi_implicit)
+  if (intlayergrowth_evaluation_ == S2I::growth_evaluation_monolithic or
+      intlayergrowth_evaluation_ == S2I::growth_evaluation_semi_implicit)
   {
     // initialize reader
     std::shared_ptr<Core::IO::DiscretizationReader> reader(nullptr);
@@ -3222,7 +3194,7 @@ void ScaTra::MeshtyingStrategyS2I::read_restart(
     // read state vector of discrete scatra-scatra interface layer thicknesses
     reader->read_vector(growthn_, "growthn");
 
-    if (intlayergrowth_evaluation_ == Inpar::S2I::growth_evaluation_monolithic)
+    if (intlayergrowth_evaluation_ == S2I::growth_evaluation_monolithic)
     {
       // read state vector of time derivatives of discrete scatra-scatra interface layer thicknesses
       reader->read_vector(growthdtn_, "growthdtn");
@@ -3248,14 +3220,13 @@ void ScaTra::MeshtyingStrategyS2I::collect_output_data() const
 {
   // only relevant for monolithic or semi-implicit evaluation of scatra-scatra interface layer
   // growth
-  if (intlayergrowth_evaluation_ == Inpar::S2I::growth_evaluation_monolithic or
-      intlayergrowth_evaluation_ == Inpar::S2I::growth_evaluation_semi_implicit)
+  if (intlayergrowth_evaluation_ == S2I::growth_evaluation_monolithic or
+      intlayergrowth_evaluation_ == S2I::growth_evaluation_semi_implicit)
   {
     // extract relevant state vector of discrete scatra-scatra interface layer thicknesses based on
     // map of scatra-scatra interface layer thickness variables
     const Core::LinAlg::Vector<double>& growth =
-        intlayergrowth_evaluation_ == Inpar::S2I::growth_evaluation_monolithic ? *growthnp_
-                                                                               : *growthn_;
+        intlayergrowth_evaluation_ == S2I::growth_evaluation_monolithic ? *growthnp_ : *growthn_;
 
     // for proper output, initialize target state vector of discrete scatra-scatra interface layer
     // thicknesses based on map of row nodes
@@ -3329,8 +3300,8 @@ void ScaTra::MeshtyingStrategyS2I::output_interface_flux() const
   for (auto* s2ikinetics_cond : s2ikinetics_conditions)
   {
     // only slave side has relevant information
-    if (s2ikinetics_cond->parameters().get<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE") ==
-        static_cast<int>(Inpar::S2I::side_source))
+    if (s2ikinetics_cond->parameters().get<S2I::InterfaceSides>("INTERFACE_SIDE") ==
+        static_cast<int>(S2I::side_source))
     {
       const int condition_id = s2ikinetics_cond->parameters().get<int>("ConditionID");
       auto s2i_flux =
@@ -3380,7 +3351,7 @@ void ScaTra::MeshtyingStrategyS2I::output_interface_flux() const
 void ScaTra::MeshtyingStrategyS2I::explicit_predictor() const
 {
   // only relevant for monolithic evaluation of scatra-scatra interface layer growth
-  if (intlayergrowth_evaluation_ == Inpar::S2I::growth_evaluation_monolithic)
+  if (intlayergrowth_evaluation_ == S2I::growth_evaluation_monolithic)
     // predict state vector of discrete scatra-scatra interface layer thicknesses at time n+1
     growthnp_->update(scatratimint_->dt(), *growthdtn_, 1.);
 }
@@ -3421,7 +3392,7 @@ void ScaTra::MeshtyingStrategyS2I::extract_matrix_rows(
 void ScaTra::MeshtyingStrategyS2I::add_time_integration_specific_vectors() const
 {
   // only relevant for scatra-scatra interface coupling with pairwise coinciding interface nodes
-  if (couplingtype_ == Inpar::S2I::coupling_matching_nodes)
+  if (couplingtype_ == S2I::coupling_matching_nodes)
   {
     // add state vector containing master-side scatra degrees of freedom to scatra discretization
     interfacemaps_->insert_vector(
@@ -3443,13 +3414,12 @@ void ScaTra::MeshtyingStrategyS2I::add_time_integration_specific_vectors() const
 
   // only relevant for monolithic or semi-implicit evaluation of scatra-scatra interface layer
   // growth
-  if (intlayergrowth_evaluation_ == Inpar::S2I::growth_evaluation_monolithic or
-      intlayergrowth_evaluation_ == Inpar::S2I::growth_evaluation_semi_implicit)
+  if (intlayergrowth_evaluation_ == S2I::growth_evaluation_monolithic or
+      intlayergrowth_evaluation_ == S2I::growth_evaluation_semi_implicit)
   {
     // extract relevant state vector of discrete scatra-scatra interface layer thicknesses
     const std::shared_ptr<Core::LinAlg::Vector<double>>& growth =
-        intlayergrowth_evaluation_ == Inpar::S2I::growth_evaluation_monolithic ? growthnp_
-                                                                               : growthn_;
+        intlayergrowth_evaluation_ == S2I::growth_evaluation_monolithic ? growthnp_ : growthn_;
 
     // set state vector
     scatratimint_->discretization()->set_state(2, "growth", *growth);
@@ -3490,28 +3460,28 @@ void ScaTra::MeshtyingStrategyS2I::init_meshtying()
           "Can't have more than one boundary condition for scatra-scatra interface layer growth at "
           "the moment!");
     }
-    if (intlayergrowth_evaluation_ == Inpar::S2I::growth_evaluation_none)
+    if (intlayergrowth_evaluation_ == S2I::growth_evaluation_none)
     {
       FOUR_C_THROW(
           "Invalid flag for evaluation of scatra-scatra interface coupling involving interface "
           "layer growth!");
     }
-    if (intlayergrowth_evaluation_ == Inpar::S2I::growth_evaluation_monolithic and
+    if (intlayergrowth_evaluation_ == S2I::growth_evaluation_monolithic and
         scatratimint_->method_name() != ScaTra::timeint_one_step_theta)
     {
       FOUR_C_THROW(
           "Monolithic evaluation of scatra-scatra interface layer growth only implemented for "
           "one-step-theta time integration scheme at the moment!");
     }
-    if (intlayergrowth_evaluation_ == Inpar::S2I::growth_evaluation_semi_implicit and
-        conditions[0]->parameters().get<Inpar::S2I::RegularizationType>("REGTYPE") !=
-            Inpar::S2I::RegularizationType::regularization_none)
+    if (intlayergrowth_evaluation_ == S2I::growth_evaluation_semi_implicit and
+        conditions[0]->parameters().get<S2I::RegularizationType>("REGTYPE") !=
+            S2I::RegularizationType::regularization_none)
     {
       FOUR_C_THROW(
           "No regularization implemented for semi-implicit evaluation of scatra-scatra interface "
           "layer growth!");
     }
-    if (couplingtype_ != Inpar::S2I::coupling_matching_nodes)
+    if (couplingtype_ != S2I::coupling_matching_nodes)
     {
       FOUR_C_THROW(
           "Evaluation of scatra-scatra interface layer growth only implemented for conforming "
@@ -3543,7 +3513,7 @@ void ScaTra::MeshtyingStrategyS2I::init_meshtying()
     scatratimint_->set_number_of_dof_set_growth(number_dofsets);
     // initialize linear solver for monolithic scatra-scatra interface coupling involving interface
     // layer growth
-    if (intlayergrowth_evaluation_ == Inpar::S2I::growth_evaluation_monolithic)
+    if (intlayergrowth_evaluation_ == S2I::growth_evaluation_monolithic)
     {
       const int extendedsolver = Global::Problem::instance()
                                      ->scalar_transport_dynamic_params()
@@ -3565,7 +3535,7 @@ void ScaTra::MeshtyingStrategyS2I::init_meshtying()
   }  // initialize scatra-scatra interface layer growth
 
   // safety check
-  else if (intlayergrowth_evaluation_ != Inpar::S2I::growth_evaluation_none)
+  else if (intlayergrowth_evaluation_ != S2I::growth_evaluation_none)
   {
     FOUR_C_THROW(
         "Cannot evaluate scatra-scatra interface coupling involving interface layer growth without "
@@ -3634,7 +3604,7 @@ void ScaTra::MeshtyingStrategyS2I::build_block_map_extractors()
 void ScaTra::MeshtyingStrategyS2I::equip_extended_solver_with_null_space_info() const
 {
   // consider extended linear solver for scatra-scatra interface layer growth if applicable
-  if (intlayergrowth_evaluation_ == Inpar::S2I::growth_evaluation_monolithic)
+  if (intlayergrowth_evaluation_ == S2I::growth_evaluation_monolithic)
   {
     // loop over blocks of scalar transport system matrix
     for (int iblock = 0; iblock < scatratimint_->dof_block_maps()->num_maps(); ++iblock)
@@ -3684,16 +3654,16 @@ void ScaTra::MeshtyingStrategyS2I::solve(const std::shared_ptr<Core::LinAlg::Sol
   switch (intlayergrowth_evaluation_)
   {
     // no or semi-implicit treatment of scatra-scatra interface layer growth
-    case Inpar::S2I::growth_evaluation_none:
-    case Inpar::S2I::growth_evaluation_semi_implicit:
+    case S2I::growth_evaluation_none:
+    case S2I::growth_evaluation_semi_implicit:
     {
       switch (couplingtype_)
       {
-        case Inpar::S2I::coupling_matching_nodes:
-        case Inpar::S2I::coupling_mortar_standard:
-        case Inpar::S2I::coupling_mortar_condensed_petrov:
-        case Inpar::S2I::coupling_mortar_condensed_bubnov:
-        case Inpar::S2I::coupling_nts_standard:
+        case S2I::coupling_matching_nodes:
+        case S2I::coupling_mortar_standard:
+        case S2I::coupling_mortar_condensed_petrov:
+        case S2I::coupling_mortar_condensed_bubnov:
+        case S2I::coupling_nts_standard:
         {
           // equilibrate global system of equations if necessary
           equilibration_->equilibrate_system(
@@ -3710,8 +3680,8 @@ void ScaTra::MeshtyingStrategyS2I::solve(const std::shared_ptr<Core::LinAlg::Sol
           break;
         }
 
-        case Inpar::S2I::coupling_mortar_saddlepoint_petrov:
-        case Inpar::S2I::coupling_mortar_saddlepoint_bubnov:
+        case S2I::coupling_mortar_saddlepoint_petrov:
+        case S2I::coupling_mortar_saddlepoint_bubnov:
         {
           // check scalar transport system matrix
           std::shared_ptr<Core::LinAlg::SparseMatrix> sparsematrix =
@@ -3723,7 +3693,7 @@ void ScaTra::MeshtyingStrategyS2I::solve(const std::shared_ptr<Core::LinAlg::Sol
           Core::LinAlg::BlockSparseMatrix<Core::LinAlg::DefaultBlockMatrixStrategy>
               extendedsystemmatrix(*extendedmaps_, *extendedmaps_);
           extendedsystemmatrix.assign(0, 0, Core::LinAlg::DataAccess::Share, *sparsematrix);
-          if (lmside_ == Inpar::S2I::side_source)
+          if (lmside_ == S2I::side_source)
           {
             Core::LinAlg::matrix_add(*D_, true, 1., extendedsystemmatrix.matrix(0, 1), 0.);
             Core::LinAlg::matrix_add(*M_, true, -1., extendedsystemmatrix.matrix(0, 1), 1.);
@@ -3780,11 +3750,11 @@ void ScaTra::MeshtyingStrategyS2I::solve(const std::shared_ptr<Core::LinAlg::Sol
     }
 
     // monolithic treatment of scatra-scatra interface layer growth
-    case Inpar::S2I::growth_evaluation_monolithic:
+    case S2I::growth_evaluation_monolithic:
     {
       switch (couplingtype_)
       {
-        case Inpar::S2I::coupling_matching_nodes:
+        case S2I::coupling_matching_nodes:
         {
           switch (matrixtype_)
           {
@@ -3918,7 +3888,7 @@ const Core::LinAlg::Solver& ScaTra::MeshtyingStrategyS2I::solver() const
 {
   const Core::LinAlg::Solver* solver(nullptr);
 
-  if (intlayergrowth_evaluation_ == Inpar::S2I::growth_evaluation_monolithic)
+  if (intlayergrowth_evaluation_ == S2I::growth_evaluation_monolithic)
   {
     if (extendedsolver_ == nullptr) FOUR_C_THROW("Invalid linear solver!");
     solver = extendedsolver_.get();
@@ -4134,8 +4104,8 @@ void ScaTra::MeshtyingStrategyS2I::fd_check(
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-ScaTra::MortarCellInterface::MortarCellInterface(const Inpar::S2I::CouplingType& couplingtype,
-    const Inpar::S2I::InterfaceSides& lmside, const int& numdofpernode_slave,
+ScaTra::MortarCellInterface::MortarCellInterface(const S2I::CouplingType& couplingtype,
+    const S2I::InterfaceSides& lmside, const int& numdofpernode_slave,
     const int& numdofpernode_master)
     : lmside_(lmside),
       couplingtype_(couplingtype),
@@ -4148,12 +4118,12 @@ ScaTra::MortarCellInterface::MortarCellInterface(const Inpar::S2I::CouplingType&
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_s, Core::FE::CellType distype_m>
 ScaTra::MortarCellCalc<distype_s, distype_m>*
-ScaTra::MortarCellCalc<distype_s, distype_m>::instance(const Inpar::S2I::CouplingType& couplingtype,
-    const Inpar::S2I::InterfaceSides& lmside, const int& numdofpernode_slave,
+ScaTra::MortarCellCalc<distype_s, distype_m>::instance(const S2I::CouplingType& couplingtype,
+    const S2I::InterfaceSides& lmside, const int& numdofpernode_slave,
     const int& numdofpernode_master, const std::string& disname)
 {
   static auto singleton_map = Core::Utils::make_singleton_map<std::string>(
-      [](const Inpar::S2I::CouplingType& couplingtype, const Inpar::S2I::InterfaceSides& lmside,
+      [](const S2I::CouplingType& couplingtype, const S2I::InterfaceSides& lmside,
           const int& numdofpernode_slave, const int& numdofpernode_master)
       {
         return std::unique_ptr<MortarCellCalc<distype_s, distype_m>>(
@@ -4177,9 +4147,9 @@ void ScaTra::MortarCellCalc<distype_s, distype_m>::evaluate(
     Core::LinAlg::SerialDenseVector& cellvector1, Core::LinAlg::SerialDenseVector& cellvector2)
 {
   // extract and evaluate action
-  switch (Teuchos::getIntegralValue<Inpar::S2I::EvaluationActions>(params, "action"))
+  switch (Teuchos::getIntegralValue<S2I::EvaluationActions>(params, "action"))
   {
-    case Inpar::S2I::evaluate_mortar_matrices:
+    case S2I::evaluate_mortar_matrices:
     {
       // evaluate mortar matrices
       evaluate_mortar_matrices(
@@ -4188,7 +4158,7 @@ void ScaTra::MortarCellCalc<distype_s, distype_m>::evaluate(
       break;
     }
 
-    case Inpar::S2I::evaluate_condition:
+    case S2I::evaluate_condition:
     {
       // evaluate and assemble interface linearizations and residuals
       evaluate_condition(idiscret, cell, slaveelement, masterelement, la_slave, la_master, params,
@@ -4218,9 +4188,9 @@ void ScaTra::MortarCellCalc<distype_s, distype_m>::evaluate_nts(
     Core::LinAlg::SerialDenseVector& ntsvector2)
 {
   // extract and evaluate action
-  switch (Teuchos::getIntegralValue<Inpar::S2I::EvaluationActions>(params, "action"))
+  switch (Teuchos::getIntegralValue<S2I::EvaluationActions>(params, "action"))
   {
-    case Inpar::S2I::evaluate_condition_nts:
+    case S2I::evaluate_condition_nts:
     {
       // extract condition from parameter list
       const Core::Conditions::Condition* condition =
@@ -4258,9 +4228,9 @@ void ScaTra::MortarCellCalc<distype_s, distype_m>::evaluate_mortar_element(
     Core::LinAlg::SerialDenseVector& elevector1, Core::LinAlg::SerialDenseVector& elevector2)
 {
   // extract and evaluate action
-  switch (Teuchos::getIntegralValue<Inpar::S2I::EvaluationActions>(params, "action"))
+  switch (Teuchos::getIntegralValue<S2I::EvaluationActions>(params, "action"))
   {
-    case Inpar::S2I::evaluate_nodal_area_fractions:
+    case S2I::evaluate_nodal_area_fractions:
     {
       // evaluate and assemble lumped interface area fractions associated with element nodes
       evaluate_nodal_area_fractions(element, elevector1);
@@ -4279,9 +4249,9 @@ void ScaTra::MortarCellCalc<distype_s, distype_m>::evaluate_mortar_element(
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_s, Core::FE::CellType distype_m>
-ScaTra::MortarCellCalc<distype_s, distype_m>::MortarCellCalc(
-    const Inpar::S2I::CouplingType& couplingtype, const Inpar::S2I::InterfaceSides& lmside,
-    const int& numdofpernode_slave, const int& numdofpernode_master)
+ScaTra::MortarCellCalc<distype_s, distype_m>::MortarCellCalc(const S2I::CouplingType& couplingtype,
+    const S2I::InterfaceSides& lmside, const int& numdofpernode_slave,
+    const int& numdofpernode_master)
     : MortarCellInterface(couplingtype, lmside, numdofpernode_slave, numdofpernode_master),
       scatraparamsboundary_(Discret::Elements::ScaTraEleParameterBoundary::instance("scatra")),
       ephinp_slave_(numdofpernode_slave,
@@ -4389,7 +4359,7 @@ double ScaTra::MortarCellCalc<distype_s, distype_m>::eval_shape_func_and_dom_int
   Coupling::VolMortar::Utils::shape_function<distype_m>(funct_master_, coordinates_master.data());
   switch (couplingtype_)
   {
-    case Inpar::S2I::coupling_mortar_standard:
+    case S2I::coupling_mortar_standard:
     {
       // there actually aren't any Lagrange multipliers, but we still need to set pseudo Lagrange
       // multiplier test functions equal to the standard shape and test functions for correct
@@ -4400,12 +4370,12 @@ double ScaTra::MortarCellCalc<distype_s, distype_m>::eval_shape_func_and_dom_int
       break;
     }
 
-    case Inpar::S2I::coupling_mortar_saddlepoint_petrov:
-    case Inpar::S2I::coupling_mortar_condensed_petrov:
+    case S2I::coupling_mortar_saddlepoint_petrov:
+    case S2I::coupling_mortar_condensed_petrov:
     {
       // dual Lagrange multiplier shape functions combined with standard Lagrange multiplier test
       // functions
-      if (lmside_ == Inpar::S2I::side_source)
+      if (lmside_ == S2I::side_source)
       {
         Coupling::VolMortar::Utils::dual_shape_function<distype_s>(
             shape_lm_slave_, coordinates_slave.data(), slaveelement);
@@ -4421,12 +4391,12 @@ double ScaTra::MortarCellCalc<distype_s, distype_m>::eval_shape_func_and_dom_int
       break;
     }
 
-    case Inpar::S2I::coupling_mortar_saddlepoint_bubnov:
-    case Inpar::S2I::coupling_mortar_condensed_bubnov:
+    case S2I::coupling_mortar_saddlepoint_bubnov:
+    case S2I::coupling_mortar_condensed_bubnov:
     {
       // dual Lagrange multiplier shape functions combined with dual Lagrange multiplier test
       // functions
-      if (lmside_ == Inpar::S2I::side_source)
+      if (lmside_ == S2I::side_source)
       {
         Coupling::VolMortar::Utils::dual_shape_function<distype_s>(
             shape_lm_slave_, coordinates_slave.data(), slaveelement);
@@ -4499,7 +4469,7 @@ void ScaTra::MortarCellCalc<distype_s, distype_m>::eval_shape_func_at_slave_node
     const Mortar::Node& slavenode, Mortar::Element& slaveelement, Mortar::Element& masterelement)
 {
   // safety check
-  if (couplingtype_ != Inpar::S2I::coupling_nts_standard)
+  if (couplingtype_ != S2I::coupling_nts_standard)
     FOUR_C_THROW("This function should only be called when evaluating node-to-segment coupling!");
 
   // extract global ID of slave-side node
@@ -4555,7 +4525,7 @@ void ScaTra::MortarCellCalc<distype_s, distype_m>::evaluate_mortar_matrices(Mort
     const double fac = eval_shape_func_and_dom_int_fac_at_int_point(
         slaveelement, masterelement, cell, intpoints, iquad);
 
-    if (lmside_ == Inpar::S2I::side_source)
+    if (lmside_ == S2I::side_source)
     {
       // loop over all degrees of freedom per node
       for (int k = 0; k < numdofpernode_slave_; ++k)
@@ -4566,15 +4536,15 @@ void ScaTra::MortarCellCalc<distype_s, distype_m>::evaluate_mortar_matrices(Mort
 
           switch (couplingtype_)
           {
-            case Inpar::S2I::coupling_mortar_saddlepoint_petrov:
-            case Inpar::S2I::coupling_mortar_saddlepoint_bubnov:
-            case Inpar::S2I::coupling_mortar_condensed_petrov:
-            case Inpar::S2I::coupling_mortar_condensed_bubnov:
+            case S2I::coupling_mortar_saddlepoint_petrov:
+            case S2I::coupling_mortar_saddlepoint_bubnov:
+            case S2I::coupling_mortar_condensed_petrov:
+            case S2I::coupling_mortar_condensed_bubnov:
             {
               D(row_slave, row_slave) += shape_lm_slave_(vi) * fac;
 
-              if (couplingtype_ == Inpar::S2I::coupling_mortar_saddlepoint_bubnov or
-                  couplingtype_ == Inpar::S2I::coupling_mortar_condensed_bubnov)
+              if (couplingtype_ == S2I::coupling_mortar_saddlepoint_bubnov or
+                  couplingtype_ == S2I::coupling_mortar_condensed_bubnov)
               {
                 for (int ui = 0; ui < nen_slave_; ++ui)
                   E(row_slave, ui * numdofpernode_slave_ + k) +=
@@ -4612,15 +4582,15 @@ void ScaTra::MortarCellCalc<distype_s, distype_m>::evaluate_mortar_matrices(Mort
 
           switch (couplingtype_)
           {
-            case Inpar::S2I::coupling_mortar_saddlepoint_petrov:
-            case Inpar::S2I::coupling_mortar_saddlepoint_bubnov:
-            case Inpar::S2I::coupling_mortar_condensed_petrov:
-            case Inpar::S2I::coupling_mortar_condensed_bubnov:
+            case S2I::coupling_mortar_saddlepoint_petrov:
+            case S2I::coupling_mortar_saddlepoint_bubnov:
+            case S2I::coupling_mortar_condensed_petrov:
+            case S2I::coupling_mortar_condensed_bubnov:
             {
               D(row_master, row_master) += shape_lm_master_(vi) * fac;
 
-              if (couplingtype_ == Inpar::S2I::coupling_mortar_saddlepoint_bubnov or
-                  couplingtype_ == Inpar::S2I::coupling_mortar_condensed_bubnov)
+              if (couplingtype_ == S2I::coupling_mortar_saddlepoint_bubnov or
+                  couplingtype_ == S2I::coupling_mortar_condensed_bubnov)
               {
                 for (int ui = 0; ui < nen_master_; ++ui)
                   E(row_master, ui * numdofpernode_master_ + k) +=
@@ -4766,21 +4736,17 @@ void ScaTra::MortarCellCalc<distype_s, distype_m>::evaluate_nodal_area_fractions
  *----------------------------------------------------------------------*/
 ScaTra::MortarCellAssemblyStrategy::MortarCellAssemblyStrategy(
     std::shared_ptr<Core::LinAlg::SparseOperator> systemmatrix1,
-    const Inpar::S2I::InterfaceSides matrix1_side_rows,
-    const Inpar::S2I::InterfaceSides matrix1_side_cols,
+    const S2I::InterfaceSides matrix1_side_rows, const S2I::InterfaceSides matrix1_side_cols,
     std::shared_ptr<Core::LinAlg::SparseOperator> systemmatrix2,
-    const Inpar::S2I::InterfaceSides matrix2_side_rows,
-    const Inpar::S2I::InterfaceSides matrix2_side_cols,
+    const S2I::InterfaceSides matrix2_side_rows, const S2I::InterfaceSides matrix2_side_cols,
     std::shared_ptr<Core::LinAlg::SparseOperator> systemmatrix3,
-    const Inpar::S2I::InterfaceSides matrix3_side_rows,
-    const Inpar::S2I::InterfaceSides matrix3_side_cols,
+    const S2I::InterfaceSides matrix3_side_rows, const S2I::InterfaceSides matrix3_side_cols,
     std::shared_ptr<Core::LinAlg::SparseOperator> systemmatrix4,
-    const Inpar::S2I::InterfaceSides matrix4_side_rows,
-    const Inpar::S2I::InterfaceSides matrix4_side_cols,
+    const S2I::InterfaceSides matrix4_side_rows, const S2I::InterfaceSides matrix4_side_cols,
     std::shared_ptr<Core::LinAlg::MultiVector<double>> systemvector1,
-    const Inpar::S2I::InterfaceSides vector1_side,
+    const S2I::InterfaceSides vector1_side,
     std::shared_ptr<Core::LinAlg::FEVector<double>> systemvector2,
-    const Inpar::S2I::InterfaceSides vector2_side, const int nds_rows, const int nds_cols)
+    const S2I::InterfaceSides vector2_side, const int nds_rows, const int nds_cols)
     : matrix1_side_rows_(matrix1_side_rows),
       matrix1_side_cols_(matrix1_side_cols),
       matrix2_side_rows_(matrix2_side_rows),
@@ -4845,25 +4811,24 @@ void ScaTra::MortarCellAssemblyStrategy::assemble_cell_matrices_and_vectors(
  *----------------------------------------------------------------------------------*/
 void ScaTra::MortarCellAssemblyStrategy::assemble_cell_matrix(
     const std::shared_ptr<Core::LinAlg::SparseOperator>& systemmatrix,
-    const Core::LinAlg::SerialDenseMatrix& cellmatrix, const Inpar::S2I::InterfaceSides side_rows,
-    const Inpar::S2I::InterfaceSides side_cols, Core::Elements::LocationArray& la_slave,
+    const Core::LinAlg::SerialDenseMatrix& cellmatrix, const S2I::InterfaceSides side_rows,
+    const S2I::InterfaceSides side_cols, Core::Elements::LocationArray& la_slave,
     Core::Elements::LocationArray& la_master, const int assembler_pid_master) const
 {
   // determine location array associated with matrix columns
-  Core::Elements::LocationArray& la_cols =
-      side_cols == Inpar::S2I::side_source ? la_slave : la_master;
+  Core::Elements::LocationArray& la_cols = side_cols == S2I::side_source ? la_slave : la_master;
 
   // assemble cell matrix into system matrix
   switch (side_rows)
   {
-    case Inpar::S2I::side_source:
+    case S2I::side_source:
     {
       systemmatrix->assemble(-1, la_cols[nds_cols_].stride_, cellmatrix, la_slave[nds_rows_].lm_,
           la_slave[nds_rows_].lmowner_, la_cols[nds_cols_].lm_);
       break;
     }
 
-    case Inpar::S2I::side_master:
+    case S2I::side_master:
     {
       std::dynamic_pointer_cast<Core::LinAlg::SparseMatrix>(systemmatrix)
           ->fe_assemble(cellmatrix, la_master[nds_rows_].lm_,
@@ -4885,14 +4850,14 @@ void ScaTra::MortarCellAssemblyStrategy::assemble_cell_matrix(
  *----------------------------------------------------------------------------------*/
 void ScaTra::MortarCellAssemblyStrategy::assemble_cell_vector(
     Core::LinAlg::MultiVector<double>& systemvector,
-    const Core::LinAlg::SerialDenseVector& cellvector, const Inpar::S2I::InterfaceSides side,
+    const Core::LinAlg::SerialDenseVector& cellvector, const S2I::InterfaceSides side,
     Core::Elements::LocationArray& la_slave, Core::Elements::LocationArray& la_master,
     const int assembler_pid_master) const
 {
   // assemble cell vector into system vector
   switch (side)
   {
-    case Inpar::S2I::side_source:
+    case S2I::side_source:
     {
       if (systemvector.num_vectors() != 1)
         FOUR_C_THROW("Invalid number of vectors inside Core::LinAlg::MultiVector<double>!");
@@ -4902,7 +4867,7 @@ void ScaTra::MortarCellAssemblyStrategy::assemble_cell_vector(
       break;
     }
 
-    case Inpar::S2I::side_master:
+    case S2I::side_master:
     {
       if (assembler_pid_master == Core::Communication::my_mpi_rank(systemvector.get_comm()))
       {
@@ -4925,20 +4890,20 @@ void ScaTra::MortarCellAssemblyStrategy::assemble_cell_vector(
  *----------------------------------------------------------------------------------*/
 void ScaTra::MortarCellAssemblyStrategy::assemble_cell_vector(
     const std::shared_ptr<Core::LinAlg::FEVector<double>>& systemvector,
-    const Core::LinAlg::SerialDenseVector& cellvector, const Inpar::S2I::InterfaceSides side,
+    const Core::LinAlg::SerialDenseVector& cellvector, const S2I::InterfaceSides side,
     Core::Elements::LocationArray& la_slave, Core::Elements::LocationArray& la_master,
     const int assembler_pid_master) const
 {
   // assemble cell vector into system vector
   switch (side)
   {
-    case Inpar::S2I::side_source:
+    case S2I::side_source:
     {
       FOUR_C_ASSERT(false, "Don't know what to do, does not work for FE-Vectors.");
       break;
     }
 
-    case Inpar::S2I::side_master:
+    case S2I::side_master:
     {
       if (assembler_pid_master == Core::Communication::my_mpi_rank(systemvector->get_comm()))
       {
@@ -4990,15 +4955,15 @@ void ScaTra::MortarCellAssemblyStrategy::init_cell_matrices_and_vectors(
 /*---------------------------------------------------------------------------*
  *---------------------------------------------------------------------------*/
 void ScaTra::MortarCellAssemblyStrategy::init_cell_matrix(
-    Core::LinAlg::SerialDenseMatrix& cellmatrix, const Inpar::S2I::InterfaceSides side_rows,
-    const Inpar::S2I::InterfaceSides side_cols, Core::Elements::LocationArray& la_slave,
+    Core::LinAlg::SerialDenseMatrix& cellmatrix, const S2I::InterfaceSides side_rows,
+    const S2I::InterfaceSides side_cols, Core::Elements::LocationArray& la_slave,
     Core::Elements::LocationArray& la_master) const
 {
   // determine number of matrix rows and number of matrix columns
-  const int nrows = side_rows == Inpar::S2I::side_source ? la_slave[nds_rows_].size()
-                                                         : la_master[nds_rows_].size();
-  const int ncols = side_cols == Inpar::S2I::side_source ? la_slave[nds_cols_].size()
-                                                         : la_master[nds_cols_].size();
+  const int nrows =
+      side_rows == S2I::side_source ? la_slave[nds_rows_].size() : la_master[nds_rows_].size();
+  const int ncols =
+      side_cols == S2I::side_source ? la_slave[nds_cols_].size() : la_master[nds_cols_].size();
 
   // reshape cell matrix if necessary
   if (cellmatrix.numRows() != nrows or cellmatrix.numCols() != ncols)
@@ -5015,12 +4980,12 @@ void ScaTra::MortarCellAssemblyStrategy::init_cell_matrix(
 /*---------------------------------------------------------------------------*
  *---------------------------------------------------------------------------*/
 void ScaTra::MortarCellAssemblyStrategy::init_cell_vector(
-    Core::LinAlg::SerialDenseVector& cellvector, const Inpar::S2I::InterfaceSides side,
+    Core::LinAlg::SerialDenseVector& cellvector, const S2I::InterfaceSides side,
     Core::Elements::LocationArray& la_slave, Core::Elements::LocationArray& la_master) const
 {
   // determine number of vector components
   const int ndofs =
-      side == Inpar::S2I::side_source ? la_slave[nds_rows_].size() : la_master[nds_rows_].size();
+      side == S2I::side_source ? la_slave[nds_rows_].size() : la_master[nds_rows_].size();
 
   // reshape cell vector if necessary
   if (cellvector.length() != ndofs)

--- a/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.hpp
+++ b/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.hpp
@@ -16,11 +16,11 @@
 #include "4C_fem_condition.hpp"
 #include "4C_fem_general_element.hpp"
 #include "4C_fem_general_utils_local_connectivity_matrices.hpp"
-#include "4C_inpar_s2i.hpp"
 #include "4C_io_runtime_csv_writer.hpp"
 #include "4C_linalg_fevector.hpp"
 #include "4C_linalg_serialdensevector.hpp"
 #include "4C_scatra_input.hpp"
+#include "4C_scatra_s2i_input.hpp"
 #include "4C_scatra_timint_meshtying_strategy_base.hpp"
 
 FOUR_C_NAMESPACE_OPEN
@@ -113,7 +113,7 @@ namespace ScaTra
     std::shared_ptr<const Coupling::Adapter::Coupling> coupling_adapter() const { return icoup_; };
 
     //! return flag for meshtying method
-    const Inpar::S2I::CouplingType& coupling_type() const { return couplingtype_; }
+    const S2I::CouplingType& coupling_type() const { return couplingtype_; }
 
     //! return global map of degrees of freedom
     const Core::LinAlg::Map& dof_row_map() const override;
@@ -182,7 +182,7 @@ namespace ScaTra
 
     //! return flag for evaluation of scatra-scatra interface coupling involving interface layer
     //! growth
-    const Inpar::S2I::GrowthEvaluation& int_layer_growth_evaluation() const
+    const S2I::GrowthEvaluation& int_layer_growth_evaluation() const
     {
       return intlayergrowth_evaluation_;
     };
@@ -353,7 +353,7 @@ namespace ScaTra
     std::shared_ptr<Core::LinAlg::SparseMatrix> imasterslavematrix_;
 
     //! flag for meshtying method
-    const Inpar::S2I::CouplingType couplingtype_;
+    const S2I::CouplingType couplingtype_;
 
     //! mortar matrix D
     std::shared_ptr<Core::LinAlg::SparseMatrix> D_;
@@ -404,7 +404,7 @@ namespace ScaTra
     std::shared_ptr<Core::LinAlg::Vector<double>> imasterphi_on_slave_side_np_;
 
     //! flag for interface side underlying Lagrange multiplier definition
-    const Inpar::S2I::InterfaceSides lmside_;
+    const S2I::InterfaceSides lmside_;
 
     //! type of global system matrix in global system of equations
     const Core::LinAlg::MatrixType matrixtype_;
@@ -413,7 +413,7 @@ namespace ScaTra
     const double ntsprojtol_;
 
     //! flag for evaluation of scatra-scatra interface coupling involving interface layer growth
-    const Inpar::S2I::GrowthEvaluation intlayergrowth_evaluation_;
+    const S2I::GrowthEvaluation intlayergrowth_evaluation_;
 
     //! local Newton-Raphson convergence tolerance for scatra-scatra interface coupling involving
     //! interface layer growth
@@ -603,21 +603,17 @@ namespace ScaTra
     void evaluate_mortar_cells(const Core::FE::Discretization& idiscret,
         const Teuchos::ParameterList& params,
         const std::shared_ptr<Core::LinAlg::SparseOperator>& systemmatrix1,
-        const Inpar::S2I::InterfaceSides matrix1_side_rows,
-        const Inpar::S2I::InterfaceSides matrix1_side_cols,
+        const S2I::InterfaceSides matrix1_side_rows, const S2I::InterfaceSides matrix1_side_cols,
         const std::shared_ptr<Core::LinAlg::SparseOperator>& systemmatrix2,
-        const Inpar::S2I::InterfaceSides matrix2_side_rows,
-        const Inpar::S2I::InterfaceSides matrix2_side_cols,
+        const S2I::InterfaceSides matrix2_side_rows, const S2I::InterfaceSides matrix2_side_cols,
         const std::shared_ptr<Core::LinAlg::SparseOperator>& systemmatrix3,
-        const Inpar::S2I::InterfaceSides matrix3_side_rows,
-        const Inpar::S2I::InterfaceSides matrix3_side_cols,
+        const S2I::InterfaceSides matrix3_side_rows, const S2I::InterfaceSides matrix3_side_cols,
         const std::shared_ptr<Core::LinAlg::SparseOperator>& systemmatrix4,
-        const Inpar::S2I::InterfaceSides matrix4_side_rows,
-        const Inpar::S2I::InterfaceSides matrix4_side_cols,
+        const S2I::InterfaceSides matrix4_side_rows, const S2I::InterfaceSides matrix4_side_cols,
         const std::shared_ptr<Core::LinAlg::MultiVector<double>>& systemvector1,
-        const Inpar::S2I::InterfaceSides vector1_side,
+        const S2I::InterfaceSides vector1_side,
         const std::shared_ptr<Core::LinAlg::FEVector<double>>& systemvector2,
-        const Inpar::S2I::InterfaceSides vector2_side) const;
+        const S2I::InterfaceSides vector2_side) const;
 
     /*!
      * @brief  evaluate node-to-segment coupling
@@ -651,21 +647,17 @@ namespace ScaTra
         const Core::LinAlg::Vector<int>& islavenodesimpltypes,
         const Core::FE::Discretization& idiscret, const Teuchos::ParameterList& params,
         const std::shared_ptr<Core::LinAlg::SparseOperator>& systemmatrix1,
-        const Inpar::S2I::InterfaceSides matrix1_side_rows,
-        const Inpar::S2I::InterfaceSides matrix1_side_cols,
+        const S2I::InterfaceSides matrix1_side_rows, const S2I::InterfaceSides matrix1_side_cols,
         const std::shared_ptr<Core::LinAlg::SparseOperator>& systemmatrix2,
-        const Inpar::S2I::InterfaceSides matrix2_side_rows,
-        const Inpar::S2I::InterfaceSides matrix2_side_cols,
+        const S2I::InterfaceSides matrix2_side_rows, const S2I::InterfaceSides matrix2_side_cols,
         const std::shared_ptr<Core::LinAlg::SparseOperator>& systemmatrix3,
-        const Inpar::S2I::InterfaceSides matrix3_side_rows,
-        const Inpar::S2I::InterfaceSides matrix3_side_cols,
+        const S2I::InterfaceSides matrix3_side_rows, const S2I::InterfaceSides matrix3_side_cols,
         const std::shared_ptr<Core::LinAlg::SparseOperator>& systemmatrix4,
-        const Inpar::S2I::InterfaceSides matrix4_side_rows,
-        const Inpar::S2I::InterfaceSides matrix4_side_cols,
+        const S2I::InterfaceSides matrix4_side_rows, const S2I::InterfaceSides matrix4_side_cols,
         const std::shared_ptr<Core::LinAlg::MultiVector<double>>& systemvector1,
-        const Inpar::S2I::InterfaceSides vector1_side,
+        const S2I::InterfaceSides vector1_side,
         const std::shared_ptr<Core::LinAlg::FEVector<double>>& systemvector2,
-        const Inpar::S2I::InterfaceSides vector2_side) const;
+        const S2I::InterfaceSides vector2_side) const;
 
     /*!
      * @brief  evaluate mortar elements
@@ -695,21 +687,17 @@ namespace ScaTra
         const Core::LinAlg::Vector<int>& ieleimpltypes, const Core::FE::Discretization& idiscret,
         const Teuchos::ParameterList& params,
         const std::shared_ptr<Core::LinAlg::SparseOperator>& systemmatrix1,
-        const Inpar::S2I::InterfaceSides matrix1_side_rows,
-        const Inpar::S2I::InterfaceSides matrix1_side_cols,
+        const S2I::InterfaceSides matrix1_side_rows, const S2I::InterfaceSides matrix1_side_cols,
         const std::shared_ptr<Core::LinAlg::SparseOperator>& systemmatrix2,
-        const Inpar::S2I::InterfaceSides matrix2_side_rows,
-        const Inpar::S2I::InterfaceSides matrix2_side_cols,
+        const S2I::InterfaceSides matrix2_side_rows, const S2I::InterfaceSides matrix2_side_cols,
         const std::shared_ptr<Core::LinAlg::SparseOperator>& systemmatrix3,
-        const Inpar::S2I::InterfaceSides matrix3_side_rows,
-        const Inpar::S2I::InterfaceSides matrix3_side_cols,
+        const S2I::InterfaceSides matrix3_side_rows, const S2I::InterfaceSides matrix3_side_cols,
         const std::shared_ptr<Core::LinAlg::SparseOperator>& systemmatrix4,
-        const Inpar::S2I::InterfaceSides matrix4_side_rows,
-        const Inpar::S2I::InterfaceSides matrix4_side_cols,
+        const S2I::InterfaceSides matrix4_side_rows, const S2I::InterfaceSides matrix4_side_cols,
         const std::shared_ptr<Core::LinAlg::MultiVector<double>>& systemvector1,
-        const Inpar::S2I::InterfaceSides vector1_side,
+        const S2I::InterfaceSides vector1_side,
         const std::shared_ptr<Core::LinAlg::FEVector<double>>& systemvector2,
-        const Inpar::S2I::InterfaceSides vector2_side) const;
+        const S2I::InterfaceSides vector2_side) const;
 
     //! flag indicating if we have capacitive interface flux contributions
     bool has_capacitive_contributions_;
@@ -788,19 +776,18 @@ namespace ScaTra
 
    protected:
     //! protected constructor for singletons
-    MortarCellInterface(
-        const Inpar::S2I::CouplingType& couplingtype,  //!< flag for meshtying method
-        const Inpar::S2I::InterfaceSides&
+    MortarCellInterface(const S2I::CouplingType& couplingtype,  //!< flag for meshtying method
+        const S2I::InterfaceSides&
             lmside,  //!< flag for interface side underlying Lagrange multiplier definition
         const int& numdofpernode_slave,  //!< number of slave-side degrees of freedom per node
         const int& numdofpernode_master  //!< number of master-side degrees of freedom per node
     );
 
     //! flag for interface side underlying Lagrange multiplier definition
-    const Inpar::S2I::InterfaceSides lmside_;
+    const S2I::InterfaceSides lmside_;
 
     //! flag for meshtying method
-    const Inpar::S2I::CouplingType couplingtype_;
+    const S2I::CouplingType couplingtype_;
 
     //! number of slave-side degrees of freedom per node
     const int numdofpernode_slave_;
@@ -816,8 +803,8 @@ namespace ScaTra
    public:
     //! singleton access method
     static MortarCellCalc<distype_s, distype_m>* instance(
-        const Inpar::S2I::CouplingType& couplingtype,  //!< flag for meshtying method
-        const Inpar::S2I::InterfaceSides&
+        const S2I::CouplingType& couplingtype,  //!< flag for meshtying method
+        const S2I::InterfaceSides&
             lmside,  //!< flag for interface side underlying Lagrange multiplier definition
         const int& numdofpernode_slave,   //!< number of slave-side degrees of freedom per node
         const int& numdofpernode_master,  //!< number of master-side degrees of freedom per node
@@ -887,8 +874,8 @@ namespace ScaTra
     static constexpr int nsd_master_ = Core::FE::dim<distype_m>;
 
     //! protected constructor for singletons
-    MortarCellCalc(const Inpar::S2I::CouplingType& couplingtype,  //!< flag for meshtying method
-        const Inpar::S2I::InterfaceSides&
+    MortarCellCalc(const S2I::CouplingType& couplingtype,  //!< flag for meshtying method
+        const S2I::InterfaceSides&
             lmside,  //!< flag for interface side underlying Lagrange multiplier definition
         const int& numdofpernode_slave,  //!< number of slave-side degrees of freedom per node
         const int& numdofpernode_master  //!< number of master-side degrees of freedom per node
@@ -1056,10 +1043,10 @@ namespace ScaTra
     static MortarCellInterface* mortar_cell_calc(
         const ScaTra::ImplType&
             impltype,  //!< physical implementation type of mortar integration cell
-        const Mortar::Element& slaveelement,           //!< slave-side mortar element
-        const Mortar::Element& masterelement,          //!< master-side mortar element
-        const Inpar::S2I::CouplingType& couplingtype,  //!< flag for meshtying method
-        const Inpar::S2I::InterfaceSides&
+        const Mortar::Element& slaveelement,    //!< slave-side mortar element
+        const Mortar::Element& masterelement,   //!< master-side mortar element
+        const S2I::CouplingType& couplingtype,  //!< flag for meshtying method
+        const S2I::InterfaceSides&
             lmside,  //!< flag for interface side underlying Lagrange multiplier definition
         const std::string& disname  //!< name of interface discretization
     );
@@ -1071,9 +1058,9 @@ namespace ScaTra
     static MortarCellInterface* mortar_cell_calc(
         const ScaTra::ImplType&
             impltype,  //!< physical implementation type of mortar integration cell
-        const Mortar::Element& masterelement,          //!< master-side mortar element
-        const Inpar::S2I::CouplingType& couplingtype,  //!< flag for meshtying method
-        const Inpar::S2I::InterfaceSides&
+        const Mortar::Element& masterelement,   //!< master-side mortar element
+        const S2I::CouplingType& couplingtype,  //!< flag for meshtying method
+        const S2I::InterfaceSides&
             lmside,  //!< flag for interface side underlying Lagrange multiplier definition
         const int& numdofpernode_slave,  //!< number of slave-side degrees of freedom per node
         const std::string& disname       //!< name of interface discretization
@@ -1084,8 +1071,8 @@ namespace ScaTra
     static MortarCellInterface* mortar_cell_calc(
         const ScaTra::ImplType&
             impltype,  //!< physical implementation type of mortar integration cell
-        const Inpar::S2I::CouplingType& couplingtype,  //!< flag for meshtying method
-        const Inpar::S2I::InterfaceSides&
+        const S2I::CouplingType& couplingtype,  //!< flag for meshtying method
+        const S2I::InterfaceSides&
             lmside,  //!< flag for interface side underlying Lagrange multiplier definition
         const int& numdofpernode_slave,   //!< number of slave-side degrees of freedom per node
         const int& numdofpernode_master,  //!< number of master-side degrees of freedom per node
@@ -1100,33 +1087,31 @@ namespace ScaTra
     //! constructor
     MortarCellAssemblyStrategy(
         std::shared_ptr<Core::LinAlg::SparseOperator> systemmatrix1,  //!< system matrix 1
-        const Inpar::S2I::InterfaceSides
+        const S2I::InterfaceSides
             matrix1_side_rows,  //!< interface side associated with rows of system matrix 1
-        const Inpar::S2I::InterfaceSides
+        const S2I::InterfaceSides
             matrix1_side_cols,  //!< interface side associated with columns of system matrix 1
         std::shared_ptr<Core::LinAlg::SparseOperator> systemmatrix2,  //!< system matrix 2
-        const Inpar::S2I::InterfaceSides
+        const S2I::InterfaceSides
             matrix2_side_rows,  //!< interface side associated with rows of system matrix 2
-        const Inpar::S2I::InterfaceSides
+        const S2I::InterfaceSides
             matrix2_side_cols,  //!< interface side associated with columns of system matrix 2
         std::shared_ptr<Core::LinAlg::SparseOperator> systemmatrix3,  //!< system matrix 3
-        const Inpar::S2I::InterfaceSides
+        const S2I::InterfaceSides
             matrix3_side_rows,  //!< interface side associated with rows of system matrix 3
-        const Inpar::S2I::InterfaceSides
+        const S2I::InterfaceSides
             matrix3_side_cols,  //!< interface side associated with columns of system matrix 3
         std::shared_ptr<Core::LinAlg::SparseOperator> systemmatrix4,  //!< system matrix 4
-        const Inpar::S2I::InterfaceSides
+        const S2I::InterfaceSides
             matrix4_side_rows,  //!< interface side associated with rows of system matrix 4
-        const Inpar::S2I::InterfaceSides
+        const S2I::InterfaceSides
             matrix4_side_cols,  //!< interface side associated with columns of system matrix 4
         std::shared_ptr<Core::LinAlg::MultiVector<double>> systemvector1,  //!< system vector 1
-        const Inpar::S2I::InterfaceSides
-            vector1_side,  //!< interface side associated with system vector 1
+        const S2I::InterfaceSides vector1_side,  //!< interface side associated with system vector 1
         std::shared_ptr<Core::LinAlg::FEVector<double>> systemvector2,
-        const Inpar::S2I::InterfaceSides
-            vector2_side,        //!< interface side associated with system vector 2
-        const int nds_rows = 0,  //!< number of dofset associated with matrix rows
-        const int nds_cols = 0   //!< number of dofset associated with matrix columns
+        const S2I::InterfaceSides vector2_side,  //!< interface side associated with system vector 2
+        const int nds_rows = 0,                  //!< number of dofset associated with matrix rows
+        const int nds_cols = 0  //!< number of dofset associated with matrix columns
     );
 
     /*!
@@ -1195,10 +1180,9 @@ namespace ScaTra
      * @param assembler_pid_master   ID of processor performing master-side matrix assembly
      */
     void assemble_cell_matrix(const std::shared_ptr<Core::LinAlg::SparseOperator>& systemmatrix,
-        const Core::LinAlg::SerialDenseMatrix& cellmatrix,
-        const Inpar::S2I::InterfaceSides side_rows, const Inpar::S2I::InterfaceSides side_cols,
-        Core::Elements::LocationArray& la_slave, Core::Elements::LocationArray& la_master,
-        const int assembler_pid_master) const;
+        const Core::LinAlg::SerialDenseMatrix& cellmatrix, const S2I::InterfaceSides side_rows,
+        const S2I::InterfaceSides side_cols, Core::Elements::LocationArray& la_slave,
+        Core::Elements::LocationArray& la_master, const int assembler_pid_master) const;
 
     /*!
      * @brief  assemble cell vector into system vector
@@ -1211,12 +1195,12 @@ namespace ScaTra
      * @param assembler_pid_master  ID of processor performing master-side vector assembly
      */
     void assemble_cell_vector(Core::LinAlg::MultiVector<double>& systemvector,
-        const Core::LinAlg::SerialDenseVector& cellvector, const Inpar::S2I::InterfaceSides side,
+        const Core::LinAlg::SerialDenseVector& cellvector, const S2I::InterfaceSides side,
         Core::Elements::LocationArray& la_slave, Core::Elements::LocationArray& la_master,
         const int assembler_pid_master) const;
 
     void assemble_cell_vector(const std::shared_ptr<Core::LinAlg::FEVector<double>>& systemvector,
-        const Core::LinAlg::SerialDenseVector& cellvector, const Inpar::S2I::InterfaceSides side,
+        const Core::LinAlg::SerialDenseVector& cellvector, const S2I::InterfaceSides side,
         Core::Elements::LocationArray& la_slave, Core::Elements::LocationArray& la_master,
         const int assembler_pid_master) const;
 
@@ -1230,7 +1214,7 @@ namespace ScaTra
      * @param la_master  master-side location array
      */
     void init_cell_matrix(Core::LinAlg::SerialDenseMatrix& cellmatrix,
-        const Inpar::S2I::InterfaceSides side_rows, const Inpar::S2I::InterfaceSides side_cols,
+        const S2I::InterfaceSides side_rows, const S2I::InterfaceSides side_cols,
         Core::Elements::LocationArray& la_slave, Core::Elements::LocationArray& la_master) const;
 
     /*!
@@ -1242,7 +1226,7 @@ namespace ScaTra
      * @param la_master   master-side location array
      */
     void init_cell_vector(Core::LinAlg::SerialDenseVector& cellvector,
-        const Inpar::S2I::InterfaceSides side, Core::Elements::LocationArray& la_slave,
+        const S2I::InterfaceSides side, Core::Elements::LocationArray& la_slave,
         Core::Elements::LocationArray& la_master) const;
 
     //! cell matrix 1
@@ -1264,28 +1248,28 @@ namespace ScaTra
     Core::LinAlg::SerialDenseVector cellvector2_;
 
     //! interface side associated with rows of system matrix 1
-    const Inpar::S2I::InterfaceSides matrix1_side_rows_;
+    const S2I::InterfaceSides matrix1_side_rows_;
 
     //! interface side associated with columns of system matrix 1
-    const Inpar::S2I::InterfaceSides matrix1_side_cols_;
+    const S2I::InterfaceSides matrix1_side_cols_;
 
     //! interface side associated with rows of system matrix 2
-    const Inpar::S2I::InterfaceSides matrix2_side_rows_;
+    const S2I::InterfaceSides matrix2_side_rows_;
 
     //! interface side associated with columns of system matrix 2
-    const Inpar::S2I::InterfaceSides matrix2_side_cols_;
+    const S2I::InterfaceSides matrix2_side_cols_;
 
     //! interface side associated with rows of system matrix 3
-    const Inpar::S2I::InterfaceSides matrix3_side_rows_;
+    const S2I::InterfaceSides matrix3_side_rows_;
 
     //! interface side associated with columns of system matrix 3
-    const Inpar::S2I::InterfaceSides matrix3_side_cols_;
+    const S2I::InterfaceSides matrix3_side_cols_;
 
     //! interface side associated with rows of system matrix 4
-    const Inpar::S2I::InterfaceSides matrix4_side_rows_;
+    const S2I::InterfaceSides matrix4_side_rows_;
 
     //! interface side associated with columns of system matrix 4
-    const Inpar::S2I::InterfaceSides matrix4_side_cols_;
+    const S2I::InterfaceSides matrix4_side_cols_;
 
     //! system matrix 1
     const std::shared_ptr<Core::LinAlg::SparseOperator> systemmatrix1_;
@@ -1306,10 +1290,10 @@ namespace ScaTra
     const std::shared_ptr<Core::LinAlg::FEVector<double>> systemvector2_;
 
     //! interface side associated with system vector 1
-    const Inpar::S2I::InterfaceSides vector1_side_;
+    const S2I::InterfaceSides vector1_side_;
 
     //! interface side associated with system vector 2
-    const Inpar::S2I::InterfaceSides vector2_side_;
+    const S2I::InterfaceSides vector2_side_;
 
     //! number of dofset associated with matrix rows
     const int nds_rows_;

--- a/src/scatra/4C_scatra_timint_meshtying_strategy_s2i_elch.cpp
+++ b/src/scatra/4C_scatra_timint_meshtying_strategy_s2i_elch.cpp
@@ -202,12 +202,11 @@ void ScaTra::MeshtyingStrategyS2IElch::evaluate_point_coupling()
 
     // compute matrix and vector contributions according to kinetic model for current point coupling
     // condition
-    const int kinetic_model =
-        cond_slave->parameters().get<Inpar::S2I::KineticModels>("KINETIC_MODEL");
+    const int kinetic_model = cond_slave->parameters().get<S2I::KineticModels>("KINETIC_MODEL");
     switch (kinetic_model)
     {
-      case Inpar::S2I::kinetics_butlervolmer:
-      case Inpar::S2I::kinetics_butlervolmerreduced:
+      case S2I::kinetics_butlervolmer:
+      case S2I::kinetics_butlervolmerreduced:
       {
         // access material of electrode
         auto matelectrode = std::dynamic_pointer_cast<const Mat::Electrode>(
@@ -279,8 +278,8 @@ void ScaTra::MeshtyingStrategyS2IElch::evaluate_point_coupling()
         const double eta = ed_pot - el_pot - epd;
 
         // Butler-Volmer exchange mass flux density
-        const double j0 = cond_slave->parameters().get<Inpar::S2I::KineticModels>(
-                              "KINETIC_MODEL") == Inpar::S2I::kinetics_butlervolmerreduced
+        const double j0 = cond_slave->parameters().get<S2I::KineticModels>("KINETIC_MODEL") ==
+                                  S2I::kinetics_butlervolmerreduced
                               ? kr
                               : kr * std::pow(el_conc, alphaa) * std::pow(cmax - ed_conc, alphaa) *
                                     std::pow(ed_conc, alphac);
@@ -337,7 +336,7 @@ void ScaTra::MeshtyingStrategyS2IElch::evaluate_point_coupling()
 
         break;
       }
-      case Inpar::S2I::kinetics_nointerfaceflux:
+      case S2I::kinetics_nointerfaceflux:
         break;
 
       default:
@@ -353,8 +352,8 @@ void ScaTra::MeshtyingStrategyS2IElch::evaluate_point_coupling()
  *------------------------------------------------------------------------*/
 void ScaTra::MeshtyingStrategyS2IElch::init_conv_check_strategy()
 {
-  if (couplingtype_ == Inpar::S2I::coupling_mortar_saddlepoint_petrov or
-      couplingtype_ == Inpar::S2I::coupling_mortar_saddlepoint_bubnov)
+  if (couplingtype_ == S2I::coupling_mortar_saddlepoint_petrov or
+      couplingtype_ == S2I::coupling_mortar_saddlepoint_bubnov)
   {
     convcheckstrategy_ = std::make_shared<ScaTra::ConvCheckStrategyS2ILMElch>(
         scatratimint_->scatra_parameter_list()->sublist("NONLINEAR"));
@@ -376,7 +375,7 @@ void ScaTra::MeshtyingStrategyS2IElch::init_conv_check_strategy()
 void ScaTra::MeshtyingStrategyS2IElch::update() const
 {
   // update scatra-scatra interface layer thicknesses in case of semi-implicit solution approach
-  if (intlayergrowth_evaluation_ == Inpar::S2I::growth_evaluation_semi_implicit)
+  if (intlayergrowth_evaluation_ == S2I::growth_evaluation_semi_implicit)
   {
     // extract boundary conditions for scatra-scatra interface layer growth
     std::vector<const Core::Conditions::Condition*> conditions;
@@ -387,9 +386,9 @@ void ScaTra::MeshtyingStrategyS2IElch::update() const
     {
       // extract current condition
       // extract kinetic model from current condition
-      switch (condition->parameters().get<Inpar::S2I::GrowthKineticModels>("KINETIC_MODEL"))
+      switch (condition->parameters().get<S2I::GrowthKineticModels>("KINETIC_MODEL"))
       {
-        case Inpar::S2I::growth_kinetics_butlervolmer:
+        case S2I::growth_kinetics_butlervolmer:
         {
           // extract parameters from current condition
           const auto kr = condition->parameters().get<double>("K_R");
@@ -540,8 +539,8 @@ void ScaTra::MeshtyingStrategyS2IElch::update() const
 template <Core::FE::CellType distype_s, Core::FE::CellType distype_m>
 ScaTra::MortarCellCalcElch<distype_s, distype_m>*
 ScaTra::MortarCellCalcElch<distype_s, distype_m>::instance(
-    const Inpar::S2I::CouplingType& couplingtype,  //!< flag for meshtying method
-    const Inpar::S2I::InterfaceSides&
+    const S2I::CouplingType& couplingtype,  //!< flag for meshtying method
+    const S2I::InterfaceSides&
         lmside,  //!< flag for interface side underlying Lagrange multiplier definition
     const int& numdofpernode_slave,   //!< number of slave-side degrees of freedom per node
     const int& numdofpernode_master,  //!< number of master-side degrees of freedom per node
@@ -549,7 +548,7 @@ ScaTra::MortarCellCalcElch<distype_s, distype_m>::instance(
 )
 {
   static auto singleton_map = Core::Utils::make_singleton_map<std::string>(
-      [](const Inpar::S2I::CouplingType& couplingtype, const Inpar::S2I::InterfaceSides& lmside,
+      [](const S2I::CouplingType& couplingtype, const S2I::InterfaceSides& lmside,
           const int& numdofpernode_slave, const int& numdofpernode_master)
       {
         return std::unique_ptr<MortarCellCalcElch<distype_s, distype_m>>(
@@ -567,8 +566,8 @@ ScaTra::MortarCellCalcElch<distype_s, distype_m>::instance(
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_s, Core::FE::CellType distype_m>
 ScaTra::MortarCellCalcElch<distype_s, distype_m>::MortarCellCalcElch(
-    const Inpar::S2I::CouplingType& couplingtype,  //!< flag for meshtying method
-    const Inpar::S2I::InterfaceSides&
+    const S2I::CouplingType& couplingtype,  //!< flag for meshtying method
+    const S2I::InterfaceSides&
         lmside,  //!< flag for interface side underlying Lagrange multiplier definition
     const int& numdofpernode_slave,  //!< number of slave-side degrees of freedom per node
     const int& numdofpernode_master  //!< number of master-side degrees of freedom per node
@@ -717,8 +716,8 @@ double ScaTra::MortarCellCalcElch<distype_s, distype_m>::get_frt() const
 template <Core::FE::CellType distype_s, Core::FE::CellType distype_m>
 ScaTra::MortarCellCalcElchSTIThermo<distype_s, distype_m>*
 ScaTra::MortarCellCalcElchSTIThermo<distype_s, distype_m>::instance(
-    const Inpar::S2I::CouplingType& couplingtype,  //!< flag for meshtying method
-    const Inpar::S2I::InterfaceSides&
+    const S2I::CouplingType& couplingtype,  //!< flag for meshtying method
+    const S2I::InterfaceSides&
         lmside,  //!< flag for interface side underlying Lagrange multiplier definition
     const int& numdofpernode_slave,   //!< number of slave-side degrees of freedom per node
     const int& numdofpernode_master,  //!< number of master-side degrees of freedom per node
@@ -726,7 +725,7 @@ ScaTra::MortarCellCalcElchSTIThermo<distype_s, distype_m>::instance(
 )
 {
   static auto singleton_map = Core::Utils::make_singleton_map<std::string>(
-      [](const Inpar::S2I::CouplingType& couplingtype, const Inpar::S2I::InterfaceSides& lmside,
+      [](const S2I::CouplingType& couplingtype, const S2I::InterfaceSides& lmside,
           const int& numdofpernode_slave, const int& numdofpernode_master)
       {
         return std::unique_ptr<MortarCellCalcElchSTIThermo<distype_s, distype_m>>(
@@ -744,8 +743,8 @@ ScaTra::MortarCellCalcElchSTIThermo<distype_s, distype_m>::instance(
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_s, Core::FE::CellType distype_m>
 ScaTra::MortarCellCalcElchSTIThermo<distype_s, distype_m>::MortarCellCalcElchSTIThermo(
-    const Inpar::S2I::CouplingType& couplingtype,  //!< flag for meshtying method
-    const Inpar::S2I::InterfaceSides&
+    const S2I::CouplingType& couplingtype,  //!< flag for meshtying method
+    const S2I::InterfaceSides&
         lmside,  //!< flag for interface side underlying Lagrange multiplier definition
     const int& numdofpernode_slave,  //!< number of slave-side degrees of freedom per node
     const int& numdofpernode_master  //!< number of master-side degrees of freedom per node
@@ -781,10 +780,10 @@ void ScaTra::MortarCellCalcElchSTIThermo<distype_s, distype_m>::evaluate(
 )
 {
   // extract and evaluate action
-  switch (Teuchos::getIntegralValue<Inpar::S2I::EvaluationActions>(params, "action"))
+  switch (Teuchos::getIntegralValue<S2I::EvaluationActions>(params, "action"))
   {
     // evaluate and assemble off-diagonal interface linearizations
-    case Inpar::S2I::evaluate_condition_od:
+    case S2I::evaluate_condition_od:
     {
       evaluate_condition_od(idiscret, cell, slaveelement, masterelement, la_slave, la_master,
           params, cellmatrix1, cellmatrix3);
@@ -931,8 +930,8 @@ double ScaTra::MortarCellCalcElchSTIThermo<distype_s, distype_m>::get_frt() cons
 template <Core::FE::CellType distype_s, Core::FE::CellType distype_m>
 ScaTra::MortarCellCalcSTIElch<distype_s, distype_m>*
 ScaTra::MortarCellCalcSTIElch<distype_s, distype_m>::instance(
-    const Inpar::S2I::CouplingType& couplingtype,  //!< flag for meshtying method
-    const Inpar::S2I::InterfaceSides&
+    const S2I::CouplingType& couplingtype,  //!< flag for meshtying method
+    const S2I::InterfaceSides&
         lmside,  //!< flag for interface side underlying Lagrange multiplier definition
     const int& numdofpernode_slave,   //!< number of slave-side degrees of freedom per node
     const int& numdofpernode_master,  //!< number of master-side degrees of freedom per node
@@ -940,7 +939,7 @@ ScaTra::MortarCellCalcSTIElch<distype_s, distype_m>::instance(
 )
 {
   static auto singleton_map = Core::Utils::make_singleton_map<std::string>(
-      [](const Inpar::S2I::CouplingType& couplingtype, const Inpar::S2I::InterfaceSides& lmside,
+      [](const S2I::CouplingType& couplingtype, const S2I::InterfaceSides& lmside,
           const int& numdofpernode_slave, const int& numdofpernode_master)
       {
         return std::unique_ptr<MortarCellCalcSTIElch<distype_s, distype_m>>(
@@ -958,8 +957,8 @@ ScaTra::MortarCellCalcSTIElch<distype_s, distype_m>::instance(
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_s, Core::FE::CellType distype_m>
 ScaTra::MortarCellCalcSTIElch<distype_s, distype_m>::MortarCellCalcSTIElch(
-    const Inpar::S2I::CouplingType& couplingtype,  //!< flag for meshtying method
-    const Inpar::S2I::InterfaceSides&
+    const S2I::CouplingType& couplingtype,  //!< flag for meshtying method
+    const S2I::InterfaceSides&
         lmside,  //!< flag for interface side underlying Lagrange multiplier definition
     const int& numdofpernode_slave,  //!< number of slave-side degrees of freedom per node
     const int& numdofpernode_master  //!< number of master-side degrees of freedom per node
@@ -996,10 +995,10 @@ void ScaTra::MortarCellCalcSTIElch<distype_s, distype_m>::evaluate(
 )
 {
   // extract and evaluate action
-  switch (Teuchos::getIntegralValue<Inpar::S2I::EvaluationActions>(params, "action"))
+  switch (Teuchos::getIntegralValue<S2I::EvaluationActions>(params, "action"))
   {
     // evaluate and assemble interface linearizations and residuals
-    case Inpar::S2I::evaluate_condition:
+    case S2I::evaluate_condition:
     {
       evaluate_condition(idiscret, cell, slaveelement, masterelement, la_slave, la_master, params,
           cellmatrix1, cellvector1);
@@ -1008,7 +1007,7 @@ void ScaTra::MortarCellCalcSTIElch<distype_s, distype_m>::evaluate(
     }
 
     // evaluate and assemble off-diagonal interface linearizations
-    case Inpar::S2I::evaluate_condition_od:
+    case S2I::evaluate_condition_od:
     {
       evaluate_condition_od(idiscret, cell, slaveelement, masterelement, la_slave, la_master,
           params, cellmatrix1, cellmatrix2);
@@ -1229,15 +1228,15 @@ void ScaTra::MeshtyingStrategyS2IElchSCL::setup_meshtying()
     if (s2imeshtying_condition->parameters().get<int>("S2I_KINETICS_ID") != -1)
       FOUR_C_THROW("No kinetics condition is allowed for the coupled space-charge layer problem.");
 
-    switch (s2imeshtying_condition->parameters().get<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE"))
+    switch (s2imeshtying_condition->parameters().get<S2I::InterfaceSides>("INTERFACE_SIDE"))
     {
-      case Inpar::S2I::side_source:
+      case S2I::side_source:
       {
         Core::Communication::add_owned_node_gid_from_list(*scatratimint_->discretization(),
             *s2imeshtying_condition->get_nodes(), islavenodegidset);
         break;
       }
-      case Inpar::S2I::side_master:
+      case S2I::side_master:
       {
         Core::Communication::add_owned_node_gid_from_list(*scatratimint_->discretization(),
             *s2imeshtying_condition->get_nodes(), imasternodegidset);

--- a/src/scatra/4C_scatra_timint_meshtying_strategy_s2i_elch.hpp
+++ b/src/scatra/4C_scatra_timint_meshtying_strategy_s2i_elch.hpp
@@ -102,8 +102,8 @@ namespace ScaTra
    public:
     //! singleton access method
     static MortarCellCalcElch<distype_s, distype_m>* instance(
-        const Inpar::S2I::CouplingType& couplingtype,  //!< flag for meshtying method
-        const Inpar::S2I::InterfaceSides&
+        const S2I::CouplingType& couplingtype,  //!< flag for meshtying method
+        const S2I::InterfaceSides&
             lmside,  //!< flag for interface side underlying Lagrange multiplier definition
         const int& numdofpernode_slave,   //!< number of slave-side degrees of freedom per node
         const int& numdofpernode_master,  //!< number of master-side degrees of freedom per node
@@ -113,8 +113,8 @@ namespace ScaTra
 
    protected:
     //! protected constructor for singletons
-    MortarCellCalcElch(const Inpar::S2I::CouplingType& couplingtype,  //!< flag for meshtying method
-        const Inpar::S2I::InterfaceSides&
+    MortarCellCalcElch(const S2I::CouplingType& couplingtype,  //!< flag for meshtying method
+        const S2I::InterfaceSides&
             lmside,  //!< flag for interface side underlying Lagrange multiplier definition
         const int& numdofpernode_slave,  //!< number of slave-side degrees of freedom per node
         const int& numdofpernode_master  //!< number of master-side degrees of freedom per node
@@ -185,8 +185,8 @@ namespace ScaTra
    public:
     //! singleton access method
     static MortarCellCalcElchSTIThermo<distype_s, distype_m>* instance(
-        const Inpar::S2I::CouplingType& couplingtype,  //!< flag for meshtying method
-        const Inpar::S2I::InterfaceSides&
+        const S2I::CouplingType& couplingtype,  //!< flag for meshtying method
+        const S2I::InterfaceSides&
             lmside,  //!< flag for interface side underlying Lagrange multiplier definition
         const int& numdofpernode_slave,   //!< number of slave-side degrees of freedom per node
         const int& numdofpernode_master,  //!< number of master-side degrees of freedom per node
@@ -221,8 +221,8 @@ namespace ScaTra
 
     //! private constructor for singletons
     MortarCellCalcElchSTIThermo(
-        const Inpar::S2I::CouplingType& couplingtype,  //!< flag for meshtying method
-        const Inpar::S2I::InterfaceSides&
+        const S2I::CouplingType& couplingtype,  //!< flag for meshtying method
+        const S2I::InterfaceSides&
             lmside,  //!< flag for interface side underlying Lagrange multiplier definition
         const int& numdofpernode_slave,  //!< number of slave-side degrees of freedom per node
         const int& numdofpernode_master  //!< number of master-side degrees of freedom per node
@@ -264,8 +264,8 @@ namespace ScaTra
    public:
     //! singleton access method
     static MortarCellCalcSTIElch<distype_s, distype_m>* instance(
-        const Inpar::S2I::CouplingType& couplingtype,  //!< flag for meshtying method
-        const Inpar::S2I::InterfaceSides&
+        const S2I::CouplingType& couplingtype,  //!< flag for meshtying method
+        const S2I::InterfaceSides&
             lmside,  //!< flag for interface side underlying Lagrange multiplier definition
         const int& numdofpernode_slave,   //!< number of slave-side degrees of freedom per node
         const int& numdofpernode_master,  //!< number of master-side degrees of freedom per node
@@ -297,9 +297,8 @@ namespace ScaTra
     using my::nsd_slave_;
 
     //! private constructor for singletons
-    MortarCellCalcSTIElch(
-        const Inpar::S2I::CouplingType& couplingtype,  //!< flag for meshtying method
-        const Inpar::S2I::InterfaceSides&
+    MortarCellCalcSTIElch(const S2I::CouplingType& couplingtype,  //!< flag for meshtying method
+        const S2I::InterfaceSides&
             lmside,  //!< flag for interface side underlying Lagrange multiplier definition
         const int& numdofpernode_slave,  //!< number of slave-side degrees of freedom per node
         const int& numdofpernode_master  //!< number of master-side degrees of freedom per node

--- a/src/scatra/4C_scatra_utils.cpp
+++ b/src/scatra/4C_scatra_utils.cpp
@@ -12,9 +12,9 @@
 #include "4C_fem_general_extract_values.hpp"
 #include "4C_fem_general_utils_fem_shapefunctions.hpp"
 #include "4C_fem_geometry_position_array.hpp"
-#include "4C_inpar_s2i.hpp"
 #include "4C_linalg_serialdensevector.hpp"
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
+#include "4C_scatra_s2i_input.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -131,14 +131,14 @@ void ScaTra::ScaTraUtils::check_consistency_with_s2_i_kinetics_condition(
     const int s2ikinetics_id = conditionToBeTested->parameters().get<int>("S2I_KINETICS_ID");
 
     // check the interface side
-    switch (conditionToBeTested->parameters().get<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE"))
+    switch (conditionToBeTested->parameters().get<S2I::InterfaceSides>("INTERFACE_SIDE"))
     {
-      case Inpar::S2I::side_source:
+      case S2I::side_source:
       {
         isslave = true;
         break;
       }
-      case Inpar::S2I::side_master:
+      case S2I::side_master:
       {
         isslave = false;
         break;
@@ -159,15 +159,15 @@ void ScaTra::ScaTraUtils::check_consistency_with_s2_i_kinetics_condition(
       if (s2ikinetics_id != s2ikinetics_cond_id) continue;
 
       // check the interface side
-      switch (s2ikinetics_cond->parameters().get<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE"))
+      switch (s2ikinetics_cond->parameters().get<S2I::InterfaceSides>("INTERFACE_SIDE"))
       {
-        case Inpar::S2I::side_source:
+        case S2I::side_source:
         {
           if (isslave) assert_same_nodes(conditionToBeTested, s2ikinetics_cond);
 
           break;
         }
-        case Inpar::S2I::side_master:
+        case S2I::side_master:
         {
           if (!isslave) assert_same_nodes(conditionToBeTested, s2ikinetics_cond);
 

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc.cpp
@@ -1203,7 +1203,7 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::
     switch (kineticmodel)
     {
       // constant permeability model
-      case Inpar::S2I::kinetics_constperm:
+      case S2I::kinetics_constperm:
       {
         if (permeabilities == nullptr)
           FOUR_C_THROW(
@@ -1448,7 +1448,7 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::evaluate_s2_i_c
       switch (scatraparamsboundary_->kinetic_model())
       {
         // constant permeability model
-        case Inpar::S2I::kinetics_constperm:
+        case S2I::kinetics_constperm:
         {
           // dervivative of interface flux w.r.t. displacement
           switch (differentiationtype)

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_diffcond.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_diffcond.cpp
@@ -270,9 +270,9 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchDiffCond<distype, probdim>::eva
 {
   switch (my::scatraparamsboundary_->kinetic_model())
   {
-    case Inpar::S2I::kinetics_nointerfaceflux:
+    case S2I::kinetics_nointerfaceflux:
       break;
-    case Inpar::S2I::kinetics_constantinterfaceresistance:
+    case S2I::kinetics_constantinterfaceresistance:
     {
       myelectrode::evaluate_s2_i_coupling(
           ele, params, discretization, la, eslavematrix, emastermatrix, eslaveresidual);
@@ -299,9 +299,9 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchDiffCond<distype,
 {
   switch (my::scatraparamsboundary_->kinetic_model())
   {
-    case Inpar::S2I::kinetics_nointerfaceflux:
+    case S2I::kinetics_nointerfaceflux:
       break;
-    case Inpar::S2I::kinetics_constantinterfaceresistance:
+    case S2I::kinetics_constantinterfaceresistance:
     {
       myelectrode::evaluate_s2_i_coupling_od(ele, params, discretization, la, eslavematrix);
       break;

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode.cpp
@@ -83,7 +83,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
 
   Core::LinAlg::Matrix<nen_, 1> eslavetempnp(Core::LinAlg::Initialization::zero);
   Core::LinAlg::Matrix<nen_, 1> emastertempnp(Core::LinAlg::Initialization::zero);
-  if (kineticmodel == Inpar::S2I::kinetics_butlervolmerreducedthermoresistance)
+  if (kineticmodel == S2I::kinetics_butlervolmerreducedthermoresistance)
   {
     my::extract_node_values(
         eslavetempnp, discretization, la, "islavetemp", my::scatraparams_->nds_thermo());
@@ -185,7 +185,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype, probdim>::
   // get faraday constant
   const double faraday = Discret::Elements::ScaTraEleParameterElch::instance("scatra")->faraday();
 
-  if (kineticmodel == Inpar::S2I::kinetics_butlervolmerreducedthermoresistance)
+  if (kineticmodel == S2I::kinetics_butlervolmerreducedthermoresistance)
   {
     const double gasconstant =
         Discret::Elements::ScaTraEleParameterElch::instance("scatra")->gas_constant();
@@ -197,15 +197,15 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype, probdim>::
   switch (kineticmodel)
   {
     // Butler-Volmer kinetics
-    case Inpar::S2I::kinetics_butlervolmer:
-    case Inpar::S2I::kinetics_butlervolmerlinearized:
-    case Inpar::S2I::kinetics_butlervolmerpeltier:
-    case Inpar::S2I::kinetics_butlervolmerreducedthermoresistance:
-    case Inpar::S2I::kinetics_butlervolmerreduced:
-    case Inpar::S2I::kinetics_butlervolmerreducedcapacitance:
-    case Inpar::S2I::kinetics_butlervolmerreducedlinearized:
-    case Inpar::S2I::kinetics_butlervolmerresistance:
-    case Inpar::S2I::kinetics_butlervolmerreducedresistance:
+    case S2I::kinetics_butlervolmer:
+    case S2I::kinetics_butlervolmerlinearized:
+    case S2I::kinetics_butlervolmerpeltier:
+    case S2I::kinetics_butlervolmerreducedthermoresistance:
+    case S2I::kinetics_butlervolmerreduced:
+    case S2I::kinetics_butlervolmerreducedcapacitance:
+    case S2I::kinetics_butlervolmerreducedlinearized:
+    case S2I::kinetics_butlervolmerresistance:
+    case S2I::kinetics_butlervolmerreducedresistance:
     {
       if (matelectrode == nullptr)
         FOUR_C_THROW("Invalid electrode material for scatra-scatra interface coupling!");
@@ -232,13 +232,13 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype, probdim>::
 
       switch (kineticmodel)
       {
-        case Inpar::S2I::kinetics_butlervolmer:
-        case Inpar::S2I::kinetics_butlervolmerlinearized:
-        case Inpar::S2I::kinetics_butlervolmerpeltier:
-        case Inpar::S2I::kinetics_butlervolmerreducedthermoresistance:
-        case Inpar::S2I::kinetics_butlervolmerreduced:
-        case Inpar::S2I::kinetics_butlervolmerreducedcapacitance:
-        case Inpar::S2I::kinetics_butlervolmerreducedlinearized:
+        case S2I::kinetics_butlervolmer:
+        case S2I::kinetics_butlervolmerlinearized:
+        case S2I::kinetics_butlervolmerpeltier:
+        case S2I::kinetics_butlervolmerreducedthermoresistance:
+        case S2I::kinetics_butlervolmerreduced:
+        case S2I::kinetics_butlervolmerreducedcapacitance:
+        case S2I::kinetics_butlervolmerreducedlinearized:
         {
           // electrode-electrolyte overpotential at integration point
           const double eta = eslavepotint - emasterpotint - epd;
@@ -272,8 +272,8 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype, probdim>::
           break;
         }
 
-        case Inpar::S2I::kinetics_butlervolmerresistance:
-        case Inpar::S2I::kinetics_butlervolmerreducedresistance:
+        case S2I::kinetics_butlervolmerresistance:
+        case S2I::kinetics_butlervolmerreducedresistance:
         {
           // compute Butler-Volmer mass flux density via Newton-Raphson method
           const double j = calculate_modified_butler_volmer_mass_flux_density(j0, alphaa, alphac,
@@ -305,7 +305,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype, probdim>::
               k_sm, k_ms, k_mm, r_s, r_m);
 
           break;
-        }  // case Inpar::S2I::kinetics_butlervolmerresistance:
+        }  // case S2I::kinetics_butlervolmerresistance:
         default:
         {
           FOUR_C_THROW("something went wrong");
@@ -314,7 +314,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype, probdim>::
       break;
     }
 
-    case Inpar::S2I::kinetics_constantinterfaceresistance:
+    case S2I::kinetics_constantinterfaceresistance:
     {
       // core residual
       const double inv_massfluxresistance = 1.0 / (resistance * faraday);
@@ -421,13 +421,13 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype, probdim>::
             "Must provide both master-side matrices and master-side vector or none of them!");
 
       break;
-    }  // case Inpar::S2I::kinetics_constantinterfaceresistance
+    }  // case S2I::kinetics_constantinterfaceresistance
 
-    case Inpar::S2I::kinetics_nointerfaceflux:
+    case S2I::kinetics_nointerfaceflux:
     {
       // do nothing
       break;
-    }  // case Inpar::S2I::kinetics_nointerfaceflux
+    }  // case S2I::kinetics_nointerfaceflux
 
     default:
     {
@@ -454,7 +454,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
       my::numdofpernode_, Core::LinAlg::Matrix<nen_, 1>(Core::LinAlg::Initialization::zero));
   std::vector<Core::LinAlg::Matrix<nen_, 1>> emasterphidtnp(
       my::numdofpernode_, Core::LinAlg::Matrix<nen_, 1>(Core::LinAlg::Initialization::zero));
-  if (kineticmodel == Inpar::S2I::kinetics_butlervolmerreducedcapacitance)
+  if (kineticmodel == S2I::kinetics_butlervolmerreducedcapacitance)
   {
     my::extract_node_values(eslavephidtnp, discretization, la, "islavephidtnp");
     my::extract_node_values(emasterphidtnp, discretization, la, "imasterphidtnp");
@@ -536,7 +536,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype, probdim>::
   // interface coupling condition
   switch (kineticmodel)
   {
-    case Inpar::S2I::kinetics_butlervolmerreducedcapacitance:
+    case S2I::kinetics_butlervolmerreducedcapacitance:
     {
       // evaluate time derivative of potential values at current integration point on slave- and
       // master-side of scatra-scatra interface
@@ -645,11 +645,11 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
     switch (kineticmodel)
     {
       // Butler-Volmer kinetics
-      case Inpar::S2I::kinetics_butlervolmer:
-      case Inpar::S2I::kinetics_butlervolmerlinearized:
-      case Inpar::S2I::kinetics_butlervolmerreduced:
-      case Inpar::S2I::kinetics_butlervolmerreducedcapacitance:
-      case Inpar::S2I::kinetics_butlervolmerreducedlinearized:
+      case S2I::kinetics_butlervolmer:
+      case S2I::kinetics_butlervolmerlinearized:
+      case S2I::kinetics_butlervolmerreduced:
+      case S2I::kinetics_butlervolmerreducedcapacitance:
+      case S2I::kinetics_butlervolmerreducedlinearized:
       {
         // access input parameters associated with current condition
         const auto conditiontype = my::scatraparamsboundary_->condition_type();
@@ -735,7 +735,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
         }
         break;
       }
-      case Inpar::S2I::kinetics_constantinterfaceresistance:
+      case S2I::kinetics_constantinterfaceresistance:
       {
         switch (differentiationtype)
         {
@@ -788,7 +788,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
 
         break;
       }
-      case Inpar::S2I::kinetics_nointerfaceflux:
+      case S2I::kinetics_nointerfaceflux:
       {
         // nothing to do
         break;
@@ -825,7 +825,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
       my::numdofpernode_, Core::LinAlg::Matrix<nen_, 1>(Core::LinAlg::Initialization::zero));
   std::vector<Core::LinAlg::Matrix<nen_, 1>> emasterphidtnp(
       my::numdofpernode_, Core::LinAlg::Matrix<nen_, 1>(Core::LinAlg::Initialization::zero));
-  if (kineticmodel == Inpar::S2I::kinetics_butlervolmerreducedcapacitance)
+  if (kineticmodel == S2I::kinetics_butlervolmerreducedcapacitance)
   {
     my::extract_node_values(eslavephidtnp, discretization, la, "islavephidtnp");
     my::extract_node_values(emasterphidtnp, discretization, la, "imasterphidtnp");
@@ -873,7 +873,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
     switch (kineticmodel)
     {
       // Butler-Volmer kinetics
-      case Inpar::S2I::kinetics_butlervolmerreducedcapacitance:
+      case S2I::kinetics_butlervolmerreducedcapacitance:
       {
         // evaluate time derivative of potential values at current integration point on slave- and
         // master-side of scatra-scatra interface
@@ -1179,7 +1179,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
 
     Core::LinAlg::Matrix<nen_, 1> eslavetempnp(Core::LinAlg::Initialization::zero);
     Core::LinAlg::Matrix<nen_, 1> emastertempnp(Core::LinAlg::Initialization::zero);
-    if (kineticmodel == Inpar::S2I::kinetics_butlervolmerreducedthermoresistance)
+    if (kineticmodel == S2I::kinetics_butlervolmerreducedthermoresistance)
     {
       my::extract_node_values(
           eslavetempnp, discretization, la, "islavetemp", my::scatraparams_->nds_thermo());
@@ -1197,7 +1197,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
     const double etempint = 0.5 * (eslavetempint + emastertempint);
 
     double frt = 0.0;
-    if (kineticmodel == Inpar::S2I::kinetics_butlervolmerreducedthermoresistance)
+    if (kineticmodel == S2I::kinetics_butlervolmerreducedthermoresistance)
     {
       const double gasconstant =
           Discret::Elements::ScaTraEleParameterElch::instance("scatra")->gas_constant();
@@ -1211,15 +1211,15 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
     switch (kineticmodel)
     {
         // Butler-Volmer kinetics
-      case Inpar::S2I::kinetics_butlervolmer:
-      case Inpar::S2I::kinetics_butlervolmerlinearized:
-      case Inpar::S2I::kinetics_butlervolmerpeltier:
-      case Inpar::S2I::kinetics_butlervolmerreducedthermoresistance:
-      case Inpar::S2I::kinetics_butlervolmerreduced:
-      case Inpar::S2I::kinetics_butlervolmerreducedcapacitance:
-      case Inpar::S2I::kinetics_butlervolmerreducedlinearized:
-      case Inpar::S2I::kinetics_butlervolmerresistance:
-      case Inpar::S2I::kinetics_butlervolmerreducedresistance:
+      case S2I::kinetics_butlervolmer:
+      case S2I::kinetics_butlervolmerlinearized:
+      case S2I::kinetics_butlervolmerpeltier:
+      case S2I::kinetics_butlervolmerreducedthermoresistance:
+      case S2I::kinetics_butlervolmerreduced:
+      case S2I::kinetics_butlervolmerreducedcapacitance:
+      case S2I::kinetics_butlervolmerreducedlinearized:
+      case S2I::kinetics_butlervolmerresistance:
+      case S2I::kinetics_butlervolmerreducedresistance:
       {
         if (matelectrode == nullptr)
           FOUR_C_THROW("Invalid electrode material for scatra-scatra interface coupling!");
@@ -1241,13 +1241,13 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
 
         switch (kineticmodel)
         {
-          case Inpar::S2I::kinetics_butlervolmer:
-          case Inpar::S2I::kinetics_butlervolmerlinearized:
-          case Inpar::S2I::kinetics_butlervolmerpeltier:
-          case Inpar::S2I::kinetics_butlervolmerreducedthermoresistance:
-          case Inpar::S2I::kinetics_butlervolmerreduced:
-          case Inpar::S2I::kinetics_butlervolmerreducedcapacitance:
-          case Inpar::S2I::kinetics_butlervolmerreducedlinearized:
+          case S2I::kinetics_butlervolmer:
+          case S2I::kinetics_butlervolmerlinearized:
+          case S2I::kinetics_butlervolmerpeltier:
+          case S2I::kinetics_butlervolmerreducedthermoresistance:
+          case S2I::kinetics_butlervolmerreduced:
+          case S2I::kinetics_butlervolmerreducedcapacitance:
+          case S2I::kinetics_butlervolmerreducedlinearized:
           {
             // electrode-electrolyte overpotential at integration point
             const double eta = eslavepotint - emasterpotint - epd;
@@ -1275,8 +1275,8 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
             break;
           }
 
-          case Inpar::S2I::kinetics_butlervolmerresistance:
-          case Inpar::S2I::kinetics_butlervolmerreducedresistance:
+          case S2I::kinetics_butlervolmerresistance:
+          case S2I::kinetics_butlervolmerreducedresistance:
           {
             // compute Butler-Volmer mass flux density via Newton-Raphson method
             const double j = calculate_modified_butler_volmer_mass_flux_density(j0, alphaa, alphac,
@@ -1296,7 +1296,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
             }
 
             break;
-          }  // case Inpar::S2I::kinetics_butlervolmerresistance:
+          }  // case S2I::kinetics_butlervolmerresistance:
           default:
           {
             FOUR_C_THROW("something went wrong");
@@ -1304,7 +1304,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
         }
         break;
       }
-      case Inpar::S2I::kinetics_constantinterfaceresistance:
+      case S2I::kinetics_constantinterfaceresistance:
       {
         const double inv_massfluxresistance = 1.0 / (resistance * faraday);
 
@@ -1326,7 +1326,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
 
       break;
 
-      case Inpar::S2I::kinetics_nointerfaceflux:
+      case S2I::kinetics_nointerfaceflux:
       {
         // do nothing
         break;

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode_growth.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode_growth.cpp
@@ -76,7 +76,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeGrowth<distype,
   const double faraday = myelch::elchparams_->faraday();
   const double resistivity = my::scatraparamsboundary_->resistivity();
   const int kineticmodel = my::scatraparamsboundary_->kinetic_model();
-  if (kineticmodel != Inpar::S2I::growth_kinetics_butlervolmer)
+  if (kineticmodel != S2I::growth_kinetics_butlervolmer)
   {
     FOUR_C_THROW(
         "Received illegal kinetic model for scatra-scatra interface coupling involving interface "
@@ -109,7 +109,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeGrowth<distype,
 
     switch (kineticmodel)
     {
-      case Inpar::S2I::growth_kinetics_butlervolmer:
+      case S2I::growth_kinetics_butlervolmer:
       {
         const double alphaa = my::scatraparamsboundary_->alphadata();
         const double kr = my::scatraparamsboundary_->charge_transfer_constant();
@@ -609,7 +609,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeGrowth<distype,
 
   // access input parameters associated with condition
   const int kineticmodel = my::scatraparamsboundary_->kinetic_model();
-  if (kineticmodel != Inpar::S2I::growth_kinetics_butlervolmer)
+  if (kineticmodel != S2I::growth_kinetics_butlervolmer)
   {
     FOUR_C_THROW(
         "Received illegal kinetic model for scatra-scatra interface coupling involving interface "
@@ -725,7 +725,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeGrowth<distype,
 
   // access input parameters associated with condition
   const int kineticmodel = my::scatraparamsboundary_->kinetic_model();
-  if (kineticmodel != Inpar::S2I::growth_kinetics_butlervolmer)
+  if (kineticmodel != S2I::growth_kinetics_butlervolmer)
   {
     FOUR_C_THROW(
         "Received illegal kinetic model for scatra-scatra interface coupling involving interface "

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode_growth_utils.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode_growth_utils.cpp
@@ -26,7 +26,7 @@ double Discret::Elements::calculate_growth_exchange_mass_flux_density(const doub
 
   switch (kinetic_model)
   {
-    case Inpar::S2I::growth_kinetics_butlervolmer:
+    case S2I::growth_kinetics_butlervolmer:
     {
       return kr * std::pow(c_el, alpha_a);
     }
@@ -57,7 +57,7 @@ void Discret::Elements::calculate_s2_i_growth_elch_linearizations(const double j
 
   switch (scatraeleparamsboundary->regularization_type())
   {
-    case Inpar::S2I::RegularizationType::regularization_none:
+    case S2I::RegularizationType::regularization_none:
     {
       const double expterm = expterm1 - expterm2;
 
@@ -78,8 +78,8 @@ void Discret::Elements::calculate_s2_i_growth_elch_linearizations(const double j
 
       break;
     }
-    case Inpar::S2I::RegularizationType::regularization_trigonometrical:
-    case Inpar::S2I::RegularizationType::regularization_polynomial:
+    case S2I::RegularizationType::regularization_trigonometrical:
+    case S2I::RegularizationType::regularization_polynomial:
     {
       const double expterm = regfac * (expterm1 - expterm2);
 
@@ -94,7 +94,7 @@ void Discret::Elements::calculate_s2_i_growth_elch_linearizations(const double j
 
       break;
     }
-    case Inpar::S2I::RegularizationType::regularization_hein:
+    case S2I::RegularizationType::regularization_hein:
     {
       const double expterm = regfac * expterm1 - expterm2;
 
@@ -136,7 +136,7 @@ double Discret::Elements::calculate_s2_i_elch_growth_linearizations(const double
 
   switch (scatraeleparamsboundary->regularization_type())
   {
-    case Inpar::S2I::RegularizationType::regularization_none:
+    case S2I::RegularizationType::regularization_none:
     {
       // compute linearization of Butler-Volmer mass flux density w.r.t. scatra-scatra interface
       // layer thickness via implicit differentiation, where F = j0*expterm - j = 0
@@ -146,8 +146,8 @@ double Discret::Elements::calculate_s2_i_elch_growth_linearizations(const double
 
       break;
     }
-    case Inpar::S2I::RegularizationType::regularization_trigonometrical:
-    case Inpar::S2I::RegularizationType::regularization_polynomial:
+    case S2I::RegularizationType::regularization_trigonometrical:
+    case S2I::RegularizationType::regularization_polynomial:
     {
       // compute linearization of Butler-Volmer mass flux density w.r.t. scatra-scatra interface
       // layer thickness via implicit differentiation, where F = j0*expterm - j = 0
@@ -158,7 +158,7 @@ double Discret::Elements::calculate_s2_i_elch_growth_linearizations(const double
 
       break;
     }
-    case Inpar::S2I::RegularizationType::regularization_hein:
+    case S2I::RegularizationType::regularization_hein:
     {
       // compute linearization of Butler-Volmer mass flux density w.r.t. scatra-scatra interface
       // layer thickness via implicit differentiation, where F = j0*expterm - j = 0
@@ -207,7 +207,7 @@ double Discret::Elements::calculate_growth_mass_flux_density(const double j0, co
     double eta = pot_ed - pot_el - epd;
     double regfac = get_regularization_factor(thickness, eta, scatraeleparamsboundary);
     i = (scatraeleparamsboundary->regularization_type() ==
-            Inpar::S2I::RegularizationType::regularization_hein)
+            S2I::RegularizationType::regularization_hein)
             ? i0 * (regfac * std::exp(alphaa * frt * eta) - std::exp(-alphac * frt * eta))
             : i0 * regfac * (std::exp(alphaa * frt * eta) - std::exp(-alphac * frt * eta));
 
@@ -227,7 +227,7 @@ double Discret::Elements::calculate_growth_mass_flux_density(const double j0, co
       const double expterm1 = std::exp(alphaa * frt * eta);
       const double expterm2 = std::exp(-alphac * frt * eta);
       const double residual = (scatraeleparamsboundary->regularization_type() ==
-                                  Inpar::S2I::RegularizationType::regularization_hein)
+                                  S2I::RegularizationType::regularization_hein)
                                   ? i0 * (regfac * expterm1 - expterm2) - i
                                   : i0 * regfac * (expterm1 - expterm2) - i;
 
@@ -242,7 +242,7 @@ double Discret::Elements::calculate_growth_mass_flux_density(const double j0, co
       // density
       const double linearization =
           (scatraeleparamsboundary->regularization_type() ==
-              Inpar::S2I::RegularizationType::regularization_hein)
+              S2I::RegularizationType::regularization_hein)
               ? -i0 * resistance * frt * (regfac * alphaa * expterm1 + alphac * expterm2) - 1.0
               : -i0 * resistance * frt * regfac * (alphaa * expterm1 + alphac * expterm2) - 1.0;
 
@@ -271,12 +271,11 @@ double Discret::Elements::get_regularization_factor(const double thickness, cons
   const Core::Conditions::ConditionType conditiontype = scatraeleparamsboundary->condition_type();
 
   // get the S2I coupling growth regularization type
-  const Inpar::S2I::RegularizationType regularizationtype =
-      scatraeleparamsboundary->regularization_type();
+  const S2I::RegularizationType regularizationtype = scatraeleparamsboundary->regularization_type();
 
   // actually compute regularization factor if lithium stripping is relevant
   if (conditiontype == Core::Conditions::S2IKineticsGrowth and
-      (eta > 0.0 or regularizationtype == Inpar::S2I::RegularizationType::regularization_hein))
+      (eta > 0.0 or regularizationtype == S2I::RegularizationType::regularization_hein))
   {
     // get the S2I coupling growth regularization parameter
     const double regularizationparameter = scatraeleparamsboundary->regularization_parameter();
@@ -286,9 +285,9 @@ double Discret::Elements::get_regularization_factor(const double thickness, cons
     // evaluate dependent on the regularization type
     switch (regularizationtype)
     {
-      case Inpar::S2I::RegularizationType::regularization_polynomial:
+      case S2I::RegularizationType::regularization_polynomial:
       // polynomial regularization, cf. Hein, Latz, Electrochimica Acta 201 (2016) 354-365
-      case Inpar::S2I::RegularizationType::regularization_hein:
+      case S2I::RegularizationType::regularization_hein:
       {
         // use regularization parameter if specified, otherwise take default value according to
         // reference
@@ -302,7 +301,7 @@ double Discret::Elements::get_regularization_factor(const double thickness, cons
         break;
       }
       // trigonometrical regularization involving (co)sine half-wave
-      case Inpar::S2I::RegularizationType::regularization_trigonometrical:
+      case S2I::RegularizationType::regularization_trigonometrical:
       {
         // use regularization parameter if specified, otherwise take lithium atom diameter as
         // default value
@@ -320,7 +319,7 @@ double Discret::Elements::get_regularization_factor(const double thickness, cons
         break;
       }
       // non-regularized Heaviside function
-      case Inpar::S2I::RegularizationType::regularization_none:
+      case S2I::RegularizationType::regularization_none:
       {
         if (thickness <= 0.0) regfac = 0.0;
 
@@ -349,12 +348,11 @@ double Discret::Elements::get_regularization_factor_derivative(const double thic
   const Core::Conditions::ConditionType conditiontype = scatraeleparamsboundary->condition_type();
 
   // get the S2I coupling growth regularization type
-  const Inpar::S2I::RegularizationType regularizationtype =
-      scatraeleparamsboundary->regularization_type();
+  const S2I::RegularizationType regularizationtype = scatraeleparamsboundary->regularization_type();
 
   // actually compute derivative of regularization factor if lithium stripping is relevant
   if (conditiontype == Core::Conditions::S2IKineticsGrowth and thickness > 0.0 and
-      (eta > 0.0 or regularizationtype == Inpar::S2I::RegularizationType::regularization_hein))
+      (eta > 0.0 or regularizationtype == S2I::RegularizationType::regularization_hein))
   {
     // get the S2I coupling growth regularization parameter
     const double regularizationparameter = scatraeleparamsboundary->regularization_parameter();
@@ -362,9 +360,9 @@ double Discret::Elements::get_regularization_factor_derivative(const double thic
     // evaluate dependent on the regularization type
     switch (regularizationtype)
     {
-      case Inpar::S2I::RegularizationType::regularization_polynomial:
+      case S2I::RegularizationType::regularization_polynomial:
       // polynomial regularization, cf. Hein, Latz, Electrochimica Acta 201 (2016) 354-365
-      case Inpar::S2I::RegularizationType::regularization_hein:
+      case S2I::RegularizationType::regularization_hein:
       {
         // use regularization parameter if specified, otherwise take default value according to
         // reference
@@ -378,7 +376,7 @@ double Discret::Elements::get_regularization_factor_derivative(const double thic
         break;
       }
       // trigonometrical regularization involving (co)sine half-wave
-      case Inpar::S2I::RegularizationType::regularization_trigonometrical:
+      case S2I::RegularizationType::regularization_trigonometrical:
       {
         // use regularization parameter if specified, otherwise take lithium atom diameter as
         // default value
@@ -393,7 +391,7 @@ double Discret::Elements::get_regularization_factor_derivative(const double thic
 
         break;
       }
-      case Inpar::S2I::RegularizationType::regularization_none:
+      case S2I::RegularizationType::regularization_none:
       {
         // do nothing and retain derivative as initialized, since non-regularized Heaviside function
         // cannot be properly differentiated

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode_sti_thermo.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode_sti_thermo.cpp
@@ -8,13 +8,13 @@
 #include "4C_scatra_ele_boundary_calc_elch_electrode_sti_thermo.hpp"
 
 #include "4C_fem_general_utils_boundary_integration.hpp"
-#include "4C_inpar_s2i.hpp"
 #include "4C_mat_electrode.hpp"
 #include "4C_scatra_ele_boundary_calc_elch_electrode_utils.hpp"
 #include "4C_scatra_ele_parameter_boundary.hpp"
 #include "4C_scatra_ele_parameter_elch.hpp"
 #include "4C_scatra_ele_parameter_std.hpp"
 #include "4C_scatra_ele_parameter_timint.hpp"
+#include "4C_scatra_s2i_input.hpp"
 #include "4C_utils_singleton_owner.hpp"
 
 FOUR_C_NAMESPACE_OPEN
@@ -80,7 +80,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeSTIThermo<distype,
   my::extract_node_values(emasterphinp, discretization, la, "imasterphinp");
 
   Core::LinAlg::Matrix<nen_, 1> emastertempnp(Core::LinAlg::Initialization::zero);
-  if (kineticmodel == Inpar::S2I::kinetics_butlervolmerreducedthermoresistance)
+  if (kineticmodel == S2I::kinetics_butlervolmerreducedthermoresistance)
     my::extract_node_values(
         emastertempnp, discretization, la, "imastertemp", my::scatraparams_->nds_thermo());
 
@@ -189,7 +189,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeSTIThermo<distype,
   switch (kineticmodel)
   {
     // Butler-Volmer-Peltier kinetics
-    case Inpar::S2I::kinetics_butlervolmerpeltier:
+    case S2I::kinetics_butlervolmerpeltier:
     {
       switch (differentiationtype)
       {
@@ -264,7 +264,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeSTIThermo<distype,
       }
       break;
     }
-    case Inpar::S2I::kinetics_butlervolmerreducedthermoresistance:
+    case S2I::kinetics_butlervolmerreducedthermoresistance:
     {
       // average temperature at interface
       const double etempint = 0.5 * (eslavetempint + emastertempint);
@@ -369,8 +369,8 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeSTIThermo<distype,
       }
       break;
     }
-    case Inpar::S2I::kinetics_constantinterfaceresistance:
-    case Inpar::S2I::kinetics_nointerfaceflux:
+    case S2I::kinetics_constantinterfaceresistance:
+    case S2I::kinetics_nointerfaceflux:
       break;
 
     default:

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode_utils.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode_utils.cpp
@@ -7,7 +7,7 @@
 
 #include "4C_scatra_ele_boundary_calc_elch_electrode_utils.hpp"
 
-#include "4C_inpar_s2i.hpp"
+#include "4C_scatra_s2i_input.hpp"
 #include "4C_utils_exceptions.hpp"
 
 #include <cmath>
@@ -27,9 +27,9 @@ void Discret::Elements::calculate_butler_volmer_elch_linearizations(const int ki
   // core linearizations associated with Butler-Volmer mass flux density
   switch (kineticmodel)
   {
-    case Inpar::S2I::kinetics_butlervolmerreduced:
-    case Inpar::S2I::kinetics_butlervolmerreducedthermoresistance:
-    case Inpar::S2I::kinetics_butlervolmerreducedcapacitance:
+    case S2I::kinetics_butlervolmerreduced:
+    case S2I::kinetics_butlervolmerreducedthermoresistance:
+    case S2I::kinetics_butlervolmerreducedcapacitance:
     {
       dj_dc_slave = j0 * frt * epdderiv * (-alphaa * expterm1 - alphac * expterm2);
       dj_dc_master = 0.0;
@@ -37,7 +37,7 @@ void Discret::Elements::calculate_butler_volmer_elch_linearizations(const int ki
       dj_dpot_master = -dj_dpot_slave;
       break;
     }
-    case Inpar::S2I::kinetics_butlervolmerreducedlinearized:
+    case S2I::kinetics_butlervolmerreducedlinearized:
     {
       dj_dc_slave = -j0 * frt * epdderiv;
       dj_dc_master = 0.0;
@@ -45,8 +45,8 @@ void Discret::Elements::calculate_butler_volmer_elch_linearizations(const int ki
       dj_dpot_master = -dj_dpot_slave;
       break;
     }
-    case Inpar::S2I::kinetics_butlervolmer:
-    case Inpar::S2I::kinetics_butlervolmerpeltier:
+    case S2I::kinetics_butlervolmer:
+    case S2I::kinetics_butlervolmerpeltier:
     {
       dj_dc_slave =
           (kr * std::pow(emasterphiint, alphaa) * std::pow(cmax - eslavephiint, alphaa - 1.0) *
@@ -58,7 +58,7 @@ void Discret::Elements::calculate_butler_volmer_elch_linearizations(const int ki
       dj_dpot_master = -dj_dpot_slave;
       break;
     }
-    case Inpar::S2I::kinetics_butlervolmerlinearized:
+    case S2I::kinetics_butlervolmerlinearized:
     {
       dj_dc_slave =
           (kr * std::pow(emasterphiint, alphaa) * std::pow(cmax - eslavephiint, alphaa - 1.0) *
@@ -70,7 +70,7 @@ void Discret::Elements::calculate_butler_volmer_elch_linearizations(const int ki
       dj_dpot_master = -dj_dpot_slave;
       break;
     }
-    case Inpar::S2I::kinetics_butlervolmerresistance:
+    case S2I::kinetics_butlervolmerresistance:
     {
       // core linearizations associated with Butler-Volmer current density according to MA Schmidt
       // 2016 via implicit differentiation where F(x,i) = i - i0 * expterm
@@ -91,8 +91,8 @@ void Discret::Elements::calculate_butler_volmer_elch_linearizations(const int ki
       dj_dpot_slave = -dF_dpot_slave * dF_di_inverse;
       dj_dpot_master = -dF_dpot_master * dF_di_inverse;
       break;
-    }  // case Inpar::S2I::kinetics_butlervolmerresistance
-    case Inpar::S2I::kinetics_butlervolmerreducedresistance:
+    }  // case S2I::kinetics_butlervolmerresistance
+    case S2I::kinetics_butlervolmerreducedresistance:
     {
       // core linearizations associated with Butler-Volmer current density according to MA Schmidt
       // 2016 via implicit differentiation where F(x,i) = i - i0 * expterm
@@ -109,7 +109,7 @@ void Discret::Elements::calculate_butler_volmer_elch_linearizations(const int ki
       dj_dpot_slave = -dF_dpot_slave * dF_di_inverse;
       dj_dpot_master = -dF_dpot_master * dF_di_inverse;
       break;
-    }  // case Inpar::S2I::kinetics_butlervolmerreducedwithresistance
+    }  // case S2I::kinetics_butlervolmerreducedresistance
     default:
     {
       FOUR_C_THROW("Unknown scatra-scatra interface kinetic model: {}", kineticmodel);
@@ -255,18 +255,18 @@ double Discret::Elements::calculate_modified_butler_volmer_mass_flux_density(con
  *----------------------------------------------------------------------*/
 bool Discret::Elements::is_butler_volmer_linearized(const int kineticmodel)
 {
-  return (kineticmodel == Inpar::S2I::kinetics_butlervolmerlinearized or
-          kineticmodel == Inpar::S2I::kinetics_butlervolmerreducedlinearized);
+  return (kineticmodel == S2I::kinetics_butlervolmerlinearized or
+          kineticmodel == S2I::kinetics_butlervolmerreducedlinearized);
 }
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 bool Discret::Elements::is_reduced_butler_volmer(const int kineticmodel)
 {
-  return (kineticmodel == Inpar::S2I::kinetics_butlervolmerreduced or
-          kineticmodel == Inpar::S2I::kinetics_butlervolmerreducedlinearized or
-          kineticmodel == Inpar::S2I::kinetics_butlervolmerreducedresistance or
-          kineticmodel == Inpar::S2I::kinetics_butlervolmerreducedthermoresistance or
-          kineticmodel == Inpar::S2I::kinetics_butlervolmerreducedcapacitance);
+  return (kineticmodel == S2I::kinetics_butlervolmerreduced or
+          kineticmodel == S2I::kinetics_butlervolmerreducedlinearized or
+          kineticmodel == S2I::kinetics_butlervolmerreducedresistance or
+          kineticmodel == S2I::kinetics_butlervolmerreducedthermoresistance or
+          kineticmodel == S2I::kinetics_butlervolmerreducedcapacitance);
 }
 FOUR_C_NAMESPACE_CLOSE

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_sti_electrode.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_sti_electrode.cpp
@@ -10,7 +10,6 @@
 #include "4C_fem_discretization.hpp"
 #include "4C_fem_general_utils_boundary_integration.hpp"
 #include "4C_fem_general_utils_fem_shapefunctions.hpp"
-#include "4C_inpar_s2i.hpp"
 #include "4C_mat_electrode.hpp"
 #include "4C_mat_fourier.hpp"
 #include "4C_mat_soret.hpp"
@@ -19,6 +18,7 @@
 #include "4C_scatra_ele_parameter_elch.hpp"
 #include "4C_scatra_ele_parameter_std.hpp"
 #include "4C_scatra_ele_parameter_timint.hpp"
+#include "4C_scatra_s2i_input.hpp"
 #include "4C_utils_singleton_owner.hpp"
 
 FOUR_C_NAMESPACE_OPEN
@@ -89,7 +89,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<distype, probdim>::eva
   const int kineticmodel = my::scatraparamsboundary_->kinetic_model();
 
   Core::LinAlg::Matrix<nen_, 1> emastertemp(Core::LinAlg::Initialization::zero);
-  if (kineticmodel == Inpar::S2I::kinetics_butlervolmerreducedthermoresistance)
+  if (kineticmodel == S2I::kinetics_butlervolmerreducedthermoresistance)
     my::extract_node_values(emastertemp, discretization, la, "imastertemp", 3);
 
   // element slave mechanical stress tensor
@@ -172,7 +172,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<distype,
   switch (kineticmodel)
   {
     // Butler-Volmer-Peltier kinetics
-    case Inpar::S2I::kinetics_butlervolmerpeltier:
+    case S2I::kinetics_butlervolmerpeltier:
     {
       // extract saturation value of intercalated lithium concentration from electrode material
       const double cmax = matelectrode.c_max();
@@ -215,7 +215,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<distype,
 
       break;
     }
-    case Inpar::S2I::kinetics_butlervolmerreducedthermoresistance:
+    case S2I::kinetics_butlervolmerreducedthermoresistance:
     {
       // Flux of energy from mass flux and from difference in temperature
       double j_timefacrhsfac(0.0);
@@ -291,9 +291,9 @@ void Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<distype,
 
       break;
     }
-    case Inpar::S2I::kinetics_butlervolmerreduced:
-    case Inpar::S2I::kinetics_constantinterfaceresistance:
-    case Inpar::S2I::kinetics_nointerfaceflux:
+    case S2I::kinetics_butlervolmerreduced:
+    case S2I::kinetics_constantinterfaceresistance:
+    case S2I::kinetics_nointerfaceflux:
     {
       // do nothing
       break;
@@ -339,7 +339,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<distype,
   const int kineticmodel = my::scatraparamsboundary_->kinetic_model();
 
   Core::LinAlg::Matrix<nen_, 1> emastertemp(Core::LinAlg::Initialization::zero);
-  if (kineticmodel == Inpar::S2I::kinetics_butlervolmerreducedthermoresistance)
+  if (kineticmodel == S2I::kinetics_butlervolmerreducedthermoresistance)
     my::extract_node_values(emastertemp, discretization, la, "imastertemp", 3);
 
   // get primary variable to derive the linearization
@@ -436,7 +436,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<distype,
   switch (kineticmodel)
   {
     // Butler-Volmer-Peltier kinetics
-    case Inpar::S2I::kinetics_butlervolmerpeltier:
+    case S2I::kinetics_butlervolmerpeltier:
     {
       switch (differentiationtype)
       {
@@ -528,7 +528,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<distype,
       }
       break;
     }
-    case Inpar::S2I::kinetics_butlervolmerreducedthermoresistance:
+    case S2I::kinetics_butlervolmerreducedthermoresistance:
     {
       switch (differentiationtype)
       {
@@ -691,9 +691,9 @@ void Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<distype,
       }
       break;
     }
-    case Inpar::S2I::kinetics_butlervolmerreduced:
-    case Inpar::S2I::kinetics_constantinterfaceresistance:
-    case Inpar::S2I::kinetics_nointerfaceflux:
+    case S2I::kinetics_butlervolmerreduced:
+    case S2I::kinetics_constantinterfaceresistance:
+    case S2I::kinetics_nointerfaceflux:
     {
       // do nothing
       break;

--- a/src/scatra_ele/4C_scatra_ele_parameter_boundary.cpp
+++ b/src/scatra_ele/4C_scatra_ele_parameter_boundary.cpp
@@ -51,7 +51,7 @@ Discret::Elements::ScaTraEleParameterBoundary::ScaTraEleParameterBoundary(
       peltier_(0.0),
       permeabilities_(nullptr),
       regularizationparameter_(-1.0),
-      regularizationtype_(Inpar::S2I::RegularizationType::regularization_undefined),
+      regularizationtype_(S2I::RegularizationType::regularization_undefined),
       resistance_(0.0),
       resistivity_(0.0),
       capacitance_(0.0),
@@ -77,8 +77,8 @@ void Discret::Elements::ScaTraEleParameterBoundary::set_parameters(
       // set parameters to internal members depending on kinetic model
       switch (kineticmodel_)
       {
-        case Inpar::S2I::kinetics_constperm:
-        case Inpar::S2I::kinetics_linearperm:
+        case S2I::kinetics_constperm:
+        case S2I::kinetics_linearperm:
         {
           set_is_pseudo_contact(parameters);
           set_num_scal(parameters);
@@ -86,7 +86,7 @@ void Discret::Elements::ScaTraEleParameterBoundary::set_parameters(
           break;
         }
 
-        case Inpar::S2I::kinetics_constantinterfaceresistance:
+        case S2I::kinetics_constantinterfaceresistance:
         {
           set_is_pseudo_contact(parameters);
           set_resistance(parameters);
@@ -95,21 +95,21 @@ void Discret::Elements::ScaTraEleParameterBoundary::set_parameters(
           break;
         }
 
-        case Inpar::S2I::kinetics_nointerfaceflux:
+        case S2I::kinetics_nointerfaceflux:
         {
           // do nothing
           break;
         }
 
-        case Inpar::S2I::kinetics_butlervolmer:
-        case Inpar::S2I::kinetics_butlervolmerlinearized:
-        case Inpar::S2I::kinetics_butlervolmerreduced:
-        case Inpar::S2I::kinetics_butlervolmerreducedcapacitance:
-        case Inpar::S2I::kinetics_butlervolmerreducedlinearized:
-        case Inpar::S2I::kinetics_butlervolmerpeltier:
-        case Inpar::S2I::kinetics_butlervolmerresistance:
-        case Inpar::S2I::kinetics_butlervolmerreducedthermoresistance:
-        case Inpar::S2I::kinetics_butlervolmerreducedresistance:
+        case S2I::kinetics_butlervolmer:
+        case S2I::kinetics_butlervolmerlinearized:
+        case S2I::kinetics_butlervolmerreduced:
+        case S2I::kinetics_butlervolmerreducedcapacitance:
+        case S2I::kinetics_butlervolmerreducedlinearized:
+        case S2I::kinetics_butlervolmerpeltier:
+        case S2I::kinetics_butlervolmerresistance:
+        case S2I::kinetics_butlervolmerreducedthermoresistance:
+        case S2I::kinetics_butlervolmerreducedresistance:
         {
           set_alpha(parameters);
           set_charge_transfer_constant(parameters);
@@ -117,19 +117,19 @@ void Discret::Elements::ScaTraEleParameterBoundary::set_parameters(
           set_num_electrons(parameters);
           set_num_scal(parameters);
           set_stoichiometries(parameters);
-          if (kineticmodel_ == Inpar::S2I::kinetics_butlervolmerreducedcapacitance)
+          if (kineticmodel_ == S2I::kinetics_butlervolmerreducedcapacitance)
           {
             set_capacitance(parameters);
           }
-          if (kineticmodel_ == Inpar::S2I::kinetics_butlervolmerpeltier)
+          if (kineticmodel_ == S2I::kinetics_butlervolmerpeltier)
             set_peltier(parameters);
-          else if (kineticmodel_ == Inpar::S2I::kinetics_butlervolmerresistance or
-                   kineticmodel_ == Inpar::S2I::kinetics_butlervolmerreducedresistance)
+          else if (kineticmodel_ == S2I::kinetics_butlervolmerresistance or
+                   kineticmodel_ == S2I::kinetics_butlervolmerreducedresistance)
           {
             set_conv_tol_iter_num(parameters);
             set_resistance(parameters);
           }
-          if (kineticmodel_ == Inpar::S2I::kinetics_butlervolmerreducedthermoresistance)
+          if (kineticmodel_ == S2I::kinetics_butlervolmerreducedthermoresistance)
           {
             set_energy_substance_ratio(parameters);
             set_thermo_perm(parameters);
@@ -144,7 +144,7 @@ void Discret::Elements::ScaTraEleParameterBoundary::set_parameters(
       }
 
       // regularization is not relevant for scatra-scatra interface coupling without growth
-      regularizationtype_ = Inpar::S2I::RegularizationType::regularization_none;
+      regularizationtype_ = S2I::RegularizationType::regularization_none;
 
       break;
     }
@@ -154,7 +154,7 @@ void Discret::Elements::ScaTraEleParameterBoundary::set_parameters(
       // set parameters to internal members depending on kinetic model
       switch (kineticmodel_)
       {
-        case Inpar::S2I::growth_kinetics_butlervolmer:
+        case S2I::growth_kinetics_butlervolmer:
         {
           set_alpha(parameters);
           set_charge_transfer_constant(parameters);
@@ -289,7 +289,7 @@ void Discret::Elements::ScaTraEleParameterBoundary::set_regularization(
   regularizationparameter_ = parameters.get<double>("REGPAR", -1.0);
   if (regularizationparameter_ < 0.0)
     FOUR_C_THROW("Regularization parameter for lithium stripping must not be negative!");
-  regularizationtype_ = parameters.get<Inpar::S2I::RegularizationType>("REGTYPE");
+  regularizationtype_ = parameters.get<S2I::RegularizationType>("REGTYPE");
 }
 
 /*----------------------------------------------------------------------*

--- a/src/scatra_ele/4C_scatra_ele_parameter_boundary.hpp
+++ b/src/scatra_ele/4C_scatra_ele_parameter_boundary.hpp
@@ -11,8 +11,8 @@
 #include "4C_config.hpp"
 
 #include "4C_fem_condition.hpp"
-#include "4C_inpar_s2i.hpp"
 #include "4C_scatra_ele_parameter_base.hpp"
+#include "4C_scatra_s2i_input.hpp"
 
 #include <vector>
 
@@ -73,7 +73,7 @@ namespace Discret
       double peltier() const { return peltier_; }
       const std::vector<double>* permeabilities() const { return permeabilities_; }
       double regularization_parameter() const { return regularizationparameter_; }
-      Inpar::S2I::RegularizationType regularization_type() const { return regularizationtype_; }
+      S2I::RegularizationType regularization_type() const { return regularizationtype_; }
       double resistance() const { return resistance_; }
       double resistivity() const { return resistivity_; }
       const std::vector<int>* stoichiometries() const { return stoichiometries_; }
@@ -140,7 +140,7 @@ namespace Discret
       double regularizationparameter_;
 
       /// type of regularization for S2IKineticsGrowth condition
-      Inpar::S2I::RegularizationType regularizationtype_;
+      S2I::RegularizationType regularizationtype_;
 
       /// interface resistance associated with S2ICoupling condition
       double resistance_;

--- a/src/ssi/4C_ssi_base.cpp
+++ b/src/ssi/4C_ssi_base.cpp
@@ -895,10 +895,10 @@ bool SSI::SSIBase::check_s2i_kinetics_condition_for_pseudo_contact(
   structdis->get_condition("SSIInterfaceContact", ssi_contact_conditions);
   for (auto* s2ikinetics_cond : s2ikinetics_conditions)
   {
-    if ((s2ikinetics_cond->parameters().get<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE") ==
-            Inpar::S2I::side_source) and
-        (s2ikinetics_cond->parameters().get<Inpar::S2I::KineticModels>("KINETIC_MODEL") !=
-            Inpar::S2I::kinetics_nointerfaceflux) and
+    if ((s2ikinetics_cond->parameters().get<S2I::InterfaceSides>("INTERFACE_SIDE") ==
+            S2I::side_source) and
+        (s2ikinetics_cond->parameters().get<S2I::KineticModels>("KINETIC_MODEL") !=
+            S2I::kinetics_nointerfaceflux) and
         s2ikinetics_cond->parameters().get<bool>("IS_PSEUDO_CONTACT"))
     {
       is_s2i_kinetic_with_pseudo_contact = true;

--- a/src/ssi/4C_ssi_input.cpp
+++ b/src/ssi/4C_ssi_input.cpp
@@ -8,11 +8,11 @@
 #include "4C_ssi_input.hpp"
 
 #include "4C_fem_condition_definition.hpp"
-#include "4C_inpar_s2i.hpp"
 #include "4C_io_input_spec_builders.hpp"
 #include "4C_linalg_equilibrate.hpp"
 #include "4C_linalg_sparseoperator.hpp"
 #include "4C_scatra_input.hpp"
+#include "4C_scatra_s2i_input.hpp"
 FOUR_C_NAMESPACE_OPEN
 
 std::vector<Core::IO::InputSpec> SSI::valid_parameters()
@@ -338,9 +338,9 @@ void SSI::set_valid_conditions(std::vector<Core::Conditions::ConditionDefinition
   const auto make_ssiinterfacemeshtying = [&condlist](Core::Conditions::ConditionDefinition& cond)
   {
     cond.add_component(parameter<int>("ConditionID"));
-    cond.add_component(deprecated_selection<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE",
-        {{"Undefined", Inpar::S2I::side_undefined}, {"Slave", Inpar::S2I::side_source},
-            {"Master", Inpar::S2I::side_master}},
+    cond.add_component(deprecated_selection<S2I::InterfaceSides>("INTERFACE_SIDE",
+        {{"Undefined", S2I::side_undefined}, {"Slave", S2I::side_source},
+            {"Master", S2I::side_master}},
         {.description = "interface_side"}));
     cond.add_component(parameter<int>("S2I_KINETICS_ID"));
 
@@ -395,16 +395,15 @@ void SSI::set_valid_conditions(std::vector<Core::Conditions::ConditionDefinition
 
     surfmanifoldkinetics.add_component(one_of({
         all_of({
-            deprecated_selection<Inpar::S2I::KineticModels>(
-                "KINETIC_MODEL", {{"ConstantInterfaceResistance",
-                                     Inpar::S2I::kinetics_constantinterfaceresistance}}),
+            deprecated_selection<S2I::KineticModels>("KINETIC_MODEL",
+                {{"ConstantInterfaceResistance", S2I::kinetics_constantinterfaceresistance}}),
             parameter<std::vector<int>>("ONOFF", {.size = 2}),
             parameter<double>("RESISTANCE"),
             parameter<int>("E-"),
         }),
         all_of({
-            deprecated_selection<Inpar::S2I::KineticModels>("KINETIC_MODEL",
-                {{"Butler-VolmerReduced", Inpar::S2I::kinetics_butlervolmerreduced}}),
+            deprecated_selection<S2I::KineticModels>(
+                "KINETIC_MODEL", {{"Butler-VolmerReduced", S2I::kinetics_butlervolmerreduced}}),
             parameter<int>("NUMSCAL"),
             parameter<std::vector<int>>(
                 "STOICHIOMETRIES", {.size = from_parameter<int>("NUMSCAL")}),
@@ -413,8 +412,8 @@ void SSI::set_valid_conditions(std::vector<Core::Conditions::ConditionDefinition
             parameter<double>("ALPHA_A"),
             parameter<double>("ALPHA_C"),
         }),
-        deprecated_selection<Inpar::S2I::KineticModels>(
-            "KINETIC_MODEL", {{"NoInterfaceFlux", Inpar::S2I::kinetics_nointerfaceflux}}),
+        deprecated_selection<S2I::KineticModels>(
+            "KINETIC_MODEL", {{"NoInterfaceFlux", S2I::kinetics_nointerfaceflux}}),
     }));
   }
 
@@ -474,9 +473,9 @@ void SSI::set_valid_conditions(std::vector<Core::Conditions::ConditionDefinition
   const auto make_ssiinterfacecontact = [&condlist](Core::Conditions::ConditionDefinition& cond)
   {
     cond.add_component(parameter<int>("ConditionID"));
-    cond.add_component(deprecated_selection<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE",
-        {{"Undefined", Inpar::S2I::side_undefined}, {"Slave", Inpar::S2I::side_source},
-            {"Master", Inpar::S2I::side_master}},
+    cond.add_component(deprecated_selection<S2I::InterfaceSides>("INTERFACE_SIDE",
+        {{"Undefined", S2I::side_undefined}, {"Slave", S2I::side_source},
+            {"Master", S2I::side_master}},
         {.description = "interface_side"}));
     cond.add_component(parameter<int>("S2I_KINETICS_ID"));
     cond.add_component(parameter<int>("CONTACT_CONDITION_ID"));

--- a/src/ssi/4C_ssi_manifold_utils.cpp
+++ b/src/ssi/4C_ssi_manifold_utils.cpp
@@ -14,12 +14,12 @@
 #include "4C_fem_condition_utils.hpp"
 #include "4C_fem_general_assemblestrategy.hpp"
 #include "4C_global_data.hpp"
-#include "4C_inpar_s2i.hpp"
 #include "4C_io_runtime_csv_writer.hpp"
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
 #include "4C_linalg_utils_sparse_algebra_math.hpp"
 #include "4C_scatra_ele_action.hpp"
 #include "4C_scatra_ele_parameter_boundary.hpp"
+#include "4C_scatra_s2i_input.hpp"
 #include "4C_scatra_timint_implicit.hpp"
 #include "4C_ssi_monolithic.hpp"
 #include "4C_ssi_problem_access.hpp"
@@ -686,13 +686,12 @@ void SSI::ScaTraManifoldScaTraFluxEvaluator::pre_evaluate(
   eleparams.set<Core::Conditions::ConditionType>(
       "condition type", Core::Conditions::ConditionType::S2IKinetics);
 
-  switch (
-      scatra_manifold_coupling.condition_kinetics()->parameters().get<Inpar::S2I::KineticModels>(
-          "KINETIC_MODEL"))
+  switch (scatra_manifold_coupling.condition_kinetics()->parameters().get<S2I::KineticModels>(
+      "KINETIC_MODEL"))
   {
-    case Inpar::S2I::kinetics_constantinterfaceresistance:
+    case S2I::kinetics_constantinterfaceresistance:
     {
-      eleparams.set<int>("KINETIC_MODEL", Inpar::S2I::kinetics_constantinterfaceresistance);
+      eleparams.set<int>("KINETIC_MODEL", S2I::kinetics_constantinterfaceresistance);
       eleparams.set<double>("RESISTANCE",
           scatra_manifold_coupling.condition_kinetics()->parameters().get<double>("RESISTANCE"));
       eleparams.set<const std::vector<int>*>("ONOFF",
@@ -702,9 +701,9 @@ void SSI::ScaTraManifoldScaTraFluxEvaluator::pre_evaluate(
           scatra_manifold_coupling.condition_kinetics()->parameters().get<int>("E-"));
       break;
     }
-    case Inpar::S2I::kinetics_butlervolmerreduced:
+    case S2I::kinetics_butlervolmerreduced:
     {
-      eleparams.set<int>("KINETIC_MODEL", Inpar::S2I::kinetics_butlervolmerreduced);
+      eleparams.set<int>("KINETIC_MODEL", S2I::kinetics_butlervolmerreduced);
       eleparams.set<int>("NUMSCAL",
           scatra_manifold_coupling.condition_kinetics()->parameters().get<int>("NUMSCAL"));
       eleparams.set<const std::vector<int>*>("STOICHIOMETRIES",
@@ -720,9 +719,9 @@ void SSI::ScaTraManifoldScaTraFluxEvaluator::pre_evaluate(
           scatra_manifold_coupling.condition_kinetics()->parameters().get<double>("ALPHA_C"));
       break;
     }
-    case Inpar::S2I::kinetics_nointerfaceflux:
+    case S2I::kinetics_nointerfaceflux:
     {
-      eleparams.set<int>("KINETIC_MODEL", Inpar::S2I::kinetics_nointerfaceflux);
+      eleparams.set<int>("KINETIC_MODEL", S2I::kinetics_nointerfaceflux);
       break;
     }
     default:

--- a/src/ssi/4C_ssi_monolithic.cpp
+++ b/src/ssi/4C_ssi_monolithic.cpp
@@ -713,7 +713,7 @@ void SSI::SsiMono::setup()
         "Must have incremental solution approach for monolithic scalar-structure interaction!");
 
   if (ssi_interface_meshtying() and
-      meshtying_strategy_s2i()->coupling_type() != Inpar::S2I::coupling_matching_nodes)
+      meshtying_strategy_s2i()->coupling_type() != S2I::coupling_matching_nodes)
   {
     FOUR_C_THROW(
         "Monolithic scalar-structure interaction only implemented for scatra-scatra "

--- a/src/ssi/4C_ssi_monolithic_evaluate_OffDiag.cpp
+++ b/src/ssi/4C_ssi_monolithic_evaluate_OffDiag.cpp
@@ -393,8 +393,8 @@ void SSI::ScatraStructureOffDiagCoupling::
   for (auto kinetics_slave_cond :
       meshtying_strategy_s2i_->kinetics_conditions_meshtying_slave_side())
   {
-    if (kinetics_slave_cond.second->parameters().get<Inpar::S2I::KineticModels>("KINETIC_MODEL") ==
-        static_cast<int>(Inpar::S2I::kinetics_butlervolmerreducedcapacitance))
+    if (kinetics_slave_cond.second->parameters().get<S2I::KineticModels>("KINETIC_MODEL") ==
+        static_cast<int>(S2I::kinetics_butlervolmerreducedcapacitance))
     {
       // collect condition specific data and store to scatra boundary parameter class
       meshtying_strategy_s2i_->set_condition_specific_scatra_parameters(
@@ -630,8 +630,8 @@ void SSI::ScatraStructureOffDiagCoupling::
   for (auto kinetics_slave_cond :
       meshtying_strategy_s2i_->kinetics_conditions_meshtying_slave_side())
   {
-    if (kinetics_slave_cond.second->parameters().get<Inpar::S2I::KineticModels>("KINETIC_MODEL") !=
-        static_cast<int>(Inpar::S2I::kinetics_nointerfaceflux))
+    if (kinetics_slave_cond.second->parameters().get<S2I::KineticModels>("KINETIC_MODEL") !=
+        static_cast<int>(S2I::kinetics_nointerfaceflux))
     {
       // collect condition specific data and store to scatra boundary parameter class
       meshtying_strategy_s2i_->set_condition_specific_scatra_parameters(

--- a/src/ssi/4C_ssi_utils.cpp
+++ b/src/ssi/4C_ssi_utils.cpp
@@ -16,9 +16,9 @@
 #include "4C_fem_general_utils_createdis.hpp"
 #include "4C_geometric_search_matchingoctree.hpp"
 #include "4C_global_data.hpp"
-#include "4C_inpar_s2i.hpp"
 #include "4C_linalg_utils_sparse_algebra_create.hpp"
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
+#include "4C_scatra_s2i_input.hpp"
 #include "4C_scatra_timint_implicit.hpp"
 #include "4C_scatra_timint_meshtying_strategy_s2i.hpp"
 #include "4C_ssi_monolithic.hpp"
@@ -1304,8 +1304,8 @@ void SSI::Utils::SSIMeshTying::find_slave_slave_transformation_nodes(
   std::vector<int> original_slave_gids;
   for (auto* meshtying_condition : meshtying_conditions)
   {
-    if (meshtying_condition->parameters().get<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE") ==
-        Inpar::S2I::side_source)
+    if (meshtying_condition->parameters().get<S2I::InterfaceSides>("INTERFACE_SIDE") ==
+        S2I::side_source)
     {
       Core::Communication::add_owned_node_gid_from_list(
           dis, *meshtying_condition->get_nodes(), original_slave_gids);

--- a/src/ssti/4C_ssti_algorithm.cpp
+++ b/src/ssti/4C_ssti_algorithm.cpp
@@ -205,7 +205,7 @@ void SSTI::SSTIAlgorithm::setup()
     // safety checks
     if (meshtying_strategy_scatra_ == nullptr)
       FOUR_C_THROW("Invalid scatra-scatra interface coupling strategy!");
-    if (meshtying_strategy_scatra_->coupling_type() != Inpar::S2I::coupling_matching_nodes)
+    if (meshtying_strategy_scatra_->coupling_type() != S2I::coupling_matching_nodes)
       FOUR_C_THROW("SSTI only implemented for interface coupling with matching interface nodes!");
 
     // extract meshtying strategy for scatra-scatra interface coupling on thermo discretization
@@ -213,7 +213,7 @@ void SSTI::SSTIAlgorithm::setup()
         thermo_->scatra_field()->strategy());
     if (meshtying_strategy_thermo_ == nullptr)
       FOUR_C_THROW("Invalid scatra-scatra interface coupling strategy!");
-    if (meshtying_strategy_thermo_->coupling_type() != Inpar::S2I::coupling_matching_nodes)
+    if (meshtying_strategy_thermo_->coupling_type() != S2I::coupling_matching_nodes)
       FOUR_C_THROW("SSTI only implemented for interface coupling with matching interface nodes!");
 
     // setup everything for SSTI structure meshtying

--- a/src/ssti/4C_ssti_input.cpp
+++ b/src/ssti/4C_ssti_input.cpp
@@ -8,11 +8,11 @@
 #include "4C_ssti_input.hpp"
 
 #include "4C_fem_condition_definition.hpp"
-#include "4C_inpar_s2i.hpp"
 #include "4C_io_input_spec_builders.hpp"
 #include "4C_linalg_equilibrate.hpp"
 #include "4C_linalg_sparseoperator.hpp"
 #include "4C_scatra_input.hpp"
+#include "4C_scatra_s2i_input.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -149,9 +149,9 @@ void SSTI::set_valid_conditions(std::vector<Core::Conditions::ConditionDefinitio
   const auto make_sstiinterfacemeshtying = [&condlist](Core::Conditions::ConditionDefinition& cond)
   {
     cond.add_component(parameter<int>("ConditionID"));
-    cond.add_component(deprecated_selection<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE",
-        {{"Undefined", Inpar::S2I::side_undefined}, {"Slave", Inpar::S2I::side_source},
-            {"Master", Inpar::S2I::side_master}},
+    cond.add_component(deprecated_selection<S2I::InterfaceSides>("INTERFACE_SIDE",
+        {{"Undefined", S2I::side_undefined}, {"Slave", S2I::side_source},
+            {"Master", S2I::side_master}},
         {.description = "interface side"}));
     cond.add_component(parameter<int>("S2I_KINETICS_ID"));
     condlist.push_back(cond);

--- a/src/ssti/4C_ssti_monolithic_evaluate_OffDiag.cpp
+++ b/src/ssti/4C_ssti_monolithic_evaluate_OffDiag.cpp
@@ -319,8 +319,8 @@ void SSTI::ThermoStructureOffDiagCoupling::evaluate_thermo_structure_interface_s
   for (auto kinetics_slave_cond :
       meshtying_strategy_thermo_->kinetics_conditions_meshtying_slave_side())
   {
-    if (kinetics_slave_cond.second->parameters().get<Inpar::S2I::KineticModels>("KINETIC_MODEL") !=
-        static_cast<int>(Inpar::S2I::kinetics_nointerfaceflux))
+    if (kinetics_slave_cond.second->parameters().get<S2I::KineticModels>("KINETIC_MODEL") !=
+        static_cast<int>(S2I::kinetics_nointerfaceflux))
     {
       // collect condition specific data and store to scatra boundary parameter class
       meshtying_strategy_thermo_->set_condition_specific_scatra_parameters(

--- a/src/sti/4C_sti_algorithm.cpp
+++ b/src/sti/4C_sti_algorithm.cpp
@@ -93,10 +93,10 @@ STI::Algorithm::Algorithm(MPI_Comm comm, const Teuchos::ParameterList& stidyn,
     // perform initializations depending on type of meshtying method
     switch (strategyscatra_->coupling_type())
     {
-      case Inpar::S2I::coupling_matching_nodes:
+      case S2I::coupling_matching_nodes:
       {
         // safety check
-        if (strategythermo_->coupling_type() != Inpar::S2I::coupling_matching_nodes)
+        if (strategythermo_->coupling_type() != S2I::coupling_matching_nodes)
         {
           FOUR_C_THROW(
               "Must have matching nodes at scatra-scatra coupling interfaces in both the scatra "
@@ -106,10 +106,10 @@ STI::Algorithm::Algorithm(MPI_Comm comm, const Teuchos::ParameterList& stidyn,
         break;
       }
 
-      case Inpar::S2I::coupling_mortar_standard:
+      case S2I::coupling_mortar_standard:
       {
         // safety check
-        if (strategythermo_->coupling_type() != Inpar::S2I::coupling_mortar_condensed_bubnov)
+        if (strategythermo_->coupling_type() != S2I::coupling_mortar_condensed_bubnov)
           FOUR_C_THROW("Invalid type of scatra-scatra interface coupling for thermo field!");
 
         // extract scatra-scatra interface mesh tying conditions
@@ -120,8 +120,8 @@ STI::Algorithm::Algorithm(MPI_Comm comm, const Teuchos::ParameterList& stidyn,
         for (auto& condition : conditions)
         {
           // consider conditions for slave side only
-          if (condition->parameters().get<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE") ==
-              Inpar::S2I::side_source)
+          if (condition->parameters().get<S2I::InterfaceSides>("INTERFACE_SIDE") ==
+              S2I::side_source)
           {
             // extract ID of current condition
             const int condid = condition->parameters().get<int>("ConditionID");
@@ -183,21 +183,20 @@ void STI::Algorithm::modify_field_parameters_for_thermo_field()
     fieldparameters_->sublist("S2I COUPLING").set<bool>("SLAVEONLY", true);
 
     // adapt type of meshtying method for thermo field
-    if (fieldparameters_->sublist("S2I COUPLING").get<Inpar::S2I::CouplingType>("COUPLINGTYPE") ==
-        Inpar::S2I::CouplingType::coupling_mortar_standard)
+    if (fieldparameters_->sublist("S2I COUPLING").get<S2I::CouplingType>("COUPLINGTYPE") ==
+        S2I::CouplingType::coupling_mortar_standard)
     {
       fieldparameters_->sublist("S2I COUPLING")
-          .set<Inpar::S2I::CouplingType>(
-              "COUPLINGTYPE", Inpar::S2I::CouplingType::coupling_mortar_condensed_bubnov);
+          .set<S2I::CouplingType>(
+              "COUPLINGTYPE", S2I::CouplingType::coupling_mortar_condensed_bubnov);
     }
-    else if (fieldparameters_->sublist("S2I COUPLING")
-                 .get<Inpar::S2I::CouplingType>("COUPLINGTYPE") !=
-             Inpar::S2I::CouplingType::coupling_matching_nodes)
+    else if (fieldparameters_->sublist("S2I COUPLING").get<S2I::CouplingType>("COUPLINGTYPE") !=
+             S2I::CouplingType::coupling_matching_nodes)
       FOUR_C_THROW("Invalid type of scatra-scatra interface coupling!");
 
     // make sure that interface side underlying Lagrange multiplier definition is slave side
     fieldparameters_->sublist("S2I COUPLING")
-        .set<Inpar::S2I::InterfaceSides>("LMSIDE", Inpar::S2I::InterfaceSides::side_source);
+        .set<S2I::InterfaceSides>("LMSIDE", S2I::InterfaceSides::side_source);
   }
 }  // STI::Algorithm::modify_field_parameters_for_thermo_field()
 
@@ -307,7 +306,7 @@ void STI::Algorithm::transfer_scatra_to_thermo(
   {
     switch (strategythermo_->coupling_type())
     {
-      case Inpar::S2I::coupling_matching_nodes:
+      case S2I::coupling_matching_nodes:
       {
         // pass master-side scatra degrees of freedom to thermo discretization
         const std::shared_ptr<Core::LinAlg::Vector<double>> imasterphinp =
@@ -322,7 +321,7 @@ void STI::Algorithm::transfer_scatra_to_thermo(
         break;
       }
 
-      case Inpar::S2I::coupling_mortar_condensed_bubnov:
+      case S2I::coupling_mortar_condensed_bubnov:
       {
         // extract scatra-scatra interface mesh tying conditions
         std::vector<const Core::Conditions::Condition*> conditions;
@@ -332,8 +331,8 @@ void STI::Algorithm::transfer_scatra_to_thermo(
         for (auto& condition : conditions)
         {
           // consider conditions for slave side only
-          if (condition->parameters().get<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE") ==
-              Inpar::S2I::side_source)
+          if (condition->parameters().get<S2I::InterfaceSides>("INTERFACE_SIDE") ==
+              S2I::side_source)
           {
             // extract ID of current condition
             const int condid = condition->parameters().get<int>("ConditionID");
@@ -370,7 +369,7 @@ void STI::Algorithm::transfer_thermo_to_scatra(
 
   // transfer state vector for evaluation of scatra-scatra interface mesh tying
   if (scatra_->scatra_field()->s2i_meshtying() and
-      strategyscatra_->coupling_type() == Inpar::S2I::coupling_mortar_standard)
+      strategyscatra_->coupling_type() == S2I::coupling_mortar_standard)
   {
     // extract scatra-scatra interface mesh tying conditions
     std::vector<const Core::Conditions::Condition*> conditions;
@@ -380,8 +379,7 @@ void STI::Algorithm::transfer_thermo_to_scatra(
     for (auto& condition : conditions)
     {
       // consider conditions for slave side only
-      if (condition->parameters().get<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE") ==
-          Inpar::S2I::side_source)
+      if (condition->parameters().get<S2I::InterfaceSides>("INTERFACE_SIDE") == S2I::side_source)
       {
         // extract ID of current condition
         const int condid = condition->parameters().get<int>("ConditionID");

--- a/src/sti/4C_sti_monolithic.cpp
+++ b/src/sti/4C_sti_monolithic.cpp
@@ -80,7 +80,7 @@ STI::Monolithic::Monolithic(MPI_Comm comm, const Teuchos::ParameterList& stidyn,
 
   // extract coupling adapters for scatra-scatra interface mesh tying
   if (scatra_field()->s2i_meshtying() and
-      strategyscatra_->coupling_type() == Inpar::S2I::coupling_matching_nodes)
+      strategyscatra_->coupling_type() == S2I::coupling_matching_nodes)
   {
     icoupscatra_ = strategyscatra_->coupling_adapter();
     icoupthermo_ = strategythermo_->coupling_adapter();
@@ -809,7 +809,7 @@ void STI::Monolithic::assemble_mat_and_rhs()
 
               switch (strategyscatra_->coupling_type())
               {
-                case Inpar::S2I::coupling_matching_nodes:
+                case S2I::coupling_matching_nodes:
                 {
                   Coupling::Adapter::CouplingSlaveConverter converter(*icoupthermo_);
                   Coupling::Adapter::MatrixLogicalSplitAndTransform()(scatrathermoblock,
@@ -818,7 +818,7 @@ void STI::Monolithic::assemble_mat_and_rhs()
                       true, true);
                   break;
                 }
-                case Inpar::S2I::coupling_mortar_standard:
+                case S2I::coupling_mortar_standard:
                 {
                   // initialize temporary matrix for slave-side columns of current matrix block
                   Core::LinAlg::SparseMatrix scatrathermocolsslave(scatrathermoblock.row_map(), 81);
@@ -880,7 +880,7 @@ void STI::Monolithic::assemble_mat_and_rhs()
 
             switch (strategyscatra_->coupling_type())
             {
-              case Inpar::S2I::coupling_matching_nodes:
+              case S2I::coupling_matching_nodes:
               {
                 Coupling::Adapter::CouplingSlaveConverter converter(*icoupthermo_);
                 Coupling::Adapter::MatrixLogicalSplitAndTransform()(
@@ -889,7 +889,7 @@ void STI::Monolithic::assemble_mat_and_rhs()
                     blocksystemmatrix->matrix(nblockmapsscatra, nblockmapsscatra), true, true);
                 break;
               }
-              case Inpar::S2I::coupling_mortar_standard:
+              case S2I::coupling_mortar_standard:
               {
                 // initialize temporary matrix for slave-side columns of thermo-thermo matrix block
                 Core::LinAlg::SparseMatrix thermothermocolsslave(*maps_->map(1), 81);
@@ -957,7 +957,7 @@ void STI::Monolithic::assemble_mat_and_rhs()
 
             switch (strategyscatra_->coupling_type())
             {
-              case Inpar::S2I::coupling_matching_nodes:
+              case S2I::coupling_matching_nodes:
               {
                 Coupling::Adapter::CouplingSlaveConverter converter(*icoupthermo_);
                 Coupling::Adapter::MatrixLogicalSplitAndTransform()(scatrathermoblock,
@@ -972,7 +972,7 @@ void STI::Monolithic::assemble_mat_and_rhs()
                 break;
               }
 
-              case Inpar::S2I::coupling_mortar_standard:
+              case S2I::coupling_mortar_standard:
               {
                 // initialize temporary matrix for slave-side columns of scatra-thermo matrix block
                 Core::LinAlg::SparseMatrix scatrathermocolsslave(
@@ -1081,7 +1081,7 @@ void STI::Monolithic::assemble_mat_and_rhs()
 
         switch (strategyscatra_->coupling_type())
         {
-          case Inpar::S2I::coupling_matching_nodes:
+          case S2I::coupling_matching_nodes:
           {
             Coupling::Adapter::CouplingSlaveConverter converter(*icoupthermo_);
             Coupling::Adapter::MatrixLogicalSplitAndTransform()(scatrathermoblock,
@@ -1095,7 +1095,7 @@ void STI::Monolithic::assemble_mat_and_rhs()
             break;
           }
 
-          case Inpar::S2I::coupling_mortar_standard:
+          case S2I::coupling_mortar_standard:
           {
             // initialize temporary matrix for slave-side columns of global system matrix
             Core::LinAlg::SparseMatrix systemmatrixcolsslave(*dof_row_map(), 81);
@@ -1526,12 +1526,12 @@ void STI::Monolithic::solve()
               *strategythermo_->interface_maps()->map(1));
       switch (strategyscatra_->coupling_type())
       {
-        case Inpar::S2I::coupling_matching_nodes:
+        case S2I::coupling_matching_nodes:
         {
           icoupthermo_->target_to_source(*masterincrement, *slaveincrement);
           break;
         }
-        case Inpar::S2I::coupling_mortar_standard:
+        case S2I::coupling_mortar_standard:
         {
           strategythermo_->p()->multiply(false, *masterincrement, *slaveincrement);
           break;
@@ -1571,14 +1571,14 @@ void STI::Monolithic::apply_dirichlet_off_diag(
   {
     switch (strategythermo_->coupling_type())
     {
-      case Inpar::S2I::coupling_matching_nodes:
+      case S2I::coupling_matching_nodes:
       {
         if (!thermo_field()->discretization()->has_condition("PointCoupling"))
           thermoscatra_domain_interface->apply_dirichlet(*icoupthermo_->source_dof_map(), false);
         break;
       }
 
-      case Inpar::S2I::coupling_mortar_condensed_bubnov:
+      case S2I::coupling_mortar_condensed_bubnov:
       {
         thermoscatra_domain_interface->apply_dirichlet(
             *(strategythermo_->interface_maps()->map(1)), false);
@@ -1634,7 +1634,7 @@ void STI::Monolithic::assemble_domain_interface_off_diag(
   thermoscatra_domain_interface->add(*thermoscatrablockdomain_, false, 1.0, 1.0);
   thermoscatra_domain_interface->add(*thermoscatrablockinterface_, false, 1.0, 1.0);
 
-  if (strategythermo_->coupling_type() == Inpar::S2I::coupling_matching_nodes)
+  if (strategythermo_->coupling_type() == S2I::coupling_matching_nodes)
   {  // standard meshtying algorithm with Lagrange multipliers condensed out
     if (!thermo_field()->discretization()->has_condition("PointCoupling"))
     {
@@ -1693,7 +1693,7 @@ void STI::Monolithic::assemble_domain_interface_off_diag(
       }
     }
   }
-  else if (strategythermo_->coupling_type() == Inpar::S2I::coupling_mortar_condensed_bubnov)
+  else if (strategythermo_->coupling_type() == S2I::coupling_mortar_condensed_bubnov)
   {
     // standard meshtying algorithm with Lagrange multipliers condensed out
     // loop over all thermo-scatra matrix blocks

--- a/src/sti/4C_sti_monolithic_evaluate_OffDiag.cpp
+++ b/src/sti/4C_sti_monolithic_evaluate_OffDiag.cpp
@@ -310,8 +310,8 @@ void STI::ScatraThermoOffDiagCouplingMatchingNodes::evaluate_scatra_thermo_inter
   for (const auto& kinetics_slave_cond :
       meshtying_strategy_scatra()->kinetics_conditions_meshtying_slave_side())
   {
-    if (kinetics_slave_cond.second->parameters().get<Inpar::S2I::KineticModels>("KINETIC_MODEL") !=
-        static_cast<int>(Inpar::S2I::kinetics_nointerfaceflux))
+    if (kinetics_slave_cond.second->parameters().get<S2I::KineticModels>("KINETIC_MODEL") !=
+        static_cast<int>(S2I::kinetics_nointerfaceflux))
     {
       // collect condition specific data and store to scatra boundary parameter class
       meshtying_strategy_scatra()->set_condition_specific_scatra_parameters(
@@ -493,8 +493,8 @@ void STI::ScatraThermoOffDiagCouplingMatchingNodes::evaluate_off_diag_block_ther
   for (const auto& kinetics_slave_cond :
       meshtying_strategy_thermo()->kinetics_conditions_meshtying_slave_side())
   {
-    if (kinetics_slave_cond.second->parameters().get<Inpar::S2I::KineticModels>("KINETIC_MODEL") !=
-        static_cast<int>(Inpar::S2I::kinetics_nointerfaceflux))
+    if (kinetics_slave_cond.second->parameters().get<S2I::KineticModels>("KINETIC_MODEL") !=
+        static_cast<int>(S2I::kinetics_nointerfaceflux))
     {
       // collect condition specific data and store to scatra boundary parameter class
       meshtying_strategy_thermo()->set_condition_specific_scatra_parameters(
@@ -648,14 +648,13 @@ void STI::ScatraThermoOffDiagCouplingMortarStandard::
   Teuchos::ParameterList condparams;
 
   // action for elements
-  condparams.set<Inpar::S2I::EvaluationActions>("action", Inpar::S2I::evaluate_condition_od);
+  condparams.set<S2I::EvaluationActions>("action", S2I::evaluate_condition_od);
 
   // create strategy for assembly of auxiliary system matrices
-  ScaTra::MortarCellAssemblyStrategy strategyscatrathermos2i(slavematrix, Inpar::S2I::side_source,
-      Inpar::S2I::side_source, nullptr, Inpar::S2I::side_undefined, Inpar::S2I::side_undefined,
-      mastermatrix_sparse, Inpar::S2I::side_master, Inpar::S2I::side_source, nullptr,
-      Inpar::S2I::side_undefined, Inpar::S2I::side_undefined, nullptr, Inpar::S2I::side_undefined,
-      nullptr, Inpar::S2I::side_undefined, 0, 1);
+  ScaTra::MortarCellAssemblyStrategy strategyscatrathermos2i(slavematrix, S2I::side_source,
+      S2I::side_source, nullptr, S2I::side_undefined, S2I::side_undefined, mastermatrix_sparse,
+      S2I::side_master, S2I::side_source, nullptr, S2I::side_undefined, S2I::side_undefined,
+      nullptr, S2I::side_undefined, nullptr, S2I::side_undefined, 0, 1);
 
   // extract scatra-scatra interface kinetics conditions
   std::vector<const Core::Conditions::Condition*> conditions;
@@ -665,8 +664,7 @@ void STI::ScatraThermoOffDiagCouplingMortarStandard::
   for (const auto& condition : conditions)
   {
     // consider conditions for slave side only
-    if (condition->parameters().get<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE") ==
-        Inpar::S2I::side_source)
+    if (condition->parameters().get<S2I::InterfaceSides>("INTERFACE_SIDE") == S2I::side_source)
     {
       // add condition to parameter list
       condparams.set<const Core::Conditions::Condition*>("condition", condition);
@@ -794,14 +792,13 @@ void STI::ScatraThermoOffDiagCouplingMortarStandard::
   Teuchos::ParameterList condparams;
 
   // action for elements
-  condparams.set<Inpar::S2I::EvaluationActions>("action", Inpar::S2I::evaluate_condition_od);
+  condparams.set<S2I::EvaluationActions>("action", S2I::evaluate_condition_od);
 
   // create strategy for assembly of auxiliary system matrix
-  ScaTra::MortarCellAssemblyStrategy strategythermoscatras2i(slavematrix, Inpar::S2I::side_source,
-      Inpar::S2I::side_source, slavematrix, Inpar::S2I::side_source, Inpar::S2I::side_master,
-      nullptr, Inpar::S2I::side_undefined, Inpar::S2I::side_undefined, nullptr,
-      Inpar::S2I::side_undefined, Inpar::S2I::side_undefined, nullptr, Inpar::S2I::side_undefined,
-      nullptr, Inpar::S2I::side_undefined, 0, 1);
+  ScaTra::MortarCellAssemblyStrategy strategythermoscatras2i(slavematrix, S2I::side_source,
+      S2I::side_source, slavematrix, S2I::side_source, S2I::side_master, nullptr,
+      S2I::side_undefined, S2I::side_undefined, nullptr, S2I::side_undefined, S2I::side_undefined,
+      nullptr, S2I::side_undefined, nullptr, S2I::side_undefined, 0, 1);
 
   // extract scatra-scatra interface kinetics conditions
   std::vector<const Core::Conditions::Condition*> conditions;
@@ -811,8 +808,7 @@ void STI::ScatraThermoOffDiagCouplingMortarStandard::
   for (const auto& condition : conditions)
   {
     // consider conditions for slave side only
-    if (condition->parameters().get<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE") ==
-        Inpar::S2I::side_source)
+    if (condition->parameters().get<S2I::InterfaceSides>("INTERFACE_SIDE") == S2I::side_source)
     {
       // add condition to parameter list
       condparams.set<const Core::Conditions::Condition*>("condition", condition);
@@ -886,7 +882,7 @@ void STI::ScatraThermoOffDiagCouplingMortarStandard::
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 std::shared_ptr<STI::ScatraThermoOffDiagCoupling> STI::build_scatra_thermo_off_diag_coupling(
-    const Inpar::S2I::CouplingType& couplingtype,
+    const S2I::CouplingType& couplingtype,
     std::shared_ptr<const Core::LinAlg::MultiMapExtractor> block_map_thermo,
     std::shared_ptr<const Core::LinAlg::MultiMapExtractor> block_map_thermo_interface,
     std::shared_ptr<const Core::LinAlg::MultiMapExtractor> block_map_thermo_interface_slave,
@@ -903,7 +899,7 @@ std::shared_ptr<STI::ScatraThermoOffDiagCoupling> STI::build_scatra_thermo_off_d
 
   switch (couplingtype)
   {
-    case Inpar::S2I::coupling_matching_nodes:
+    case S2I::coupling_matching_nodes:
     {
       scatrathermooffdiagcoupling = std::make_shared<STI::ScatraThermoOffDiagCouplingMatchingNodes>(
           block_map_thermo, block_map_thermo_interface, block_map_thermo_interface_slave,
@@ -911,7 +907,7 @@ std::shared_ptr<STI::ScatraThermoOffDiagCoupling> STI::build_scatra_thermo_off_d
           meshtying_strategy_scatra, meshtying_strategy_thermo, scatra, thermo);
       break;
     }
-    case Inpar::S2I::coupling_mortar_standard:
+    case S2I::coupling_mortar_standard:
     {
       scatrathermooffdiagcoupling =
           std::make_shared<STI::ScatraThermoOffDiagCouplingMortarStandard>(block_map_thermo,

--- a/src/sti/4C_sti_monolithic_evaluate_OffDiag.hpp
+++ b/src/sti/4C_sti_monolithic_evaluate_OffDiag.hpp
@@ -11,8 +11,8 @@
 #include "4C_config.hpp"
 
 #include "4C_adapter_scatra_base_algorithm.hpp"
-#include "4C_inpar_s2i.hpp"
 #include "4C_linalg_vector.hpp"
+#include "4C_scatra_s2i_input.hpp"
 #include "4C_utils_parameter_list.fwd.hpp"
 
 FOUR_C_NAMESPACE_OPEN
@@ -237,7 +237,7 @@ namespace STI
 
   //! build specific off diagonal coupling object
   std::shared_ptr<STI::ScatraThermoOffDiagCoupling> build_scatra_thermo_off_diag_coupling(
-      const Inpar::S2I::CouplingType& couplingtype,
+      const S2I::CouplingType& couplingtype,
       std::shared_ptr<const Core::LinAlg::MultiMapExtractor> block_map_thermo,
       std::shared_ptr<const Core::LinAlg::MultiMapExtractor> block_map_thermo_interface,
       std::shared_ptr<const Core::LinAlg::MultiMapExtractor> block_map_thermo_interface_slave,


### PR DESCRIPTION
## Description and Context

- Move S2I input definitions from `Inpar::S2I` in `src/inpar/` to the scalar transport module in `src/scatra/`.
- Relocate input files (`4C_inpar_s2i.*` -> `4C_scatra_s2i_input.*`) and update all affected includes and global registration wiring.
- Migrate S2I qualifiers from `Inpar::S2I` to `S2I` across dependent modules (`scatra`, `scatra_ele`, `sti`, `ssi`, `ssti`, `contact`, and `global_legacy_module`).

## Related Issues
Part of #59