### PR TITLE
Fix version of rapidyaml

### DIFF
--- a/utilities/four_c_python/requirements.txt
+++ b/utilities/four_c_python/requirements.txt
@@ -1,4 +1,4 @@
-rapidyaml
+rapidyaml==0.11.1
 jsonschema-rs
 
 numpy


### PR DESCRIPTION
The latest version seems to break our documentation and our schema validation in the pipeline. Let's fix the version of rapidyaml until they have fixed the underlying problem.