### PR TITLE
Minor rework of ssi solvers

### DIFF
--- a/src/ssi/4C_ssi_monolithic.cpp
+++ b/src/ssi/4C_ssi_monolithic.cpp
@@ -394,6 +394,30 @@ void SSI::SsiMono::evaluate_off_diag_contributions() const
  *-------------------------------------------------------------------------------*/
 void SSI::SsiMono::build_null_spaces(Core::LinAlg::Solver& solver) const
 {
+  // structure-related block
+  {
+    std::stringstream iblockstr;
+    iblockstr << ssi_maps_->get_block_positions(Subproblem::structure).at(0) + 1;
+
+    Teuchos::ParameterList& blocksmootherparams =
+        solver.params().sublist("Inverse" + iblockstr.str());
+
+    if (solver.params().isSublist("AMGnxn Parameters"))
+    {
+      blocksmootherparams.sublist("Belos Parameters");
+      blocksmootherparams.sublist("MueLu Parameters");
+
+      Core::FE::compute_null_space_if_necessary(
+          *structure_field()->discretization(), blocksmootherparams);
+    }
+    else
+    {
+      Core::LinearSolver::Parameters::compute_solver_parameters(
+          *structure_field()->discretization(), blocksmootherparams);
+    }
+  }
+
+  // all scalar transport-related blocks
   switch (scatra_field()->matrix_type())
   {
     case Core::LinAlg::MatrixType::block_condition:
@@ -438,27 +462,6 @@ void SSI::SsiMono::build_null_spaces(Core::LinAlg::Solver& solver) const
     {
       FOUR_C_THROW("Invalid matrix type associated with scalar transport field!");
     }
-  }
-
-  // store number of matrix block associated with structural field as string
-  std::stringstream iblockstr;
-  iblockstr << ssi_maps_->get_block_positions(Subproblem::structure).at(0) + 1;
-
-  Teuchos::ParameterList& blocksmootherparams =
-      solver.params().sublist("Inverse" + iblockstr.str());
-
-  if (solver.params().isSublist("AMGnxn Parameters"))
-  {
-    blocksmootherparams.sublist("Belos Parameters");
-    blocksmootherparams.sublist("MueLu Parameters");
-
-    Core::FE::compute_null_space_if_necessary(
-        *structure_field()->discretization(), blocksmootherparams);
-  }
-  else
-  {
-    Core::LinearSolver::Parameters::compute_solver_parameters(
-        *structure_field()->discretization(), blocksmootherparams);
   }
 }
 
@@ -740,7 +743,9 @@ void SSI::SsiMono::setup_system()
       // feed block preconditioner with null space information for each block of global block system
       // matrix
       build_null_spaces(*solver_);
-      if (init_pot_calc_solver_ != nullptr) build_null_spaces(*init_pot_calc_solver_);
+      // in case no initial potential calculation solver is set, the main solver is reused and we do
+      // not need to additionally call build_null_spaces
+      if (init_pot_calc_solver_ != solver_) build_null_spaces(*init_pot_calc_solver_);
 
       break;
     }


### PR DESCRIPTION
## Description and Context
This PR does two things:
- purely cosmetic: switch the order of the nullspace calculation to actually match the order in the block matrix
- If no specific solver for the calculation of the initial potential field is set, the main solver is reused. Thus, we do not need to call build_null_spaces a second time on the same solver in this case

