### PR TITLE
Add temperature derivative evaluation to refJC material

### DIFF
--- a/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
+++ b/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
@@ -2962,44 +2962,47 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
   {
     using namespace Core::IO::InputSpecBuilders::Validators;
 
-    known_materials[Core::Materials::mvl_reformulated_Johnson_Cook] =
-        group("MAT_ViscoplasticLawReformulatedJohnsonCook",
-            {
-                parameter<double>("STRAIN_RATE_PREFAC",
-                    {.description = "reference plastic strain rate $\\dot{P}_0$",
-                        .validator = positive<double>()}),
-                parameter<double>("STRAIN_RATE_EXP_FAC",
-                    {.description = "exponential factor of plastic strain rate $C$",
-                        .validator = positive<double>()}),
-                parameter<double>("INIT_YIELD_STRENGTH",
-                    {.description = "initial yield strength of the material $A_0$",
-                        .validator = positive<double>()}),
-                parameter<double>("ISOTROP_HARDEN_PREFAC",
-                    {.description =
-                            "prefactor of the isotropic hardening stress / hardening modulus $B_0$",
-                        .validator = positive_or_zero<double>()}),
-                parameter<double>("ISOTROP_HARDEN_EXP",
-                    {.description = "exponent of the isotropic hardening stress $n$",
-                        .validator = positive_or_zero<double>()}),
-                parameter<double>("REF_TEMPERATURE",
-                    {.description = "reference temperature $T_0$ for evaluating the "
-                                    "yield strength $A_0$ and the hardening "
-                                    "modulus $B_0$",
-                        .validator = positive<double>()}),
-                parameter<double>(
-                    "MELT_TEMPERATURE", {.description = "melting temperature $T_{\\mathrm{melt}}$",
-                                            .validator = positive<double>()}),
-                parameter<double>("TEMPERATURE_SENS", {.description = "temperature sensitivity $m$",
-                                                          .validator = positive_or_zero<double>()}),
+    known_materials[Core::Materials::mvl_reformulated_Johnson_Cook] = group(
+        "MAT_ViscoplasticLawReformulatedJohnsonCook",
+        {
+            parameter<double>(
+                "STRAIN_RATE_PREFAC", {.description = "reference plastic strain rate $\\dot{P}_0$",
+                                          .validator = positive<double>()}),
+            parameter<double>("STRAIN_RATE_EXP_FAC",
+                {.description = "exponential factor of plastic strain rate $C$",
+                    .validator = positive<double>()}),
+            parameter<double>("INIT_YIELD_STRENGTH",
+                {.description = "initial yield strength of the material $A_0$",
+                    .validator = positive<double>()}),
+            parameter<double>("ISOTROP_HARDEN_PREFAC",
+                {.description =
+                        "prefactor of the isotropic hardening stress / hardening modulus $B_0$",
+                    .validator = positive_or_zero<double>()}),
+            parameter<double>("ISOTROP_HARDEN_EXP",
+                {.description = "exponent of the isotropic hardening stress $n$",
+                    .validator = positive_or_zero<double>()}),
+            parameter<double>("REF_TEMPERATURE",
+                {.description = "reference temperature $T_0$ for evaluating the "
+                                "yield strength $A_0$ and the hardening "
+                                "modulus $B_0$. Has no effect for isothermal simulations.",
+                    .validator = positive<double>()}),
+            parameter<double>(
+                "MELT_TEMPERATURE", {.description = "melting temperature $T_{\\mathrm{melt}}$. Has "
+                                                    "no effect for isothermal simulations.",
+                                        .validator = positive<double>()}),
+            parameter<double>("TEMPERATURE_SENS",
+                {.description =
+                        "temperature sensitivity $m$. Has no effect for isothermal simulations.",
+                    .validator = positive<double>()}),
 
-            },
-            {.description = "Reformulation of the Johnson-Cook viscoplastic law (comprising flow "
-                            "rule $\\dot{P} = \\dot{P}_0 \\exp \\left( \\frac{ \\sigma_{eq}}{C "
-                            "\\sigma_{\\mathrm{Y}}} - \\frac{1}{C} \\right) - \\dot{P}_0$ and "
-                            "hardening law $\\sigma_{\\mathrm{Y}} = (A_0 + "
-                            "B_0 \\cdot P^{n}) \\cdot (1 - \\frac{T^m - "
-                            "T_{0}^m}{T_{\\mathrm{melt}}^m - T_{0}^m})$), "
-                            "as shown in Mareau et al. (Mechanics of Materials 143, 2020)"});
+        },
+        {.description = "Reformulation of the Johnson-Cook viscoplastic law (comprising flow "
+                        "rule $\\dot{P} = \\dot{P}_0 \\exp \\left( \\frac{ \\sigma_{eq}}{C "
+                        "\\sigma_{\\mathrm{Y}}} - \\frac{1}{C} \\right) - \\dot{P}_0$ and "
+                        "hardening law $\\sigma_{\\mathrm{Y}} = (A_0 + "
+                        "B_0 \\cdot P^{n}) \\cdot (1 - \\frac{T^m - "
+                        "T_{0}^m}{T_{\\mathrm{melt}}^m - T_{0}^m})$), "
+                        "as shown in Mareau et al. (Mechanics of Materials 143, 2020)"});
   }
 
   /*----------------------------------------------------------------------*/

