### PR TITLE
Enable possibility to use functions for body force contributions in porofluid_pressure_based_elast* framework

### DIFF
--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_input.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_input.cpp
@@ -48,9 +48,10 @@ std::vector<Core::IO::InputSpec> PoroPressureBased::valid_parameters_porofluid_e
               {.required = false}),
 
           // body force contribution for solid part
-          parameter<std::optional<std::vector<double>>>("body_force",
-              {.description = "External body force contribution vector. The vector must "
-                              "have the same dimension as the problem (2D/3D)."}),
+          parameter<std::optional<int>>("body_force_function",
+              {.description = "Function defining the external body force contribution vector. The "
+                              "vector must have the same dimension (number of components) as the "
+                              "problem (2D/3D)."}),
 
           // nonlinear solver
           group("nonlinear_solver",

--- a/src/solid_poro_ele/4C_solid_poro_ele_calc_pressure_based.cpp
+++ b/src/solid_poro_ele/4C_solid_poro_ele_calc_pressure_based.cpp
@@ -230,7 +230,7 @@ void Discret::Elements::SolidPoroPressureBasedEleCalc<celltype>::
     add_bodyforce_contribution_to_nonlinear_force_stiffness(const Core::Elements::Element& ele,
         Mat::StructPoro& porostructmat, Mat::FluidPoroMultiPhase& porofluidmat,
         const Inpar::Solid::KinemType& kinematictype,
-        const Core::LinAlg::Tensor<double, Core::FE::dim<celltype>>& bodyforce_contribution,
+        const Core::Utils::FunctionOfSpaceTime* bodyforce_contribution_function, const double time,
         const Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
         Teuchos::ParameterList& params, Core::LinAlg::SerialDenseVector* force_vector,
         Core::LinAlg::SerialDenseMatrix* stiffness_matrix)
@@ -356,6 +356,23 @@ void Discret::Elements::SolidPoroPressureBasedEleCalc<celltype>::
           }
         }
 
+        // calculate the coordinates of the gauss point
+        std::array<double, num_dim_> gp_coordinate{};
+        for (int idim = 0; idim < num_dim_; idim++)
+        {
+          for (int inode = 0; inode < num_nodes_; inode++)
+          {
+            gp_coordinate.at(idim) += shape_functions.shapefunctions_(inode) *
+                                      nodal_coordinates.current_coordinates(idim, inode);
+          }
+        }
+
+        // evaluate bodyforce function
+        Core::LinAlg::Tensor<double, num_dim_> bodyforce_contribution{};
+        for (int idim = 0; idim < num_dim_; idim++)
+          bodyforce_contribution(idim) =
+              bodyforce_contribution_function->evaluate(gp_coordinate, time, idim);
+
         Core::LinAlg::Matrix<num_dof_per_ele_, 1> bodyforce(Core::LinAlg::Initialization::zero);
         for (int j = 0; j < num_dim_; ++j)
         {
@@ -375,7 +392,6 @@ void Discret::Elements::SolidPoroPressureBasedEleCalc<celltype>::
 
           force->update(-1.0 * pre_factor * integration_factor, bodyforce, 1.0);
         }
-
 
         // update stiffness matrix dvolfrac/dJ dJ/du
         if (stiff.has_value())

--- a/src/solid_poro_ele/4C_solid_poro_ele_calc_pressure_based.hpp
+++ b/src/solid_poro_ele/4C_solid_poro_ele_calc_pressure_based.hpp
@@ -16,7 +16,7 @@
 #include "4C_inpar_structure.hpp"
 #include "4C_linalg_tensor.hpp"
 #include "4C_solid_ele_calc_lib.hpp"
-
+#include "4C_utils_function.hpp"
 FOUR_C_NAMESPACE_OPEN
 
 namespace Mat
