### PR TITLE
Introduce non-local growth remodeling

### DIFF
--- a/src/core/legacy_enum_definitions/4C_legacy_enum_definitions_materials.cpp
+++ b/src/core/legacy_enum_definitions/4C_legacy_enum_definitions_materials.cpp
@@ -41,6 +41,8 @@ std::string_view Core::Materials::to_string(Core::Materials::MaterialType materi
       return "MAT_scatra";
     case m_scatra_gr:
       return "MAT_scatra_gr";
+    case m_scatra_nl_stimulus:
+      return "MAT_scatra_nl_stimulus";
     case m_scatra_reaction_poroECM:
       return "MAT_scatra_reaction_poro";
     case m_scatra_reaction:

--- a/src/core/legacy_enum_definitions/4C_legacy_enum_definitions_materials.hpp
+++ b/src/core/legacy_enum_definitions/4C_legacy_enum_definitions_materials.hpp
@@ -167,6 +167,7 @@ namespace Core::Materials
     m_scatra_reaction,          ///< reaction definition and parameters
     m_scatra_chemotaxis,        ///< chemotaxis definition parameters
     m_scatra_gr,                ///< scalar transport for growth and remodeling
+    m_scatra_nl_stimulus,       ///< scalar transport for non-local G&R stimulus (Helmholtz)
     m_scl,                      ///< material for modeling space charge layers in solid electrolytes
     m_soret,   ///< material for heat transport due to Fourier-type thermal conduction and the
                ///< Soret effect

--- a/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
+++ b/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
@@ -20,6 +20,7 @@
 #include "4C_mat_inelastic_defgrad_factors_service.hpp"
 #include "4C_mat_micromaterial.hpp"
 #include "4C_mat_scatra_growth_remodel.hpp"
+#include "4C_mat_scatra_nonlocal_stimulus.hpp"
 #include "4C_porofluid_pressure_based_elast_scatra_input.hpp"
 
 #include <filesystem>
@@ -397,6 +398,22 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
         },
         {.description = "Simple transport material with linear reaction used in growth "
                         "and remodeling"});
+  }
+
+  /*----------------------------------------------------------------------*/
+  // scalar transport material for non-local G&R stimulus (Helmholtz smoothing)
+  {
+    known_materials[Core::Materials::m_scatra_nl_stimulus] = group("MAT_scatra_nl_stimulus",
+        {
+            parameter<double>("CHAR_LENGTH_SQ",
+                {.description =
+                        "Squared characteristic length scale lc for the Helmholtz equation"}),
+            parameter<int>("STRUCTURE_MAT_ID",
+                {.description = "Material ID of the MixtureConstituentRemodelFiberSsi constituent "
+                                "that provides the local stimulus"}),
+        },
+        {.description = "Helmholtz equation for non-local G&R stimulus: "
+                        "psi - lc^2 * laplace(psi) = (sigma-sigma_h)"});
   }
 
   /*----------------------------------------------------------------------*/
@@ -4331,17 +4348,25 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
             parameter<bool>("INELASTIC_GROWTH",
                 {.description = "Mixture rule has inelastic growth (default false)",
                     .default_value = false}),
-            parameter<int>("GROWTH_SCALAR_ID",
+            parameter<std::optional<int>>("GROWTH_SCALAR_ID",
                 {.description =
-                        "Index of the corresponding growth scalar material in the scatra matlist",
-                    .validator = positive_or_zero<int>()}),
-            parameter<int>(
-                "REMODELING_SCALAR_ID", {.description = "Index of the corresponding remodeling "
-                                                        "scalar material in the scatra matlist",
-                                            .validator = positive_or_zero<int>()}),
+                        "Index of the corresponding growth scalar material in the scatra matlist "
+                        "(leave unset to disable)",
+                    .validator = null_or(positive_or_zero<int>())}),
+            parameter<std::optional<int>>("REMODELING_SCALAR_ID",
+                {.description =
+                        "Index of the corresponding remodeling scalar material in the scatra "
+                        "matlist (leave unset to disable)",
+                    .validator = null_or(positive_or_zero<int>())}),
+            parameter<std::optional<int>>("NONLOCAL_STIMULUS_SCALAR_ID",
+                {.description = "Index of the non-local stimulus scalar in the scatra matlist "
+                                "(leave unset to disable)",
+                    .validator = null_or(positive_or_zero<int>())}),
         },
         {.description =
-                "A 1D constituent where the g&r evolution is solved in a coupled ssi framework"});
+                "A 1D constituent where the g&r evolution ODEs can be solved either as own scatra "
+                "dofs (using GROWTH_SCALAR_ID & REMODELING_SCALAR_ID) or Gauss-point wise based on "
+                "a non-local stimulus (using NONLOCAL_STIMULUS_SCALAR_ID)."});
   }
 
   /*----------------------------------------------------------------------*/

--- a/src/mat/4C_mat_material_factory.cpp
+++ b/src/mat/4C_mat_material_factory.cpp
@@ -124,6 +124,7 @@
 #include "4C_mat_scatra_growth_remodel.hpp"
 #include "4C_mat_scatra_multiporo.hpp"
 #include "4C_mat_scatra_multiscale.hpp"
+#include "4C_mat_scatra_nonlocal_stimulus.hpp"
 #include "4C_mat_scatra_poro_ecm.hpp"
 #include "4C_mat_scatra_reaction.hpp"
 #include "4C_mat_scl.hpp"
