### PR TITLE
[MultSplit Material] Add thermal stress evaluation helper

### DIFF
--- a/src/mat/4C_mat_multiplicative_split_defgrad_elasthyper_service.hpp
+++ b/src/mat/4C_mat_multiplicative_split_defgrad_elasthyper_service.hpp
@@ -12,6 +12,9 @@
 #include "4C_linalg_fixedsizematrix.hpp"
 #include "4C_linalg_fixedsizematrix_tensor_products.hpp"
 #include "4C_linalg_fixedsizematrix_voigt_notation.hpp"
+#include "4C_linalg_symmetric_tensor.hpp"
+#include "4C_linalg_tensor_conversion.hpp"
+#include "4C_linalg_tensor_generators.hpp"
 #include "4C_mat_elasthyper_service.hpp"
 #include "4C_mat_service.hpp"
 
@@ -28,6 +31,37 @@ namespace Mat
     Core::LinAlg::Matrix<3, 1> gamma{Core::LinAlg::Initialization::zero};
     /// Constitutive tensor factors, cf. Holzapfel p. 261.
     Core::LinAlg::Matrix<8, 1> delta{Core::LinAlg::Initialization::zero};
+  };
+
+  /// Thermal stretch quantities used by multiplicative-split thermoelastic stress evaluation.
+  struct ThermalQuantities
+  {
+    // ----- variables of thermal quantities ----- //
+    /// thermal right Cauchy-Green deformation tensor \f$ \mathbf{C}_T \f$ stored as 6x1
+    /// vector (stress-form!)
+    Core::LinAlg::Matrix<6, 1> CTV{Core::LinAlg::Initialization::zero};
+    /// inverse thermal right Cauchy-Green deformation tensor \f$ \mathbf{C}_T^{-1} \f$ stored as
+    /// 6x1 vector (stress-form)
+    Core::LinAlg::Matrix<6, 1> iCTV{Core::LinAlg::Initialization::zero};
+    /// \f$ \mathbf{F}_{\text{in}}^{-1} \mathbf{C}_T \mathbf{F}_{\text{in}}^{-T} \f$ stored as 6x1
+    /// vector (stress-form!)
+    Core::LinAlg::Matrix<6, 1> iFinCTiFinTV{Core::LinAlg::Initialization::zero};
+    /// \f$ \mathbf{F}_{\text{in}}^{-1} \mathbf{C}_T^{-1} \mathbf{F}_{\text{in}}^{-T} \f$ stored
+    /// as 6x1 vector (stress-form!)
+    Core::LinAlg::Matrix<6, 1> iFiniCTiFinTV{Core::LinAlg::Initialization::zero};
+    /// derivative of thermal right Cauchy-Green deformation tensor wrt temperature \f$ \mathrm{d}
+    /// \mathbf{C}_T / \mathrm{d} T \f$ stored as 6x1 vector (strain-form!)
+    Core::LinAlg::Matrix<6, 1> dCTdTV{Core::LinAlg::Initialization::zero};
+
+    /// principal invariants of the thermal right Cauchy-Green tensor
+    Core::LinAlg::Matrix<3, 1> prinv{Core::LinAlg::Initialization::zero};
+
+    // ----- derivatives of principal invariants ----- //
+
+    /// first derivatives of principal invariants
+    Core::LinAlg::Matrix<3, 1> dPI{Core::LinAlg::Initialization::zero};
+    /// second derivatives of principal invariants
+    Core::LinAlg::Matrix<6, 1> ddPII{Core::LinAlg::Initialization::zero};
   };
 
   inline void evaluate_ce(const Core::LinAlg::Matrix<3, 3>& F,
@@ -126,6 +160,163 @@ namespace Mat
     cmat.multiply_nt(delta(5), iCv, iCv, 1.);
     Core::LinAlg::FourTensorOperations::add_holzapfel_product(cmat, iCv, delta(6));
     Core::LinAlg::FourTensorOperations::add_holzapfel_product(cmat, iCinv, delta(7));
+  }
+
+  /*!
+   * @brief Subtracts the thermal contribution from the 2nd Piola-Kirchhoff stress
+   *
+   * \f[\texttt{stress} \mathrel{{-}{=}} \det(\boldsymbol{F}_\text{in})
+   * \boldsymbol{F}_\text{in}^{-1}
+   * \boldsymbol{S}_\text{he}[\boldsymbol{C}_\text{he} = \boldsymbol{C}_T]
+   * \boldsymbol{F}_\text{in}^{-T}\f]
+   * where \f$\boldsymbol{S}_\text{he}[\boldsymbol{C}_\text{he} = \boldsymbol{C}_T]\f$ denotes
+   * the hyperelastic 2nd Piola-Kirchhoff stress evaluated
+   * at the thermal right Cauchy-Green tensor \f$\boldsymbol{C}_T\f$.
+   *
+   * @param[in] thermal_quant Thermal stretch quantities and invariants
+   * @param[in] thermal_stress_fact Holzapfel stress factors for the thermal stretch
+   * @param[in] iCinV inverse inelastic right Cauchy-Green tensor in stress-like Voigt notation
+   * @param[in] detFin determinant of the inelastic deformation gradient
+   * @param[in,out] stress 2nd Piola-Kirchhoff stress in stress-like Voigt notation to be updated by
+   * the thermal contribution
+   */
+  inline void add_thermal_stress_contribution(Core::LinAlg::Matrix<6, 1>& stress,
+      const ThermalQuantities& thermal_quant, const StressFactors& thermal_stress_fact,
+      const Core::LinAlg::Matrix<6, 1>& iCinV, const double detFin)
+  {
+    const Core::LinAlg::Matrix<3, 1>& thermal_gamma = thermal_stress_fact.gamma;
+
+    stress.update(-detFin * thermal_gamma(0), iCinV, 1.0);
+    stress.update(-detFin * thermal_gamma(1), thermal_quant.iFinCTiFinTV, 1.0);
+    stress.update(-detFin * thermal_gamma(2), thermal_quant.iFiniCTiFinTV, 1.0);
+  }
+
+
+
+  /*!
+   * @brief Evaluate the partial derivative of the 2nd Piola-Kirchhoff stress wrt. temperature:
+   *
+   * \f[\frac{\partial \boldsymbol{S}}{\partial T}
+   * = -\det(\boldsymbol{F}_\text{in}) \boldsymbol{F}_{\text{in}}^{-1}
+   * \left(\frac{1}{2}\left.\mathbb{C}_\text{he}\right|_{\boldsymbol{C}_T}
+   * : \frac{\partial \boldsymbol{C}_T}{\partial T} \right)
+   * \boldsymbol{F}_{\text{in}}^{-T}\f]
+   *
+   * where \f$\left.\mathbb{C}_\text{he}\right|_{\boldsymbol{C}_T}\f$ denotes the hyperelastic
+   * stiffness evaluated at the thermal right Cauchy-Green tensor \f$\boldsymbol{C}_T\f$.
+   *
+   * @param[in] iFinM inverse inelastic deformation gradient
+   * @param[in] thermal_quant Thermal stretch quantities and temperature derivative
+   * @return derivative of the thermal 2nd Piola-Kirchhoff stress w.r.t. temperature
+   */
+  inline Core::LinAlg::Matrix<6, 1> compute_partial_d_stress_d_temperature(
+      const Core::LinAlg::Matrix<3, 3>& iFinM, const ThermalQuantities& thermal_quant)
+  {
+    Core::LinAlg::Matrix<6, 1> thermal_stress_deriv{Core::LinAlg::Initialization::zero};
+
+    const Core::LinAlg::Matrix<6, 1>& dCTdTV = thermal_quant.dCTdTV;
+    const double detFin = 1.0 / iFinM.determinant();
+
+    // evaluate purely hyperelastic stiffness with the thermal right CG tensor as input
+    Core::LinAlg::SymmetricTensor<double, 3, 3> hyperelast_stress{};
+    Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3> hyperelast_stiffness{};
+    elast_hyper_add_isotropic_stress_cmat(hyperelast_stress, hyperelast_stiffness,
+        Core::LinAlg::make_symmetric_tensor_from_stress_like_voigt_matrix(thermal_quant.CTV),
+        Core::LinAlg::make_symmetric_tensor_from_stress_like_voigt_matrix(thermal_quant.iCTV),
+        thermal_quant.prinv, thermal_quant.dPI, thermal_quant.ddPII);
+
+
+    /// compute derivative \f$ \frac{\partial \mathbf{S}_{\theta}}{\partial T} \f$
+
+    Core::LinAlg::Matrix<6, 1> pStheta_pT_stress{Core::LinAlg::Initialization::zero};
+    pStheta_pT_stress.multiply_nn(
+        0.5, Core::LinAlg::make_stress_like_voigt_view(hyperelast_stiffness), dCTdTV, 0.0);
+    Core::LinAlg::Matrix<3, 3> pStheta_pT{Core::LinAlg::Initialization::zero};
+    Core::LinAlg::Voigt::Stresses::vector_to_matrix(pStheta_pT_stress, pStheta_pT);
+
+    /// compute product \f$ \mathbf{F}_{\text{in}}^{-1}  \frac{\partial
+    /// \mathbf{S}_{\theta}}{\partial T} \mathbf{F}_{\text{in}}^{-T} \f$
+    Core::LinAlg::Matrix<3, 3> iFin_pStheta_pT{Core::LinAlg::Initialization::zero};
+    iFin_pStheta_pT.multiply_nn(1.0, iFinM, pStheta_pT, 0.0);
+    Core::LinAlg::Matrix<3, 3> iFin_pStheta_pT_iFinT{Core::LinAlg::Initialization::zero};
+    iFin_pStheta_pT_iFinT.multiply_nt(1.0, iFin_pStheta_pT, iFinM, 0.0);
+    Core::LinAlg::Matrix<6, 1> iFin_pStheta_pT_iFinT_V{Core::LinAlg::Initialization::zero};
+    Core::LinAlg::Voigt::Stresses::matrix_to_vector(iFin_pStheta_pT_iFinT, iFin_pStheta_pT_iFinT_V);
+
+    // thermal derivative
+    thermal_stress_deriv.update(-detFin, iFin_pStheta_pT_iFinT_V, 0.0);
+
+    return thermal_stress_deriv;
+  }
+
+  /*!
+   * @brief Compute thermal stretch quantities for isotropic thermal expansion.
+   *
+   * @param[in] delta_temperature current absolute temperature minus reference temperature
+   * @param[in] thermal_expansion_fac isotropic thermal expansion factor
+   * @param[in] iFinM inverse inelastic deformation gradient
+   * @param[in] gp Gauss point
+   * @param[in] eleGID element global ID
+   * @param[in] potsumel isotropic elastic summands used to evaluate invariant derivatives
+   * @return collected thermal kinematic quantities and invariant derivatives
+   */
+  inline ThermalQuantities evaluate_thermal_quantities(const double delta_temperature,
+      const double thermal_expansion_fac, const Core::LinAlg::Matrix<3, 3>& iFinM, const int gp,
+      const int eleGID, const std::vector<std::shared_ptr<Mat::Elastic::Summand>>& potsumel)
+  {
+    ThermalQuantities quantities{};
+
+    // compute the thermal stretch, along with its temperature
+    // derivative
+    Core::LinAlg::SymmetricTensor<double, 3, 3> thermal_right_cg_tensor{
+        Core::LinAlg::TensorGenerators::identity<double, 3, 3>};
+    Core::LinAlg::SymmetricTensor<double, 3, 3> thermal_right_cg_temp_deriv_tensor{};
+    thermal_right_cg_tensor += 2 * thermal_expansion_fac * delta_temperature *
+                               Core::LinAlg::TensorGenerators::identity<double, 3, 3>;
+    thermal_right_cg_temp_deriv_tensor +=
+        2 * thermal_expansion_fac * Core::LinAlg::TensorGenerators::identity<double, 3, 3>;
+
+    // compute inverse of the thermal stretch
+    Core::LinAlg::SymmetricTensor<double, 3, 3> inv_thermal_right_cg_tensor =
+        inv(thermal_right_cg_tensor);
+
+    // get matrices for the thermal stretch
+    const Core::LinAlg::Matrix<3, 3> CTM =
+        Core::LinAlg::make_matrix(get_full(thermal_right_cg_tensor));
+    const Core::LinAlg::Matrix<3, 3> iCTM =
+        Core::LinAlg::make_matrix(Core::LinAlg::get_full(inv_thermal_right_cg_tensor));
+
+    // compute terms with iFin
+    Core::LinAlg::Matrix<3, 3> iFinCT{};
+    iFinCT.multiply(1.0, iFinM, CTM, 0.0);
+    Core::LinAlg::Matrix<3, 3> iFinCTiFinT{};
+    iFinCTiFinT.multiply_nt(1.0, iFinCT, iFinM, 0.0);
+    Core::LinAlg::Matrix<3, 3> iFiniCT{};
+    iFiniCT.multiply(1.0, iFinM, iCTM, 0.0);
+    Core::LinAlg::Matrix<3, 3> iFiniCTiFinT{};
+    iFiniCTiFinT.multiply_nt(1.0, iFiniCT, iFinM, 0.0);
+
+    // add computed tensors to quantities in the specified form
+    quantities.CTV = Core::LinAlg::make_stress_like_voigt_view(thermal_right_cg_tensor);
+    quantities.iCTV = Core::LinAlg::make_stress_like_voigt_view(inv_thermal_right_cg_tensor);
+    Core::LinAlg::Voigt::Stresses::matrix_to_vector(iFinCTiFinT, quantities.iFinCTiFinTV);
+    Core::LinAlg::Voigt::Stresses::matrix_to_vector(iFiniCTiFinT, quantities.iFiniCTiFinTV);
+    quantities.dCTdTV = Core::LinAlg::make_strain_like_voigt_matrix(
+        thermal_right_cg_temp_deriv_tensor);  // must be in strain-form for contraction afterwards!
+
+    // compute principal invariants of the thermal stretch
+    Core::LinAlg::Voigt::Stresses::invariants_principal(quantities.prinv, quantities.CTV);
+
+    // compute derivatives of the thermal stretch principal invariants
+    quantities.dPI.clear();
+    quantities.ddPII.clear();
+    for (const auto& p : potsumel)  // only for isotropic components
+    {
+      p->add_derivatives_principal(quantities.dPI, quantities.ddPII, quantities.prinv, gp, eleGID);
+    }
+
+
+    return quantities;
   }
 
 }  // namespace Mat