@@ -62,9 +62,10 @@ namespace Discret
       void add_bodyforce_contribution_to_nonlinear_force_stiffness(
           const Core::Elements::Element& ele, Mat::StructPoro& porostructmat,
           Mat::FluidPoroMultiPhase& porofluidmat, const Inpar::Solid::KinemType& kinematictype,
-          const Core::LinAlg::Tensor<double, Core::FE::dim<celltype>>& bodyforce_contribution,
-          const Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
-          Teuchos::ParameterList& params, Core::LinAlg::SerialDenseVector* force_vector,
+          const Core::Utils::FunctionOfSpaceTime* bodyforce_contribution_function,
+          const double time, const Core::FE::Discretization& discretization,
+          Core::Elements::LocationArray& la, Teuchos::ParameterList& params,
+          Core::LinAlg::SerialDenseVector* force_vector,
           Core::LinAlg::SerialDenseMatrix* stiffness_matrix);
 
       void evaluate_nonlinear_force_stiffness_od(const Core::Elements::Element& ele,

--- a/src/solid_poro_ele/4C_solid_poro_ele_pressure_based.cpp
+++ b/src/solid_poro_ele/4C_solid_poro_ele_pressure_based.cpp
@@ -284,9 +284,8 @@ bool Discret::Elements::SolidPoroPressureBased<dim>::read_element(const std::str
   // read scalar transport implementation type
   poro_ele_property_.impltype = container.get<ScaTra::ImplType>("TYPE");
 
-  // possible bodyforce contribution
-  bodyforce_contribution_ = get_bodyforce_contribution_from_input();
-
+  // get possible bodyforce contribution
+  bodyforce_function_ = get_bodyforce_function_from_input();
 
   SolidIntegrationRules<dim> rules =
       Core::FE::cell_type_switch<Discret::Elements::ImplementedSolidCellTypes<dim>>(celltype_,
@@ -332,8 +331,6 @@ void Discret::Elements::SolidPoroPressureBased<dim>::pack(
 
   data.add_to_pack(material_post_setup_);
 
-  add_to_pack(data, bodyforce_contribution_);
-
   // optional data, e.g., EAS data
   FOUR_C_ASSERT(solid_calc_variant_.has_value(),
       "The solid calculation interface is not initialized for element id {}. The element needs to "
@@ -364,7 +361,7 @@ void Discret::Elements::SolidPoroPressureBased<dim>::unpack(
 
   extract_from_pack(buffer, material_post_setup_);
 
-  extract_from_pack(buffer, bodyforce_contribution_);
+  bodyforce_function_ = get_bodyforce_function_from_input();
 
   // reset solid and poro interfaces
   SolidIntegrationRules<dim> rules =
@@ -440,30 +437,26 @@ Mat::FluidPoroMultiPhase& Discret::Elements::SolidPoroPressureBased<dim>::fluid_
 }
 
 template <unsigned dim>
-std::optional<Core::LinAlg::Tensor<double, dim>>
-Discret::Elements::SolidPoroPressureBased<dim>::get_bodyforce_contribution_from_input() const
+std::optional<const Core::Utils::FunctionOfSpaceTime*>
+Discret::Elements::SolidPoroPressureBased<dim>::get_bodyforce_function_from_input() const
 {
   // get poro-solid parameter
   const Teuchos::ParameterList& solid_poro_params =
       Global::Problem::instance()->poro_multi_phase_dynamic_params();
 
-  // get optional bodyforce contribution
-  const auto body_force = solid_poro_params.get<std::optional<std::vector<double>>>("body_force");
 
-  if (body_force.has_value())
+  if (solid_poro_params.get<std::optional<int>>("body_force_function").has_value())
   {
-    // safety check
-    FOUR_C_ASSERT_ALWAYS(
-        static_cast<int>(body_force->size()) == Global::Problem::instance()->n_dim() &&
-            Global::Problem::instance()->n_dim() == dim,
-        "The dimension of your bodyforce vector and the dimension of the problem must be equal!");
+    const auto& funct =
+        Global::Problem::instance()->function_by_id<Core::Utils::FunctionOfSpaceTime>(
+            solid_poro_params.get<std::optional<int>>("body_force_function").value());
 
-    Core::LinAlg::Tensor<double, dim> bodyforce{};
-    for (unsigned idim = 0; idim < dim; idim++)
-    {
-      bodyforce(idim) = body_force.value()[idim];
-    }
-    return bodyforce;
+    // safety check
+    FOUR_C_ASSERT_ALWAYS(static_cast<int>(funct.number_components()) == dim,
+        "The dimension of your bodyforce vector and the dimension of the problem must be "
+        "equal!");
+
+    return &funct;
   }
   else
   {

--- a/src/solid_poro_ele/4C_solid_poro_ele_pressure_based.hpp
+++ b/src/solid_poro_ele/4C_solid_poro_ele_pressure_based.hpp
@@ -19,6 +19,7 @@
 #include "4C_solid_poro_ele_factory.hpp"
 #include "4C_solid_poro_ele_properties.hpp"
 #include "4C_structure_new_elements_paramsinterface.hpp"
+#include "4C_utils_function.hpp"
 
 #include <memory>
 
@@ -171,8 +172,8 @@ namespace Discret::Elements
 
     [[nodiscard]] Mat::FluidPoroMultiPhase& fluid_poro_material(int nummat = 1) const;
 
-    [[nodiscard]] std::optional<Core::LinAlg::Tensor<double, dim>>
-    get_bodyforce_contribution_from_input() const;
+    [[nodiscard]] std::optional<const Core::Utils::FunctionOfSpaceTime*>
+    get_bodyforce_function_from_input() const;
 
     [[nodiscard]] Mat::So3Material& solid_poro_material(int nummat = 0) const;
 
@@ -185,11 +186,6 @@ namespace Discret::Elements
     Inpar::Solid::KinemType get_ele_kinematic_type() { return solid_ele_property_.kintype; }
 
     ScaTra::ImplType get_impl_type() { return poro_ele_property_.impltype; }
-
-    std::optional<Core::LinAlg::Tensor<double, dim>> get_possible_bodyforce_contribution()
-    {
-      return bodyforce_contribution_;
-    }
 
     void vis_names(std::map<std::string, int>& names) override;
 
@@ -220,9 +216,8 @@ namespace Discret::Elements
     //! flag, whether the post setup of materials is already called
     bool material_post_setup_ = false;
 
-    //! optional body force contribution
-    std::optional<Core::LinAlg::Tensor<double, dim>> bodyforce_contribution_{};
-
+    //! function for possible bodyforce contribution
+    std::optional<const Core::Utils::FunctionOfSpaceTime*> bodyforce_function_{std::nullopt};
   };  // class SolidPoro
 
 }  // namespace Discret::Elements

--- a/src/solid_poro_ele/4C_solid_poro_ele_pressure_based_evaluate.cpp
+++ b/src/solid_poro_ele/4C_solid_poro_ele_pressure_based_evaluate.cpp
@@ -43,6 +43,15 @@ int Discret::Elements::SolidPoroPressureBased<dim>::evaluate(Teuchos::ParameterL
         else
           return Core::Elements::string_to_action_type(params.get<std::string>("action", "none"));
       });
+  // get time
+  const double time = std::invoke(
+      [&]()
+      {
+        if (is_params_interface())
+          return params_interface().get_total_time();
+        else
+          return params.get("total time", -1.0);
+      });
 
   switch (action)
   {
@@ -68,16 +77,15 @@ int Discret::Elements::SolidPoroPressureBased<dim>::evaluate(Teuchos::ParameterL
                     this->get_ele_kinematic_type(), discretization, la, params, &elevec1, &elemat1);
               },
               *solidporo_press_based_calc_variant_);
-          if (this->get_possible_bodyforce_contribution().has_value())
+          if (this->bodyforce_function_.has_value())
           {
             std::visit(
                 [&](auto& interface)
                 {
                   interface->add_bodyforce_contribution_to_nonlinear_force_stiffness(*this,
                       this->struct_poro_material(), this->fluid_poro_material(),
-                      this->get_ele_kinematic_type(),
-                      this->get_possible_bodyforce_contribution().value(), discretization, la,
-                      params, &elevec1, &elemat1);
+                      this->get_ele_kinematic_type(), this->bodyforce_function_.value(), time,
+                      discretization, la, params, &elevec1, &elemat1);
                 },
                 *solidporo_press_based_calc_variant_);
           }
@@ -107,16 +115,15 @@ int Discret::Elements::SolidPoroPressureBased<dim>::evaluate(Teuchos::ParameterL
                     this->get_ele_kinematic_type(), discretization, la, params, &elevec1, nullptr);
               },
               *solidporo_press_based_calc_variant_);