@@ -345,6 +346,10 @@ std::unique_ptr<Core::Mat::PAR::Parameter> Mat::make_parameter(
     case Core::Materials::m_scatra_gr:
     {
       return make_parameter_impl<Mat::PAR::ScatraGrowthRemodelMat>(id, type, input_data);
+    }
+    case Core::Materials::m_scatra_nl_stimulus:
+    {
+      return make_parameter_impl<Mat::PAR::ScatraNonlocalStimulusMat>(id, type, input_data);
     }
     case Core::Materials::m_muscle_combo:
     {

--- a/src/mat/4C_mat_scatra_nonlocal_stimulus.cpp
+++ b/src/mat/4C_mat_scatra_nonlocal_stimulus.cpp
@@ -1,0 +1,83 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "4C_mat_scatra_nonlocal_stimulus.hpp"
+
+#include "4C_comm_pack_helpers.hpp"
+#include "4C_comm_utils.hpp"
+#include "4C_global_data.hpp"
+#include "4C_mat_par_bundle.hpp"
+
+
+FOUR_C_NAMESPACE_OPEN
+
+Mat::PAR::ScatraNonlocalStimulusMat::ScatraNonlocalStimulusMat(
+    const Core::Mat::PAR::Parameter::Data& matdata)
+    : Parameter(matdata),
+      characteristic_length_sq_(matdata.parameters.get<double>("CHAR_LENGTH_SQ")),
+      structure_material_id_(matdata.parameters.get<int>("STRUCTURE_MAT_ID"))
+{
+}
+
+std::shared_ptr<Core::Mat::Material> Mat::PAR::ScatraNonlocalStimulusMat::create_material()
+{
+  return std::make_shared<Mat::ScatraNonlocalStimulusMat>(this);
+}
+
+Mat::ScatraNonlocalStimulusMatType Mat::ScatraNonlocalStimulusMatType::instance_;
+
+Core::Communication::ParObject* Mat::ScatraNonlocalStimulusMatType::create(
+    Core::Communication::UnpackBuffer& buffer)
+{
+  Mat::ScatraNonlocalStimulusMat* mat = new Mat::ScatraNonlocalStimulusMat();
+  mat->unpack(buffer);
+  return mat;
+}
+
+/*----------------------------------------------------------------------*/
+Mat::ScatraNonlocalStimulusMat::ScatraNonlocalStimulusMat() : params_(nullptr) {}
+
+Mat::ScatraNonlocalStimulusMat::ScatraNonlocalStimulusMat(
+    Mat::PAR::ScatraNonlocalStimulusMat* params)
+    : params_(params)
+{
+}
+
+/*----------------------------------------------------------------------*/
+void Mat::ScatraNonlocalStimulusMat::pack(Core::Communication::PackBuffer& data) const
+{
+  int type = unique_par_object_id();
+  add_to_pack(data, type);
+
+  int matid = -1;
+  if (params_ != nullptr) matid = params_->id();
+  add_to_pack(data, matid);
+}
+
+/*----------------------------------------------------------------------*/
+void Mat::ScatraNonlocalStimulusMat::unpack(Core::Communication::UnpackBuffer& buffer)
+{
+  Core::Communication::extract_and_assert_id(buffer, unique_par_object_id());
+
+  int matid;
+  extract_from_pack(buffer, matid);
+  params_ = nullptr;
+  if (Global::Problem::instance()->materials() != nullptr)
+    if (Global::Problem::instance()->materials()->num() != 0)
+    {
+      const int probinst = Global::Problem::instance()->materials()->get_read_from_problem();
+      Core::Mat::PAR::Parameter* mat =
+          Global::Problem::instance(probinst)->materials()->parameter_by_id(matid);
+      if (mat->type() == material_type())
+        params_ = static_cast<Mat::PAR::ScatraNonlocalStimulusMat*>(mat);
+      else
+        FOUR_C_THROW("Type of parameter material {} does not fit to calling type {}", mat->type(),
+            material_type());
+    }
+}
+
+FOUR_C_NAMESPACE_CLOSE

--- a/src/mat/4C_mat_scatra_nonlocal_stimulus.hpp
+++ b/src/mat/4C_mat_scatra_nonlocal_stimulus.hpp
@@ -1,0 +1,115 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef FOUR_C_MAT_SCATRA_NONLOCAL_STIMULUS_HPP
+#define FOUR_C_MAT_SCATRA_NONLOCAL_STIMULUS_HPP
+
+#include "4C_config.hpp"
+
+#include "4C_comm_parobjectfactory.hpp"
+#include "4C_mat_material_factory.hpp"
+#include "4C_material_base.hpp"
+#include "4C_material_parameter_base.hpp"
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace Mat
+{
+  namespace PAR
+  {
+
+    /*----------------------------------------------------------------------*/
+    /// parameters for the Helmholtz non-local stimulus scalar transport material
+    class ScatraNonlocalStimulusMat : public Core::Mat::PAR::Parameter
+    {
+     public:
+      /// standard constructor
+      ScatraNonlocalStimulusMat(const Core::Mat::PAR::Parameter::Data& matdata);
+
+      /// create material instance of matching type with my parameters
+      std::shared_ptr<Core::Mat::Material> create_material() override;
+
+      /// characteristic length scale squared \f$ \ell_c^2 \f$
+      [[nodiscard]] double characteristic_length_sq() const { return characteristic_length_sq_; }
+
+      /// ID of structure material (RemodelFiberSsi constituent) that provides the local stimulus
+      [[nodiscard]] int structure_material_id() const { return structure_material_id_; }
+
+     private:
+      double characteristic_length_sq_;
+      int structure_material_id_;
+
+    };  // class ScatraNonlocalStimulusMat
+
+  }  // namespace PAR
+
+  class ScatraNonlocalStimulusMatType : public Core::Communication::ParObjectType
+  {
+   public:
+    std::string name() const override { return "ScatraNonlocalStimulusMatType"; }
+
+    static ScatraNonlocalStimulusMatType& instance() { return instance_; };
+
+    Core::Communication::ParObject* create(Core::Communication::UnpackBuffer& buffer) override;
+
+   private:
+    static ScatraNonlocalStimulusMatType instance_;
+  };
+
+  /*----------------------------------------------------------------------*/
+  /// wrapper for Helmholtz non-local G&R stimulus scalar transport material
+  class ScatraNonlocalStimulusMat : public Core::Mat::Material
+  {
+   public:
+    /// construct empty material object
+    ScatraNonlocalStimulusMat();
+
+    /// construct the material object given material parameters
+    explicit ScatraNonlocalStimulusMat(Mat::PAR::ScatraNonlocalStimulusMat* params);
+
+    int unique_par_object_id() const override
+    {
+      return ScatraNonlocalStimulusMatType::instance().unique_par_object_id();
+    }
+
+    void pack(Core::Communication::PackBuffer& data) const override;
+
+    void unpack(Core::Communication::UnpackBuffer& buffer) override;
+
+    /// material type
+    Core::Materials::MaterialType material_type() const override
+    {
+      return Core::Materials::m_scatra_nl_stimulus;
+    }
+
+    /// return copy of this material object
+    std::shared_ptr<Core::Mat::Material> clone() const override
+    {
+      return std::make_shared<ScatraNonlocalStimulusMat>(*this);
+    }
+
+    /// characteristic length squared \ell_c^2
+    [[nodiscard]] double characteristic_length_sq() const
+    {
+      return params_->characteristic_length_sq();
+    }
+
+    /// ID of structure material (RemodelFiberSsi constituent) that provides the local stimulus
+    [[nodiscard]] int structure_material_id() const { return params_->structure_material_id(); }
+
+    /// Return material parameter data
+    [[nodiscard]] Core::Mat::PAR::Parameter* parameter() const override { return params_; }
+
+   private:
+    Mat::PAR::ScatraNonlocalStimulusMat* params_;
+  };
+
+}  // namespace Mat
+
+FOUR_C_NAMESPACE_CLOSE
+
+#endif  // FOUR_C_MAT_SCATRA_NONLOCAL_STIMULUS_HPP

--- a/src/mixture/src/4C_mixture_constituent_remodelfiber_ssi.cpp
+++ b/src/mixture/src/4C_mixture_constituent_remodelfiber_ssi.cpp
@@ -54,8 +54,10 @@ Mixture::PAR::MixtureConstituentRemodelFiberSsi::MixtureConstituentRemodelFiberS
       deposition_stretch_(matdata.parameters.get<double>("DEPOSITION_STRETCH")),
       deposition_stretch_timefunc_num_(matdata.parameters.get<int>("DEPOSITION_STRETCH_TIMEFUNCT")),
       inelastic_external_deformation_(matdata.parameters.get<bool>("INELASTIC_GROWTH")),
-      growth_scalar_id_(matdata.parameters.get<int>("GROWTH_SCALAR_ID")),
-      remodeling_scalar_id_(matdata.parameters.get<int>("REMODELING_SCALAR_ID"))
+      growth_scalar_id_(matdata.parameters.get<std::optional<int>>("GROWTH_SCALAR_ID")),
+      remodeling_scalar_id_(matdata.parameters.get<std::optional<int>>("REMODELING_SCALAR_ID")),
+      nonlocal_stimulus_scalar_id_(
+          matdata.parameters.get<std::optional<int>>("NONLOCAL_STIMULUS_SCALAR_ID"))
 {
 }
 
@@ -125,6 +127,24 @@ void Mixture::MixtureConstituentRemodelFiberSsi::setup(
 {
   Mixture::MixtureConstituent::setup(params, eleGID);
   update_homeostatic_values(params, 0.0, eleGID);
+
+  // Validate scalar-ID configuration: exactly one of the two coupling modes must be active.
+  if (is_nonlocal_stimulus_mode())
+  {
+    FOUR_C_ASSERT_ALWAYS(
+        !params_->growth_scalar_id_.has_value() and !params_->remodeling_scalar_id_.has_value(),
+        "MIX_Constituent_SsiRemodelFiber NONLOCAL_STIMULUS_SCALAR_ID is set, but "
+        "GROWTH_SCALAR_ID and/or REMODELING_SCALAR_ID are also set. Specify exactly "
+        "one coupling mode: either NONLOCAL_STIMULUS_SCALAR_ID or both GROWTH_SCALAR_ID and "
+        "REMODELING_SCALAR_ID.");
+  }
+  else
+  {
+    FOUR_C_ASSERT_ALWAYS(
+        params_->growth_scalar_id_.has_value() and params_->remodeling_scalar_id_.has_value(),
+        "MIX_Constituent_SsiRemodelFiber requires either NONLOCAL_STIMULUS_SCALAR_ID or both "
+        "GROWTH_SCALAR_ID and REMODELING_SCALAR_ID to be set.");
+  }
 }
 
 void Mixture::MixtureConstituentRemodelFiberSsi::update_elastic_part(
@@ -149,8 +169,19 @@ void Mixture::MixtureConstituentRemodelFiberSsi::update_elastic_part(
 
   if (params_->enable_growth_)
   {
-    set_current_growth_scalar(params, gp);
-    set_current_lambda_r(params, gp);
+    if (is_nonlocal_stimulus_mode())
+    {
+      const auto& scalars = *params.get<std::shared_ptr<std::vector<double>>>("scalars");
+      const double psi =
+          scalars[static_cast<std::size_t>(params_->nonlocal_stimulus_scalar_id_.value())];
+      remodel_fiber_[gp].integrate_local_evolution_equations_explicit_with_nonlocal_stimulus(
+          psi, dt);
+    }
+    else
+    {
+      set_current_growth_scalar(params, gp);
+      set_current_lambda_r(params, gp);
+    }
   }
 }
 
@@ -172,8 +203,20 @@ void Mixture::MixtureConstituentRemodelFiberSsi::update(const Core::LinAlg::Tens
 
     if (params_->enable_growth_)
     {
-      set_current_growth_scalar(params, gp);
-      set_current_lambda_r(params, gp);
+      if (is_nonlocal_stimulus_mode())
+      {
+        const double dt = *context.time_step_size;
+        const auto& scalars = *params.get<std::shared_ptr<std::vector<double>>>("scalars");
+        const double psi =
+            scalars[static_cast<std::size_t>(params_->nonlocal_stimulus_scalar_id_.value())];
+        remodel_fiber_[gp].integrate_local_evolution_equations_explicit_with_nonlocal_stimulus(
+            psi, dt);
+      }
+      else
+      {
+        set_current_growth_scalar(params, gp);
+        set_current_lambda_r(params, gp);
+      }
     }
   }
 }
@@ -324,14 +367,14 @@ void Mixture::MixtureConstituentRemodelFiberSsi::set_current_growth_scalar(
     const Teuchos::ParameterList& params, int gp)
 {
   const auto& scalars = *params.get<std::shared_ptr<std::vector<double>>>("scalars");
-  double scalar = scalars[static_cast<std::size_t>(params_->growth_scalar_id_)];
+  double scalar = scalars[static_cast<std::size_t>(params_->growth_scalar_id_.value())];
   remodel_fiber_[gp].set_growth_scalar(scalar);
 }
 void Mixture::MixtureConstituentRemodelFiberSsi::set_current_lambda_r(
     const Teuchos::ParameterList& params, int gp)
 {
   const auto& scalars = *params.get<std::shared_ptr<std::vector<double>>>("scalars");
-  double scalar = scalars[static_cast<std::size_t>(params_->remodeling_scalar_id_)];
+  double scalar = scalars[static_cast<std::size_t>(params_->remodeling_scalar_id_.value())];
   remodel_fiber_[gp].set_lambda_r(scalar);
 }
 
@@ -347,6 +390,13 @@ double Mixture::MixtureConstituentRemodelFiberSsi::evaluate_growth_reaction_coef
 {
   if (params_->enable_growth_) return remodel_fiber_[gp].evaluate_growth_reaction_coefficient();
   return 0.0;
+}
+
+double Mixture::MixtureConstituentRemodelFiberSsi::evaluate_local_stimulus(int gp) const
+{
+  const double sigma = remodel_fiber_[gp].evaluate_current_fiber_cauchy_stress();
+  const double sigma_h = remodel_fiber_[gp].evaluate_current_homeostatic_fiber_cauchy_stress();
+  return sigma - sigma_h;
 }
 
 double Mixture::MixtureConstituentRemodelFiberSsi::evaluate_deposition_stretch(

--- a/src/mixture/src/4C_mixture_constituent_remodelfiber_ssi.hpp
+++ b/src/mixture/src/4C_mixture_constituent_remodelfiber_ssi.hpp
@@ -56,8 +56,9 @@ namespace Mixture
 
       const bool inelastic_external_deformation_;
 
-      const int growth_scalar_id_;
-      const int remodeling_scalar_id_;
+      const std::optional<int> growth_scalar_id_;
+      const std::optional<int> remodeling_scalar_id_;
+      const std::optional<int> nonlocal_stimulus_scalar_id_;
     };
   }  // namespace PAR
 
@@ -110,6 +111,13 @@ namespace Mixture
 
     [[nodiscard]] double evaluate_growth_reaction_coefficient(int gp) const;
     [[nodiscard]] double evaluate_remodeling_reaction_coefficient(int gp) const;
+
+    [[nodiscard]] double evaluate_local_stimulus(int gp) const;
+
+    [[nodiscard]] bool is_nonlocal_stimulus_mode() const
+    {
+      return params_->nonlocal_stimulus_scalar_id_.has_value();
+    }
 
     void set_current_growth_scalar(const Teuchos::ParameterList& params, int gp);
     void set_current_lambda_r(const Teuchos::ParameterList& params, int gp);

--- a/src/mixture/src/4C_mixture_remodelfiber-internal.hpp
+++ b/src/mixture/src/4C_mixture_remodelfiber-internal.hpp
@@ -126,6 +126,8 @@ namespace Mixture
 
       [[nodiscard]] T evaluate_growth_reaction_coefficient(
           T lambda_f, T lambda_r, T lambda_ext) const;
+      [[nodiscard]] T evaluate_growth_evolution_equation_dt_with_nonlocal_stimulus(
+          T psi, T lambda_f, T lambda_r, T lambda_ext, T growth_scalar) const;
       [[nodiscard]] T evaluate_growth_evolution_equation_dt(
           T lambda_f, T lambda_r, T lambda_ext, T growth_scalar) const;
       [[nodiscard]] T evaluate_d_growth_evolution_equation_dt_d_sig(
@@ -168,6 +170,9 @@ namespace Mixture
 
       [[nodiscard]] IntegrationState<numstates, T> get_integration_state_lambda_r() const;
 
+      [[nodiscard]] IntegrationState<numstates, T>
+      get_integration_state_growth_scalar_with_nonlocal_stimulus(T psi) const;
+
       /// @name Methods for doing explicit or implicit time integration
       /// @{
       /*!
@@ -183,6 +188,15 @@ namespace Mixture
        * @param dt (in) : timestep
        */
       void integrate_local_evolution_equations_explicit(T dt);
+
+      /*!
+       * @brief Integrate the local evolution equations explicitly, driven by a non-local stimulus
+       * \psi.
+       *
+       * @param psi (in) : non-local stimulus \psi
+       * @param dt (in) : timestep
+       */
+      void integrate_local_evolution_equations_explicit_with_nonlocal_stimulus(T psi, T dt);
       /// @}
       /// @brief Evaluation methods
       ///

--- a/src/mixture/src/4C_mixture_remodelfiber.cpp
+++ b/src/mixture/src/4C_mixture_remodelfiber.cpp
@@ -179,6 +179,23 @@ void Mixture::Implementation::RemodelFiberImplementation<numstates, T>::set_lamb
 template <int numstates, typename T>
 Mixture::Implementation::IntegrationState<numstates, T>
 Mixture::Implementation::RemodelFiberImplementation<numstates,
+    T>::get_integration_state_growth_scalar_with_nonlocal_stimulus(const T psi) const
+{
+  IntegrationState<numstates, T> growth_state;
+  std::transform(states_.begin(), states_.end(), growth_state.x.begin(),
+      [](const GRState& state) { return state.growth_scalar; });
+  std::transform(states_.begin(), states_.end(), growth_state.f.begin(),
+      [&](const GRState& state)
+      {
+        return evaluate_growth_evolution_equation_dt_with_nonlocal_stimulus(
+            psi, state.lambda_f, state.lambda_r, state.lambda_ext, state.growth_scalar);
+      });
+  return growth_state;
+}
+
+template <int numstates, typename T>
+Mixture::Implementation::IntegrationState<numstates, T>
+Mixture::Implementation::RemodelFiberImplementation<numstates,
     T>::get_integration_state_growth_scalar() const
 {
   return std::invoke(
@@ -322,6 +339,20 @@ void Mixture::Implementation::RemodelFiberImplementation<numstates,
 }
 
 
+template <int numstates, typename T>
+void Mixture::Implementation::RemodelFiberImplementation<numstates,
+    T>::integrate_local_evolution_equations_explicit_with_nonlocal_stimulus(const T psi, const T dt)
+{
+  const IntegrationState<numstates, T> growth_state =
+      get_integration_state_growth_scalar_with_nonlocal_stimulus(psi);
+  const IntegrationState<numstates, T> remodel_state = get_integration_state_lambda_r();
+
+  states_.back().growth_scalar = ExplicitIntegration<numstates, T>::integrate(growth_state, dt);
+  states_.back().lambda_r = ExplicitIntegration<numstates, T>::integrate(remodel_state, dt);
+
+  d_growth_scalar_d_lambda_f_sq_ = 0.0;
+  d_lambda_r_d_lambda_f_sq_ = 0.0;
+}
 
 template <int numstates, typename T>
 void Mixture::Implementation::RemodelFiberImplementation<numstates,
@@ -350,6 +381,17 @@ T Mixture::Implementation::RemodelFiberImplementation<numstates,
   const T dsig = (evaluate_fiber_cauchy_stress(lambda_f, lambda_r, lambda_ext) - sig_h_) / sig_h_;
   return (growth_evolution_.evaluate_true_mass_production_rate(dsig) +
           growth_evolution_.evaluate_true_mass_removal_rate(dsig));
+}
+
+template <int numstates, typename T>
+T Mixture::Implementation::RemodelFiberImplementation<numstates,
+    T>::evaluate_growth_evolution_equation_dt_with_nonlocal_stimulus(const T psi, const T lambda_f,
+    const T lambda_r, const T lambda_ext, const T growth_scalar) const
+{
+  const T dsig = psi / sig_h_;
+  return (growth_evolution_.evaluate_true_mass_production_rate(dsig) +
+             growth_evolution_.evaluate_true_mass_removal_rate(dsig)) *
+         growth_scalar;
 }
 
 template <int numstates, typename T>
@@ -790,6 +832,14 @@ template <int numstates>
 void Mixture::RemodelFiber<numstates>::integrate_local_evolution_equations_explicit(const double dt)
 {
   impl_->integrate_local_evolution_equations_explicit(dt);
+}
+
+template <int numstates>
+void Mixture::RemodelFiber<numstates>::
+    integrate_local_evolution_equations_explicit_with_nonlocal_stimulus(
+        const double psi, const double dt)
+{
+  impl_->integrate_local_evolution_equations_explicit_with_nonlocal_stimulus(psi, dt);
 }
 
 template <int numstates>

--- a/src/mixture/src/4C_mixture_remodelfiber.hpp
+++ b/src/mixture/src/4C_mixture_remodelfiber.hpp
@@ -110,6 +110,17 @@ namespace Mixture
      * @param dt (in) : timestep
      */
     void integrate_local_evolution_equations_explicit(double dt);
+
+    /*!
+     * @brief Integrate the evolution equations for one time step explicitly using an external
+     * non-local stimulus \psi (from the Helmholtz Scatra field) instead of the locally computed
+     * stress-deviation. Analogous to integrate_local_evolution_equations_explicit but driven by
+     * \psi.
+     *
+     * @param psi (in) : non-local stimulus \psi (from Scatra DOF)
+     * @param dt (in) : timestep
+     */
+    void integrate_local_evolution_equations_explicit_with_nonlocal_stimulus(double psi, double dt);
     /// @}
     [[nodiscard]] double evaluate_current_homeostatic_fiber_cauchy_stress() const;
     [[nodiscard]] double evaluate_current_fiber_cauchy_stress() const;

--- a/src/scatra/4C_scatra_input.cpp
+++ b/src/scatra/4C_scatra_input.cpp
@@ -726,6 +726,8 @@ std::string ScaTra::impltype_to_string(ImplType impltype)
       return "CardMono";
     case ScaTra::impltype_gr:
       return "GR";
+    case ScaTra::impltype_nl_stimulus:
+      return "NLS";
     case ScaTra::impltype_chemo:
       return "Chemotaxis";
     case ScaTra::impltype_chemoreac:

--- a/src/scatra/4C_scatra_input.hpp
+++ b/src/scatra/4C_scatra_input.hpp
@@ -201,6 +201,7 @@ namespace ScaTra
     impltype_aniso,
     impltype_cardiac_monodomain,
     impltype_gr,
+    impltype_nl_stimulus,
     impltype_chemo,
     impltype_chemoreac,
     impltype_std_hdg,

--- a/src/scatra_ele/4C_scatra_ele.cpp
+++ b/src/scatra_ele/4C_scatra_ele.cpp
@@ -319,6 +319,7 @@ void Discret::Elements::Transport::set_material(
       mat->material_type() == Core::Materials::m_scatra_in_solid_porofluid_pressure_based or
       mat->material_type() == Core::Materials::m_scatra_as_temperature_porofluid_pressure_based or
       mat->material_type() == Core::Materials::m_scatra_gr or
+      mat->material_type() == Core::Materials::m_scatra_nl_stimulus or
       (mat->material_type() == Core::Materials::m_electrode and impltype_ == ScaTra::impltype_std))
     numdofpernode_ = 1;  // we only have a single scalar
   else if (mat->material_type() == Core::Materials::m_electrode)

--- a/src/scatra_ele/4C_scatra_ele_boundary_factory.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_factory.cpp
@@ -21,6 +21,7 @@
 #include "4C_scatra_ele_boundary_calc_sti_electrode.hpp"
 #include "4C_scatra_ele_boundary_interface.hpp"
 #include "4C_scatra_ele_calc.hpp"
+#include "4C_scatra_input.hpp"
 #include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
@@ -133,6 +134,7 @@ Discret::Elements::ScaTraBoundaryFactory::define_problem_type(const ScaTra::Impl
     case ScaTra::impltype_aniso:
     case ScaTra::impltype_cardiac_monodomain:
     case ScaTra::impltype_gr:
+    case ScaTra::impltype_nl_stimulus:
     case ScaTra::impltype_chemo:
     case ScaTra::impltype_chemoreac:
     case ScaTra::impltype_levelset:

--- a/src/scatra_ele/4C_scatra_ele_calc_nonlocal_stimulus.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_nonlocal_stimulus.cpp
@@ -1,0 +1,218 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "4C_scatra_ele_calc_nonlocal_stimulus.hpp"
+
+#include "4C_fem_discretization.hpp"
+#include "4C_fem_general_element.hpp"
+#include "4C_mat_list.hpp"
+#include "4C_mat_mixture.hpp"
+#include "4C_mat_scatra_nonlocal_stimulus.hpp"
+#include "4C_mixture_constituent_remodelfiber_ssi.hpp"
+#include "4C_scatra_ele_calc.hpp"
+#include "4C_utils_exceptions.hpp"
+#include "4C_utils_singleton_owner.hpp"
+
+FOUR_C_NAMESPACE_OPEN
+
+/*----------------------------------------------------------------------*
+ *----------------------------------------------------------------------*/
+template <Core::FE::CellType distype, int probdim>
+Discret::Elements::ScaTraEleCalcNonlocalStimulus<distype, probdim>::ScaTraEleCalcNonlocalStimulus(
+    const int numdofpernode, const int numscal, const std::string& disname)
+    : Discret::Elements::ScaTraEleCalc<distype, probdim>::ScaTraEleCalc(
+          numdofpernode, numscal, disname),
+      source_at_gp_(numscal, 0.0)
+{
+}
+
+template <Core::FE::CellType distype, int probdim>
+Discret::Elements::ScaTraEleCalcNonlocalStimulus<distype, probdim>*
+Discret::Elements::ScaTraEleCalcNonlocalStimulus<distype, probdim>::instance(
+    const int numdofpernode, const int numscal, const std::string& disname)
+{
+  static auto singleton_map = Core::Utils::make_singleton_map<std::pair<std::string, int>>(
+      [](const int numdofpernode, const int numscal, const std::string& disname)
+      {
+        return std::unique_ptr<ScaTraEleCalcNonlocalStimulus<distype, probdim>>(
+            new ScaTraEleCalcNonlocalStimulus<distype, probdim>(numdofpernode, numscal, disname));
+      });
+
+  return singleton_map[std::make_pair(disname, numdofpernode)].instance(
+      Core::Utils::SingletonAction::create, numdofpernode, numscal, disname);
+}
+
+template <Core::FE::CellType distype, int probdim>
+void Discret::Elements::ScaTraEleCalcNonlocalStimulus<distype, probdim>::get_material_params(
+    const Core::Elements::Element* ele, std::vector<double>& densn, std::vector<double>& densnp,
+    std::vector<double>& densam, double& visc, const int iquad)
+{
+  std::shared_ptr<Core::Mat::Material> material = ele->material();
+
+  my::reamanager_->clear(my::numscal_);
+
+  if (material->material_type() == Core::Materials::m_matlist)
+  {
+    const std::shared_ptr<Mat::MatList> actmat = std::dynamic_pointer_cast<Mat::MatList>(material);
+    if (actmat->num_mat() < my::numscal_) FOUR_C_THROW("Not enough materials in MatList.");
+
+    for (int k = 0; k < my::numscal_; ++k)
+    {
+      int matid = actmat->mat_id(k);
+      const std::shared_ptr<Core::Mat::Material> singlemat = actmat->material_by_id(matid);
+      materials(singlemat, k, densn[k], densnp[k], densam[k], visc, iquad);
+    }
+  }
+  else
+  {
+    materials(material, 0, densn[0], densnp[0], densam[0], visc, iquad);
+  }
+}
+
+template <Core::FE::CellType distype, int probdim>
+void Discret::Elements::ScaTraEleCalcNonlocalStimulus<distype, probdim>::materials(
+    const std::shared_ptr<const Core::Mat::Material> material, const int k, double& densn,
+    double& densnp, double& densam, double& visc, const int iquad)
+{
+  switch (material->material_type())
+  {
+    case Core::Materials::m_scatra_nl_stimulus:
+    {
+      mat_scatra_nls(material, k, densn, densnp, densam, visc, iquad);
+      break;
+    }
+    default:
+    {
+      my::materials(material, k, densn, densnp, densam, visc, iquad);
+      break;
+    }
+  }
+}
+
+template <Core::FE::CellType distype, int probdim>
+void Discret::Elements::ScaTraEleCalcNonlocalStimulus<distype, probdim>::mat_scatra_nls(
+    const std::shared_ptr<const Core::Mat::Material> material, const int k, double& densn,
+    double& densnp, double& densam, double& visc, const int iquad)
+{
+  const auto actmat = std::dynamic_pointer_cast<const Mat::ScatraNonlocalStimulusMat>(material);
+
+  my::diffmanager_->set_isotropic_diff(actmat->characteristic_length_sq(), k);
+
+  my::reamanager_->set_rea_coeff(1.0, k);
+
+  FOUR_C_ASSERT(
+      constituent_[k] != nullptr, "constituent_[{}] is null. Was setup_calc() called?", k);
+
+  if (iquad == -1)
+    FOUR_C_THROW("Element center evaluation is not supported for ScaTraEleCalcNonlocalStimulus.");
+
+  source_at_gp_[k] = constituent_[k]->evaluate_local_stimulus(iquad);
+}
+
+template <Core::FE::CellType distype, int probdim>
+void Discret::Elements::ScaTraEleCalcNonlocalStimulus<distype, probdim>::get_rhs_int(
+    double& rhsint, const double densnp, const int k)
+{
+  my::get_rhs_int(rhsint, densnp, k);
+  rhsint += source_at_gp_[k];
+}
+
+template <Core::FE::CellType distype, int probdim>
+int Discret::Elements::ScaTraEleCalcNonlocalStimulus<distype, probdim>::setup_calc(
+    Core::Elements::Element* ele, Core::FE::Discretization& discretization)
+{
+  const int result = my::setup_calc(ele, discretization);
+  if (result == -1) return result;
+
+  const std::shared_ptr<Mat::Mixture> structmat = get_struct_material(ele);
+
+  constituent_.assign(my::numscal_, nullptr);
+
+  const std::shared_ptr<Core::Mat::Material> scatra_material = ele->material(0);
+
+  auto resolve = [&](const std::shared_ptr<const Core::Mat::Material>& mat)
+      -> const Mixture::MixtureConstituentRemodelFiberSsi*
+  {
+    if (mat->material_type() != Core::Materials::m_scatra_nl_stimulus) return nullptr;
+
+    const auto actmat = std::dynamic_pointer_cast<const Mat::ScatraNonlocalStimulusMat>(mat);
+    const int struct_mat_id = actmat->structure_material_id();
+
+    const auto* constituent = structmat->ssi_constituent_by_material_id(struct_mat_id);
+
+    FOUR_C_ASSERT_ALWAYS(constituent != nullptr,
+        "Constituent with material id {} is not a MixtureConstituentRemodelFiberSsi. "
+        "ScaTraEleCalcNonlocalStimulus requires SSI RemodelFiber constituents.",
+        struct_mat_id);
+
+    FOUR_C_ASSERT_ALWAYS(constituent->is_nonlocal_stimulus_mode(),
+        "Constituent with material id {} does not have NONLOCAL_STIMULUS_SCALAR_ID set. "
+        "Please set NONLOCAL_STIMULUS_SCALAR_ID >= 0 in the constituent parameters.",
+        struct_mat_id);
+
+    return constituent;
+  };
+
+  if (scatra_material->material_type() == Core::Materials::m_matlist)
+  {
+    const auto actmat = std::dynamic_pointer_cast<const Mat::MatList>(scatra_material);
+    for (int k = 0; k < my::numscal_; ++k)
+      constituent_[k] = resolve(actmat->material_by_id(actmat->mat_id(k)));
+  }
+  else
+  {
+    constituent_[0] = resolve(scatra_material);
+  }
+
+  return 0;
+}
+
+template <Core::FE::CellType distype, int probdim>
+std::shared_ptr<Mat::Mixture>
+Discret::Elements::ScaTraEleCalcNonlocalStimulus<distype, probdim>::get_struct_material(
+    const Core::Elements::Element* ele)
+{
+  if (ele->num_material() <= 1)
+    FOUR_C_THROW(
+        "ScaTra NLS coupling requires a second structural material, but this is not defined for "
+        "the element");
+
+  auto mixture = std::dynamic_pointer_cast<Mat::Mixture>(ele->material(1));
+  if (!mixture)
+    FOUR_C_THROW(
+        "ScaTra NLS coupling expects material(1) to be a Mat::Mixture structural material, but "
+        "material(1) is not Mat::Mixture.");
+
+  return mixture;
+}
+
+
+// template classes
+
+// 1D elements
+template class Discret::Elements::ScaTraEleCalcNonlocalStimulus<Core::FE::CellType::line2, 1>;
+template class Discret::Elements::ScaTraEleCalcNonlocalStimulus<Core::FE::CellType::line2, 2>;
+template class Discret::Elements::ScaTraEleCalcNonlocalStimulus<Core::FE::CellType::line2, 3>;
+template class Discret::Elements::ScaTraEleCalcNonlocalStimulus<Core::FE::CellType::line3, 1>;
+
+// 2D elements
+template class Discret::Elements::ScaTraEleCalcNonlocalStimulus<Core::FE::CellType::tri3, 2>;
+template class Discret::Elements::ScaTraEleCalcNonlocalStimulus<Core::FE::CellType::tri3, 3>;
+template class Discret::Elements::ScaTraEleCalcNonlocalStimulus<Core::FE::CellType::tri6, 2>;
+template class Discret::Elements::ScaTraEleCalcNonlocalStimulus<Core::FE::CellType::quad4, 2>;
+template class Discret::Elements::ScaTraEleCalcNonlocalStimulus<Core::FE::CellType::quad4, 3>;
+template class Discret::Elements::ScaTraEleCalcNonlocalStimulus<Core::FE::CellType::quad9, 2>;
+template class Discret::Elements::ScaTraEleCalcNonlocalStimulus<Core::FE::CellType::nurbs9, 2>;
+
+// 3D elements
+template class Discret::Elements::ScaTraEleCalcNonlocalStimulus<Core::FE::CellType::hex8, 3>;
+template class Discret::Elements::ScaTraEleCalcNonlocalStimulus<Core::FE::CellType::hex27, 3>;
+template class Discret::Elements::ScaTraEleCalcNonlocalStimulus<Core::FE::CellType::tet4, 3>;
+template class Discret::Elements::ScaTraEleCalcNonlocalStimulus<Core::FE::CellType::tet10, 3>;
+template class Discret::Elements::ScaTraEleCalcNonlocalStimulus<Core::FE::CellType::pyramid5, 3>;
+
+FOUR_C_NAMESPACE_CLOSE

--- a/src/scatra_ele/4C_scatra_ele_calc_nonlocal_stimulus.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_nonlocal_stimulus.hpp
@@ -1,0 +1,83 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef FOUR_C_SCATRA_ELE_CALC_NONLOCAL_STIMULUS_HPP
+#define FOUR_C_SCATRA_ELE_CALC_NONLOCAL_STIMULUS_HPP
+
+#include "4C_config.hpp"
+
+#include "4C_scatra_ele_calc.hpp"
+
+#include <vector>
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace Mixture
+{
+  class MixtureConstituentRemodelFiberSsi;
+}
+
+namespace Mat
+{
+  class Mixture;
+}
+
+namespace Discret::Elements
+{
+  /*!
+   * @brief Scatra element calculator for the Helmholtz non-local G&R stimulus equation:
+   *
+   *   \f$\psi - \ell_c^2 \Delta\psi = (\sigma - \sigma_h)\f$
+   *
+   * The solution \psi is then used by the structural mixture constituent
+   * MixtureConstituentRemodelFiberSsi (non-local mode) to drive growth.
+   */
+  template <Core::FE::CellType distype, int probdim = Core::FE::dim<distype>>
+  class ScaTraEleCalcNonlocalStimulus : public ScaTraEleCalc<distype, probdim>
+  {
+    using my = ScaTraEleCalc<distype, probdim>;
+
+   public:
+    /// singleton access method
+    static ScaTraEleCalcNonlocalStimulus<distype, probdim>* instance(
+        const int numdofpernode, const int numscal, const std::string& disname);
+
+    int setup_calc(Core::Elements::Element* ele, Core::FE::Discretization& discretization) override;
+
+   protected:
+    ScaTraEleCalcNonlocalStimulus(
+        const int numdofpernode, const int numscal, const std::string& disname);
+
+    void get_material_params(const Core::Elements::Element* ele, std::vector<double>& densn,
+        std::vector<double>& densnp, std::vector<double>& densam, double& visc,
+        const int iquad) override;
+
+    void materials(const std::shared_ptr<const Core::Mat::Material> material, const int k,
+        double& densn, double& densnp, double& densam, double& visc, const int iquad) override;
+
+    /// evaluates the material, sets up the coefficients of the Helmholtz equation
+    /// and caches the local stimulus, therefore source term at the gauss point
+    void mat_scatra_nls(const std::shared_ptr<const Core::Mat::Material> material, const int k,
+        double& densn, double& densnp, double& densam, double& visc, const int iquad);
+
+    void get_rhs_int(double& rhsint, const double densnp, const int k) override;
+
+   private:
+    static std::shared_ptr<Mat::Mixture> get_struct_material(const Core::Elements::Element* ele);
+
+    /// SSI RemodelFiber constituents per scalar (set in setup_calc)
+    std::vector<const Mixture::MixtureConstituentRemodelFiberSsi*> constituent_;
+
+    /// Local stimulus \f$(\sigma - \sigma_h)\f$ at the current Gauss point, per scalar
+    std::vector<double> source_at_gp_;
+  };
+
+}  // namespace Discret::Elements
+
+FOUR_C_NAMESPACE_CLOSE
+
+#endif  // FOUR_C_SCATRA_ELE_CALC_NONLOCAL_STIMULUS_HPP

--- a/src/scatra_ele/4C_scatra_ele_calc_utils.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_utils.cpp
@@ -135,6 +135,11 @@ namespace ScaTra
         impltypestring = "Growth and remodeling";
         break;
       }
+      case ScaTra::impltype_nl_stimulus:
+      {
+        impltypestring = "Non-local stimulus";
+        break;
+      }
       case ScaTra::impltype_elch_diffcond:
       {
         impltypestring = "Electrochemistry for diffusion-conduction formulation";

--- a/src/scatra_ele/4C_scatra_ele_evaluate.cpp
+++ b/src/scatra_ele/4C_scatra_ele_evaluate.cpp
@@ -99,6 +99,7 @@ int Discret::Elements::Transport::evaluate(Teuchos::ParameterList& params,
     case ScaTra::impltype_aniso:
     case ScaTra::impltype_cardiac_monodomain:
     case ScaTra::impltype_gr:
+    case ScaTra::impltype_nl_stimulus:
     case ScaTra::impltype_loma:
     case ScaTra::impltype_poro:
     case ScaTra::impltype_pororeac:

--- a/src/scatra_ele/4C_scatra_ele_factory.cpp
+++ b/src/scatra_ele/4C_scatra_ele_factory.cpp
@@ -28,6 +28,7 @@
 #include "4C_scatra_ele_calc_ls.hpp"
 #include "4C_scatra_ele_calc_lsreinit.hpp"
 #include "4C_scatra_ele_calc_no_physics.hpp"
+#include "4C_scatra_ele_calc_nonlocal_stimulus.hpp"
 #include "4C_scatra_ele_calc_poro.hpp"
 #include "4C_scatra_ele_calc_poro_reac.hpp"
 #include "4C_scatra_ele_calc_poro_reac_ECM.hpp"
@@ -422,6 +423,11 @@ Discret::Elements::ScaTraEleInterface* Discret::Elements::ScaTraFactory::define_
     case ScaTra::impltype_gr:
     {
       return Discret::Elements::ScaTraEleCalcGrowthRemodel<distype, probdim>::instance(
+          numdofpernode, numscal, disname);
+    }
+    case ScaTra::impltype_nl_stimulus:
+    {
+      return Discret::Elements::ScaTraEleCalcNonlocalStimulus<distype, probdim>::instance(
           numdofpernode, numscal, disname);
     }
     case ScaTra::impltype_one_d_artery:

--- a/src/solid_scatra_ele/4C_solid_scatra_ele_lib.cpp
+++ b/src/solid_scatra_ele/4C_solid_scatra_ele_lib.cpp
@@ -25,6 +25,8 @@ ScaTra::ImplType Discret::Elements::read_scatra_impl_type(
     return ScaTra::impltype_cardiac_monodomain;
   else if (impltype == "GR")
     return ScaTra::impltype_gr;
+  else if (impltype == "NLS")
+    return ScaTra::impltype_nl_stimulus;
   else if (impltype == "Chemo")
     return ScaTra::impltype_chemo;
   else if (impltype == "ChemoReac")

--- a/tests/input_files/ssi_homogenized_constraint_mixture_qcyl_nonlocal.4C.yaml
+++ b/tests/input_files/ssi_homogenized_constraint_mixture_qcyl_nonlocal.4C.yaml
@@ -1,0 +1,340 @@
+TITLE:
+  - "Test case for non-local stimulus driven growth and remodeling:"
+  - "- non-local stimulus psi computed in scalar transport dynamics based on Helmholtz-type equation"
+  - "- structure integrates growth/remodeling ODEs locally at GP"
+  - "- growth is driven by non-local stimulus psi instead of local (sigma - sigma_h)"
+  - "- quarter cylinder with four fiber directions, geometry/BCs identical to"
+  - "- quarter cylinder with four fiber directions and material adapted from Braeu et al. 2017"
+  - "- each fiber equipped with its own corresponding non-local stimulus scalar"
+  - "- quasi-static structural dynamics"
+PROBLEM TYPE:
+  PROBLEMTYPE: "Structure_Scalar_Interaction"
+CLONING MATERIAL MAP:
+  - SRC_FIELD: "structure"
+    SRC_MAT: 1
+    TAR_FIELD: "scatra"
+    TAR_MAT: 101
+fields:
+  - name: "fiber5"
+    discretization: "structure"
+    source:
+      from_mesh:
+        basis: "points"
+  - name: "fiber4"
+    discretization: "structure"
+    source:
+      from_mesh:
+        basis: "points"
+  - name: "fiber3"
+    discretization: "structure"
+    source:
+      from_mesh:
+        basis: "points"
+  - name: "fiber2"
+    discretization: "structure"
+    source:
+      from_mesh:
+        basis: "points"
+  - name: "fiber1"
+    discretization: "structure"
+    source:
+      from_mesh:
+        basis: "points"
+IO:
+  VERBOSITY: "Standard"
+  STRUCT_STRAIN: "gl"
+  STRUCT_STRESS: "cauchy"
+  WRITE_FINAL_STATE: true
+  WRITE_INITIAL_STATE: false
+IO/RUNTIME VTK OUTPUT:
+  OUTPUT_DATA_FORMAT: "ascii"
+  INTERVAL_STEPS: 1
+IO/RUNTIME VTK OUTPUT/STRUCTURE:
+  OUTPUT_STRUCTURE: true
+  DISPLACEMENT: true
+  STRESS_STRAIN: true
+SCALAR TRANSPORT DYNAMIC:
+  SOLVERTYPE: "linear_full"
+  TIMEINTEGR: "Stationary"
+  THETA: 1.0
+  SKIPINITDER: true
+  RESULTSEVERY: 1
+  MATID: 101
+  VELOCITYFIELD: "Navier_Stokes"
+  INITIALFIELD: "zero_field"
+  CONVFORM: "convective"
+  IS_INTENSIVE_SCALAR: true
+  LINEAR_SOLVER: 1
+SCALAR TRANSPORT DYNAMIC/NONLINEAR:
+  ITEMAX: 20
+  CONVTOL: 1e-09
+SCALAR TRANSPORT DYNAMIC/STABILIZATION:
+  STABTYPE: "no_stabilization"
+  DEFINITION_TAU: "Zero"
+  EVALUATION_TAU: "integration_point"
+  EVALUATION_MAT: "integration_point"
+SOLVER 1:
+  NAME: "Structure_Solver"
+  SOLVER: "MUMPS"
+SSI CONTROL:
+  NUMSTEP: 40
+  MAXTIME: 1000.0000000001
+  TIMESTEP: 10.0
+  RESULTSEVERY: 1
+  ITEMAX: 20
+SSI CONTROL/PARTITIONED:
+  CONVTOL: 1e-10
+STRUCT NOX/Direction:
+  Method: "Newton"
+STRUCT NOX/Printing:
+  Outer Iteration: true
+  Inner Iteration: false
+  Outer Iteration StatusTest: false
+STRUCTURAL DYNAMIC:
+  DYNAMICTYPE: "OneStepTheta"
+  NEGLECTINERTIA: true
+  TOLDISP: 1e-12
+  TOLRES: 1e-12
+  LINEAR_SOLVER: 1
+  NLNSOL: "noxnln"
+  LOADLIN: true
+STRUCTURAL DYNAMIC/ONESTEPTHETA:
+  THETA: 1.0
+STRUCTURE GEOMETRY:
+  FILE: "vtu/homogenized-constrained-mixture-qcyl.vtu"
+  ELEMENT_BLOCKS:
+    - ID: 1
+      SOLIDSCATRA:
+        HEX8:
+          MAT: 1
+          KINEM: "nonlinear"
+          TYPE: "NLS"
+MATERIALS:
+  - MAT: 1
+    MAT_Mixture:
+      MATIDSCONST: [11, 12, 13, 14, 15]
+      MATIDMIXTURERULE: 10
+  - MAT: 10
+    MIX_GrowthRemodelMixtureRule:
+      GROWTH_STRATEGY: 100
+      MASSFRAC: [0.8, 0.05, 0.05, 0.05, 0.05]
+      DENS: 10.500000000000002
+  - MAT: 100
+    MIX_GrowthStrategy_Anisotropic:
+      GROWTH_DIRECTION:
+        from_mesh: "fiber5"
+  - MAT: 11
+    MIX_Constituent_ElastHyper:
+      NUMMAT: 2
+      MATIDS: [111, 112]
+      PRESTRESS_STRATEGY: 119
+  - MAT: 111
+    ELAST_IsoNeoHooke:
+      MUE:
+        constant: 0.09769999999999998
+  - MAT: 112
+    ELAST_VolSussmanBathe:
+      KAPPA: 0.09999999999999999
+  - MAT: 119
+    MIX_Prestress_Strategy_Prescribed:
+      PRESTRETCH:
+        constant: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+  - MAT: 12
+    MIX_Constituent_SsiRemodelFiber:
+      FIBER_MATERIAL_ID: 120
+      DECAY_TIME: 101.0
+      GROWTH_CONSTANT: 0.0009900990099009901
+      DEPOSITION_STRETCH: 0.0
+      DEPOSITION_STRETCH_TIMEFUNCT: 2
+      ORIENTATION:
+        from_mesh: "fiber1"
+      INELASTIC_GROWTH: true
+      ENABLE_GROWTH: true
+      NONLOCAL_STIMULUS_SCALAR_ID: 0
+  - MAT: 120
+    MIX_Constituent_RemodelFiber_Material_Exponential:
+      K1: 0.22009519999999996
+      K2: 1.23
+      COMPRESSION: false
+  - MAT: 13
+    MIX_Constituent_SsiRemodelFiber:
+      FIBER_MATERIAL_ID: 130
+      DECAY_TIME: 101.0
+      GROWTH_CONSTANT: 0.0009900990099009901
+      DEPOSITION_STRETCH: 0.0
+      DEPOSITION_STRETCH_TIMEFUNCT: 3
+      ORIENTATION:
+        from_mesh: "fiber2"
+      INELASTIC_GROWTH: true
+      ENABLE_GROWTH: true
+      NONLOCAL_STIMULUS_SCALAR_ID: 1
+  - MAT: 130
+    MIX_Constituent_RemodelFiber_Material_Exponential:
+      K1: 0.22009519999999996
+      K2: 1.23
+      COMPRESSION: false
+  - MAT: 14
+    MIX_Constituent_SsiRemodelFiber:
+      FIBER_MATERIAL_ID: 140
+      DECAY_TIME: 101.0
+      GROWTH_CONSTANT: 0.0009900990099009901
+      DEPOSITION_STRETCH: 0.0
+      DEPOSITION_STRETCH_TIMEFUNCT: 4
+      ORIENTATION:
+        from_mesh: "fiber3"
+      INELASTIC_GROWTH: true
+      ENABLE_GROWTH: true
+      NONLOCAL_STIMULUS_SCALAR_ID: 2
+  - MAT: 140
+    MIX_Constituent_RemodelFiber_Material_Exponential:
+      K1: 0.22009519999999996
+      K2: 1.23
+      COMPRESSION: false
+  - MAT: 15
+    MIX_Constituent_SsiRemodelFiber:
+      FIBER_MATERIAL_ID: 150
+      DECAY_TIME: 101.0
+      GROWTH_CONSTANT: 0.0009900990099009901
+      DEPOSITION_STRETCH: 0.0
+      DEPOSITION_STRETCH_TIMEFUNCT: 5
+      ORIENTATION:
+        from_mesh: "fiber4"
+      INELASTIC_GROWTH: true
+      ENABLE_GROWTH: true
+      NONLOCAL_STIMULUS_SCALAR_ID: 3
+  - MAT: 150
+    MIX_Constituent_RemodelFiber_Material_Exponential:
+      K1: 0.22009519999999996
+      K2: 1.23
+      COMPRESSION: false
+  - MAT: 1000
+    MAT_scatra_nl_stimulus:
+      CHAR_LENGTH_SQ: 1.0e-6
+      STRUCTURE_MAT_ID: 12
+  - MAT: 1001
+    MAT_scatra_nl_stimulus:
+      CHAR_LENGTH_SQ: 1.0e-6
+      STRUCTURE_MAT_ID: 13
+  - MAT: 1002
+    MAT_scatra_nl_stimulus:
+      CHAR_LENGTH_SQ: 1.0e-6
+      STRUCTURE_MAT_ID: 14
+  - MAT: 1003
+    MAT_scatra_nl_stimulus:
+      CHAR_LENGTH_SQ: 1.0e-6
+      STRUCTURE_MAT_ID: 15
+  - MAT: 101
+    MAT_matlist:
+      LOCAL: false
+      NUMMAT: 4
+      MATIDS: [1000, 1001, 1002, 1003]
+DESIGN SURF DIRICH CONDITIONS:
+  - E: 4
+    ENTITY_TYPE: "node_set_id"
+    NUMDOF: 3
+    ONOFF: [0, 1, 0]
+    VAL: [0.0, 0.0, 0.0]
+    FUNCT: [0, 0, 0]
+  - E: 6
+    ENTITY_TYPE: "node_set_id"
+    NUMDOF: 3
+    ONOFF: [1, 0, 0]
+    VAL: [0.0, 0.0, 0.0]
+    FUNCT: [0, 0, 0]
+  - E: 5
+    ENTITY_TYPE: "node_set_id"
+    NUMDOF: 3
+    ONOFF: [0, 0, 1]
+    VAL: [0.0, 0.0, 0.0]
+    FUNCT: [0, 0, 0]
+  - E: 3
+    ENTITY_TYPE: "node_set_id"
+    NUMDOF: 3
+    ONOFF: [0, 0, 1]
+    VAL: [0.0, 0.0, 0.0]
+    FUNCT: [0, 0, 0]
+DESIGN SURF NEUMANN CONDITIONS:
+  - E: 1
+    ENTITY_TYPE: "node_set_id"
+    NUMDOF: 3
+    ONOFF: [1, 0, 0]
+    VAL: [-1.0, 0.0, 0.0]
+    FUNCT: [1, 0, 0]
+    TYPE: "orthopressure"
+FUNCT1:
+  - SYMBOLIC_FUNCTION_OF_SPACE_TIME: "v"
+  - VARIABLE: 0
+    NAME: "v"
+    TYPE: "linearinterpolation"
+    NUMPOINTS: 3
+    TIMES: [0, 1, 1010.0000000001]
+    VALUES: [0.0, 0.11999779932000001, 0.11999779932000001]
+FUNCT2:
+  - SYMBOLIC_FUNCTION_OF_TIME: "v"
+  - VARIABLE: 0
+    NAME: "v"
+    TYPE: "linearinterpolation"
+    NUMPOINTS: 3
+    TIMES: [0.0, 1.0, 1010.0000000001]
+    VALUES: [1.1, 1.1, 1.1]
+FUNCT3:
+  - SYMBOLIC_FUNCTION_OF_TIME: "v"
+  - VARIABLE: 0
+    NAME: "v"
+    TYPE: "linearinterpolation"
+    NUMPOINTS: 3
+    TIMES: [0.0, 1.0, 1010.0000000001]
+    VALUES: [1.1, 1.1, 1.1]
+FUNCT4:
+  - SYMBOLIC_FUNCTION_OF_TIME: "v"
+  - VARIABLE: 0
+    NAME: "v"
+    TYPE: "linearinterpolation"
+    NUMPOINTS: 3
+    TIMES: [0.0, 1.0, 1010.0000000001]
+    VALUES: [1.1, 1.1, 1.1]
+FUNCT5:
+  - SYMBOLIC_FUNCTION_OF_TIME: "v"
+  - VARIABLE: 0
+    NAME: "v"
+    TYPE: "linearinterpolation"
+    NUMPOINTS: 3
+    TIMES: [0.0, 1.0, 1010.0000000001]
+    VALUES: [1.1, 1.1, 1.1]
+RESULT DESCRIPTION:
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 24
+      QUANTITY: "dispx"
+      VALUE: 8.11245006493310251e-03
+      TOLERANCE: 8.2e-10
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 24
+      QUANTITY: "dispy"
+      VALUE: 1.85161378863692920e-03
+      TOLERANCE: 1.9e-10
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 24
+      QUANTITY: "dispz"
+      VALUE: 0.0
+      TOLERANCE: 1e-12
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 40
+      QUANTITY: "dispx"
+      VALUE: 7.95796479401767939e-03
+      TOLERANCE: 8.0e-10
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 40
+      QUANTITY: "dispy"
+      VALUE: 3.83235386216280180e-03
+      TOLERANCE: 3.9e-10
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 40
+      QUANTITY: "dispz"
+      VALUE: 0.0
+      TOLERANCE: 1e-12

--- a/tests/list_of_tests.cmake
+++ b/tests/list_of_tests.cmake
@@ -2675,6 +2675,7 @@ four_c_test(TEST_FILE xfsi_push_1D_1st_order.4C.yaml)
 four_c_test(TEST_FILE xfsi_push_1D_2nd_order.4C.yaml)
 
 # Tests requiring VTK
+four_c_test(TEST_FILE ssi_homogenized_constraint_mixture_qcyl_nonlocal.4C.yaml NP 2 REQUIRED_DEPENDENCIES VTK TRILINOS_MUMPS)
 four_c_test(TEST_FILE mixture_prestress_iterative_prescribed.4C.yaml NP 2 REQUIRED_DEPENDENCIES VTK TRILINOS_MUMPS)
 four_c_test(TEST_FILE ssi_homogenized_constraint_mixture_qcyl.4C.yaml NP 2 REQUIRED_DEPENDENCIES VTK TRILINOS_MUMPS)
 four_c_test(TEST_FILE ssi_homogenized_constraint_mixture_prestress_qcyl.4C.yaml NP 2 REQUIRED_DEPENDENCIES VTK TRILINOS_MUMPS)


### PR DESCRIPTION
# Description and Context
This PR introduces the non-local stimulus $\psi$ as input for the local growth evolution equation of MixtureConstituentRemodelFiberSsi. Instead of driving growth/remodeling locally by the fiber Cauchy stress deviation ($\sigma - \sigma_h$) at each Gauss point, $\psi$ is computed as the Helmholtz-smoothed version of that quantity in the SSI scalar transport field:

$$\psi - \ell_c^2\Delta\psi = \sigma - \sigma_h$$

The structure side then integrates the growth/remodeling ODEs explicitly at each Gauss point, using $\psi$ in place of $\sigma - \sigma_h$. This makes the G&R driver non-local with characteristic length scale $\ell_c$.

# What's added

1. MAT_scatra_nl_stimulus as scatra material containing relevat parameters: CHAR_LENGTH_SQ, STRUCTURE_MAT_ID.
2. ScaTraEleCalcNonlocalStimulus (TYPE: "NLS" on SOLIDSCATRA elements) — assembles $\psi - \ell_c^2\Delta\psi = \sigma - \sigma_h$ as a stationary PDE, with the source term $\sigma - \sigma_h$ from the corresponding mixture constituent at each GP.