--- a/unittests/mat/4C_multiplicative_split_defgrad_elasthyper_service_test.cpp
+++ b/unittests/mat/4C_multiplicative_split_defgrad_elasthyper_service_test.cpp
@@ -8,11 +8,12 @@
 #include <gtest/gtest.h>
 
 #include "4C_linalg_fixedsizematrix.hpp"
-#include "4C_linalg_fixedsizematrix_tensor_products.hpp"
+#include "4C_linalg_fixedsizematrix_voigt_notation.hpp"
+#include "4C_mat_elast_coupneohooke.hpp"
 #include "4C_mat_elast_isoneohooke.hpp"
+#include "4C_mat_elasthyper_service.hpp"
 #include "4C_mat_material_factory.hpp"
 #include "4C_mat_multiplicative_split_defgrad_elasthyper_service.hpp"
-#include "4C_material_parameter_base.hpp"
 #include "4C_unittest_utils_assertions_test.hpp"
 
 namespace
@@ -155,5 +156,119 @@ namespace
 
     FOUR_C_EXPECT_NEAR(S_stress, S_stress_target, 1.0e-9);
     FOUR_C_EXPECT_NEAR(cmat, cmat_target, 1.0e-9);
+  }
+
+  TEST_F(MultiplicativeSplitDefgradElastHyperServiceTest,
+      TestEvaluateThermalQuantitiesStressAndStiffness)
+  {
+    //**************************************************
+    double delta_temperature = 100.0000000000000000;
+    //**************************************************
+    Core::LinAlg::Matrix<3, 3> iFinM{Core::LinAlg::Initialization::zero};
+    iFinM(0, 0) = 1.0026809779767947;
+    iFinM(0, 1) = 0.2005361955953590;
+    iFinM(0, 2) = 0.0000000000000000;
+    iFinM(1, 0) = 0.3008042933930384;
+    iFinM(1, 1) = 1.3034852713698331;
+    iFinM(1, 2) = 0.0000000000000000;
+    iFinM(2, 0) = 0.0000000000000000;
+    iFinM(2, 1) = 0.0000000000000000;
+    iFinM(2, 2) = 0.8021447823814358;
+    //**************************************************
+    Core::LinAlg::Matrix<3, 3> CTM_ref_{Core::LinAlg::Initialization::zero};
+    CTM_ref_(0, 0) = 21.0000000000000000;
+    CTM_ref_(0, 1) = 0.0000000000000000;
+    CTM_ref_(0, 2) = 0.0000000000000000;
+    CTM_ref_(1, 0) = 0.0000000000000000;
+    CTM_ref_(1, 1) = 21.0000000000000000;
+    CTM_ref_(1, 2) = 0.0000000000000000;
+    CTM_ref_(2, 0) = 0.0000000000000000;
+    CTM_ref_(2, 1) = 0.0000000000000000;
+    CTM_ref_(2, 2) = 21.0000000000000000;
+    //**************************************************
+    Core::LinAlg::Matrix<3, 3> dCTM_dT_ref_{Core::LinAlg::Initialization::zero};
+    dCTM_dT_ref_(0, 0) = 0.2000000000000000;
+    dCTM_dT_ref_(0, 1) = 0.0000000000000000;
+    dCTM_dT_ref_(0, 2) = 0.0000000000000000;
+    dCTM_dT_ref_(1, 0) = 0.0000000000000000;
+    dCTM_dT_ref_(1, 1) = 0.2000000000000000;
+    dCTM_dT_ref_(1, 2) = 0.0000000000000000;
+    dCTM_dT_ref_(2, 0) = 0.0000000000000000;
+    dCTM_dT_ref_(2, 1) = 0.0000000000000000;
+    dCTM_dT_ref_(2, 2) = 0.2000000000000000;
+    //**************************************************
+    Core::LinAlg::Matrix<3, 3> S_ref{Core::LinAlg::Initialization::zero};
+    S_ref(0, 0) = -60.3191058810404357;
+    S_ref(0, 1) = -32.4795185513294626;
+    S_ref(0, 2) = 0.0000000000000000;
+    S_ref(1, 0) = -32.4795185513294626;
+    S_ref(1, 1) = -103.2384696810115088;
+    S_ref(1, 2) = 0.0000000000000000;
+    S_ref(2, 0) = 0.0000000000000000;
+    S_ref(2, 1) = 0.0000000000000000;
+    S_ref(2, 2) = -37.1194497729479664;
+    //**************************************************
+    Core::LinAlg::Matrix<3, 3> pS_pT_ref_{Core::LinAlg::Initialization::zero};
+    pS_pT_ref_(0, 0) = -0.0000941798851085;
+    pS_pT_ref_(0, 1) = -0.0000507122458277;
+    pS_pT_ref_(0, 2) = -0.0000000000000000;
+    pS_pT_ref_(1, 0) = -0.0000507122458277;
+    pS_pT_ref_(1, 1) = -0.0001611924956665;
+    pS_pT_ref_(1, 2) = -0.0000000000000000;
+    pS_pT_ref_(2, 0) = -0.0000000000000000;
+    pS_pT_ref_(2, 1) = -0.0000000000000000;
+    pS_pT_ref_(2, 2) = -0.0000579568523745;
+
+    // set thermal info
+    const double thermal_expansion_fac = 0.1;
+
+    Core::LinAlg::Matrix<3, 3> iCinM{Core::LinAlg::Initialization::zero};
+    iCinM.multiply_nt(1.0, iFinM, iFinM, 0.0);
+    Core::LinAlg::Matrix<6, 1> iCinV{Core::LinAlg::Initialization::zero};
+    Core::LinAlg::Voigt::Stresses::matrix_to_vector(iCinM, iCinV);
+
+    // Create summand vector
+    std::vector<std::shared_ptr<Mat::Elastic::Summand>> potsum;
+    Core::IO::InputParameterContainer elast_pot_coup_neo_hooke_data;
+    elast_pot_coup_neo_hooke_data.add("YOUNG", 1.5e2);
+    elast_pot_coup_neo_hooke_data.add("NUE", 0.3);
+    auto coup_neo_hooke_params = Mat::make_parameter(
+        200, Core::Materials::MaterialType::mes_coupneohooke, elast_pot_coup_neo_hooke_data);
+    potsum.emplace_back(std::make_shared<Mat::Elastic::CoupNeoHooke>(
+        dynamic_cast<Mat::Elastic::PAR::CoupNeoHooke*>(coup_neo_hooke_params.get())));
+
+
+    // evaluate thermal quantities
+    Mat::ThermalQuantities thermal_quantities = Mat::evaluate_thermal_quantities(
+        delta_temperature, thermal_expansion_fac, iFinM, 0, 0, potsum);
+
+    // evaluate thermal stress factors
+    Mat::StressFactors thermal_stress_factors;
+    Mat::calculate_gamma_delta(thermal_stress_factors.gamma, thermal_stress_factors.delta,
+        thermal_quantities.prinv, thermal_quantities.dPI, thermal_quantities.ddPII);
+
+    // evaluate thermal contribution to second Piola-Kirchhoff stress
+    Core::LinAlg::Matrix<6, 1> S_V{Core::LinAlg::Initialization::zero};
+    Mat::add_thermal_stress_contribution(
+        S_V, thermal_quantities, thermal_stress_factors, iCinV, 1.0 / iFinM.determinant());
+    Core::LinAlg::Matrix<3, 3> S_M{Core::LinAlg::Initialization::zero};
+    Core::LinAlg::Voigt::Stresses::vector_to_matrix(S_V, S_M);
+    // evaluate partial derivative of 2nd Piola-Kirchhoff stress wrt temperature
+    Core::LinAlg::Matrix<6, 1> pS_pT_V =
+        Mat::compute_partial_d_stress_d_temperature(iFinM, thermal_quantities);
+    Core::LinAlg::Matrix<3, 3> pS_pT_M{Core::LinAlg::Initialization::zero};
+    Core::LinAlg::Voigt::Stresses::vector_to_matrix(pS_pT_V, pS_pT_M);
+
+
+    // postprocessed data for assertions
+    Core::LinAlg::Matrix<3, 3> CTM{Core::LinAlg::Initialization::zero};
+    Core::LinAlg::Voigt::Stresses::vector_to_matrix(thermal_quantities.CTV, CTM);
+    Core::LinAlg::Matrix<3, 3> dCTM_dT{Core::LinAlg::Initialization::zero};
+    Core::LinAlg::Voigt::Strains::vector_to_matrix(thermal_quantities.dCTdTV, dCTM_dT);
+
+    FOUR_C_EXPECT_NEAR(CTM, CTM_ref_, 1.0e-10);
+    FOUR_C_EXPECT_NEAR(dCTM_dT, dCTM_dT_ref_, 1.0e-10);
+    FOUR_C_EXPECT_NEAR(S_M, S_ref, 1.0e-10);
+    FOUR_C_EXPECT_NEAR(pS_pT_M, pS_pT_ref_, 1.0e-10);
   }
 }  // namespace


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context

Add a `ThermalQuantities` struct to hold quantities related to the thermal deformation. This will be used by both the multiplicative split material and the factor. Those quantities are evaluated with `evaluate_thermal_quantities`.

Added two new service functions:
- `add_thermal_stress_contribution` updates the second PK using thermal stress factors.
- `calculate_thermal_stress_derivative` calculates the partial derivative of the 2PK stress with respect to temperature. 

A unittest covers `ThermalQuantities` evaluation and the stress computation helpers.

Thanks again to @dragos-ana who initially started working on this.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