-          if (this->get_possible_bodyforce_contribution().has_value())
+          if (this->bodyforce_function_.has_value())
           {
             std::visit(
                 [&](auto& interface)
                 {
                   interface->add_bodyforce_contribution_to_nonlinear_force_stiffness(*this,
                       this->struct_poro_material(), this->fluid_poro_material(),
-                      this->get_ele_kinematic_type(),
-                      this->get_possible_bodyforce_contribution().value(), discretization, la,
-                      params, &elevec1, &elemat1);
+                      this->get_ele_kinematic_type(), this->bodyforce_function_.value(), time,
+                      discretization, la, params, &elevec1, &elemat1);
                 },
                 *solidporo_press_based_calc_variant_);
           }
@@ -151,16 +158,15 @@ int Discret::Elements::SolidPoroPressureBased<dim>::evaluate(Teuchos::ParameterL
                     this->get_ele_kinematic_type(), discretization, la, params, &elevec1, &elemat1);
               },
               *solidporo_press_based_calc_variant_);
-          if (this->get_possible_bodyforce_contribution().has_value())
+          if (this->bodyforce_function_.has_value())
           {
             std::visit(
                 [&](auto& interface)
                 {
                   interface->add_bodyforce_contribution_to_nonlinear_force_stiffness(*this,
                       this->struct_poro_material(), this->fluid_poro_material(),
-                      this->get_ele_kinematic_type(),
-                      this->get_possible_bodyforce_contribution().value(), discretization, la,
-                      params, &elevec1, &elemat1);
+                      this->get_ele_kinematic_type(), this->bodyforce_function_.value(), time,
+                      discretization, la, params, &elevec1, &elemat1);
                 },
                 *solidporo_press_based_calc_variant_);
           }