--- a/src/mat/4C_mat_inelastic_defgrad_factors_service.hpp
+++ b/src/mat/4C_mat_inelastic_defgrad_factors_service.hpp
@@ -499,6 +499,9 @@ namespace Mat
 
       //! derivative with respect to the plastic strain
       double deriv_plastic_strain;
+
+      //! derivative with respect to the temperature
+      double deriv_temperature;
     };
 
 

--- a/src/mat/vplast/4C_mat_vplast_law.hpp
+++ b/src/mat/vplast/4C_mat_vplast_law.hpp
@@ -153,10 +153,10 @@ namespace Mat
        * numerically evaluable increment of the
        * plastic strain derivatives (before throwing an overflow error),
        * i.e. \f$ \Delta t \frac{\partial \dot{\varepsilon}^{\text{p}}}{\partial s},~ s \in
-       * \{\varepsilon^{\text{p}}, \overline{\sigma}\} \f$
+       * \{\varepsilon^{\text{p}}, \overline{\sigma}, T\} \f$
        * @param[out] err_status output variable: error of the terms considered in @note?
-       * @return Derivatives of the equivalent plastic strain rate w.r.t. the equivalent stress
-       *         (element 0 of matrix) and the plastic strain (element 1 of matrix)
+       * @return Derivatives of the equivalent plastic strain rate w.r.t. the equivalent stress,
+       *         plastic strain, and temperature.
        */
       virtual InelasticDefgradTransvIsotropElastViscoplastUtils::PlasticStrainRateDerivs
       evaluate_derivatives_of_plastic_strain_rate(const double equiv_stress,
@@ -181,7 +181,7 @@ namespace Mat
        * @brief Pre-evaluation, intended to be used for stuff that has to be done only once per
        *        evaluate()
        *
-       * @param[in] params  parameter list
+       * @param[in] params  Various parameters, such as e.g. the temperature in TSI simulations
        * @param[in] gp      Current Gauss point
        */
       virtual void pre_evaluate(const Teuchos::ParameterList& params, int gp) { gp_ = gp; };

--- a/src/mat/vplast/4C_mat_vplast_reform_johnsoncook.cpp
+++ b/src/mat/vplast/4C_mat_vplast_reform_johnsoncook.cpp
@@ -84,6 +84,7 @@ void Mat::Viscoplastic::ReformulatedJohnsonCook::pre_evaluate(
 
   // set temperature ratio
   temperature_ratio_ = 1.0;
+  log_temperature_ratio_ = 0.0;
   if (T != T_ref)
   {
     FOUR_C_ASSERT_ALWAYS(T_ref < T_melt,
@@ -92,7 +93,12 @@ void Mat::Viscoplastic::ReformulatedJohnsonCook::pre_evaluate(
         T_ref, T_melt);
     temperature_ratio_ =
         1.0 - (std::pow(T, M) - std::pow(T_ref, M)) / (std::pow(T_melt, M) - std::pow(T_ref, M));
+    log_temperature_ratio_ = std::log(temperature_ratio_);
   }
+
+  // set temperature ratio derivative
+  log_neg_temperature_ratio_deriv_ =
+      std::log(M * (std::pow(T, M - 1.0)) / (std::pow(T_melt, M) - std::pow(T_ref, M)));
 }
 
 /*--------------------------------------------------------------------*
@@ -210,6 +216,7 @@ Mat::Viscoplastic::ReformulatedJohnsonCook::evaluate_derivatives_of_plastic_stra
   // declare derivatives to be computed
   double deriv_equiv_stress{0.0};
   double deriv_plastic_strain{0.0};
+  double deriv_temperature{0.0};
 
   // first set error status to "no errors"
   err_status = ViscoplastErrorType::no_errors;
@@ -229,7 +236,7 @@ Mat::Viscoplastic::ReformulatedJohnsonCook::evaluate_derivatives_of_plastic_stra
   {
     err_status = ViscoplastErrorType::negative_plastic_strain;
     return InelasticDefgradTransvIsotropElastViscoplastUtils::PlasticStrainRateDerivs{
-        .deriv_equiv_stress = 0.0, .deriv_plastic_strain = 0.0};
+        .deriv_equiv_stress = 0.0, .deriv_plastic_strain = 0.0, .deriv_temperature = 0.0};
   }
 
   // extraction of the yield strength from the plastic strain and the material parameters
@@ -244,6 +251,8 @@ Mat::Viscoplastic::ReformulatedJohnsonCook::evaluate_derivatives_of_plastic_stra
       EnumTools::enum_name(yield_strength_err_status));
   const double log_yield_strength = std::log(yield_strength);
   const double inv_yield_strength = 1.0 / yield_strength;
+  const double log_yield_strength_reference_temperature =
+      log_yield_strength - log_temperature_ratio_;
 
 
   // logarithms of equivalent stress and plastic strain
@@ -263,6 +272,13 @@ Mat::Viscoplastic::ReformulatedJohnsonCook::evaluate_derivatives_of_plastic_stra
                              const_pars_.e * (equiv_stress * inv_yield_strength - 1.0) -
                              log_yield_strength;
 
+    const double log_neg_d_yield_strength_d_temperature =
+        log_yield_strength_reference_temperature + log_neg_temperature_ratio_deriv_;
+
+    const double log_deriv_temperature =
+        const_pars_.log_p_e + const_pars_.e * (equiv_stress * inv_yield_strength - 1.0) +
+        log_equiv_stress - 2.0 * log_yield_strength + log_neg_d_yield_strength_d_temperature;
+
     // verify whether the maximum plastic strain derivative increment is larger than 0, since we
     // will take its logarithm
     FOUR_C_ASSERT_ALWAYS(max_plastic_strain_deriv_incr > 0.0,
@@ -274,42 +290,48 @@ Mat::Viscoplastic::ReformulatedJohnsonCook::evaluate_derivatives_of_plastic_stra
     {
       // check overflow error using these logarithms
       double log_max_plastic_strain_deriv_value = std::log(max_plastic_strain_deriv_incr);
-      if ((log_dt + log_deriv_sigma > log_max_plastic_strain_deriv_value))
+      if ((log_dt + log_deriv_sigma > log_max_plastic_strain_deriv_value) or
+          (log_dt + log_deriv_temperature > log_max_plastic_strain_deriv_value))
       {
         err_status = ViscoplastErrorType::failed_computation_flow_resistance_derivs;
         return InelasticDefgradTransvIsotropElastViscoplastUtils::PlasticStrainRateDerivs{
-            .deriv_equiv_stress = 0.0, .deriv_plastic_strain = 0.0};
+            .deriv_equiv_stress = 0.0, .deriv_plastic_strain = 0.0, .deriv_temperature = 0.0};
       }
 
       // compute the exact derivatives using these logarithms
       deriv_equiv_stress = std::exp(log_deriv_sigma);
       deriv_plastic_strain = 0.0;
+      deriv_temperature = std::exp(log_deriv_temperature);
     }
     // hardening case
     else
     {
-      const double log_deriv_eps =
+      const double log_neg_deriv_eps =
           const_pars_.log_p_e + const_pars_.e * (equiv_stress * inv_yield_strength - 1.0) +
           log_equiv_stress - 2.0 * log_yield_strength + const_pars_.log_B_N +
-          (const_pars_.N - 1.0) * log_equiv_plastic_strain;
+          (const_pars_.N - 1.0) * log_equiv_plastic_strain + log_temperature_ratio_;
       // check overflow error using these logarithms
       double log_max_plastic_strain_deriv_value = std::log(max_plastic_strain_deriv_incr);
-      if ((log_dt + log_deriv_sigma > log_max_plastic_strain_deriv_value) &&
-          (log_dt + log_deriv_eps > log_max_plastic_strain_deriv_value))
+      if ((log_dt + log_deriv_sigma > log_max_plastic_strain_deriv_value) or
+          (log_dt + log_neg_deriv_eps > log_max_plastic_strain_deriv_value) or
+          (log_dt + log_deriv_temperature > log_max_plastic_strain_deriv_value))
       {
         err_status = ViscoplastErrorType::failed_computation_flow_resistance_derivs;
         return InelasticDefgradTransvIsotropElastViscoplastUtils::PlasticStrainRateDerivs{
-            .deriv_equiv_stress = 0.0, .deriv_plastic_strain = 0.0};
+            .deriv_equiv_stress = 0.0, .deriv_plastic_strain = 0.0, .deriv_temperature = 0.0};
       }
 
       // compute the exact derivatives using these logarithms
       deriv_equiv_stress = std::exp(log_deriv_sigma);
-      deriv_plastic_strain = -std::exp(log_deriv_eps);
+      deriv_plastic_strain = -std::exp(log_neg_deriv_eps);
+      deriv_temperature = std::exp(log_deriv_temperature);
     }
   }
 
   return InelasticDefgradTransvIsotropElastViscoplastUtils::PlasticStrainRateDerivs{
-      .deriv_equiv_stress = deriv_equiv_stress, .deriv_plastic_strain = deriv_plastic_strain};
+      .deriv_equiv_stress = deriv_equiv_stress,
+      .deriv_plastic_strain = deriv_plastic_strain,
+      .deriv_temperature = deriv_temperature};
 }
 
 void Mat::Viscoplastic::ReformulatedJohnsonCook::setup(const int numgp,

--- a/src/mat/vplast/4C_mat_vplast_reform_johnsoncook.hpp
+++ b/src/mat/vplast/4C_mat_vplast_reform_johnsoncook.hpp
@@ -212,9 +212,9 @@ namespace Mat
          * @brief Computes log(B * N) for the Johnson-Cook hardening law, assuming B * N > 0.0
          *
          *
-         *@param[in] B Hardening prefactor.
-         *@param[in] Hardening exponent.
-         *@return logarithm log(B * N)
+         * @param[in] B Hardening prefactor.
+         * @param[in] N Hardening exponent.
+         * @return logarithm log(B * N)
          */
         double set_log_b_n(const double B, const double N)
         {
@@ -230,6 +230,16 @@ namespace Mat
       /// temperature ratio \f$ D_T = 1 - \frac{T^M - T_{\mathrm{ref}}^M}{T_{\mathrm{melt}}^M -
       /// T_{\mathrm{ref}}^M} \f$
       double temperature_ratio_ = 1.0;
+
+      /// logarithm of temperature ratio \f$ \log(D_T) =  \log( 1 - \frac{T^M -
+      /// T_{\mathrm{ref}}^M}{T_{\mathrm{melt}}^M - T_{\mathrm{ref}}^M} ) \f$
+      double log_temperature_ratio_;
+
+      /// logarithm of negative temperature ratio derivative wrt temperature \f$ \log( - \partial
+      /// D_T / \partial T) = \log(M
+      /// \frac{T^{M-1}}{T_{\mathrm{melt}}^M - T_{\mathrm{ref}}^M} ) \f$
+      double log_neg_temperature_ratio_deriv_;
+
 
       //! struct containing quantities at different time points (i.e., "current" at \f[ t_{n+1} \f])
       struct TimeStepQuantities

--- a/tests/input_files/mat_iso_viscoplast_refJC_log_timint_substepping.4C.yaml
+++ b/tests/input_files/mat_iso_viscoplast_refJC_log_timint_substepping.4C.yaml
@@ -95,25 +95,25 @@ RESULT DESCRIPTION:
       DIS: "structure"
       NODE: 4
       QUANTITY: "dispy"
-      VALUE: -4.01558458380913558e-03
+      VALUE: -4.01592180458057706e-03
       TOLERANCE: 4e-11
   - STRUCTURE:
       DIS: "structure"
       NODE: 5
       QUANTITY: "dispx"
-      VALUE: -4.01558458411293510e-03
+      VALUE: -4.01592180458140973e-03
       TOLERANCE: 4e-11
   - STRUCTURE:
       DIS: "structure"
       NODE: 8
       QUANTITY: "dispx"
-      VALUE: -4.01558458411200268e-03
+      VALUE: -4.01592180458110789e-03
       TOLERANCE: 4e-11
   - STRUCTURE:
       DIS: "structure"
       NODE: 8
       QUANTITY: "dispy"
-      VALUE: -4.01558458380949987e-03
+      VALUE: -4.01592180458025701e-03
       TOLERANCE: 4e-11
   - STRUCTURE:
       DIS: "structure"
@@ -125,19 +125,19 @@ RESULT DESCRIPTION:
       DIS: "structure"
       NODE: 6
       QUANTITY: "dispx"
-      VALUE: -4.01558458411173293e-03
+      VALUE: -4.01592180458238204e-03
       TOLERANCE: 4e-11
   - STRUCTURE:
       DIS: "structure"
       NODE: 4
       QUANTITY: "stress_zz"
-      VALUE: 9.31099439481390959e+02
+      VALUE: 9.30776106020185466e+02
       TOLERANCE: 0.00098
   - STRUCTURE:
       DIS: "structure"
       NODE: 8
       QUANTITY: "stress_zz"
-      VALUE: 9.31099439481206900e+02
+      VALUE: 9.30776106016615358e+02
       TOLERANCE: 0.00098
 DESIGN POINT DIRICH CONDITIONS:
   - E: 1

--- a/unittests/mat/4C_inelastic_defgrad_factors_test.cpp
+++ b/unittests/mat/4C_inelastic_defgrad_factors_test.cpp
@@ -2349,9 +2349,9 @@ namespace
     // the local substepping formulation converges
     material_substepping->evaluate_inverse_inelastic_def_grad(&FM, iFin_other, iFin_result);
     Core::LinAlg::Matrix<3, 3> iFin_result_ref{Core::LinAlg::Initialization::zero};
-    iFin_result_ref(0, 0) = 0.71055158583;
-    iFin_result_ref(1, 1) = 1.18632093229;
-    iFin_result_ref(2, 2) = 1.18632093229;
+    iFin_result_ref(0, 0) = 0.71055164642;
+    iFin_result_ref(1, 1) = 1.18632088172;
+    iFin_result_ref(2, 2) = 1.18632088172;
     FOUR_C_EXPECT_NEAR(iFin_result, iFin_result_ref, 1.0e-10);
   }
 

--- a/unittests/mat/vplast/4C_vplast_reform_johnsoncook_test.cpp
+++ b/unittests/mat/vplast/4C_vplast_reform_johnsoncook_test.cpp
@@ -56,7 +56,7 @@ namespace
 
       // parameter list
       Teuchos::ParameterList param_list{};
-      param_list.set<double>("temperature", 293);
+      param_list.set<double>("temperature", 313.0);
 
 
       // call pre_evaluate
@@ -87,7 +87,7 @@ namespace
   TEST_F(ReformJohnsonCookTest, TestEvaluateStressRatio)
   {
     // set reference solution
-    stress_ratio_reformulated_JC_solution_ = 1.14072049868917;
+    stress_ratio_reformulated_JC_solution_ = 1.1556126603348709;
 
     // compute solution from the viscoplasticity law
     double stress_ratio_reformulated_JC =
@@ -100,7 +100,8 @@ namespace
   TEST_F(ReformJohnsonCookTest, TestEvaluatePlasticStrainRate)
   {
     // set reference solution
-    plastic_strain_rate_reformulated_JC_solution_ = 23188.7161986626;
+    plastic_strain_rate_reformulated_JC_solution_ = 67182.9745369580195984;
+
 
     // declare error status
     Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::ErrorType err_status =
@@ -123,8 +124,10 @@ namespace
   TEST_F(ReformJohnsonCookTest, TestEvaluatePlasticStrainRateDerivatives)
   {
     // set reference solution
-    deriv_plastic_strain_rate_reformulated_JC_solution_.deriv_equiv_stress = 1889.49890189991;
-    deriv_plastic_strain_rate_reformulated_JC_solution_.deriv_plastic_strain = -47431778.9968811;
+    deriv_plastic_strain_rate_reformulated_JC_solution_.deriv_equiv_stress = 5545.6179676088768247;
+    deriv_plastic_strain_rate_reformulated_JC_solution_.deriv_plastic_strain =
+        -139210732.3144087791442871;
+    deriv_plastic_strain_rate_reformulated_JC_solution_.deriv_temperature = 3623.4626950498809492;
 
 
     // declare error status
@@ -145,6 +148,8 @@ namespace
         deriv_plastic_strain_rate_reformulated_JC.deriv_equiv_stress, 1.0e-6);
     EXPECT_NEAR(deriv_plastic_strain_rate_reformulated_JC_solution_.deriv_plastic_strain,
         deriv_plastic_strain_rate_reformulated_JC.deriv_plastic_strain, 1.0e-6);
+    EXPECT_NEAR(deriv_plastic_strain_rate_reformulated_JC_solution_.deriv_temperature,
+        deriv_plastic_strain_rate_reformulated_JC.deriv_temperature, 1.0e-6);
   }
 
 }  // namespace


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

This adds the temperature derivative to the plastic strain rate derivatives evaluation of the reformulated Johnson-Cook material.

This is completely independent of #2015 and tested by adapting the existing unittest to a more general case where the current temperature is not equal to the refJC reference temperature. The reference values were obtained using a separate Python script.

Note: The changes in this PR were almost completely done previously by @dragos-ana, I just refactored the test. So credits go there :)

In the overflow check, one existing `and` condition was changed to `or`, which is more consistent. This required slightly adjusting some reference values for the substepping tests.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
