### PR TITLE
[TSI] Fix solver increment handling in partitioned solver

### DIFF
--- a/src/tsi/4C_tsi_partitioned.cpp
+++ b/src/tsi/4C_tsi_partitioned.cpp
@@ -478,6 +478,12 @@ void TSI::Partitioned::outer_iteration_loop()
         // get current temperatures due to solve thermo step, like predictor in FSI
         if (itnum != 1) temp_ = thermo_field()->tempnp();
 
+        // Store the current outer iterates before the sub-solves overwrite them.
+        // convergence_check() turns these into increments by subtracting them
+        // from the updated field solutions.
+        tempincnp_->update(1.0, *thermo_field()->tempnp(), 0.0);
+        dispincnp_->update(1.0, *structure_field()->dispnp(), 0.0);
+
         // begin nonlinear solver / outer iteration ***************************
 
         // ---------------------------------------------- structure field


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

The increment vectors need to store the current states before an outer iteration. This is done in every `outer_iteration_loop` except for `IterStagg` with temperature as the coupling variable.

Consequently, the corresponding tests `tsi_lincompression_iterstaggtemp.4C.yaml-p1` so far never detected that the outer iteration loop is actually converged, as can be seen by its output:

```shell
**************************************************************
      OUTER ITERATION LOOP 
      Time Step   9/2000 
**************************************************************
|    95/100    |   1.000E-06[L_2 ]      |  1.641E+02         |  1.704E+00         |
|    96/100    |   1.000E-06[L_2 ]      |  1.039E+03         |  5.085E-03         |
|    97/100    |   1.000E-06[L_2 ]      |  1.641E+02         |  1.704E+00         |
|    98/100    |   1.000E-06[L_2 ]      |  1.039E+03         |  5.085E-03         |
|    99/100    |   1.000E-06[L_2 ]      |  1.641E+02         |  1.704E+00         |
|   100/100    |   1.000E-06[L_2 ]      |  1.039E+03         |  5.085E-03         |
```

With this change, we get:
```shell
**************************************************************
      OUTER ITERATION LOOP 
      Time Step   9/2000 
**************************************************************
|     1/100    |   1.000E-06[L_2 ]      |  1.751E+01         |  1.704E-01         |
|     2/100    |   1.000E-06[L_2 ]      |  5.660E-02         |  5.426E-04         |
|     3/100    |   1.000E-06[L_2 ]      |  1.829E-04         |  1.754E-06         |
|     4/100    |   1.000E-06[L_2 ]      |  5.911E-07         |  5.667E-09         |
``` 





## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