--- a/tests/input_files/porofluid_pressure_based_elast_scatra_2D_quad4_bodyforce_solid.4C.yaml
+++ b/tests/input_files/porofluid_pressure_based_elast_scatra_2D_quad4_bodyforce_solid.4C.yaml
@@ -21,10 +21,10 @@ IO/RUNTIME VTK OUTPUT/STRUCTURE:
 STRUCTURAL DYNAMIC/ONESTEPTHETA:
   THETA: 1
 porofluid_elasticity_scatra_dynamic:
-  total_simulation_time: 0.2
+  total_simulation_time: 0.5
   time_integration:
     time_step_size: 0.1
-    number_of_time_steps: 2
+    number_of_time_steps: 5
     theta: 1
   output:
     restart_data_every: 1
@@ -41,7 +41,7 @@ porofluid_dynamic:
 porofluid_elasticity_dynamic:
   solve_structure: true
   coupling_scheme: twoway_monolithic
-  body_force: [0.0, -9810.0]
+  body_force_function: 4
 SCALAR TRANSPORT DYNAMIC:
   SOLVERTYPE: "nonlinear"
   MAXTIME: 0.2
@@ -178,43 +178,48 @@ FUNCT3:
     SYMBOLIC_FUNCTION_OF_SPACE_TIME: "0.0"
   - COMPONENT: 1
     SYMBOLIC_FUNCTION_OF_SPACE_TIME: "0.0"
+FUNCT4:
+  - COMPONENT: 0
+    SYMBOLIC_FUNCTION_OF_SPACE_TIME: "0.0"
+  - COMPONENT: 1
+    SYMBOLIC_FUNCTION_OF_SPACE_TIME: "heaviside(-y)*t*(-19620.0)"
 
 RESULT DESCRIPTION:
   - STRUCTURE:
       DIS: "structure"
       NODE: 89
       QUANTITY: "dispx"
-      VALUE: -5.44184225531693547e-04
+      VALUE: -1.55461652839454962e-04
       TOLERANCE: 1e-09
   - STRUCTURE:
       DIS: "structure"
       NODE: 28
       QUANTITY: "dispy"
-      VALUE: -1.13515215893868950e-02
+      VALUE: -2.90229016293844233e-03
       TOLERANCE: 1e-09
   - STRUCTURE:
       DIS: "structure"
       NODE: 54
       QUANTITY: "dispx"
-      VALUE: -5.10980644159250643e-04
+      VALUE: 2.51869101569604830e-06
       TOLERANCE: 1e-09
   - STRUCTURE:
       DIS: "structure"
       NODE: 21
       QUANTITY: "dispy"
-      VALUE: -1.15596926602809340e-02
+      VALUE: -2.90228536364839276e-03
       TOLERANCE: 1e-09
   - STRUCTURE:
       DIS: "structure"
       NODE: 32
       QUANTITY: "dispx"
-      VALUE: 3.18975646227633405e-04
+      VALUE: -4.83949397730845728e-07
       TOLERANCE: 1e-09
   - STRUCTURE:
       DIS: "structure"
       NODE: 45
       QUANTITY: "dispy"
-      VALUE: -1.03674462400365243e-02
+      VALUE: -2.90427056677836949e-03
       TOLERANCE: 1e-09
 
 DESIGN SURF PORO DIRICH CONDITIONS:

--- a/tests/input_files/porofluid_pressure_based_elast_scatra_3D_hex8_volfrac_closing_relation_lung_bodyforce_solid_mono.4C.yaml
+++ b/tests/input_files/porofluid_pressure_based_elast_scatra_3D_hex8_volfrac_closing_relation_lung_bodyforce_solid_mono.4C.yaml
@@ -37,7 +37,7 @@ porofluid_dynamic:
 porofluid_elasticity_dynamic:
   solve_structure: true
   coupling_scheme: twoway_monolithic
-  body_force: [0.0, 9.81e-1, 0.0]
+  body_force_function: 5
 SCALAR TRANSPORT DYNAMIC:
   SOLVERTYPE: "nonlinear"
   MAXTIME: 2.5
@@ -155,6 +155,13 @@ FUNCT3:
   - SYMBOLIC_FUNCTION_OF_SPACE_TIME: "0.0"
 FUNCT4:
   - VARFUNCTION: "0.0"
+FUNCT5:
+  - COMPONENT: 0
+    SYMBOLIC_FUNCTION_OF_SPACE_TIME: "0.0"
+  - COMPONENT: 1
+    SYMBOLIC_FUNCTION_OF_SPACE_TIME: "9.81e-1"
+  - COMPONENT: 2
+    SYMBOLIC_FUNCTION_OF_SPACE_TIME: "0.0"
 RESULT DESCRIPTION:
   - STRUCTURE:
       DIS: "structure"


### PR DESCRIPTION
This pr enables the use of functions for adding body force contributions to the solid equation in the porofluid_pressure_based_elast* framework.
