### PR TITLE
Add thermal effects to the viscoplastic factor

### DIFF
--- a/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
+++ b/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
@@ -2652,6 +2652,12 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
                         .default_value = std::vector{0},
                         .size = from_parameter<int>("NUMFACINEL")}),
                 parameter<double>("DENS", {.description = "material mass density"}),
+                parameter<double>("REF_TEMPERATURE",
+                    {.description = "reference temperature for thermoelastic expansion.",
+                        .default_value = 0.0}),
+                parameter<double>("THERMAL_EXPANSION_COEFFICIENT",
+                    {.description = "coefficient of thermal expansion $\\alpha_T$",
+                        .default_value = 0.0}),
             },
             {.description = "multiplicative split of deformation gradient"});
   }
@@ -2831,6 +2837,12 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
                 "FIBER_READER_ID", {.description = "MAT ID of the used fiber direction reader for "
                                                    "transversely isotropic behavior",
                                        .validator = positive<int>()}),
+            parameter<double>("TAYLOR_QUINNEY_COEFFICIENT",
+                {.description =
+                        "Taylor-Quinney coefficient $\\xi_{TQ}$ modeling the internal dissipation",
+                    .default_value = 0.0,
+                    .validator =
+                        Core::IO::InputSpecBuilders::Validators::positive_or_zero<double>()}),
             parameter<std::optional<double>>(
                 "YIELD_COND_A", {.description = "transversely isotropic version of the Hill(1948) "
                                                 "yield condition: parameter A, following the "

--- a/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
+++ b/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
@@ -2654,7 +2654,8 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
                 parameter<double>("DENS", {.description = "material mass density"}),
                 parameter<double>("REF_TEMPERATURE",
                     {.description = "reference temperature for thermoelastic expansion.",
-                        .default_value = 0.0}),
+                        .default_value = 0.0,
+                        .validator = Validators::positive_or_zero<double>()}),
                 parameter<double>("THERMAL_EXPANSION_COEFFICIENT",
                     {.description = "coefficient of thermal expansion $\\alpha_T$",
                         .default_value = 0.0}),
@@ -2841,8 +2842,7 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
                 {.description =
                         "Taylor-Quinney coefficient $\\xi_{TQ}$ modeling the internal dissipation",
                     .default_value = 0.0,
-                    .validator =
-                        Core::IO::InputSpecBuilders::Validators::positive_or_zero<double>()}),
+                    .validator = positive_or_zero<double>()}),
             parameter<std::optional<double>>(
                 "YIELD_COND_A", {.description = "transversely isotropic version of the Hill(1948) "
                                                 "yield condition: parameter A, following the "

--- a/src/mat/4C_mat_inelastic_defgrad_factors.cpp
+++ b/src/mat/4C_mat_inelastic_defgrad_factors.cpp
@@ -2906,7 +2906,7 @@ Mat::HeatSource
 Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_taylor_quinney_heat_source(
     const Mat::EvaluationContext<3>& context, const int gp, const int eleGID,
     const Core::LinAlg::Matrix<3, 3>* defgrad, const Core::LinAlg::Matrix<3, 3>& iFin_other,
-    const double& temperature)
+    const double temperature)
 {
   const ReducedKinematics reduced_kinematics = evaluate_reduced_kinematics(*defgrad, iFin_other);
 

--- a/src/mat/4C_mat_inelastic_defgrad_factors.cpp
+++ b/src/mat/4C_mat_inelastic_defgrad_factors.cpp
@@ -8,12 +8,15 @@
 #include "4C_mat_inelastic_defgrad_factors.hpp"
 
 #include "4C_comm_mpi_utils.hpp"
+#include "4C_fem_discretization.hpp"
 #include "4C_global_data.hpp"
 #include "4C_legacy_enum_definitions_materials.hpp"
 #include "4C_linalg_fixedsizematrix.hpp"
 #include "4C_linalg_fixedsizematrix_solver.hpp"
 #include "4C_linalg_fixedsizematrix_tensor_products.hpp"
 #include "4C_linalg_fixedsizematrix_voigt_notation.hpp"
+#include "4C_linalg_four_tensor.hpp"
+#include "4C_linalg_serialdensematrix.hpp"
 #include "4C_linalg_symmetric_tensor.hpp"
 #include "4C_linalg_tensor.hpp"
 #include "4C_linalg_tensor_conversion.hpp"
@@ -26,6 +29,7 @@
 #include "4C_mat_electrode.hpp"
 #include "4C_mat_inelastic_defgrad_factors_service.hpp"
 #include "4C_mat_multiplicative_split_defgrad_elasthyper.hpp"
+#include "4C_mat_multiplicative_split_defgrad_elasthyper_service.hpp"
 #include "4C_mat_par_bundle.hpp"
 #include "4C_mat_vplast_law.hpp"
 #include "4C_utils_enum.hpp"
@@ -58,6 +62,21 @@ namespace
     Core::LinAlg::Matrix<3, 3> diff{Core::LinAlg::Initialization::zero};
     diff.update(1.0, lhs, -1.0, rhs, 0.0);
     return diff.norm2();
+  }
+
+  struct ReducedKinematics
+  {
+    Core::LinAlg::Matrix<3, 3> defgrad{Core::LinAlg::Initialization::zero};
+    Core::LinAlg::Matrix<3, 3> right_cauchy_green{Core::LinAlg::Initialization::zero};
+  };
+
+  ReducedKinematics evaluate_reduced_kinematics(const Core::LinAlg::Matrix<3, 3>& defgrad,
+      const Core::LinAlg::Matrix<3, 3>& inverse_other_inelastic_defgrad)
+  {
+    ReducedKinematics result;
+    result.defgrad.multiply_nn(1.0, defgrad, inverse_other_inelastic_defgrad, 0.0);
+    result.right_cauchy_green.multiply_tn(1.0, result.defgrad, result.defgrad, 0.0);
+    return result;
   }
 
   // read input parameter container of parent material (i.e., underlying
@@ -367,6 +386,32 @@ namespace
     return diFin_dC_V;
   }
 
+  /**
+   * @brief Extract the derivative of the plastic strain w.r.t. right CG tensor from the
+   solution of the linear system of equations arising in the additional cmat calculation.
+   *
+   * @param SOL
+   * @return Core::LinAlg::Matrix<1, 6> \f[ \frac{\mathrm{d} \varepsilon_p}{\mathrm{d}
+   \boldsymbol{C}}
+   \f] in Voigt Notation
+   */
+  Core::LinAlg::Matrix<1, 6> extract_derivative_of_plastic_strain(
+      const Core::LinAlg::Matrix<10, 6>& SOL)
+  {
+    // declare output derivative
+    Core::LinAlg::Matrix<1, 6> depsp_dC_V(Core::LinAlg::Initialization::zero);
+
+    // set its components
+    depsp_dC_V(0, 0) = SOL(9, 0);
+    depsp_dC_V(0, 1) = SOL(9, 1);
+    depsp_dC_V(0, 2) = SOL(9, 2);
+    depsp_dC_V(0, 3) = SOL(9, 3);
+    depsp_dC_V(0, 4) = SOL(9, 4);
+    depsp_dC_V(0, 5) = SOL(9, 5);
+
+    return depsp_dC_V;
+  }
+
   // wrap inverse inelastic defgrad and plastic strain to a vector of unknowns for the Local
   // Newton Loop (helper function: InelasticDefgradTransvIsotropElastViscoplast)
   Core::LinAlg::Matrix<10, 1> wrap_unknowns(
@@ -638,6 +683,7 @@ Mat::PAR::InelasticDefgradTransvIsotropElastViscoplast::
     InelasticDefgradTransvIsotropElastViscoplast(const Core::Mat::PAR::Parameter::Data& matdata)
     : Parameter(matdata),
       viscoplastic_law_id_(matdata.parameters.get<int>("VISCOPLAST_LAW_ID")),
+      taylor_quinney_coefficient_(matdata.parameters.get<double>("TAYLOR_QUINNEY_COEFFICIENT")),
       fiber_reader_gid_(matdata.parameters.get<int>("FIBER_READER_ID")),
       yield_cond_a_(matdata.parameters.get<std::optional<double>>("YIELD_COND_A").value_or(0.0)),
       yield_cond_b_(matdata.parameters.get<std::optional<double>>("YIELD_COND_B").value_or(0.0)),
@@ -823,9 +869,15 @@ std::shared_ptr<Mat::InelasticDefgradFactors> Mat::InelasticDefgradFactors::fact
         }
       }
 
+      const double thermal_expansion_coefficient =
+          parentmat_input_params.get<double>("THERMAL_EXPANSION_COEFFICIENT");
+
+      const auto ref_temperature = parentmat_input_params.get<double>("REF_TEMPERATURE");
+
       // return shared pointer to the inelastic factor
-      return std::make_shared<InelasticDefgradTransvIsotropElastViscoplast>(
-          params, viscoplastic_law, fiber_reader, potsumel, potsumel_transviso);
+      return std::make_shared<InelasticDefgradTransvIsotropElastViscoplast>(params,
+          viscoplastic_law, fiber_reader, potsumel, potsumel_transviso,
+          thermal_expansion_coefficient, ref_temperature);
     }
 
     default:
@@ -1731,8 +1783,11 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::InelasticDefgradTransvIsotrop
     Core::Mat::PAR::Parameter* params, std::shared_ptr<Mat::Viscoplastic::Law> viscoplastic_law,
     Mat::Elastic::CoupTransverselyIsotropic fiber_reader,
     std::vector<std::shared_ptr<Mat::Elastic::Summand>> pot_sum_el,
-    std::vector<std::shared_ptr<Mat::Elastic::CoupTransverselyIsotropic>> pot_sum_el_transv_iso)
+    std::vector<std::shared_ptr<Mat::Elastic::CoupTransverselyIsotropic>> pot_sum_el_transv_iso,
+    const double thermal_expansion_coefficient, const double ref_temperature)
     : InelasticDefgradFactors(params),
+      thermal_expansion_coefficient_(thermal_expansion_coefficient),
+      ref_temperature_(ref_temperature),
       potsumel_(std::move(pot_sum_el)),
       potsumel_transviso_(std::move(pot_sum_el_transv_iso)),
       viscoplastic_law_(std::move(viscoplastic_law)),
@@ -1750,7 +1805,7 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::InelasticDefgradTransvIsotrop
   time_step_tracker_.min_dt = 0.0;
 
   // initialize time step quantities
-  time_step_quantities_.init();
+  time_step_quantities_.init(ref_temperature_);
 }
 
 
@@ -1768,6 +1823,23 @@ void Mat::InelasticDefgradTransvIsotropElastViscoplast::pre_evaluate(
 
   // set element ID
   ele_gid_ = eleGID;
+
+
+  const double previous_temperature = time_step_quantities_.current_temperature[gp];
+
+  // set current absolute temperature
+  time_step_quantities_.current_temperature[gp] = ref_temperature_;
+  if (params.isParameter("temperature"))
+  {
+    time_step_quantities_.current_temperature[gp] = params.get<double>("temperature");
+  }
+
+  // invalidate the caches if the temperature changed
+  if (std::abs(time_step_quantities_.current_temperature[gp] - previous_temperature) > 1.0e-16)
+  {
+    time_step_quantities_.current_defgrad[gp].clear();
+    thermo_mechanical_coupling_cache_.reset(gp);
+  }
 
   // set time step
   FOUR_C_ASSERT(context.time_step_size, "Time step size not given in evaluation context.");
@@ -1835,8 +1907,9 @@ void Mat::InelasticDefgradTransvIsotropElastViscoplast::calculate_gamma_delta(
  *--------------------------------------------------------------------*/
 ViscoplastUtils::StateQuantities
 Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_state_quantities(
-    const Core::LinAlg::Matrix<3, 3>& CM, const Core::LinAlg::Matrix<3, 3>& iFinM,
-    const double plastic_strain, ViscoplastUtils::ErrorType& err_status, const double dt,
+    const Core::LinAlg::Matrix<3, 3>& CM, const double temperature,
+    const Core::LinAlg::Matrix<3, 3>& iFinM, const double plastic_strain,
+    ViscoplastUtils::ErrorType& err_status, const double dt,
     const ViscoplastUtils::StateQuantityEvalType& eval_type) const
 {
   ViscoplastUtils::StateQuantities state_quantities{};
@@ -1873,6 +1946,9 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_state_quantities(
     Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3> dSedCe{};
     for (const auto& p : potsumel_transviso_)
     {
+      FOUR_C_ASSERT_ALWAYS(std::abs(temperature - ref_temperature_) <= 1.0e-16,
+          "Thermoelastic coupling with transversely isotropic elastic summands is not supported "
+          "yet. Use isotropic elastic summands only.");
       p->add_stress_aniso_principal(CeV, dSedCe, SeV, param_list, gp_, ele_gid_);
     }
     state_quantities.curr_dSedCe.clear();
@@ -1884,11 +1960,38 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_state_quantities(
   Core::LinAlg::Matrix<3, 3> CeCeM(Core::LinAlg::Initialization::zero);
   CeCeM.multiply_nn(1.0, state_quantities.curr_CeM, state_quantities.curr_CeM, 0.0);
 
-  // compute symmetric part of Mandel stress tensor
+  // thermal quantities and stress factors
+  Mat::ThermalQuantities thermal_quantities =
+      Mat::evaluate_thermal_quantities(temperature - ref_temperature_,
+          thermal_expansion_coefficient_, iFinM, gp_, ele_gid_, potsumel_);
+  Mat::StressFactors thermal_stress_factors;
+  Mat::calculate_gamma_delta(thermal_stress_factors.gamma, thermal_stress_factors.delta,
+      thermal_quantities.prinv, thermal_quantities.dPI, thermal_quantities.ddPII);
+
+  // compute mixed thermo-elastic tensors required for reducing the Mandel stress based on
+  // temperature
+  Core::LinAlg::Matrix<3, 3> CT{Core::LinAlg::Initialization::zero};
+  Core::LinAlg::Voigt::Stresses::vector_to_matrix(thermal_quantities.CTV, CT);
+  Core::LinAlg::Matrix<3, 3> iCT{Core::LinAlg::Initialization::zero};
+  Core::LinAlg::Voigt::Stresses::vector_to_matrix(thermal_quantities.iCTV, iCT);
+  Core::LinAlg::Matrix<3, 3> CeCT{Core::LinAlg::Initialization::zero};
+  CeCT.multiply_nn(1.0, state_quantities.curr_CeM, CT, 0.0);
+  Core::LinAlg::Matrix<3, 3> CeiCT{Core::LinAlg::Initialization::zero};
+  CeiCT.multiply_nn(1.0, state_quantities.curr_CeM, iCT, 0.0);
+
+
+  /**
+  compute symmetric part of thermo-elastic Mandel stress tensor
+  \f[\boldsymbol{M}_{\theta,\text{sym}}  = \boldsymbol{C}_e \cdot \left( \boldsymbol{S}_{e} -
+  \boldsymbol{S}_T \right)\f]
+   */
   Core::LinAlg::Matrix<3, 3> Mtheta_sym_M(Core::LinAlg::Initialization::zero);
   Mtheta_sym_M.update(state_quantities.curr_gamma(0), state_quantities.curr_CeM,
       state_quantities.curr_gamma(1), CeCeM, 0.0);
   Mtheta_sym_M.update(state_quantities.curr_gamma(2), const_non_mat_tensors.id3x3, 1.0);
+  Mtheta_sym_M.update(-1.0 * thermal_stress_factors.gamma(0), state_quantities.curr_CeM, 1.0);
+  Mtheta_sym_M.update(-1.0 * thermal_stress_factors.gamma(1), CeCT, 1.0);
+  Mtheta_sym_M.update(-1.0 * thermal_stress_factors.gamma(2), CeiCT, 1.0);
   if (parameter()->mat_behavior() == ViscoplastUtils::MatBehavior::transv_isotropic)
   {
     Core::LinAlg::Matrix<3, 3> addMeM(Core::LinAlg::Initialization::zero);
@@ -2078,8 +2181,9 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_state_quantities(
  *--------------------------------------------------------------------*/
 ViscoplastUtils::StateQuantityDerivatives
 Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_state_quantity_derivatives(
-    const Core::LinAlg::Matrix<3, 3>& CM, const Core::LinAlg::Matrix<3, 3>& iFinM,
-    const double plastic_strain, ViscoplastUtils::ErrorType& err_status, const double dt,
+    const Core::LinAlg::Matrix<3, 3>& CM, const double temperature,
+    const Core::LinAlg::Matrix<3, 3>& iFinM, const double plastic_strain,
+    ViscoplastUtils::ErrorType& err_status, const double dt,
     const ViscoplastUtils::StateQuantityDerivEvalType& eval_type, const bool eval_state) const
 {
   ViscoplastUtils::StateQuantityDerivatives state_quantity_derivatives{};
@@ -2091,13 +2195,14 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_state_quantity_deriv
   Core::LinAlg::Matrix<6, 9> temp6x9(Core::LinAlg::Initialization::zero);
   Core::LinAlg::Matrix<9, 6> temp9x6(Core::LinAlg::Initialization::zero);
   Core::LinAlg::Matrix<9, 9> temp9x9(Core::LinAlg::Initialization::zero);
+  Core::LinAlg::FourTensor<3> temp_four_tensor(true);
 
   // check whether to reevaluate the state or to keep the available state quantity values
   ViscoplastUtils::StateQuantities relevant_state_quantities = state_quantities_;
   if (eval_state)
   {
-    relevant_state_quantities = evaluate_state_quantities(CM, iFinM, plastic_strain, err_status, dt,
-        ViscoplastUtils::StateQuantityEvalType::full_eval);
+    relevant_state_quantities = evaluate_state_quantities(CM, temperature, iFinM, plastic_strain,
+        err_status, dt, ViscoplastUtils::StateQuantityEvalType::full_eval);
   }
 
   // get the state quantities
@@ -2190,10 +2295,29 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_state_quantity_deriv
   Core::LinAlg::Matrix<6, 1> iCV(Core::LinAlg::Initialization::zero);
   Core::LinAlg::Voigt::Stresses::matrix_to_vector(iCM, iCV);
 
+  // thermal quantities and stress factors
+  Mat::ThermalQuantities thermal_quantities =
+      Mat::evaluate_thermal_quantities(temperature - ref_temperature_,
+          thermal_expansion_coefficient_, iFinM, gp_, ele_gid_, potsumel_);
+  Core::LinAlg::SymmetricTensor<double, 3, 3> hyperelast_stress_CT{};
+  Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3> hyperelast_stiffness_CT{};
+  Mat::elast_hyper_add_isotropic_stress_cmat(hyperelast_stress_CT, hyperelast_stiffness_CT,
+      Core::LinAlg::make_symmetric_tensor_from_stress_like_voigt_matrix(thermal_quantities.CTV),
+      Core::LinAlg::make_symmetric_tensor_from_stress_like_voigt_matrix(thermal_quantities.iCTV),
+      thermal_quantities.prinv, thermal_quantities.dPI, thermal_quantities.ddPII);
+  const Core::LinAlg::Matrix<3, 3> S_T =
+      Core::LinAlg::make_matrix(Core::LinAlg::get_full(hyperelast_stress_CT));
+
   // compute the relevant derivatives of the symmetric part of the Mandel stress
 
-  // \f$ \frac{\partial \boldsymbol{M}^{\text{theta}}_{\text{sym}} }{\partial
-  // \boldsymbol{F}^{\text{in}^{-1}}_{}} \f$ (Voigt stress-form)
+  /**
+   \f$ \frac{\partial \boldsymbol{M}_{\theta, \text{sym}} }{\partial
+   \boldsymbol{F}_{\text{in}}^{-1}}  =
+   \frac{\partial}{\partial \boldsymbol{F}_{\text{in}}^{-1}}\left(\boldsymbol{C}_e \cdot
+   \boldsymbol{S}_{e}\right)
+   - \frac{\partial}{\partial \boldsymbol{F}_{\text{in}}^{-1}}\left(\boldsymbol{C}_e \cdot
+   \boldsymbol{S}_{T}\right)\f$ (Voigt stress-form)
+  */
   Core::LinAlg::Matrix<6, 9> dMtheta_sym_diFin(Core::LinAlg::Initialization::zero);
   dMtheta_sym_diFin.clear();
   Core::LinAlg::FourTensorOperations::add_right_non_symmetric_holzapfel_product(
@@ -2211,9 +2335,21 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_state_quantity_deriv
   dMtheta_sym_diFin.multiply_nt(delta(4), CeCeV, CiFiniCeV, 1.0);
   dMtheta_sym_diFin.multiply_nt(delta(4), const_non_mat_tensors.id6x1, CiFinCeV, 1.0);
   dMtheta_sym_diFin.multiply_nt(delta(5), const_non_mat_tensors.id6x1, CiFiniCeV, 1.0);
+  // thermal contribution
+  temp_four_tensor.clear();
+  Core::LinAlg::FourTensorOperations::multiply_matrix_four_tensor_by_second_index<3>(
+      temp_four_tensor, S_T, dCediFin_FourTensor, true);
+  Core::LinAlg::Matrix<6, 9> dMT_sym_dFin{Core::LinAlg::Initialization::zero};
+  Core::LinAlg::Voigt::setup_6x9_voigt_matrix_from_four_tensor(dMT_sym_dFin, temp_four_tensor);
+  dMtheta_sym_diFin.update(-1.0, dMT_sym_dFin, 1.0);
 
-  // \f$ \frac{\partial \boldsymbol{M}^{\text{theta}}_{\text{sym}} }{\partial
-  // \boldsymbol{C}^{}_{}} \f$ (Voigt stress-stress form)
+  /**
+   \f$ \frac{\partial \boldsymbol{M}_{\theta, \text{sym}} }{\partial
+   \boldsymbol{C}}  =
+   \frac{\partial}{\partial \boldsymbol{C}}\left(\boldsymbol{C}_e \cdot \boldsymbol{S}_{e}\right)
+   - \frac{\partial}{\partial \boldsymbol{C}}\left(\boldsymbol{C}_e \cdot
+   \boldsymbol{S}_{T}\right)\f$ (Voigt stress-stress form)
+  */
   Core::LinAlg::Matrix<6, 6> dMtheta_sym_dC(Core::LinAlg::Initialization::zero);
   Core::LinAlg::FourTensorOperations::add_kronecker_tensor_product(
       dMtheta_sym_dC, gamma(0), iFinTM, iFinTM, 0.0);
@@ -2230,6 +2366,27 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_state_quantity_deriv
   dMtheta_sym_dC.multiply_nt(delta(4) / 2.0, CeCeV, iCV, 1.0);
   dMtheta_sym_dC.multiply_nt(delta(4) / 2.0, const_non_mat_tensors.id6x1, iCinCiCinV, 1.0);
   dMtheta_sym_dC.multiply_nt(delta(5) / 2.0, const_non_mat_tensors.id6x1, iCV, 1.0);
+  // thermal contribution
+  Core::LinAlg::FourTensorOperations::multiply_matrix_four_tensor_by_second_index<3>(
+      temp_four_tensor, S_T, dCedC_FourTensor, true);
+  Core::LinAlg::Matrix<6, 6> dMT_sym_dC{Core::LinAlg::Initialization::zero};
+  Core::LinAlg::Voigt::setup_6x6_voigt_matrix_from_four_tensor(dMT_sym_dC, temp_four_tensor);
+  dMtheta_sym_dC.update(-1.0, dMT_sym_dC, 1.0);
+
+  /**
+   \f$ \frac{\partial \boldsymbol{M}_{\theta, \text{sym}} }{\partial T}  =
+   - \boldsymbol{C}_e \cdot \frac{\partial\boldsymbol{S}_{T}}{\partial T}\f$ (Voigt stress-form)
+  */
+  Core::LinAlg::Matrix<6, 1> dST_dT_V{Core::LinAlg::Initialization::zero};
+  dST_dT_V.multiply_nn(0.5, Core::LinAlg::make_stress_like_voigt_view(hyperelast_stiffness_CT),
+      thermal_quantities.dCTdTV, 0.0);
+  Core::LinAlg::Matrix<3, 3> dST_dT_M{Core::LinAlg::Initialization::zero};
+  Core::LinAlg::Voigt::Stresses::vector_to_matrix(dST_dT_V, dST_dT_M);
+  Core::LinAlg::Matrix<3, 3> dMtheta_sym_dT_M(Core::LinAlg::Initialization::zero);
+  dMtheta_sym_dT_M.multiply_nn(-1.0, CeM, dST_dT_M, 0.0);
+  Core::LinAlg::Matrix<6, 1> dMtheta_sym_dT_V(Core::LinAlg::Initialization::zero);
+  Core::LinAlg::Voigt::Stresses::matrix_to_vector(dMtheta_sym_dT_M, dMtheta_sym_dT_V);
+
 
   // compute derivative of the additional transversely isotropic stress (w.r.t. right
   // elastic Cauchy-Green deformation tensor) in stress-strain notation
@@ -2310,6 +2467,12 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_state_quantity_deriv
   */
   state_quantity_derivatives.curr_dMtheta_dev_sym_dC.multiply_nn(
       1.0, const_non_mat_tensors.dev_op, dMtheta_sym_dC, 0.0);
+  /**
+  \f$ \frac{\partial \boldsymbol{M}^{\theta}_{\text{dev,sym}} }{\partial
+  T} \f$ (Voigt stress form)
+  */
+  state_quantity_derivatives.curr_dMtheta_dev_sym_dT.multiply_nn(
+      1.0, const_non_mat_tensors.dev_op, dMtheta_sym_dT_V, 0.0);
 
   // plastic flow direction in Voigt strain notation
   Core::LinAlg::Matrix<6, 1> NpVstrainform(Core::LinAlg::Initialization::zero);
@@ -2325,6 +2488,13 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_state_quantity_deriv
   /// \boldsymbol{C}^{}} \f$ (Voigt stress-form)
   state_quantity_derivatives.curr_dequiv_stress_dC.multiply_tn(
       1.0, NpVstrainform, state_quantity_derivatives.curr_dMtheta_dev_sym_dC, 0.0);
+  /// \f$ \frac{\partial \overline{\sigma} }{\partial
+  /// T} \f$
+  Core::LinAlg::Matrix<1, 1> temp1x1{Core::LinAlg::Initialization::zero};
+  temp1x1.multiply_tn(1.0, NpVstrainform, state_quantity_derivatives.curr_dMtheta_dev_sym_dT, 0.0);
+  state_quantity_derivatives.curr_dequiv_stress_dT = temp1x1(0);
+
+
 
   // recompute flow direction in stress form
   Core::LinAlg::Matrix<6, 1> NpVstressform(Core::LinAlg::Initialization::zero);
@@ -2389,6 +2559,7 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_state_quantity_deriv
   // compute derivatives of the plastic strain rate
   state_quantity_derivatives.curr_dpsr_dequiv_stress = evoEqFunctionDers.deriv_equiv_stress;
   state_quantity_derivatives.curr_dpsr_depsp = evoEqFunctionDers.deriv_plastic_strain;
+  state_quantity_derivatives.curr_dpsr_dT = evoEqFunctionDers.deriv_temperature;
 
 
   if (eval_type == ViscoplastUtils::StateQuantityDerivEvalType::plastic_strain_rate_derivs_only)
@@ -2424,6 +2595,11 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_state_quantity_deriv
   // ... w.r.t. right CG
   state_quantity_derivatives.curr_ddpdC.multiply_nn(
       1.0, temp6x6, state_quantity_derivatives.curr_dMtheta_dev_sym_dC, 0.0);
+  // ... w.r.t. temperature
+  state_quantity_derivatives.curr_ddpdT.multiply_nn(
+      1.0, temp6x6, state_quantity_derivatives.curr_dMtheta_dev_sym_dT, 0.0);
+  state_quantity_derivatives.curr_ddpdT.update(
+      state_quantity_derivatives.curr_dpsr_dT, NpVstressform, 1.0);
 
   // compute derivatives of the plastic velocity gradient ...
 
@@ -2472,6 +2648,13 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_state_quantity_deriv
   dlpdepsp_M.multiply_nn(-1.0, ddpdepsp_M, const_mat_tensors_.mm, 1.0);
   Core::LinAlg::Voigt::matrix_3x3_to_9x1(dlpdepsp_M, state_quantity_derivatives.curr_dlpdepsp);
 
+  // ... w.r.t. temperature
+  Core::LinAlg::Matrix<3, 3> ddpdT_M(Core::LinAlg::Initialization::zero);
+  Core::LinAlg::Voigt::Stresses::vector_to_matrix(state_quantity_derivatives.curr_ddpdT, ddpdT_M);
+  Core::LinAlg::Matrix<3, 3> dlpdT_M(Core::LinAlg::Initialization::zero);
+  dlpdT_M.multiply_nn(1.0, const_mat_tensors_.id_plus_mm, ddpdT_M, 0.0);
+  dlpdT_M.multiply_nn(-1.0, ddpdT_M, const_mat_tensors_.mm, 1.0);
+  Core::LinAlg::Voigt::matrix_3x3_to_9x1(dlpdT_M, state_quantity_derivatives.curr_dlpdT);
 
   // compute derivatives of the update tensor (only required for standard substepping)
   if (parameter()->timint_type() == ViscoplastUtils::TimIntType::standard)
@@ -2504,6 +2687,9 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_state_quantity_deriv
     state_quantity_derivatives.curr_dEpdepsp.multiply_nn(
         -dt, expderivV, state_quantity_derivatives.curr_dlpdepsp, 0.0);
 
+    // ... w.r.t. temperature
+    state_quantity_derivatives.curr_dEpdT.multiply_nn(
+        -dt, expderivV, state_quantity_derivatives.curr_dlpdT, 0.0);
 
     return state_quantity_derivatives;
   }
@@ -2524,49 +2710,374 @@ void Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_additional_cmat
     const Core::LinAlg::Matrix<3, 3>& iFinjM, const Core::LinAlg::Matrix<6, 1>& iCV,
     const Core::LinAlg::Matrix<6, 9>& dSdiFinj, Core::LinAlg::Matrix<6, 6>& cmatadd)
 {
-  // reduced deformation gradient FredM, taking into account all the already computed
-  // inelastic factors
-  //    \f$ \boldsymbol{F_{\text{red}}} = \boldsymbol{F}
-  //    \boldsymbol{F_{\text{in,other}}^{-1}}
-  //    \f$
-  //      with \f$\boldsymbol{F}_{\text{in,other}}^{-1} = \boldsymbol{F}_{\text{in},1}^{-1}
-  //      \boldsymbol{F}_{\text{in},2}^{-1} \dots \f$ up to the current inelastic factor
-  Core::LinAlg::Matrix<3, 3> FredM(Core::LinAlg::Initialization::zero);
-  FredM.multiply_nn(1.0, *defgrad, iFin_other, 0.0);
+  const ReducedKinematics reduced_kinematics = evaluate_reduced_kinematics(*defgrad, iFin_other);
+  const double temperature = time_step_quantities_.current_temperature[gp_];
 
-  // reduced right Cauchy-Green deformation tensor
-  Core::LinAlg::Matrix<3, 3> CredM(Core::LinAlg::Initialization::zero);
-  CredM.multiply_tn(1.0, FredM, FredM, 0.0);
+  if (parameter()->linearization_type() == ViscoplastUtils::LinearizationType::perturbation_based)
+  {
+    // compute additional stiffness contribution using perturbation-based approach
+    evaluate_additional_cmat_perturb_based(
+        reduced_kinematics.defgrad, temperature, cmatadd, dSdiFinj);
+    return;
+  }
+
+  // declare error status (no errors)
+  ViscoplastUtils::ErrorType err_status = ViscoplastUtils::ErrorType::no_errors;
+  const auto& diFinjdC = evaluate_history_variables_wrt_cauchy_green(
+      reduced_kinematics.right_cauchy_green, temperature, err_status)
+                             .inv_plastic_defgrad_wrt_cauchy_green;
+
+  if (err_status != ViscoplastUtils::ErrorType::no_errors)
+  {
+    // if we get an error in evaluating the history variable derivatives: perform
+    // perturbation-based linearization
+    std::cout << "Warning: Error encountered in evaluating history variable derivatives: "
+              << ViscoplastUtils::get_detailed_error_message_for_error_type(err_status) << "\n"
+              << "Performing perturbation-based linearization for the additional stiffness "
+                 "contribution.\n";
+    evaluate_additional_cmat_perturb_based(
+        reduced_kinematics.defgrad, temperature, cmatadd, dSdiFinj);
+    return;
+  }
+  // compute additional term to stiffness matrix additional_cmat
+  cmatadd.multiply_nn(2.0, dSdiFinj, diFinjdC, 1.0);
+}
+
+ViscoplastUtils::HistoryVariablesDerivativesWrtTemperature
+Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_history_variables_wrt_temperature(
+    const Core::LinAlg::Matrix<3, 3>& CredM, const double temperature,
+    InelasticDefgradTransvIsotropElastViscoplastUtils::ErrorType& err_status)
+{
+  if (thermo_mechanical_coupling_cache_.history_variables_wrt_temperature.is_evaluated(gp_))
+  {
+    return thermo_mechanical_coupling_cache_.history_variables_wrt_temperature.value(gp_);
+  }
+
+  state_quantities_ = evaluate_state_quantities(CredM, temperature,
+      time_step_quantities_.current_plastic_defgrad_inverse[gp_],
+      time_step_quantities_.current_plastic_strain[gp_], err_status, time_step_tracker_.dt,
+      ViscoplastUtils::StateQuantityEvalType::full_eval);
+
+  thermo_mechanical_coupling_cache_.state.set(gp_, {state_quantities_});
+
+  // calculate linearization term only if we have plastic strain
+  if (std::abs(state_quantities_.curr_equiv_plastic_strain_rate * time_step_tracker_.dt) >
+      ViscoplastUtils::zero_plastic_strain_increment)
+  {
+    // calculate Jacobian
+    Core::LinAlg::Matrix<10, 1> current_sol =
+        wrap_unknowns(time_step_quantities_.current_plastic_defgrad_inverse[gp_],
+            time_step_quantities_.current_plastic_strain[gp_]);
+
+    Core::LinAlg::Matrix<10, 10> jacMat(Core::LinAlg::Initialization::zero);
+    viscoplastic_law_->pre_evaluate(params_, gp_);  // set last_substep <- last_
+    jacMat = evaluate_local_newton_jacobian(CredM, temperature, current_sol,
+        time_step_quantities_.last_plastic_strain[gp_],
+        time_step_quantities_.last_plastic_defgrad_inverse[gp_], time_step_tracker_.dt, err_status);
+    FOUR_C_ASSERT_ALWAYS(
+        err_status == InelasticDefgradTransvIsotropElastViscoplastUtils::ErrorType::no_errors,
+        "Could not evaluate Jacobian in off-diagonal stiffness evaluation!");
+
+    // if we get singular Jacobian: throw exception -> go to FD-based linearization
+    FOUR_C_ASSERT_ALWAYS(abs(jacMat.determinant()) > 1.0e-10,
+        "Singular Jacobian in off-diagonal stiffness evaluation! Jacobian determinant: {}",
+        abs(jacMat.determinant()));
+
+    // declare right-hand side (RHS) terms of the linear system of equations related to the
+    // analytical linearization
+    Core::LinAlg::Matrix<9, 1> rhs_iFin_V(Core::LinAlg::Initialization::zero);
+    Core::LinAlg::Matrix<1, 1> rhs_epsp_V(Core::LinAlg::Initialization::zero);
+
+    if (parameter()->timint_type() == ViscoplastUtils::TimIntType::standard)
+    // standard time integration
+    {
+      FOUR_C_THROW(
+          "Off-diagonal stiffness integration not yet implemented for standard local time "
+          "integration! See evaluate_additional_cmat for an implementation guideline!");
+    }
+    else if (parameter()->timint_type() == ViscoplastUtils::TimIntType::logarithmic)
+    // logarithmic substepping
+    {
+      // calculate RHS of the equation for the plastic deformation gradient
+      rhs_iFin_V.update(-time_step_tracker_.dt, state_quantity_derivatives_.curr_dlpdT, 0.0);
+
+      // calculate RHS of the equation for the plastic strain
+      /** \f$\texttt{rhs\_epsp\_V} =\frac{\partial r_{\varepsilon_{\text{p}}}}{\partial T_{n+1}}
+      = - \Delta t \cdot \left(\underbrace{\frac{\partial \dot{\varepsilon}_{\text{p}}}{\partial
+      \sigma_{\text{yield}}} \cdot
+      \frac{\partial\sigma_{\text{yield}}}{\partial T}}_\texttt{curr\_dpsr\_dT} + \frac{\partial
+      v_{\text{p}}}{\partial \sigma_\text{eq}}
+      \cdot \frac{\partial \sigma_\text{eq}}{\partial T}\right)\f$
+      */
+      rhs_epsp_V(0) =
+          time_step_tracker_.dt * (state_quantity_derivatives_.curr_dpsr_dT +
+                                      state_quantity_derivatives_.curr_dpsr_dequiv_stress *
+                                          state_quantity_derivatives_.curr_dequiv_stress_dT);
+    }
+    else
+    {
+      FOUR_C_THROW("You should not be here");
+    }
+
+    // assemble the RHS from its components
+    Core::LinAlg::Matrix<10, 1> RHS(Core::LinAlg::Initialization::zero);
+    for (int i = 0; i < 9; ++i) RHS(i) = rhs_iFin_V(i);
+    RHS(9) = rhs_epsp_V(0);
+
+    // solve the linear system of equations
+    Core::LinAlg::Matrix<10, 1> SOL(Core::LinAlg::Initialization::zero);
+    Core::LinAlg::FixedSizeSerialDenseSolver<10, 10, 1> solver;
+    solver.set_matrix(jacMat);     // set A = jacM
+    solver.set_vectors(SOL, RHS);  // set X=SOL, B=RHS
+    solver.factor_with_equilibration(true);
+    int err2 = solver.factor();
+    int err = solver.solve();  // X = A^-1 B
+
+    if ((err != 0) || (err2 != 0))
+    {
+      err_status = ViscoplastUtils::ErrorType::failed_solution_analytic_linearization;
+      FOUR_C_THROW("Evaluation of linear system for off-diagonal stiffness has failed!");
+    }
+
+    // disassemble the solution vector
+    auto extract_inv_plastic_defgrad_wrt_temperature = [&SOL]()
+    {
+      Core::LinAlg::Matrix<9, 1> result{Core::LinAlg::Initialization::zero};
+      for (int i = 0; i < 9; ++i) result(i) = SOL(i);
+      return result;
+    };
+
+    thermo_mechanical_coupling_cache_.state_derivatives.set(gp_, {state_quantity_derivatives_});
+    thermo_mechanical_coupling_cache_.history_variables_wrt_temperature.set(
+        gp_, {.inv_plastic_defgrad_wrt_temperature = extract_inv_plastic_defgrad_wrt_temperature(),
+                 .plastic_strain_wrt_temperature = SOL(9)});
+
+    return thermo_mechanical_coupling_cache_.history_variables_wrt_temperature.value(gp_);
+  }
+  else
+  {
+    thermo_mechanical_coupling_cache_.state_derivatives.set(gp_, {});
+    thermo_mechanical_coupling_cache_.history_variables_wrt_temperature.set(gp_, {});
+
+    return thermo_mechanical_coupling_cache_.history_variables_wrt_temperature.value(gp_);
+  }
+}
+
+/*--------------------------------------------------------------------*
+ *--------------------------------------------------------------------*/
+void Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_od_stiff_mat(
+    const Core::LinAlg::Matrix<3, 3>* defgrad, const Core::LinAlg::Matrix<3, 3>& iFin_other,
+    const Core::LinAlg::Matrix<3, 3>& iFinjM, const Core::LinAlg::Matrix<6, 9>& dSdiFinj,
+    Core::LinAlg::Matrix<6, 1>& dstressdT)
+{
+  const ReducedKinematics reduced_kinematics = evaluate_reduced_kinematics(*defgrad, iFin_other);
+  const double temperature = time_step_quantities_.current_temperature[gp_];
+
+  if (parameter()->linearization_type() == ViscoplastUtils::LinearizationType::perturbation_based)
+  {
+    // compute additional stiffness contribution using perturbation-based approach
+    evaluate_od_stiff_mat_perturb_based(
+        reduced_kinematics.defgrad, temperature, dstressdT, dSdiFinj);
+    return;
+  }
+
+  ViscoplastUtils::ErrorType err_status = ViscoplastUtils::ErrorType::no_errors;
+  const auto& diFinjTV = evaluate_history_variables_wrt_temperature(
+      reduced_kinematics.right_cauchy_green, temperature, err_status)
+                             .inv_plastic_defgrad_wrt_temperature;
+
+  FOUR_C_ASSERT_ALWAYS(err_status == ViscoplastUtils::ErrorType::no_errors,
+      "Could not evaluate off-diagonal stiffness matrix: {}",
+      ViscoplastUtils::get_detailed_error_message_for_error_type(err_status));
+
+  // compute off-diagonal stiffness contribution
+  dstressdT.multiply_nn(1.0, dSdiFinj, diFinjTV, 1.0);
+}
+
+Mat::MechanicalDissipation
+Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_mechanical_dissipation(const int gp,
+    const Core::LinAlg::Matrix<3, 3>* defgrad, const Core::LinAlg::Matrix<3, 3>& iFin_other,
+    const double& temperature)
+{
+  const ReducedKinematics reduced_kinematics = evaluate_reduced_kinematics(*defgrad, iFin_other);
+
+  ViscoplastUtils::ErrorType err_status = ViscoplastUtils::ErrorType::no_errors;
+
+  gp_ = gp;
+
+  if (parameter()->linearization_type() == ViscoplastUtils::LinearizationType::perturbation_based)
+  {
+    return evaluate_mechanical_dissipation_perturb_based(reduced_kinematics.defgrad, temperature);
+  }
+
+  const double& tol = ViscoplastUtils::thermo_mechanical_state_equality_tolerance;
+
+  const bool is_current_state =
+      defgrad_difference_norm(
+          reduced_kinematics.defgrad, time_step_quantities_.current_defgrad[gp]) < tol &&
+      std::abs(temperature - time_step_quantities_.current_temperature[gp]) < tol;
+
+  // Note: In monolithic tsi, the thermo-predictor comes in with the last state,
+  // so it would be possible to store the computed dissipation of the last step and
+  // return it instead of re-running returnmapping. This is probably a problem of the
+  // tsi predictor though, so not addressed here.
+
+  if (not is_current_state)
+  {
+    // new state, i.e. we need to recompute history variables for the incoming state.
+
+    // set the new temperature
+    params_.set<double>("temperature", temperature);
+    viscoplastic_law_->pre_evaluate(params_, gp);
+    // recompute the current history variables for the incoming state. This also sets the new state.
+    return_mapping(reduced_kinematics.defgrad, temperature);
+  }
+
+  // evaluate the relevant linearizations, using cached values when available
+  const auto history_variables_wrt_cauchy_green = evaluate_history_variables_wrt_cauchy_green(
+      reduced_kinematics.right_cauchy_green, temperature, err_status);
+  FOUR_C_ASSERT_ALWAYS(err_status == ViscoplastUtils::ErrorType::no_errors,
+      "Could not evaluate history variable derivatives for mechanical dissipation evaluation! "
+      "Error: {}",
+      ViscoplastUtils::get_detailed_error_message_for_error_type(err_status));
+
+  const auto history_variables_wrt_temperature = evaluate_history_variables_wrt_temperature(
+      reduced_kinematics.right_cauchy_green, temperature, err_status);
+  FOUR_C_ASSERT_ALWAYS(err_status == ViscoplastUtils::ErrorType::no_errors,
+      "Could not evaluate history variable derivatives for mechanical dissipation evaluation! "
+      "Error: {}",
+      ViscoplastUtils::get_detailed_error_message_for_error_type(err_status));
+
+  const auto thermo_mechanical_coupling_state = evaluate_thermo_mechanical_coupling_state(
+      reduced_kinematics.right_cauchy_green, temperature, err_status);
+  FOUR_C_ASSERT_ALWAYS(err_status == ViscoplastUtils::ErrorType::no_errors,
+      "Could not evaluate thermo-mechanical coupling state for mechanical dissipation evaluation! "
+      "Error: {}",
+      ViscoplastUtils::get_detailed_error_message_for_error_type(err_status));
+  const auto thermo_mechanical_coupling_state_derivatives =
+      evaluate_thermo_mechanical_coupling_state_derivatives(
+          reduced_kinematics.right_cauchy_green, temperature, err_status);
+  FOUR_C_ASSERT_ALWAYS(err_status == ViscoplastUtils::ErrorType::no_errors,
+      "Could not evaluate thermo-mechanical coupling state derivatives for mechanical dissipation "
+      "evaluation! Error: {}",
+      ViscoplastUtils::get_detailed_error_message_for_error_type(err_status));
+
+  MechanicalDissipation mechanical_dissipation;
+  mechanical_dissipation.value = parameter()->taylor_quinney_coefficient() *
+                                 thermo_mechanical_coupling_state.equiv_stress *
+                                 thermo_mechanical_coupling_state.plastic_strain_rate;
+  mechanical_dissipation.derivative_wrt_cauchy_green = compute_taylor_quinney_wrt_cauchygreen(
+      parameter()->taylor_quinney_coefficient(), thermo_mechanical_coupling_state,
+      thermo_mechanical_coupling_state_derivatives, history_variables_wrt_cauchy_green);
+  mechanical_dissipation.derivative_wrt_temperature = compute_taylor_quinney_wrt_temperature(
+      parameter()->taylor_quinney_coefficient(), thermo_mechanical_coupling_state,
+      thermo_mechanical_coupling_state_derivatives, history_variables_wrt_temperature);
+
+  return mechanical_dissipation;
+}
+
+void Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_inverse_inelastic_def_grad(
+    const Core::LinAlg::Matrix<3, 3>* defgrad, const Core::LinAlg::Matrix<3, 3>& iFin_other,
+    Core::LinAlg::Matrix<3, 3>& iFinM)
+{
+  const ReducedKinematics reduced_kinematics = evaluate_reduced_kinematics(*defgrad, iFin_other);
+
+  // check whether we have already evaluated the inverse inelastic deformation gradient for
+  // the given reduced deformation gradient (this check should only be
+  // performed for the first repetition, since we want to repeat the
+  // return mapping under the same conditions, and not simply return the
+  // computed value)
+  if (defgrad_difference_norm(
+          reduced_kinematics.defgrad, time_step_quantities_.current_defgrad[gp_]) <= 1.0e-16)
+  {
+    // just set the already computed value, no further computation
+    iFinM = time_step_quantities_.current_plastic_defgrad_inverse[gp_];
+    return;
+  }
+  // If this is a "new" deformation gradient, evaluate the inverse inelastic deformation gradient
+  // via return mapping.
+
+  const double temperature =
+      params_.isParameter("temperature") ? params_.get<double>("temperature") : ref_temperature_;
+  iFinM = return_mapping(reduced_kinematics.defgrad, temperature).inv_plastic_defgrad;
+}
+
+/*--------------------------------------------------------------------*
+ *--------------------------------------------------------------------*/
+ViscoplastUtils::ThermoMechanicalCouplingState
+Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_thermo_mechanical_coupling_state(
+    const Core::LinAlg::Matrix<3, 3>& CredM, const double temperature,
+    ViscoplastUtils::ErrorType& err_status)
+{
+  if (thermo_mechanical_coupling_cache_.state.is_evaluated(gp_))
+  {
+    return thermo_mechanical_coupling_cache_.state.value(gp_);
+  }
+
+  const auto& state_quantities = evaluate_state_quantities(CredM, temperature,
+      time_step_quantities_.current_plastic_defgrad_inverse[gp_],
+      time_step_quantities_.current_plastic_strain[gp_], err_status, time_step_tracker_.dt,
+      ViscoplastUtils::StateQuantityEvalType::full_eval);
+  if (err_status != ViscoplastUtils::ErrorType::no_errors) return {};
+
+  thermo_mechanical_coupling_cache_.state.set(gp_, {state_quantities});
+
+  return thermo_mechanical_coupling_cache_.state.value(gp_);
+}
+
+/*--------------------------------------------------------------------*
+ *--------------------------------------------------------------------*/
+ViscoplastUtils::ThermoMechanicalCouplingStateDerivatives
+Mat::InelasticDefgradTransvIsotropElastViscoplast::
+    evaluate_thermo_mechanical_coupling_state_derivatives(const Core::LinAlg::Matrix<3, 3>& CredM,
+        const double temperature, ViscoplastUtils::ErrorType& err_status)
+{
+  if (thermo_mechanical_coupling_cache_.state_derivatives.is_evaluated(gp_))
+  {
+    return thermo_mechanical_coupling_cache_.state_derivatives.value(gp_);
+  }
+
+  const auto& state_quantity_derivatives = evaluate_state_quantity_derivatives(CredM, temperature,
+      time_step_quantities_.current_plastic_defgrad_inverse[gp_],
+      time_step_quantities_.current_plastic_strain[gp_], err_status, time_step_tracker_.dt,
+      ViscoplastUtils::StateQuantityDerivEvalType::full_eval, true);
+  if (err_status != ViscoplastUtils::ErrorType::no_errors) return {};
+
+  thermo_mechanical_coupling_cache_.state_derivatives.set(gp_, {state_quantity_derivatives});
+
+  return thermo_mechanical_coupling_cache_.state_derivatives.value(gp_);
+}
+
+/*--------------------------------------------------------------------*
+ *--------------------------------------------------------------------*/
+
+ViscoplastUtils::HistoryVariablesDerivativesWrtCauchyGreen
+Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_history_variables_wrt_cauchy_green(
+    const Core::LinAlg::Matrix<3, 3>& CredM, const double temperature,
+    ViscoplastUtils::ErrorType& err_status)
+{
+  if (thermo_mechanical_coupling_cache_.history_variables_wrt_cauchy_green.is_evaluated(gp_))
+  {
+    // return the cached values.
+    return thermo_mechanical_coupling_cache_.history_variables_wrt_cauchy_green.value(gp_);
+  }
 
   // auxiliaries
   Core::LinAlg::FourTensor<3> tempFourTensor(true);
 
-  // declare error status (no errors)
-  ViscoplastUtils::ErrorType err_status = ViscoplastUtils::ErrorType::no_errors;
+  state_quantities_ = evaluate_state_quantities(CredM, temperature,
+      time_step_quantities_.current_plastic_defgrad_inverse[gp_],
+      time_step_quantities_.current_plastic_strain[gp_], err_status, time_step_tracker_.dt,
+      ViscoplastUtils::StateQuantityEvalType::full_eval);
 
-  // recompute the state to make sure that everything is evaluated properly after
-  // circumventing the stiffness evaluation
-  state_quantities_ =
-      evaluate_state_quantities(CredM, time_step_quantities_.current_plastic_defgrad_inverse[gp_],
-          time_step_quantities_.current_plastic_strain[gp_], err_status, time_step_tracker_.dt,
-          ViscoplastUtils::StateQuantityEvalType::full_eval);
+  thermo_mechanical_coupling_cache_.state.set(gp_, {state_quantities_});
 
   // calculate linearization term only if we have plastic strain
   if (std::abs(state_quantities_.curr_equiv_plastic_strain_rate * time_step_tracker_.dt) >
       ViscoplastUtils::zero_plastic_strain_increment)
   {
     // ----- perturbation-based linearization ----- //
-    if (parameter()->linearization_type() ==
-            ViscoplastUtils::LinearizationType::perturbation_based ||
-        err_status != ViscoplastUtils::ErrorType::no_errors)
-    {
-      evaluate_additional_cmat_perturb_based(FredM, cmatadd, dSdiFinj);
-
-      return;
-    }
-
-    // ----- analytical linearization ----- //
-    // if error encountered: perform perturbation-based linearization
+    if (err_status != ViscoplastUtils::ErrorType::no_errors) return {};
 
     // calculate Jacobian
     Core::LinAlg::Matrix<10, 1> current_sol =
@@ -2575,25 +3086,16 @@ void Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_additional_cmat
 
     Core::LinAlg::Matrix<10, 10> jacMat(Core::LinAlg::Initialization::zero);
     viscoplastic_law_->pre_evaluate(params_, gp_);  // set last_substep <- last_
-    jacMat = evaluate_local_newton_jacobian(CredM, current_sol,
+    jacMat = evaluate_local_newton_jacobian(CredM, temperature, current_sol,
         time_step_quantities_.last_plastic_strain[gp_],
         time_step_quantities_.last_plastic_defgrad_inverse[gp_], time_step_tracker_.dt, err_status);
 
-    if (err_status != ViscoplastUtils::ErrorType::no_errors)
-    {
-      evaluate_additional_cmat_perturb_based(FredM, cmatadd, dSdiFinj);
-
-      return;
-    }
-
     // if we get singular Jacobian: throw exception -> go to FD-based linearization
     if (abs(jacMat.determinant()) < 1.0e-10)
-    {
       err_status = ViscoplastUtils::ErrorType::singular_jacobian;
-      evaluate_additional_cmat_perturb_based(FredM, cmatadd, dSdiFinj);
 
-      return;
-    }
+    if (err_status != ViscoplastUtils::ErrorType::no_errors) return {};
+
 
     // declare right-hand side (RHS) terms of the linear system of equations related to the
     // analytical linearization
@@ -2640,62 +3142,34 @@ void Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_additional_cmat
     solver.set_matrix(jacMat);     // set A = jacM
     solver.set_vectors(SOL, RHS);  // set X=SOL, B=RHS
     solver.factor_with_equilibration(true);
-    const int err = solver.solve();  // X = A^-1 B
     const int err2 = solver.factor();
+    const int err = solver.solve();  // X = A^-1 B
     if ((err != 0) || (err2 != 0))
     {
       err_status = ViscoplastUtils::ErrorType::failed_solution_analytic_linearization;
-      evaluate_additional_cmat_perturb_based(FredM, cmatadd, dSdiFinj);
-      return;
+      return {};
     }
 
-    // disassemble the solution vector
-    const Core::LinAlg::Matrix<9, 6> diFinjdCV = extract_derivative_of_inv_inelastic_defgrad(SOL);
+    thermo_mechanical_coupling_cache_.state_derivatives.set(gp_, {state_quantity_derivatives_});
+    thermo_mechanical_coupling_cache_.history_variables_wrt_cauchy_green.set(gp_,
+        {.inv_plastic_defgrad_wrt_cauchy_green = extract_derivative_of_inv_inelastic_defgrad(SOL),
+            .plastic_strain_wrt_cauchy_green = extract_derivative_of_plastic_strain(SOL)});
 
-    // compute additional term to stiffness matrix additional_cmat
-    cmatadd.multiply_nn(2.0, dSdiFinj, diFinjdCV, 1.0);
+    return thermo_mechanical_coupling_cache_.history_variables_wrt_cauchy_green.value(gp_);
   }
-}
-
-
-/*--------------------------------------------------------------------*
- *--------------------------------------------------------------------*/
-void Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_inverse_inelastic_def_grad(
-    const Core::LinAlg::Matrix<3, 3>* defgrad, const Core::LinAlg::Matrix<3, 3>& iFin_other,
-    Core::LinAlg::Matrix<3, 3>& iFinM)
-{
-  // reduced deformation gradient FredM, taking into account all the already computed
-  // inelastic factors
-  //    \f$ \boldsymbol{F_{\text{red}}} = \boldsymbol{F}
-  //    \boldsymbol{F_{\text{in,other}}^{-1}}
-  //    \f$
-  //      with \f$\boldsymbol{F}_{\text{in,other}}^{-1} = \boldsymbol{F}_{\text{in},1}^{-1}
-  //      \boldsymbol{F}_{\text{in},2}^{-1} \dots \f$ up to the current inelastic factor
-  Core::LinAlg::Matrix<3, 3> FredM(Core::LinAlg::Initialization::zero);
-  FredM.multiply_nn(1.0, *defgrad, iFin_other, 0.0);
-
-  // check whether we have already evaluated the inverse inelastic deformation gradient for
-  // the given reduced deformation gradient (this check should only be
-  // performed for the first repetition, since we want to repeat the
-  // return mapping under the same conditions, and not simply return the
-  // computed value)
-  if (defgrad_difference_norm(FredM, time_step_quantities_.current_defgrad[gp_]) <= 1.0e-16)
+  else
   {
-    // just set the already computed value, no further computation
-    iFinM = time_step_quantities_.current_plastic_defgrad_inverse[gp_];
-    return;
-  }
-  // If this is a "new" deformation gradient, evaluate the inverse inelastic deformation gradient
-  // via return mapping.
+    // linearization terms are zero if no plastic strain increment
+    thermo_mechanical_coupling_cache_.state_derivatives.set(gp_, {});
+    thermo_mechanical_coupling_cache_.history_variables_wrt_cauchy_green.set(gp_, {});
 
-  iFinM = return_mapping(FredM).inv_plastic_defgrad;
+    return thermo_mechanical_coupling_cache_.history_variables_wrt_cauchy_green.value(gp_);
+  }
 }
 
-/*--------------------------------------------------------------------*
- *--------------------------------------------------------------------*/
 Mat::InelasticDefgradTransvIsotropElastViscoplast::HistoryVariables
 Mat::InelasticDefgradTransvIsotropElastViscoplast::return_mapping(
-    const Core::LinAlg::Matrix<3, 3>& FredM)
+    const Core::LinAlg::Matrix<3, 3>& FredM, const double temperature)
 {
   // declare output: history variables (after return mapping)
   HistoryVariables result;
@@ -2719,8 +3193,11 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::return_mapping(
   // set current defgrad and current right CG tensor
   time_step_quantities_.current_defgrad[gp_] = FredM;
   time_step_quantities_.current_rightCG[gp_] = CredM;
+  time_step_quantities_.current_temperature[gp_] = temperature;
+  thermo_mechanical_coupling_cache_.reset(gp_);
   // check whether the predictor is the solution (no plastic strain during this time step)
-  bool pred_is_sol = check_elastic_predictor(CredM, iFinM_pred, plastic_strain_pred, err_status);
+  bool pred_is_sol =
+      check_elastic_predictor(CredM, temperature, iFinM_pred, plastic_strain_pred, err_status);
   if ((err_status == ViscoplastUtils::ErrorType::no_errors) && (pred_is_sol))
   {
     // update inverse inelastic defgrad and plastic strain
@@ -2731,7 +3208,7 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::return_mapping(
   {
     // perform local time integration
     Core::LinAlg::Matrix<10, 1> x = wrap_unknowns(iFinM_pred, plastic_strain_pred);
-    Core::LinAlg::Matrix<10, 1> sol = viscoplastic_correction(FredM, x, err_status);
+    Core::LinAlg::Matrix<10, 1> sol = viscoplastic_correction(FredM, temperature, x, err_status);
     // throw error if the Local Newton Loop cannot be evaluated with the given substepping
     // settings
     if (err_status != ViscoplastUtils::ErrorType::no_errors)
@@ -2787,6 +3264,7 @@ void Mat::InelasticDefgradTransvIsotropElastViscoplast::setup(const int numgp,
 
   // resize time step quantities according to the number of Gauss points
   time_step_quantities_.resize(numgp);
+  thermo_mechanical_coupling_cache_.resize(numgp);
 
   // call corresponding method of the viscoplastic law
   viscoplastic_law_->setup(numgp, fibers, coord_system);
@@ -2859,6 +3337,10 @@ void Mat::InelasticDefgradTransvIsotropElastViscoplast::unpack_inelastic(
   // now that the fiber direction is available, we set the material-dependent constant tensors
   // with it
   const_mat_tensors_.set_material_const_tensors(m_);
+
+  // resize the thermo-mechanical coupling cache to the correct number of Gauss points
+  thermo_mechanical_coupling_cache_.resize(
+      time_step_quantities_.current_plastic_defgrad_inverse.size());
 }
 
 
@@ -2866,8 +3348,9 @@ void Mat::InelasticDefgradTransvIsotropElastViscoplast::unpack_inelastic(
  *--------------------------------------------------------------------*/
 Core::LinAlg::Matrix<10, 1>
 Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_local_newton_residual(
-    const Core::LinAlg::Matrix<3, 3>& CM, const Core::LinAlg::Matrix<10, 1>& x,
-    const double last_plastic_strain, const Core::LinAlg::Matrix<3, 3>& last_iFinM, const double dt,
+    const Core::LinAlg::Matrix<3, 3>& CM, const double temperature,
+    const Core::LinAlg::Matrix<10, 1>& x, const double last_plastic_strain,
+    const Core::LinAlg::Matrix<3, 3>& last_iFinM, const double dt,
     ViscoplastUtils::ErrorType& err_status)
 {
   // auxiliaries
@@ -2878,8 +3361,8 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_local_newton_residua
   const double plastic_strain = x(9);
 
   // evaluate state variables
-  state_quantities_ = evaluate_state_quantities(
-      CM, iFinM, plastic_strain, err_status, dt, ViscoplastUtils::StateQuantityEvalType::full_eval);
+  state_quantities_ = evaluate_state_quantities(CM, temperature, iFinM, plastic_strain, err_status,
+      dt, ViscoplastUtils::StateQuantityEvalType::full_eval);
 
   // declare residuals of the LNL
   Core::LinAlg::Matrix<3, 3> resFM(Core::LinAlg::Initialization::zero);
@@ -2963,8 +3446,9 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_local_newton_residua
  *--------------------------------------------------------------------*/
 Core::LinAlg::Matrix<10, 10>
 Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_local_newton_jacobian(
-    const Core::LinAlg::Matrix<3, 3>& CM, const Core::LinAlg::Matrix<10, 1>& x,
-    const double last_plastic_strain, const Core::LinAlg::Matrix<3, 3>& last_iFinM, const double dt,
+    const Core::LinAlg::Matrix<3, 3>& CM, const double temperature,
+    const Core::LinAlg::Matrix<10, 1>& x, const double last_plastic_strain,
+    const Core::LinAlg::Matrix<3, 3>& last_iFinM, const double dt,
     ViscoplastUtils::ErrorType& err_status)
 {
   // auxiliaries
@@ -2977,8 +3461,8 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_local_newton_jacobia
   const double plastic_strain = x(9);
 
   // evaluate state derivatives
-  state_quantity_derivatives_ = evaluate_state_quantity_derivatives(CM, iFinM, plastic_strain,
-      err_status, dt,
+  state_quantity_derivatives_ = evaluate_state_quantity_derivatives(CM, temperature, iFinM,
+      plastic_strain, err_status, dt,
       ViscoplastUtils::StateQuantityDerivEvalType::full_eval);  // we do not reevaluate the state
                                                                 // quantities, this was done in the
                                                                 // residual computation already
@@ -3101,8 +3585,8 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_local_newton_jacobia
  *--------------------------------------------------------------------*/
 Core::LinAlg::Matrix<10, 1>
 Mat::InelasticDefgradTransvIsotropElastViscoplast::viscoplastic_correction(
-    const Core::LinAlg::Matrix<3, 3>& defgrad, const Core::LinAlg::Matrix<10, 1>& x,
-    ViscoplastUtils::ErrorType& err_status)
+    const Core::LinAlg::Matrix<3, 3>& defgrad, const double temperature,
+    const Core::LinAlg::Matrix<10, 1>& x, ViscoplastUtils::ErrorType& err_status)
 {
   // calculate right Cauchy-Green deformation tensor
   Core::LinAlg::Matrix<3, 3> CM(Core::LinAlg::Initialization::zero);
@@ -3140,7 +3624,8 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::viscoplastic_correction(
           Core::LinAlg::make_error_message(tensor_interp_err_status));
 
       // perform substep local Newton loop
-      local_newton_loop(curr_CM, time_step_quantities_.last_substep_plastic_strain[gp_],
+      local_newton_loop(curr_CM, temperature,
+          time_step_quantities_.last_substep_plastic_strain[gp_],
           time_step_quantities_.last_substep_plastic_defgrad_inverse[gp_],
           local_substepping_utils_.get_substep_size(), sol, err_status);
       // update Local Newton quantities
@@ -3179,7 +3664,7 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::viscoplastic_correction(
   else
   {
     // perform local Newton loop
-    local_newton_loop(CM, time_step_quantities_.last_plastic_strain[gp_],
+    local_newton_loop(CM, temperature, time_step_quantities_.last_plastic_strain[gp_],
         time_step_quantities_.last_plastic_defgrad_inverse[gp_], time_step_tracker_.dt, sol,
         err_status);
 
@@ -3195,8 +3680,9 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::viscoplastic_correction(
 /*--------------------------------------------------------------------*
  *--------------------------------------------------------------------*/
 void Mat::InelasticDefgradTransvIsotropElastViscoplast::local_newton_loop(
-    const Core::LinAlg::Matrix<3, 3>& CM, const double last_plastic_strain,
-    const Core::LinAlg::Matrix<3, 3>& last_iFinM, const double dt, Core::LinAlg::Matrix<10, 1>& sol,
+    const Core::LinAlg::Matrix<3, 3>& CM, const double temperature,
+    const double last_plastic_strain, const Core::LinAlg::Matrix<3, 3>& last_iFinM, const double dt,
+    Core::LinAlg::Matrix<10, 1>& sol,
     InelasticDefgradTransvIsotropElastViscoplastUtils::ErrorType& err_status)
 {
   // auxiliaries
@@ -3230,8 +3716,8 @@ void Mat::InelasticDefgradTransvIsotropElastViscoplast::local_newton_loop(
     local_newton_manager_.increment_iteration_count();
 
     // evaluate residual
-    residual =
-        evaluate_local_newton_residual(CM, sol, last_plastic_strain, last_iFinM, dt, err_status);
+    residual = evaluate_local_newton_residual(
+        CM, temperature, sol, last_plastic_strain, last_iFinM, dt, err_status);
 
     // error management after residual evaluation
     temp10x1.update(1.0, sol, 0.0);
@@ -3341,8 +3827,8 @@ void Mat::InelasticDefgradTransvIsotropElastViscoplast::local_newton_loop(
     }
 
     // evaluate Jacobian
-    jacMat =
-        evaluate_local_newton_jacobian(CM, sol, last_plastic_strain, last_iFinM, dt, err_status);
+    jacMat = evaluate_local_newton_jacobian(
+        CM, temperature, sol, last_plastic_strain, last_iFinM, dt, err_status);
     // error management after Jacobian evaluation
     manage_evaluation(err_status, eval_action);
     switch (eval_action)
@@ -3609,12 +4095,14 @@ bool Mat::InelasticDefgradTransvIsotropElastViscoplast::solve_local_newton_linea
 /*--------------------------------------------------------------------*
  *--------------------------------------------------------------------*/
 bool Mat::InelasticDefgradTransvIsotropElastViscoplast::check_elastic_predictor(
-    const Core::LinAlg::Matrix<3, 3>& CM, const Core::LinAlg::Matrix<3, 3>& iFinM_pred,
-    const double plastic_strain_pred, ViscoplastUtils::ErrorType& err_status)
+    const Core::LinAlg::Matrix<3, 3>& CM, const double temperature,
+    const Core::LinAlg::Matrix<3, 3>& iFinM_pred, const double plastic_strain_pred,
+    ViscoplastUtils::ErrorType& err_status)
 {
   // evaluate state with this elastic predictor and the minimum possible time step
-  state_quantities_ = evaluate_state_quantities(CM, iFinM_pred, plastic_strain_pred, err_status,
-      time_step_tracker_.min_dt, ViscoplastUtils::StateQuantityEvalType::plastic_strain_rate_only);
+  state_quantities_ = evaluate_state_quantities(CM, temperature, iFinM_pred, plastic_strain_pred,
+      err_status, time_step_tracker_.min_dt,
+      ViscoplastUtils::StateQuantityEvalType::plastic_strain_rate_only);
 
 
   // check if the predicted plastic strain rate is 0 -> for flow rules with yield functions,
@@ -3647,8 +4135,8 @@ bool Mat::InelasticDefgradTransvIsotropElastViscoplast::halve_and_prepare_new_su
 }
 
 void Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_additional_cmat_perturb_based(
-    const Core::LinAlg::Matrix<3, 3>& FredM, Core::LinAlg::Matrix<6, 6>& cmatadd,
-    const Core::LinAlg::Matrix<6, 9>& dSdiFinj)
+    const Core::LinAlg::Matrix<3, 3>& FredM, const double temperature,
+    Core::LinAlg::Matrix<6, 6>& cmatadd, const Core::LinAlg::Matrix<6, 9>& dSdiFinj)
 {
   // ----- FD-based linearization ----- //
   // approximation using perturbations of the right Cauchy-Green deformation tensor,
@@ -3660,6 +4148,8 @@ void Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_additional_cmat
   // set update boolean to false
   update_hist_var_ = false;  // no update of the current_ values during the upcoming evaluation
   // of perturbed states
+  const auto unperturbed_state_quantities = state_quantities_;
+  const auto unperturbed_time_step_quantities = time_step_quantities_;
 
   // inverse of the reduced deformation gradient
   Core::LinAlg::Matrix<3, 3> iFredM(Core::LinAlg::Initialization::zero);
@@ -3681,7 +4171,7 @@ void Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_additional_cmat
 
   // define the delta perturbed deformation gradients
   std::vector<Core::LinAlg::Matrix<3, 3>> delta_perturbed_defgrads(6);
-  const double pert_fact = 1.0e-9;  // perturbation factor \f$ \epsilon \f$
+  const double pert_fact = 1.0e-5;  // perturbation factor \f$ \epsilon \f$
   const std::vector<std::tuple<int, int>> indices_array = {
       {0, 0}, {1, 1}, {2, 2}, {0, 1}, {1, 2}, {0, 2}};
 
@@ -3698,31 +4188,189 @@ void Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_additional_cmat
     temp3x3(std::get<1>(indices_array[i]), std::get<0>(indices_array[i])) += pert_fact / 2.0;
     delta_perturbed_defgrads[i].multiply_tn(1.0, iFredM, temp3x3, 0.0);
 
-    // get perturbed defgrad
-    perturbed_FM.update(1.0, FredM, 1.0, delta_perturbed_defgrads[i], 0.0);
-
-    // calculate perturbed right CG tensor
-    perturbed_CM.multiply_tn(1.0, perturbed_FM, perturbed_FM, 0.0);
-
-    // get corresponding inverse inelastic defgrad
-    perturbed_iFinM = return_mapping(perturbed_FM).inv_plastic_defgrad;
-    Core::LinAlg::Matrix<9, 1> perturbed_iFinV(Core::LinAlg::Initialization::zero);
-    Core::LinAlg::Voigt::matrix_3x3_to_9x1(perturbed_iFinM, perturbed_iFinV);
-
-    // update components of the required derivative
-    for (int j = 0; j < 9; ++j)
+    for (const double delta_sign : {1.0, -1.0})
     {
-      diFindC_FD(j, i) += 1.0 / 2.0 * 1.0 / pert_fact * (perturbed_iFinV(j, 0) - iFinV(j, 0));
+      // get perturbed defgrad
+      perturbed_FM.update(1.0, FredM, delta_sign, delta_perturbed_defgrads[i], 0.0);
+
+      // calculate perturbed right CG tensor
+      perturbed_CM.multiply_tn(1.0, perturbed_FM, perturbed_FM, 0.0);
+
+      // get corresponding inverse inelastic defgrad
+      perturbed_iFinM = return_mapping(perturbed_FM, temperature).inv_plastic_defgrad;
+      Core::LinAlg::Matrix<9, 1> perturbed_iFinV(Core::LinAlg::Initialization::zero);
+      Core::LinAlg::Voigt::matrix_3x3_to_9x1(perturbed_iFinM, perturbed_iFinV);
+
+      // update components of the required derivative
+      for (int j = 0; j < 9; ++j)
+      {
+        diFindC_FD(j, i) += delta_sign / (4.0 * pert_fact) * (perturbed_iFinV(j, 0) - iFinV(j, 0));
+      }
     }
   }
 
   // compute additional term to stiffness matrix additional_cmat
   cmatadd.multiply_nn(2.0, dSdiFinj, diFindC_FD, 1.0);
 
+  // restore the state quantities to the unperturbed state
+  state_quantities_ = unperturbed_state_quantities;
+  time_step_quantities_ = unperturbed_time_step_quantities;
   // reset boolean for the history update
   update_hist_var_ = true;
 }
 
+void Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_od_stiff_mat_perturb_based(
+    const Core::LinAlg::Matrix<3, 3>& FredM, const double temperature,
+    Core::LinAlg::Matrix<6, 1>& dstressdT, const Core::LinAlg::Matrix<6, 9>& dSdiFinj)
+{
+  update_hist_var_ = false;
+  const auto unperturbed_state_quantities = state_quantities_;
+  const auto unperturbed_time_step_quantities = time_step_quantities_;
+
+  const double perturbation_factor = 1.0e-7;
+  const double delta_T_perturbation =
+      std::max(perturbation_factor * std::abs(temperature), perturbation_factor);
+
+  Core::LinAlg::Matrix<9, 1> diFindT_FD(Core::LinAlg::Initialization::zero);
+
+  for (const double delta_sign : {1.0, -1.0})
+  {
+    const double perturbed_temperature = temperature + delta_T_perturbation * delta_sign;
+
+    // set the perturbed temperature in the viscoplastic law.
+    params_.set<double>("temperature", perturbed_temperature);
+    viscoplastic_law_->pre_evaluate(params_, gp_);
+
+    // run return-mapping with the perturbed temperature
+    const HistoryVariables perturbed_history_variables =
+        return_mapping(FredM, perturbed_temperature);
+
+    Core::LinAlg::Matrix<9, 1> perturbed_iFinV(Core::LinAlg::Initialization::zero);
+    Core::LinAlg::Voigt::matrix_3x3_to_9x1(
+        perturbed_history_variables.inv_plastic_defgrad, perturbed_iFinV);
+
+    diFindT_FD.update(delta_sign / (2.0 * delta_T_perturbation), perturbed_iFinV, 1.0);
+  }
+
+  // update dstressdT by the contribution of the variation of the inverse inelastic defgrad with
+  // respect to temperature
+  dstressdT.multiply_nn(1.0, dSdiFinj, diFindT_FD, 1.0);
+
+  // reset everything to the unperturbed state
+  time_step_quantities_ = unperturbed_time_step_quantities;
+  params_.set<double>("temperature", temperature);
+  viscoplastic_law_->pre_evaluate(params_, gp_);
+  state_quantities_ = unperturbed_state_quantities;
+  update_hist_var_ = true;
+}
+
+Mat::MechanicalDissipation
+Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_mechanical_dissipation_perturb_based(
+    const Core::LinAlg::Matrix<3, 3>& FredM, const double temperature)
+{
+  Core::LinAlg::Matrix<3, 3> CredM{Core::LinAlg::Initialization::zero};
+  CredM.multiply_tn(1.0, FredM, FredM, 0.0);
+
+  Mat::MechanicalDissipation result{};
+
+  const auto evaluate_taylor_quinney = [this](const ViscoplastUtils::StateQuantities& state)
+  {
+    return parameter()->taylor_quinney_coefficient() * state.curr_equiv_plastic_strain_rate *
+           state.curr_equiv_stress;
+  };
+
+  // Evaluate the incoming state
+  params_.set<double>("temperature", temperature);
+  viscoplastic_law_->pre_evaluate(params_, gp_);
+  return_mapping(FredM, temperature);
+
+  update_hist_var_ = false;  // no update of the current values during perturbed evaluations
+  const auto unperturbed_state_quantities = state_quantities_;
+  const auto unperturbed_time_step_quantities = time_step_quantities_;
+
+  result.value = evaluate_taylor_quinney(unperturbed_state_quantities);
+
+  if (std::abs(unperturbed_state_quantities.curr_equiv_plastic_strain_rate *
+               time_step_tracker_.dt) <= ViscoplastUtils::zero_plastic_strain_increment)
+  {
+    // no dissipation if plastic strain rate is 0.
+    update_hist_var_ = true;
+    return result;
+  }
+
+  // Finite-difference linearization w.r.t. the right Cauchy-Green tensor.
+  {
+    Core::LinAlg::Matrix<3, 3> iFredM(Core::LinAlg::Initialization::zero);
+    iFredM.invert(FredM);
+
+    Core::LinAlg::Matrix<3, 3> temp3x3(Core::LinAlg::Initialization::zero);
+
+    Core::LinAlg::Matrix<3, 3> perturbed_FM(Core::LinAlg::Initialization::zero);
+    Core::LinAlg::Matrix<3, 3> perturbed_CM(Core::LinAlg::Initialization::zero);
+
+    std::vector<Core::LinAlg::Matrix<3, 3>> delta_perturbed_defgrads(6);
+    const double pert_fact = 1.0e-5;  // perturbation factor \f$ \epsilon \f$
+    const std::vector<std::tuple<int, int>> indices_array = {
+        {0, 0}, {1, 1}, {2, 2}, {0, 1}, {1, 2}, {0, 2}};
+
+    for (int i = 0; i < static_cast<int>(indices_array.size()); i++)
+    {
+      // set perturbation of the form
+      // \f$ \Delta F_{pert(CD)} = \epsilon/2 F^{-T} (E_{C} \otimes  E_{D} + E_{D} \otimes
+      // E_{C} ) \f$
+      temp3x3.clear();
+      temp3x3(std::get<0>(indices_array[i]), std::get<1>(indices_array[i])) += pert_fact / 2.0;
+      temp3x3(std::get<1>(indices_array[i]), std::get<0>(indices_array[i])) += pert_fact / 2.0;
+      delta_perturbed_defgrads[i].multiply_tn(1.0, iFredM, temp3x3, 0.0);
+
+      for (const double delta_sign : {1.0, -1.0})
+      {
+        perturbed_FM.update(1.0, FredM, delta_sign, delta_perturbed_defgrads[i], 0.0);
+        perturbed_CM.multiply_tn(1.0, perturbed_FM, perturbed_FM, 0.0);
+
+        // run return-mapping with the perturbed deformation gradient. This populates the
+        // state_quantities_
+        return_mapping(perturbed_FM, temperature);
+
+        result.derivative_wrt_cauchy_green(i) +=
+            delta_sign / (4.0 * pert_fact) * evaluate_taylor_quinney(state_quantities_);
+      }
+    }
+  }
+
+  // Finite-difference linearization w.r.t. temperature.
+  {
+    const double pert_fact = 1.0e-7;
+    double delta_T_perturbation = std::max(pert_fact * std::abs(temperature),
+        pert_fact);  // avoid 0 perturbation
+
+    for (double delta_sign : {1.0, -1.0})
+    {
+      double perturbed_temperature = temperature + delta_T_perturbation * delta_sign;
+
+      // The viscoplastic law caches temperature-dependent data during pre-evaluation.
+      params_.set<double>("temperature", perturbed_temperature);
+      viscoplastic_law_->pre_evaluate(params_, gp_);
+
+      // run return-mapping with the perturbed temperature. This populates the state_quantities_
+      return_mapping(FredM, perturbed_temperature);
+
+      result.derivative_wrt_temperature +=
+          delta_sign / (2 * delta_T_perturbation) * evaluate_taylor_quinney(state_quantities_);
+    }
+  }
+
+  // reset everything to the unperturbed state
+  time_step_quantities_ = unperturbed_time_step_quantities;
+  state_quantities_ = unperturbed_state_quantities;
+
+  // reset the temperature in the viscoplastic law
+  params_.set<double>("temperature", temperature);
+  viscoplastic_law_->pre_evaluate(params_, gp_);
+  update_hist_var_ = true;
+
+  return result;
+}
 
 /*--------------------------------------------------------------------*
  *--------------------------------------------------------------------*/
@@ -3829,6 +4477,12 @@ std::string Mat::InelasticDefgradTransvIsotropElastViscoplast::get_error_info(
   time_step_quantities_.current_rightCG[gp_].print(temp_ostream);
   extended_error_string += temp_ostream.str();
   temp_ostream.str("");
+  extended_error_string += "current_temperature: \n";
+  extended_error_string += "Double<1,1> \n";
+  temp_ostream << time_step_quantities_.current_temperature[gp_] << std::endl;
+  extended_error_string += temp_ostream.str();
+  temp_ostream.str("");
+
   extended_error_string += std::string(10, '.');
 
 

--- a/src/mat/4C_mat_inelastic_defgrad_factors.cpp
+++ b/src/mat/4C_mat_inelastic_defgrad_factors.cpp
@@ -41,6 +41,7 @@
 #include <Teuchos_StandardParameterEntryValidators.hpp>
 
 #include <algorithm>
+#include <array>
 #include <map>
 #include <memory>
 #include <optional>
@@ -65,9 +66,12 @@ namespace
     return diff.norm2();
   }
 
+  /// Holds Kinematic quantities reduced by the preceding inelastic factors
   struct ReducedKinematics
   {
+    /// The deformation gradient reduced by the preceding inelastic factors
     Core::LinAlg::Matrix<3, 3> defgrad{Core::LinAlg::Initialization::zero};
+    /// The right cauchy gree tensor obtained from the reduced deformation gradient
     Core::LinAlg::Matrix<3, 3> right_cauchy_green{Core::LinAlg::Initialization::zero};
   };
 
@@ -389,9 +393,11 @@ namespace
 
   /**
    * @brief Extract the derivative of the plastic strain w.r.t. right CG tensor from the
-   solution of the linear system of equations arising in the additional cmat calculation.
+   solution of the linear system of equations arising in
+   evaluate_history_variables_wrt_cauchy_green.
    *
-   * @param SOL
+   * @param SOL Solution arising from the linear system of equations in
+   evaluate_history_variables_wrt_cauchy_green
    * @return Core::LinAlg::Matrix<1, 6> \f[ \frac{\mathrm{d} \varepsilon_p}{\mathrm{d}
    \boldsymbol{C}}
    \f] in Voigt Notation
@@ -2729,18 +2735,10 @@ void Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_additional_cmat
       reduced_kinematics.right_cauchy_green, temperature, err_status)
                              .inv_plastic_defgrad_wrt_cauchy_green;
 
-  if (err_status != ViscoplastUtils::ErrorType::no_errors)
-  {
-    // if we get an error in evaluating the history variable derivatives: perform
-    // perturbation-based linearization
-    std::cout << "Warning: Error encountered in evaluating history variable derivatives: "
-              << ViscoplastUtils::get_detailed_error_message_for_error_type(err_status) << "\n"
-              << "Performing perturbation-based linearization for the additional stiffness "
-                 "contribution.\n";
-    evaluate_additional_cmat_perturb_based(
-        reduced_kinematics.defgrad, temperature, cmatadd, dSdiFinj);
-    return;
-  }
+  FOUR_C_ASSERT_ALWAYS(err_status == ViscoplastUtils::ErrorType::no_errors,
+      "Could not evaluate additional stiffness matrix: {}",
+      ViscoplastUtils::get_detailed_error_message_for_error_type(err_status));
+
   // compute additional term to stiffness matrix additional_cmat
   cmatadd.multiply_nn(2.0, dSdiFinj, diFinjdC, 1.0);
 }
@@ -2752,6 +2750,7 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_history_variables_wr
 {
   if (thermo_mechanical_coupling_cache_.history_variables_wrt_temperature.is_evaluated(gp_))
   {
+    err_status = ViscoplastUtils::ErrorType::no_errors;
     return thermo_mechanical_coupling_cache_.history_variables_wrt_temperature.value(gp_);
   }
 
@@ -2780,7 +2779,7 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_history_variables_wr
         err_status == InelasticDefgradTransvIsotropElastViscoplastUtils::ErrorType::no_errors,
         "Could not evaluate Jacobian in off-diagonal stiffness evaluation!");
 
-    // if we get singular Jacobian: throw exception -> go to FD-based linearization
+    // Assert that jacobian is not singular
     FOUR_C_ASSERT_ALWAYS(abs(jacMat.determinant()) > 1.0e-10,
         "Singular Jacobian in off-diagonal stiffness evaluation! Jacobian determinant: {}",
         abs(jacMat.determinant()));
@@ -2804,8 +2803,8 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_history_variables_wr
       rhs_iFin_V.update(-time_step_tracker_.dt, state_quantity_derivatives_.curr_dlpdT, 0.0);
 
       // calculate RHS of the equation for the plastic strain
-      /** \f$\texttt{rhs\_epsp\_V} =\frac{\partial r_{\varepsilon_{\text{p}}}}{\partial T_{n+1}}
-      = - \Delta t \cdot \left(\underbrace{\frac{\partial \dot{\varepsilon}_{\text{p}}}{\partial
+      /** \f$\texttt{rhs\_epsp\_V} = - \frac{\partial r_{\varepsilon_{\text{p}}}}{\partial T_{n+1}}
+      = \Delta t \cdot \left(\underbrace{\frac{\partial \dot{\varepsilon}_{\text{p}}}{\partial
       \sigma_{\text{yield}}} \cdot
       \frac{\partial\sigma_{\text{yield}}}{\partial T}}_\texttt{curr\_dpsr\_dT} + \frac{\partial
       v_{\text{p}}}{\partial \sigma_\text{eq}}
@@ -2838,7 +2837,8 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_history_variables_wr
     if ((err != 0) || (err2 != 0))
     {
       err_status = ViscoplastUtils::ErrorType::failed_solution_analytic_linearization;
-      FOUR_C_THROW("Evaluation of linear system for off-diagonal stiffness has failed!");
+      FOUR_C_THROW("Evaluation of linear system for off-diagonal stiffness has failed: {}",
+          get_detailed_error_message_for_error_type(err_status));
     }
 
     // disassemble the solution vector
@@ -2906,7 +2906,7 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_mechanical_dissipati
 
   ViscoplastUtils::ErrorType err_status = ViscoplastUtils::ErrorType::no_errors;
 
-  const double& tol = ViscoplastUtils::thermo_mechanical_state_equality_tolerance;
+  const double tol = ViscoplastUtils::thermo_mechanical_state_equality_tolerance;
 
   // First determine current state, then pre_evaluate, because pre_evaluate sets state.
   const bool is_current_state =
@@ -3061,6 +3061,7 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_history_variables_wr
   if (thermo_mechanical_coupling_cache_.history_variables_wrt_cauchy_green.is_evaluated(gp_))
   {
     // return the cached values.
+    err_status = ViscoplastUtils::ErrorType::no_errors;
     return thermo_mechanical_coupling_cache_.history_variables_wrt_cauchy_green.value(gp_);
   }
 
@@ -4230,14 +4231,22 @@ void Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_od_stiff_mat_pe
   const auto unperturbed_time_step_quantities = time_step_quantities_;
 
   const double perturbation_factor = 1.0e-7;
-  const double delta_T_perturbation =
-      std::max(perturbation_factor * std::abs(temperature), perturbation_factor);
+  const double delta_T_perturbation = std::max(perturbation_factor * temperature,
+      perturbation_factor);  // ensure a minimum perturbation size for small temperatures
+
+  const std::array<double, 2> perturbed_temperatures = {temperature + delta_T_perturbation,
+      std::max(
+          0.0, temperature - delta_T_perturbation)};  // ensure non-negative absolute temperature
+
+  std::array<double, 2> delta_signs = {1.0, -1.0};
+  const double delta_T_perturbation_used = perturbed_temperatures[0] - perturbed_temperatures[1];
+
 
   Core::LinAlg::Matrix<9, 1> diFindT_FD(Core::LinAlg::Initialization::zero);
 
-  for (const double delta_sign : {1.0, -1.0})
+  for (int index : {0, 1})
   {
-    const double perturbed_temperature = temperature + delta_T_perturbation * delta_sign;
+    const double perturbed_temperature = perturbed_temperatures[index];
 
     // set the perturbed temperature in the viscoplastic law.
     params_.set<double>("temperature", perturbed_temperature);
@@ -4251,7 +4260,7 @@ void Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_od_stiff_mat_pe
     Core::LinAlg::Voigt::matrix_3x3_to_9x1(
         perturbed_history_variables.inv_plastic_defgrad, perturbed_iFinV);
 
-    diFindT_FD.update(delta_sign / (2.0 * delta_T_perturbation), perturbed_iFinV, 1.0);
+    diFindT_FD.update(delta_signs[index] / delta_T_perturbation_used, perturbed_iFinV, 1.0);
   }
 
   // update dstressdT by the contribution of the variation of the inverse inelastic defgrad with

--- a/src/mat/4C_mat_inelastic_defgrad_factors.cpp
+++ b/src/mat/4C_mat_inelastic_defgrad_factors.cpp
@@ -42,6 +42,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <map>
 #include <memory>
 #include <optional>
@@ -3600,6 +3601,8 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::viscoplastic_correction(
 
   // declare current right CG (tensor interpolated later on in each substep)
   Core::LinAlg::Matrix<3, 3> curr_CM(Core::LinAlg::Initialization::zero);
+  // declare current temperature (interpolated later on in each substep)
+  double curr_temp = 0.0;
 
   // reset substep parameters
   if (parameter()->use_local_substepping())
@@ -3625,10 +3628,12 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::viscoplastic_correction(
           tensor_interp_err_status == Core::LinAlg::TensorInterpolationErrorType::NoErrors,
           "Tensor interpolation failed with err: {}",
           Core::LinAlg::make_error_message(tensor_interp_err_status));
+      // interpolate temperature
+      curr_temp = std::lerp(time_step_quantities_.last_temperature[gp_], temperature,
+          local_substepping_utils_.get_normalized_next_time_param(time_step_tracker_.dt));
 
       // perform substep local Newton loop
-      local_newton_loop(curr_CM, temperature,
-          time_step_quantities_.last_substep_plastic_strain[gp_],
+      local_newton_loop(curr_CM, curr_temp, time_step_quantities_.last_substep_plastic_strain[gp_],
           time_step_quantities_.last_substep_plastic_defgrad_inverse[gp_],
           local_substepping_utils_.get_substep_size(), sol, err_status);
       // update Local Newton quantities

--- a/src/mat/4C_mat_inelastic_defgrad_factors.cpp
+++ b/src/mat/4C_mat_inelastic_defgrad_factors.cpp
@@ -1846,8 +1846,13 @@ void Mat::InelasticDefgradTransvIsotropElastViscoplast::pre_evaluate(
   if (std::abs(time_step_quantities_.current_temperature[gp] - previous_temperature) >
       ViscoplastUtils::thermo_mechanical_state_equality_tolerance)
   {
-    time_step_quantities_.current_defgrad[gp].clear();
     thermo_mechanical_coupling_cache_.reset(gp);
+
+    // We use the current defgrad stored in time_step_quantities in
+    // evalate_inverse_inelastic_defgrad to determine whether or not there is a new state. Since a
+    // changed temperature alone is enough to have a new state, we invalidate the stored current
+    // defgrad here by setting it to a physically meaningless value.
+    time_step_quantities_.current_defgrad[gp].clear();
   }
 
   // set time step

--- a/src/mat/4C_mat_inelastic_defgrad_factors.cpp
+++ b/src/mat/4C_mat_inelastic_defgrad_factors.cpp
@@ -31,6 +31,7 @@
 #include "4C_mat_multiplicative_split_defgrad_elasthyper.hpp"
 #include "4C_mat_multiplicative_split_defgrad_elasthyper_service.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_mat_so3_material.hpp"
 #include "4C_mat_vplast_law.hpp"
 #include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
@@ -1835,7 +1836,8 @@ void Mat::InelasticDefgradTransvIsotropElastViscoplast::pre_evaluate(
   }
 
   // invalidate the caches if the temperature changed
-  if (std::abs(time_step_quantities_.current_temperature[gp] - previous_temperature) > 1.0e-16)
+  if (std::abs(time_step_quantities_.current_temperature[gp] - previous_temperature) >
+      ViscoplastUtils::thermo_mechanical_state_equality_tolerance)
   {
     time_step_quantities_.current_defgrad[gp].clear();
     thermo_mechanical_coupling_cache_.reset(gp);
@@ -2895,7 +2897,8 @@ void Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_od_stiff_mat(
 }
 
 Mat::MechanicalDissipation
-Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_mechanical_dissipation(const int gp,
+Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_mechanical_dissipation(
+    const Mat::EvaluationContext<3>& context, const int gp, const int eleGID,
     const Core::LinAlg::Matrix<3, 3>* defgrad, const Core::LinAlg::Matrix<3, 3>& iFin_other,
     const double& temperature)
 {
@@ -2903,19 +2906,22 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_mechanical_dissipati
 
   ViscoplastUtils::ErrorType err_status = ViscoplastUtils::ErrorType::no_errors;
 
-  gp_ = gp;
+  const double& tol = ViscoplastUtils::thermo_mechanical_state_equality_tolerance;
+
+  // First determine current state, then pre_evaluate, because pre_evaluate sets state.
+  const bool is_current_state =
+      defgrad_difference_norm(
+          reduced_kinematics.defgrad, time_step_quantities_.current_defgrad[gp]) < tol &&
+      std::abs(temperature - time_step_quantities_.current_temperature[gp]) < tol;
+
+  // set the new temperature and pre-evaluate
+  params_.set<double>("temperature", temperature);
+  pre_evaluate(params_, context, gp, eleGID);
 
   if (parameter()->linearization_type() == ViscoplastUtils::LinearizationType::perturbation_based)
   {
     return evaluate_mechanical_dissipation_perturb_based(reduced_kinematics.defgrad, temperature);
   }
-
-  const double& tol = ViscoplastUtils::thermo_mechanical_state_equality_tolerance;
-
-  const bool is_current_state =
-      defgrad_difference_norm(
-          reduced_kinematics.defgrad, time_step_quantities_.current_defgrad[gp]) < tol &&
-      std::abs(temperature - time_step_quantities_.current_temperature[gp]) < tol;
 
   // Note: In monolithic tsi, the thermo-predictor comes in with the last state,
   // so it would be possible to store the computed dissipation of the last step and
@@ -2924,11 +2930,6 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_mechanical_dissipati
 
   if (not is_current_state)
   {
-    // new state, i.e. we need to recompute history variables for the incoming state.
-
-    // set the new temperature
-    params_.set<double>("temperature", temperature);
-    viscoplastic_law_->pre_evaluate(params_, gp);
     // recompute the current history variables for the incoming state. This also sets the new state.
     return_mapping(reduced_kinematics.defgrad, temperature);
   }
@@ -2997,6 +2998,7 @@ void Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_inverse_inelast
   // If this is a "new" deformation gradient, evaluate the inverse inelastic deformation gradient
   // via return mapping.
 
+  // temperature was set by pre_evaluate
   const double temperature =
       params_.isParameter("temperature") ? params_.get<double>("temperature") : ref_temperature_;
   iFinM = return_mapping(reduced_kinematics.defgrad, temperature).inv_plastic_defgrad;

--- a/src/mat/4C_mat_inelastic_defgrad_factors.cpp
+++ b/src/mat/4C_mat_inelastic_defgrad_factors.cpp
@@ -2902,8 +2902,8 @@ void Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_od_stiff_mat(
   dstressdT.multiply_nn(1.0, dSdiFinj, diFinjTV, 1.0);
 }
 
-Mat::MechanicalDissipation
-Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_mechanical_dissipation(
+Mat::HeatSource
+Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_taylor_quinney_heat_source(
     const Mat::EvaluationContext<3>& context, const int gp, const int eleGID,
     const Core::LinAlg::Matrix<3, 3>* defgrad, const Core::LinAlg::Matrix<3, 3>& iFin_other,
     const double& temperature)
@@ -2926,7 +2926,8 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_mechanical_dissipati
 
   if (parameter()->linearization_type() == ViscoplastUtils::LinearizationType::perturbation_based)
   {
-    return evaluate_mechanical_dissipation_perturb_based(reduced_kinematics.defgrad, temperature);
+    return evaluate_taylor_quinney_heat_source_perturb_based(
+        reduced_kinematics.defgrad, temperature);
   }
 
   // Note: In monolithic tsi, the thermo-predictor comes in with the last state,
@@ -2969,18 +2970,18 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_mechanical_dissipati
       "evaluation! Error: {}",
       ViscoplastUtils::get_detailed_error_message_for_error_type(err_status));
 
-  MechanicalDissipation mechanical_dissipation;
-  mechanical_dissipation.value = parameter()->taylor_quinney_coefficient() *
-                                 thermo_mechanical_coupling_state.equiv_stress *
-                                 thermo_mechanical_coupling_state.plastic_strain_rate;
-  mechanical_dissipation.derivative_wrt_cauchy_green = compute_taylor_quinney_wrt_cauchygreen(
+  HeatSource heat_source;
+  heat_source.value = parameter()->taylor_quinney_coefficient() *
+                      thermo_mechanical_coupling_state.equiv_stress *
+                      thermo_mechanical_coupling_state.plastic_strain_rate;
+  heat_source.derivative_wrt_cauchy_green = compute_taylor_quinney_wrt_cauchygreen(
       parameter()->taylor_quinney_coefficient(), thermo_mechanical_coupling_state,
       thermo_mechanical_coupling_state_derivatives, history_variables_wrt_cauchy_green);
-  mechanical_dissipation.derivative_wrt_temperature = compute_taylor_quinney_wrt_temperature(
+  heat_source.derivative_wrt_temperature = compute_taylor_quinney_wrt_temperature(
       parameter()->taylor_quinney_coefficient(), thermo_mechanical_coupling_state,
       thermo_mechanical_coupling_state_derivatives, history_variables_wrt_temperature);
 
-  return mechanical_dissipation;
+  return heat_source;
 }
 
 void Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_inverse_inelastic_def_grad(
@@ -4285,14 +4286,14 @@ void Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_od_stiff_mat_pe
   update_hist_var_ = true;
 }
 
-Mat::MechanicalDissipation
-Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_mechanical_dissipation_perturb_based(
-    const Core::LinAlg::Matrix<3, 3>& FredM, const double temperature)
+Mat::HeatSource Mat::InelasticDefgradTransvIsotropElastViscoplast::
+    evaluate_taylor_quinney_heat_source_perturb_based(
+        const Core::LinAlg::Matrix<3, 3>& FredM, const double temperature)
 {
   Core::LinAlg::Matrix<3, 3> CredM{Core::LinAlg::Initialization::zero};
   CredM.multiply_tn(1.0, FredM, FredM, 0.0);
 
-  Mat::MechanicalDissipation result{};
+  Mat::HeatSource result{};
 
   const auto evaluate_taylor_quinney = [this](const ViscoplastUtils::StateQuantities& state)
   {

--- a/src/mat/4C_mat_inelastic_defgrad_factors.hpp
+++ b/src/mat/4C_mat_inelastic_defgrad_factors.hpp
@@ -1526,7 +1526,10 @@ namespace Mat
      * @brief Evaluate the mechanical dissipation heat source and its linearizations introduced by
      * this inelastic factor.
      *
+     * @param[in] context Evaluation context, providing access to the current timestep and total
+     * time
      * @param[in] gp Gauss point
+     * @param[in] eleGID global element ID
      * @param[in] defgrad Deformation gradient
      * @param[in] iFin_other Already computed inverse inelastic deformation gradient
      *              (from already computed inelastic factors in the multiplicative split material)
@@ -1534,9 +1537,10 @@ namespace Mat
      * @return mechanical dissipation heat source and derivatives w.r.t. temperature and the right
      *         Cauchy-Green tensor
      */
-    [[nodiscard]] MechanicalDissipation evaluate_mechanical_dissipation(const int gp,
+    [[nodiscard]] MechanicalDissipation evaluate_mechanical_dissipation(
+        const EvaluationContext<3>& context, const int gp, const int eleGID,
         const Core::LinAlg::Matrix<3, 3>* defgrad, const Core::LinAlg::Matrix<3, 3>& iFin_other,
-        const double& current_temperature);
+        const double& temperature);
 
     Mat::PAR::InelasticSource get_inelastic_source() override
     {

--- a/src/mat/4C_mat_inelastic_defgrad_factors.hpp
+++ b/src/mat/4C_mat_inelastic_defgrad_factors.hpp
@@ -1533,14 +1533,14 @@ namespace Mat
      * @param[in] defgrad Deformation gradient
      * @param[in] iFin_other Already computed inverse inelastic deformation gradient
      *              (from already computed inelastic factors in the multiplicative split material)
-     * @param[in] current_temperature Absolute current temperature
+     * @param[in] temperature Absolute current temperature
      * @return mechanical dissipation heat source and derivatives w.r.t. temperature and the right
      *         Cauchy-Green tensor
      */
     [[nodiscard]] HeatSource evaluate_taylor_quinney_heat_source(
         const EvaluationContext<3>& context, const int gp, const int eleGID,
         const Core::LinAlg::Matrix<3, 3>* defgrad, const Core::LinAlg::Matrix<3, 3>& iFin_other,
-        const double& temperature);
+        const double temperature);
 
     Mat::PAR::InelasticSource get_inelastic_source() override
     {

--- a/src/mat/4C_mat_inelastic_defgrad_factors.hpp
+++ b/src/mat/4C_mat_inelastic_defgrad_factors.hpp
@@ -339,6 +339,11 @@ namespace Mat
 
       //! get ID of the viscoplasticity law
       [[nodiscard]] int viscoplastic_law_id() const { return viscoplastic_law_id_; }
+      //! get Taylor-Quinney coefficient \f$ \xi_{TQ}\f$
+      [[nodiscard]] double taylor_quinney_coefficient() const
+      {
+        return taylor_quinney_coefficient_;
+      }
       //! get global ID of the fiber reader material
       [[nodiscard]] int fiber_reader_gid() const { return fiber_reader_gid_; }
       //! get yield condition parameter \f[ A \f]
@@ -414,6 +419,9 @@ namespace Mat
      private:
       //! ID of the viscoplasticity law
       const int viscoplastic_law_id_;
+
+      //! Taylor-Quinney coefficient \f$ \xi_{TQ}\f$
+      const double taylor_quinney_coefficient_;
 
       //! global ID of the material used for fiber reading (transversely isotropic)
       const int fiber_reader_gid_;
@@ -1478,14 +1486,18 @@ namespace Mat
      * @param[in] pot_sum_el elastic components / potential summands (only isotropic)
      * @param[in] pot_sum_el_transv_iso elastic components / potential summands (only transversely
      * isotropic)
+     * @param[in] thermal_expansion_coefficient Isotropic thermal expansion coefficient (provided by
+     * the parent material)
+     * @param[in] ref_temperature Reference temperature for thermal expansion (provided by the
+     * parent material)
      */
 
     explicit InelasticDefgradTransvIsotropElastViscoplast(Core::Mat::PAR::Parameter* params,
         std::shared_ptr<Mat::Viscoplastic::Law> viscoplastic_law,
         Mat::Elastic::CoupTransverselyIsotropic fiber_reader,
         std::vector<std::shared_ptr<Mat::Elastic::Summand>> pot_sum_el,
-        std::vector<std::shared_ptr<Mat::Elastic::CoupTransverselyIsotropic>>
-            pot_sum_el_transv_iso);
+        std::vector<std::shared_ptr<Mat::Elastic::CoupTransverselyIsotropic>> pot_sum_el_transv_iso,
+        const double thermal_expansion_coefficient, const double ref_temperature);
 
     [[nodiscard]] Core::Materials::MaterialType material_type() const override
     {
@@ -1500,6 +1512,7 @@ namespace Mat
     void evaluate_inelastic_def_grad_derivative(
         double detjacobian, Core::LinAlg::Tensor<double, 3, 3>& dFindx) override
     {
+      // Only needed for scalar transport problems, but not for tsi.
     }
 
     void evaluate_inverse_inelastic_def_grad(const Core::LinAlg::Matrix<3, 3>* defgrad,
@@ -1507,10 +1520,28 @@ namespace Mat
 
     void evaluate_od_stiff_mat(const Core::LinAlg::Matrix<3, 3>* defgrad,
         const Core::LinAlg::Matrix<3, 3>& iFin_other, const Core::LinAlg::Matrix<3, 3>& iFinjM,
-        const Core::LinAlg::Matrix<6, 9>& dSdiFinj,
-        Core::LinAlg::Matrix<6, 1>& dstressdT) override {};
+        const Core::LinAlg::Matrix<6, 9>& dSdiFinj, Core::LinAlg::Matrix<6, 1>& dstressdT) override;
 
-    Mat::PAR::InelasticSource get_inelastic_source() override { return PAR::InelasticSource::none; }
+    /*!
+     * @brief Evaluate the mechanical dissipation heat source and its linearizations introduced by
+     * this inelastic factor.
+     *
+     * @param[in] gp Gauss point
+     * @param[in] defgrad Deformation gradient
+     * @param[in] iFin_other Already computed inverse inelastic deformation gradient
+     *              (from already computed inelastic factors in the multiplicative split material)
+     * @param[in] current_temperature Absolute current temperature
+     * @return mechanical dissipation heat source and derivatives w.r.t. temperature and the right
+     *         Cauchy-Green tensor
+     */
+    [[nodiscard]] MechanicalDissipation evaluate_mechanical_dissipation(const int gp,
+        const Core::LinAlg::Matrix<3, 3>* defgrad, const Core::LinAlg::Matrix<3, 3>& iFin_other,
+        const double& current_temperature);
+
+    Mat::PAR::InelasticSource get_inelastic_source() override
+    {
+      return PAR::InelasticSource::temperature;
+    }
 
     [[nodiscard]] Mat::PAR::InelasticDefgradTransvIsotropElastViscoplast* parameter() const override
     {
@@ -1554,6 +1585,7 @@ namespace Mat
      * plastic strain
      *
      * @param[in] CM right Cauchy-Green deformation tensor \f[ \boldsymbol{C} \f] in matrix form
+     * @param[in] temperature absolute temperature
      * @param[in] iFinM inverse inelastic deformation gradient
      *                  \f[ \boldsymbol{F}_{\text{in}}^{-1} \f] in matrix form
      * @param[in] plastic_strain plastic strain  \f$ \varepsilon_{\text{p}} \f$
@@ -1564,8 +1596,8 @@ namespace Mat
      * been evaluated
      */
     InelasticDefgradTransvIsotropElastViscoplastUtils::StateQuantities evaluate_state_quantities(
-        const Core::LinAlg::Matrix<3, 3>& CM, const Core::LinAlg::Matrix<3, 3>& iFinM,
-        const double plastic_strain,
+        const Core::LinAlg::Matrix<3, 3>& CM, const double temperature,
+        const Core::LinAlg::Matrix<3, 3>& iFinM, const double plastic_strain,
         InelasticDefgradTransvIsotropElastViscoplastUtils::ErrorType& err_status, const double dt,
         const InelasticDefgradTransvIsotropElastViscoplastUtils::StateQuantityEvalType& eval_type)
         const;
@@ -1575,6 +1607,7 @@ namespace Mat
      * plastic strain (for a given/calculated state)
      *
      * @param[in] CM right Cauchy-Green deformation tensor \f$ \boldsymbol{C} \f$ in matrix form
+     * @param[in] temperature absolute temperature
      * @param[in] iFinM inverse inelastic deformation gradient \f$ \boldsymbol{F}_{\text{in}}^{-1}
      *                  \f$ in matrix form
      * @param[in] plastic_strain plastic strain  \f$ \varepsilon_{\text{p}} \f$
@@ -1590,7 +1623,8 @@ namespace Mat
      */
     InelasticDefgradTransvIsotropElastViscoplastUtils::StateQuantityDerivatives
     evaluate_state_quantity_derivatives(const Core::LinAlg::Matrix<3, 3>& CM,
-        const Core::LinAlg::Matrix<3, 3>& iFinM, const double plastic_strain,
+        const double temperature, const Core::LinAlg::Matrix<3, 3>& iFinM,
+        const double plastic_strain,
         InelasticDefgradTransvIsotropElastViscoplastUtils::ErrorType& err_status, const double dt,
         const InelasticDefgradTransvIsotropElastViscoplastUtils::StateQuantityDerivEvalType&
             eval_type,
@@ -1613,6 +1647,13 @@ namespace Mat
 
     //! parameter list
     Teuchos::ParameterList params_;
+
+    /// thermal expansion coefficient
+    const double thermal_expansion_coefficient_;
+
+    /// reference temperature for thermal expansion
+    const double ref_temperature_;
+
 
     //! map to elastic materials/potential summands (only isotropic)
     std::vector<std::shared_ptr<Mat::Elastic::Summand>> potsumel_;
@@ -1641,6 +1682,10 @@ namespace Mat
     //! tracker for quantities at the last and current time points (i.e., at \f[ t_n \f] and
     //! \f[ t_{n+1} \f], respectively) for all Gauss points simultaneously
     InelasticDefgradTransvIsotropElastViscoplastUtils::TimeStepQuantities time_step_quantities_;
+
+    //! Cache to store thermo-mechanical coupling quantities across public evaluation calls
+    InelasticDefgradTransvIsotropElastViscoplastUtils::ThermoMechanicalCouplingCache
+        thermo_mechanical_coupling_cache_;
 
     //! evaluated state quantities
     InelasticDefgradTransvIsotropElastViscoplastUtils::StateQuantities state_quantities_;
@@ -1678,6 +1723,7 @@ namespace Mat
      * contribution.
      *
      * @param[in] CM right Cauchy_Green deformation tensor \f$ \boldsymbol{C} \f$ in matrix form
+     * @param[in] temperature absolute temperature
      * @param[in] iFinM_pred predictor of the inverse inelastic deformation gradient \f$
      * \bm{F}_{\text{in, pred}} \f$
      * @param[in] plastic_strain_pred predictor of the plastic strain \f$ \varepsilon_{\text{p,
@@ -1685,7 +1731,7 @@ namespace Mat
      * @param[out] err_status error status
      * @return boolean value: true (predictor = solution), or false (predictor != solution)
      */
-    bool check_elastic_predictor(const Core::LinAlg::Matrix<3, 3>& CM,
+    bool check_elastic_predictor(const Core::LinAlg::Matrix<3, 3>& CM, const double temperature,
         const Core::LinAlg::Matrix<3, 3>& iFinM_pred, const double plastic_strain_pred,
         InelasticDefgradTransvIsotropElastViscoplastUtils::ErrorType& err_status);
 
@@ -1696,6 +1742,7 @@ namespace Mat
      * are used for the computation of the residual!
      *
      * @param[in] CM right Cauchy_Green deformation tensor \f$ \boldsymbol{C} \f$ in matrix form
+     * @param[in] temperature absolute temperature
      * @param[in] x vector of Local Newton Loop unknowns, composed of the components of the
      * inverse inelastic deformation gradient \f$ \boldsymbol{F}_{\text{in}}^{-1} \f$ and plastic
      * strain \f$ \varepsilon_{\text{p}} \f$
@@ -1709,9 +1756,9 @@ namespace Mat
      * @return  residual of the LNL equations
      */
     Core::LinAlg::Matrix<10, 1> evaluate_local_newton_residual(const Core::LinAlg::Matrix<3, 3>& CM,
-        const Core::LinAlg::Matrix<10, 1>& x, const double last_plastic_strain,
-        const Core::LinAlg::Matrix<3, 3>& last_iFinM, const double dt,
-        InelasticDefgradTransvIsotropElastViscoplastUtils::ErrorType& err_status);
+        const double temperature, const Core::LinAlg::Matrix<10, 1>& x,
+        const double last_plastic_strain, const Core::LinAlg::Matrix<3, 3>& last_iFinM,
+        const double dt, InelasticDefgradTransvIsotropElastViscoplastUtils::ErrorType& err_status);
 
 
     /*!
@@ -1777,6 +1824,7 @@ namespace Mat
      * previously when calculating the residual.
      *
      * @param[in] CM right Cauchy_Green deformation tensor \f$ \boldsymbol{C} \f$ in matrix form
+     * @param[in] temperature absolute temperature
      * @param[in] x vector of Local Newton Loop unknowns, composed of the components of the
      * inverse inelastic deformation gradient \f$ \boldsymbol{F}_{\text{in}}^{-1} \f$ and plastic
      * strain \f$ \varepsilon_{\text{p}} \f$
@@ -1791,9 +1839,10 @@ namespace Mat
      *         \f$ \boldsymbol{J} \f$
      */
     Core::LinAlg::Matrix<10, 10> evaluate_local_newton_jacobian(
-        const Core::LinAlg::Matrix<3, 3>& CM, const Core::LinAlg::Matrix<10, 1>& x,
-        const double last_plastic_strain, const Core::LinAlg::Matrix<3, 3>& last_iFinM,
-        const double dt, InelasticDefgradTransvIsotropElastViscoplastUtils::ErrorType& err_status);
+        const Core::LinAlg::Matrix<3, 3>& CM, const double temperature,
+        const Core::LinAlg::Matrix<10, 1>& x, const double last_plastic_strain,
+        const Core::LinAlg::Matrix<3, 3>& last_iFinM, const double dt,
+        InelasticDefgradTransvIsotropElastViscoplastUtils::ErrorType& err_status);
 
     /*!
      * @brief Performs the viscoplastic corrector step of the return mapping.
@@ -1802,6 +1851,7 @@ namespace Mat
      * problematic numerical states, marked with an error status, are encountered
      *
      * @param[in] defgrad deformation gradient \f$ \boldsymbol{F} \f$ in matrix form
+     * @param[in] temperature absolute temperature
      * @param[in] x initial guess of Local Newton Loop, composed of the components of the
      *              inverse inelastic deformation gradient \f$ \boldsymbol{F}_{\text{in}}^{-1} \f$
      *              and plastic strain \f$ \varepsilon_{\text{p}} \f$
@@ -1810,7 +1860,7 @@ namespace Mat
      * x
      */
     Core::LinAlg::Matrix<10, 1> viscoplastic_correction(const Core::LinAlg::Matrix<3, 3>& defgrad,
-        const Core::LinAlg::Matrix<10, 1>& x,
+        const double temperature, const Core::LinAlg::Matrix<10, 1>& x,
         InelasticDefgradTransvIsotropElastViscoplastUtils::ErrorType& err_status);
 
     /*!
@@ -1821,15 +1871,16 @@ namespace Mat
      * solution of a single substep in the substep loop.
      *
      * @param[in] CM right Cauchy-Green deformation tensor at current time instant
+     * @param[in] temperature absolute temperature
      * @param[in] last_plastic_strain plastic strain at the previous time instant
      * @param[in] last_iFinM inverse inelastic deformation gradient at the previous time instant
      * @param[in] dt time step size to use for evaluation
      * @param[in,out] sol current (in) / updated (out) solution of the Local Newton Loop
      * @param[in,out] err_status error status
      */
-    void local_newton_loop(const Core::LinAlg::Matrix<3, 3>& CM, const double last_plastic_strain,
-        const Core::LinAlg::Matrix<3, 3>& last_iFinM, const double dt,
-        Core::LinAlg::Matrix<10, 1>& sol,
+    void local_newton_loop(const Core::LinAlg::Matrix<3, 3>& CM, const double temperature,
+        const double last_plastic_strain, const Core::LinAlg::Matrix<3, 3>& last_iFinM,
+        const double dt, Core::LinAlg::Matrix<10, 1>& sol,
         InelasticDefgradTransvIsotropElastViscoplastUtils::ErrorType& err_status);
 
 
@@ -1846,17 +1897,107 @@ namespace Mat
 
     /*!
      * @brief Performs return mapping (elastic predictor - viscoplastic / plastic corrector
-     * procedure) at each GP. It first evaluates whether the elastic predictor is a consistent
+     * procedure) for the current GP and updates the current values of the time_step_quantities_.
+     * It first evaluates whether the elastic predictor is a consistent
      * solution, and performs the local time integration (Local Newton Loop) afterwards if that is
      * not the case.
      *
      * @param[in] FredM reduced deformation gradient \f$ \boldsymbol{F}_{\text{red}} =
      * \boldsymbol{F} \boldsymbol{F_{\text{in,other}}^{-1}} \f$ accounting for all the already
-     * computed inelastic defgrad factors
-     * @return inverse inelastic deformation gradient \boldsymbol{F}_{\text{in}}^{-1} and plastic
-     * strain
+     * computed inelastic defgrad factors. Stored in time_step_quantities_.
+     * @param[in] temperature current absolute temperature. Stored in time_step_quantities_.
+     * @return the history variables
+     *
+     * @note After a return_mapping, the state_quantitities_ are valid for the current GP and
+     * state defined by FredM and temperature.
      */
-    HistoryVariables return_mapping(const Core::LinAlg::Matrix<3, 3>& FredM);
+    HistoryVariables return_mapping(
+        const Core::LinAlg::Matrix<3, 3>& FredM, const double temperature);
+
+    /**
+     * @brief Evaluates the analytical derivatives of the history variables with respect to
+     * temperature.
+     *
+     * The history variable derivatives are cached per Gauss point and reused if already available.
+     * The thermo-mechanical coupling state cache is updated as a side effect from the full state
+     * quantities evaluated by this method.
+     *
+     * The analytical linearization is only evaluated for active plastic flow,
+     * i.e. if the equivalent plastic strain rate is non-zero. In this case,
+     * a local linear system is assembled and solved
+     * to determine the total temperature derivatives of the history variables.
+     *
+     * Currently, analytical off-diagonal stiffness integration is implemented
+     * only for logarithmic local time integration.
+     *
+     * @param CredM Right Cauchy-Green deformation tensor.
+     * @param temperature Current temperature.
+     * @param err_status Error flag describing the evaluation status.
+     * @return derivatives of the history variables with respect to temperature
+     */
+    InelasticDefgradTransvIsotropElastViscoplastUtils::HistoryVariablesDerivativesWrtTemperature
+    evaluate_history_variables_wrt_temperature(const Core::LinAlg::Matrix<3, 3>& CredM,
+        const double temperature,
+        InelasticDefgradTransvIsotropElastViscoplastUtils::ErrorType& err_status);
+
+    /**
+     * @brief Evaluates the analytical linearization of the history variables with
+     * respect to the right Cauchy-Green deformation tensor.
+     * The history variable derivatives are cached per Gauss point and reused if already available.
+     * The thermo-mechanical coupling state cache is updated as a side effect from the full state
+     * quantities evaluated by this method.
+     *
+     * The analytical linearization is only evaluated for active plastic flow,
+     * i.e. if the equivalent plastic strain rate is non-zero. In this case,
+     * a local linear system is assembled and solved
+     * to determine the total Cauchy-Green derivatives of the history variables.
+     *
+     * @param CredM Right Cauchy-Green deformation tensor.
+     * @param temperature Current temperature.
+     * @param err_status Error flag describing the evaluation status.
+     *
+     * @return derivatives of the history variables with respect to the right Cauchy-Green
+     * deformation tensor
+     */
+    InelasticDefgradTransvIsotropElastViscoplastUtils::HistoryVariablesDerivativesWrtCauchyGreen
+    evaluate_history_variables_wrt_cauchy_green(const Core::LinAlg::Matrix<3, 3>& CredM,
+        const double temperature,
+        InelasticDefgradTransvIsotropElastViscoplastUtils::ErrorType& err_status);
+
+    /*!
+     * @brief Evaluates the reduced state quantities needed by thermo-mechanical coupling.
+     *
+     * If the reduced state was cached by a previous public evaluation call, it is returned
+     * directly. Otherwise, this method evaluates the full state quantities for the current state
+     * and fills the reduced coupling-state cache.
+     *
+     * @param[in] CredM Right Cauchy-Green deformation tensor
+     * @param[in] temperature Current temperature
+     * @param[out] err_status Error flag describing the evaluation status
+     * @return thermo-mechanical coupling state
+     */
+    InelasticDefgradTransvIsotropElastViscoplastUtils::ThermoMechanicalCouplingState
+    evaluate_thermo_mechanical_coupling_state(const Core::LinAlg::Matrix<3, 3>& CredM,
+        const double temperature,
+        InelasticDefgradTransvIsotropElastViscoplastUtils::ErrorType& err_status);
+
+    /*!
+     * @brief Evaluates the reduced state quantity derivatives needed by thermo-mechanical coupling.
+     *
+     * If the reduced state derivatives were cached by a previous public evaluation call, they are
+     * returned directly. Otherwise, this method evaluates the full state quantities and derivatives
+     * for the current state and fills the reduced coupling-state cache.
+     *
+     * @param[in] CredM Right Cauchy-Green deformation tensor
+     * @param[in] temperature Current temperature
+     * @param[out] err_status Error flag describing the evaluation status
+     * @return thermo-mechanical coupling state derivatives
+     */
+    InelasticDefgradTransvIsotropElastViscoplastUtils::ThermoMechanicalCouplingStateDerivatives
+    evaluate_thermo_mechanical_coupling_state_derivatives(const Core::LinAlg::Matrix<3, 3>& CredM,
+        const double temperature,
+        InelasticDefgradTransvIsotropElastViscoplastUtils::ErrorType& err_status);
+
 
     /*!
      * @brief Setup halved substep in case of an encountered evaluation error within the substep
@@ -1901,13 +2042,40 @@ namespace Mat
      * @param[in] FredM reduced deformation gradient \f$ \boldsymbol{F}_{\text{red}} =
      * \boldsymbol{F} \boldsymbol{F_{\text{in,other}}^{-1}} \f$ accounting for all the already
      * computed inelastic defgrad factors
+     * @param[in] temperature absolute temperature
      * @param[out] cmatadd Additional elasticity stiffness
      * @param[in] dSdiFinj Derivative of 2nd Piola Kirchhoff stresses w.r.t. the inverse inelastic
      *                     deformation gradient of current inelastic contribution
      *
      */
     void evaluate_additional_cmat_perturb_based(const Core::LinAlg::Matrix<3, 3>& FredM,
-        Core::LinAlg::Matrix<6, 6>& cmatadd, const Core::LinAlg::Matrix<6, 9>& dSdiFinj);
+        const double temperature, Core::LinAlg::Matrix<6, 6>& cmatadd,
+        const Core::LinAlg::Matrix<6, 9>& dSdiFinj);
+
+    /*!
+     * @brief Evaluate the off-diagonal stiffness contribution using a temperature perturbation.
+     *
+     * @param[in] FredM reduced deformation gradient
+     * @param[in] temperature absolute temperature
+     * @param[in,out] dstressdT contains already the partial derivative of the second
+     * Piola-Kirchhoff stresses w.r.t. temperature. This method adds the contribution of the history
+     * variable derivatives to this matrix.
+     * @param[in] dSdiFinj derivative of 2nd Piola Kirchhoff stresses w.r.t. the inverse inelastic
+     *                     deformation gradient of current inelastic contribution
+     */
+    void evaluate_od_stiff_mat_perturb_based(const Core::LinAlg::Matrix<3, 3>& FredM,
+        const double temperature, Core::LinAlg::Matrix<6, 1>& dstressdT,
+        const Core::LinAlg::Matrix<6, 9>& dSdiFinj);
+
+    /*!
+     * @brief Evaluate derivatives of \f$ R_{TQ} \f$ by perturbing the reduced deformation
+     * gradient and the temperature.
+     *
+     * @param[in] FredM reduced deformation gradient
+     * @param[in] temperature absolute temperature
+     */
+    MechanicalDissipation evaluate_mechanical_dissipation_perturb_based(
+        const Core::LinAlg::Matrix<3, 3>& FredM, const double temperature);
 
     /*!
      * @brief Get an extensive error message to be displayed when the

--- a/src/mat/4C_mat_inelastic_defgrad_factors.hpp
+++ b/src/mat/4C_mat_inelastic_defgrad_factors.hpp
@@ -1523,7 +1523,7 @@ namespace Mat
         const Core::LinAlg::Matrix<6, 9>& dSdiFinj, Core::LinAlg::Matrix<6, 1>& dstressdT) override;
 
     /*!
-     * @brief Evaluate the mechanical dissipation heat source and its linearizations introduced by
+     * @brief Evaluate the Tayor-Quinney heat source and its linearizations introduced by
      * this inelastic factor.
      *
      * @param[in] context Evaluation context, providing access to the current timestep and total
@@ -1537,7 +1537,7 @@ namespace Mat
      * @return mechanical dissipation heat source and derivatives w.r.t. temperature and the right
      *         Cauchy-Green tensor
      */
-    [[nodiscard]] MechanicalDissipation evaluate_mechanical_dissipation(
+    [[nodiscard]] HeatSource evaluate_taylor_quinney_heat_source(
         const EvaluationContext<3>& context, const int gp, const int eleGID,
         const Core::LinAlg::Matrix<3, 3>* defgrad, const Core::LinAlg::Matrix<3, 3>& iFin_other,
         const double& temperature);
@@ -2072,13 +2072,13 @@ namespace Mat
         const Core::LinAlg::Matrix<6, 9>& dSdiFinj);
 
     /*!
-     * @brief Evaluate derivatives of \f$ R_{TQ} \f$ by perturbing the reduced deformation
-     * gradient and the temperature.
+     * @brief Evaluate derivatives of the Taylor-Quinney heat source by perturbing the reduced
+     * deformation gradient and the temperature.
      *
      * @param[in] FredM reduced deformation gradient
      * @param[in] temperature absolute temperature
      */
-    MechanicalDissipation evaluate_mechanical_dissipation_perturb_based(
+    HeatSource evaluate_taylor_quinney_heat_source_perturb_based(
         const Core::LinAlg::Matrix<3, 3>& FredM, const double temperature);
 
     /*!

--- a/src/mat/4C_mat_inelastic_defgrad_factors_service.cpp
+++ b/src/mat/4C_mat_inelastic_defgrad_factors_service.cpp
@@ -5,10 +5,19 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#include "4C_config.hpp"
+
 #include "4C_mat_inelastic_defgrad_factors_service.hpp"
 
 #include "4C_linalg_fixedsizematrix.hpp"
+#include "4C_linalg_fixedsizematrix_tensor_products.hpp"
+#include "4C_linalg_fixedsizematrix_voigt_notation.hpp"
+#include "4C_linalg_four_tensor_generators.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
+
+#include <string>
+#include <tuple>
 
 
 FOUR_C_NAMESPACE_OPEN
@@ -16,8 +25,19 @@ FOUR_C_NAMESPACE_OPEN
 using namespace Mat::InelasticDefgradTransvIsotropElastViscoplastUtils;
 
 
-/*--------------------------------------------------------------------*
- *--------------------------------------------------------------------*/
+void Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::ThermoMechanicalCouplingCache::resize(
+    const unsigned int numgp)
+{
+  std::apply([numgp](auto&... quantity) { (quantity.resize(numgp), ...); }, quantities());
+}
+
+void Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::ThermoMechanicalCouplingCache::reset(
+    const int gp)
+{
+  std::apply([gp](auto&... quantity) { (quantity.reset(gp), ...); }, quantities());
+}
+
+
 std::string
 Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::get_detailed_error_message_for_error_type(
     ErrorType err_type)
@@ -169,7 +189,8 @@ void Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::LocalSubsteppingUti
 
 /*--------------------------------------------------------------------*
  *--------------------------------------------------------------------*/
-void Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::TimeStepQuantities::init()
+void Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::TimeStepQuantities::init(
+    const double& ref_temperature)
 {
   // auxiliaries
   Core::LinAlg::Matrix<3, 3> id3x3{Core::LinAlg::Initialization::zero};
@@ -191,6 +212,10 @@ void Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::TimeStepQuantities:
   last_plastic_strain.resize(1, 0.0);
   current_plastic_strain.resize(1, 0.0);  // value irrelevant at this point
   last_substep_plastic_strain.resize(1, 0.0);
+
+  // update last_ and current_ values of the temperature
+  last_temperature.resize(1, ref_temperature);
+  current_temperature.resize(1, ref_temperature);  // value irrelevant at this point
 
   // update last_ and current_ values of the equivalent stress
   last_equiv_stress.resize(1, 0.0);
@@ -241,6 +266,10 @@ void Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::TimeStepQuantities:
   last_defgrad.resize(numgp, last_defgrad[0]);
   current_defgrad.resize(numgp, current_defgrad[0]);
 
+  // default values of the temperature for ALL Gauss Points
+  last_temperature.resize(numgp, last_temperature[0]);        // value irrelevant at this point
+  current_temperature.resize(numgp, current_temperature[0]);  // value irrelevant at this point
+
   resize_called = true;
 }
 
@@ -266,6 +295,7 @@ void Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::TimeStepQuantities:
   last_plastic_strain = current_plastic_strain;
   last_equiv_stress = current_equiv_stress;
   last_substep_plastic_strain = current_plastic_strain;
+  last_temperature = current_temperature;
 }
 
 
@@ -281,6 +311,7 @@ void Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::TimeStepQuantities:
   add_to_pack(data, last_equiv_stress);
   add_to_pack(data, last_substep_plastic_defgrad_inverse);
   add_to_pack(data, last_substep_plastic_strain);
+  add_to_pack(data, last_temperature);
 }
 
 /*--------------------------------------------------------------------*
@@ -296,6 +327,7 @@ void Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::TimeStepQuantities:
   extract_from_pack(buffer, last_equiv_stress);
   extract_from_pack(buffer, last_substep_plastic_defgrad_inverse);
   extract_from_pack(buffer, last_substep_plastic_strain);
+  extract_from_pack(buffer, last_temperature);
 
   // fill current_ values with the last_ values
   current_rightCG.resize(last_rightCG.size(),
@@ -306,12 +338,62 @@ void Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::TimeStepQuantities:
       last_plastic_strain[0]);  // value irrelevant
   current_equiv_stress.resize(last_equiv_stress.size(),
       last_equiv_stress[0]);  // value irrelevant
+  current_temperature.resize(last_temperature.size(),
+      0.0);  // value irrelevant
 
   // set evaluated deformation gradient to 0, to make sure that the inverse inelastic deformation
   // gradient is evaluated fully after the restart
   current_defgrad.resize(last_substep_plastic_defgrad_inverse.size(),
       Core::LinAlg::Matrix<3, 3>{Core::LinAlg::Initialization::zero});
 }
+
+Core::LinAlg::Matrix<1, 6>
+Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::compute_taylor_quinney_wrt_cauchygreen(
+    const double taylor_quinney_coefficient, const ThermoMechanicalCouplingState& state,
+    const ThermoMechanicalCouplingStateDerivatives& state_derivatives,
+    const HistoryVariablesDerivativesWrtCauchyGreen& history_variables_derivatives)
+{
+  Core::LinAlg::Matrix<1, 6> total_dequiv_stress_dC =
+      state_derivatives.equiv_stress_wrt_cauchy_green;
+  total_dequiv_stress_dC.multiply(1.0, state_derivatives.equiv_stress_wrt_inverse_plastic_defgrad,
+      history_variables_derivatives.inv_plastic_defgrad_wrt_cauchy_green, 1.0);
+
+  Core::LinAlg::Matrix<1, 6> total_dpsr_dC = total_dequiv_stress_dC;
+  total_dpsr_dC.update(state_derivatives.plastic_strain_rate_derivs.deriv_plastic_strain,
+      history_variables_derivatives.plastic_strain_wrt_cauchy_green,
+      state_derivatives.plastic_strain_rate_derivs.deriv_equiv_stress);
+
+  Core::LinAlg::Matrix<1, 6> dR_TQ_dCV{Core::LinAlg::Initialization::zero};
+  dR_TQ_dCV.update(
+      taylor_quinney_coefficient * state.plastic_strain_rate, total_dequiv_stress_dC, 0.0);
+  dR_TQ_dCV.update(taylor_quinney_coefficient * state.equiv_stress, total_dpsr_dC, 1.0);
+
+  return dR_TQ_dCV;
+}
+
+double
+Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::compute_taylor_quinney_wrt_temperature(
+    const double taylor_quinney_coefficient, const ThermoMechanicalCouplingState& state,
+    const ThermoMechanicalCouplingStateDerivatives& state_derivatives,
+    const HistoryVariablesDerivativesWrtTemperature& history_variables_derivatives)
+{
+  double total_dequiv_stress_dT = state_derivatives.equiv_stress_wrt_temperature;
+  for (int i = 0; i < 9; ++i)
+  {
+    total_dequiv_stress_dT += state_derivatives.equiv_stress_wrt_inverse_plastic_defgrad(i) *
+                              history_variables_derivatives.inv_plastic_defgrad_wrt_temperature(i);
+  }
+
+  const double total_dpsr_dT =
+      state_derivatives.plastic_strain_rate_derivs.deriv_temperature +
+      state_derivatives.plastic_strain_rate_derivs.deriv_plastic_strain *
+          history_variables_derivatives.plastic_strain_wrt_temperature +
+      state_derivatives.plastic_strain_rate_derivs.deriv_equiv_stress * total_dequiv_stress_dT;
+
+  return taylor_quinney_coefficient *
+         (total_dequiv_stress_dT * state.plastic_strain_rate + state.equiv_stress * total_dpsr_dT);
+}
+
 
 /*--------------------------------------------------------------------*
  *--------------------------------------------------------------------*/

--- a/src/mat/4C_mat_inelastic_defgrad_factors_service.cpp
+++ b/src/mat/4C_mat_inelastic_defgrad_factors_service.cpp
@@ -190,7 +190,7 @@ void Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::LocalSubsteppingUti
 /*--------------------------------------------------------------------*
  *--------------------------------------------------------------------*/
 void Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::TimeStepQuantities::init(
-    const double& ref_temperature)
+    const double ref_temperature)
 {
   // auxiliaries
   Core::LinAlg::Matrix<3, 3> id3x3{Core::LinAlg::Initialization::zero};
@@ -358,10 +358,11 @@ Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::compute_taylor_quinney_w
   total_dequiv_stress_dC.multiply(1.0, state_derivatives.equiv_stress_wrt_inverse_plastic_defgrad,
       history_variables_derivatives.inv_plastic_defgrad_wrt_cauchy_green, 1.0);
 
-  Core::LinAlg::Matrix<1, 6> total_dpsr_dC = total_dequiv_stress_dC;
+  Core::LinAlg::Matrix<1, 6> total_dpsr_dC{Core::LinAlg::Initialization::zero};
   total_dpsr_dC.update(state_derivatives.plastic_strain_rate_derivs.deriv_plastic_strain,
-      history_variables_derivatives.plastic_strain_wrt_cauchy_green,
-      state_derivatives.plastic_strain_rate_derivs.deriv_equiv_stress);
+      history_variables_derivatives.plastic_strain_wrt_cauchy_green, 0.0);
+  total_dpsr_dC.update(
+      state_derivatives.plastic_strain_rate_derivs.deriv_equiv_stress, total_dequiv_stress_dC, 1.0);
 
   Core::LinAlg::Matrix<1, 6> dR_TQ_dCV{Core::LinAlg::Initialization::zero};
   dR_TQ_dCV.update(

--- a/src/mat/4C_mat_inelastic_defgrad_factors_service.hpp
+++ b/src/mat/4C_mat_inelastic_defgrad_factors_service.hpp
@@ -11,19 +11,13 @@
 #include "4C_config.hpp"
 
 #include "4C_comm_utils.hpp"
-#include "4C_fem_discretization.hpp"
-#include "4C_global_data.hpp"
-#include "4C_io_runtime_csv_writer.hpp"
 #include "4C_linalg_fixedsizematrix.hpp"
-#include "4C_linalg_fixedsizematrix_tensor_products.hpp"
-#include "4C_linalg_fixedsizematrix_voigt_notation.hpp"
-#include "4C_linalg_four_tensor_generators.hpp"
-#include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 
 #include <format>
-#include <map>
 #include <string>
+#include <tuple>
+#include <vector>
 
 
 FOUR_C_NAMESPACE_OPEN
@@ -34,9 +28,99 @@ namespace Mat
   /// InelasticDefgradTransvIsotropElastViscoplast
   namespace InelasticDefgradTransvIsotropElastViscoplastUtils
   {
+    /**
+     * @brief Caches values evaluated at Gauss points.
+     *
+     * This utility stores values of type `T` together with a flag indicating
+     * whether the value for a given Gauss point has already been evaluated.
+     * It is intended to avoid repeated computations across material evaluations.
+     *
+     * @tparam T Type of the cached quantity.
+     */
+    template <typename T>
+    class CachedQuantity
+    {
+     public:
+      /**
+       * @brief Returns the cached value for a given Gauss point.
+       *
+       * @param gp Gauss point index.
+       * @return const reference to the cached value for the specified Gauss point.
+       * @throws If the gauss point index is out of bounds or if the values is not evaluated yet.
+       */
+      [[nodiscard]] const T& value(std::size_t gp) const
+      {
+        FOUR_C_ASSERT_ALWAYS(gp < value_.size(), "Invalid gp {}!", gp);
+        FOUR_C_ASSERT_ALWAYS(is_evaluated_[gp], "Value is not evaluated for gp {}!", gp);
+        return value_[gp];
+      }
+
+      /**
+       * @brief Checks if the value for a given Gauss point has been evaluated.
+       *
+       * @param gp Gauss point index.
+       * @return true if the value is evaluated, false otherwise.
+       * @throws If the gauss point index is out of bounds.
+       */
+      [[nodiscard]] bool is_evaluated(std::size_t gp) const
+      {
+        FOUR_C_ASSERT_ALWAYS(gp < is_evaluated_.size(), "Invalid gp {}!", gp);
+        return is_evaluated_[gp];
+      }
+
+      /**
+       * @brief Resizes the cached quantity to the given number of Gauss points.
+       *
+       * This method initializes the cache for the specified number of Gauss points and resets all
+       * evaluation flags to false.
+       *
+       * @param numgp Number of Gauss points to resize the cache for.
+       */
+      void resize(std::size_t numgp)
+      {
+        value_.resize(numgp);
+        is_evaluated_.assign(numgp, false);
+      }
+
+      /**
+       * @brief Sets the value for a given Gauss point and marks it as evaluated.
+       *
+       * @param gp Gauss point index.
+       * @param value The value to be cached for the specified Gauss point.
+       * @throws If the gauss point index is out of bounds.
+       */
+      void set(std::size_t gp, T value)
+      {
+        FOUR_C_ASSERT_ALWAYS(gp < value_.size(), "Invalid gp {}!", gp);
+        value_[gp] = std::move(value);
+        is_evaluated_[gp] = true;
+      }
+
+      /**
+       * @brief Marks the value for a given Gauss point as not evaluated.
+       *
+       * @param gp Gauss point index.
+       * @throws If the gauss point index is out of bounds.
+       */
+      void reset(std::size_t gp)
+      {
+        FOUR_C_ASSERT_ALWAYS(gp < is_evaluated_.size(), "Invalid gp {}!", gp);
+        is_evaluated_[gp] = false;
+      }
+
+     private:
+      std::vector<T> value_;            ///< vector storing the cached values for each Gauss point
+      std::vector<bool> is_evaluated_;  ///< vector of flags indicating whether the value for each
+                                        ///< Gauss point has been evaluated
+    };
+
     /// declare numerical tolerance to be used in the verification of (numerically) zero plastic
     /// strain increments
     constexpr double zero_plastic_strain_increment{1.0e-14};
+
+    /// tolerance to determine if the incoming defgrad-temperature pair matches the last evaluated
+    /// one
+    constexpr double thermo_mechanical_state_equality_tolerance = 1.0e-12;
 
     /// enum class for error types in InelasticDefgradTransvIsotropElastViscoplast, used for
     /// triggering different procedures (e.g. Reinterpolation,
@@ -153,6 +237,9 @@ namespace Mat
       //! last (reduced) deformation gradient (for all Gauss points)
       std::vector<Core::LinAlg::Matrix<3, 3>> last_defgrad;
 
+      //! absolute temperature at the last time instant (for all Gauss points)
+      std::vector<double> last_temperature;
+
       //! temporary variable, for which we store the right Cauchy-Green deformation tensor at each
       //! evaluation (used in order to update last_rightCG_ once outer NR converges) (for all Gauss
       //! points)
@@ -172,18 +259,24 @@ namespace Mat
       std::vector<double> current_equiv_stress;
 
 
+      //! absolute temperature at the current time instant (for all Gauss points)
+      std::vector<double> current_temperature;
+
+
       //! inverse plastic deformation gradient at the last computed time instant (after the last
       //! converged substep)
       std::vector<Core::LinAlg::Matrix<3, 3>> last_substep_plastic_defgrad_inverse;
       //! plastic strain at the last computed time instant (after the last converged substep)
       std::vector<double> last_substep_plastic_strain;
 
-      /*!
+      /**
        * @brief Set meaningful initial values. Done first for one single Gauss point (extended later
        * on using the resizing function).
        *
+       * @param ref_temperature Reference temperature used to set initial values of last/current
+       * temperature.
        */
-      void init();
+      void init(const double& ref_temperature);
 
       /*!
        * @brief Resizing based on a given number of Gauss points
@@ -442,6 +535,8 @@ namespace Mat
       //! derivatives of the equivalent tensile stress w.r.t. the right Cauchy-Green deformation
       //! tensor (Voigt stress form)
       Core::LinAlg::Matrix<1, 6> curr_dequiv_stress_dC{Core::LinAlg::Initialization::zero};
+      //! derivatives of the equivalent tensile stress w.r.t. the temperature
+      double curr_dequiv_stress_dT{0.0};
 
       //! derivative of the deviatoric, symmetric part of the thermo-elastic Mandel stress tensor
       //! w.r.t. the inverse inelastic deformation gradient (Voigt stress form)
@@ -449,11 +544,16 @@ namespace Mat
       //! derivative of the deviatoric, symmetric part of the thermo-elastic Mandel stress tensor
       //! w.r.t. the right Cauchy-Green deformation tensor (Voigt stress-stress form)
       Core::LinAlg::Matrix<6, 6> curr_dMtheta_dev_sym_dC{Core::LinAlg::Initialization::zero};
+      //! derivative of the deviatoric, symmetric part of the Mandel stress tensor w.r.t. the
+      //! temperature (Voigt stress form)
+      Core::LinAlg::Matrix<6, 1> curr_dMtheta_dev_sym_dT{Core::LinAlg::Initialization::zero};
 
       //! derivative of the plastic strain rate w.r.t. the equivalent stress
       double curr_dpsr_dequiv_stress{0.0};
       //! derivative of the plastic strain rate w.r.t. the equivalent plastic strain
       double curr_dpsr_depsp{0.0};
+      //! derivative of the plastic strain rate w.r.t. the temperature
+      double curr_dpsr_dT{0.0};
 
       //! derivative of the plastic stretching tensor w.r.t. the inverse inelastic deformation
       //! gradient (Voigt stress form)
@@ -464,6 +564,8 @@ namespace Mat
       //! derivative of the plastic stretching tensor w.r.t. the right Cauchy-Green deformation
       //! tensor (Voigt stress-stress form)
       Core::LinAlg::Matrix<6, 6> curr_ddpdC{Core::LinAlg::Initialization::zero};
+      //! derivative of the plastic stretching tensor w.r.t. the temperature (Voigt stress form)
+      Core::LinAlg::Matrix<6, 1> curr_ddpdT{Core::LinAlg::Initialization::zero};
 
       //! derivative of the plastic velocity gradient tensor w.r.t. the inverse inelastic
       //! deformation gradient (Voigt notation)
@@ -474,6 +576,9 @@ namespace Mat
       //! derivative of the plastic velocity gradient tensor w.r.t. the right Cauchy-Green
       //! deformation tensor (Voigt stress form)
       Core::LinAlg::Matrix<9, 6> curr_dlpdC{Core::LinAlg::Initialization::zero};
+      //! derivative of the plastic velocity gradient tensor w.r.t. the temperature
+      //! (Voigt notation)
+      Core::LinAlg::Matrix<9, 1> curr_dlpdT{Core::LinAlg::Initialization::zero};
 
       //! derivative of the plastic update tensor w.r.t. the inverse inelastic deformation
       //! gradient (Voigt notation)
@@ -484,6 +589,9 @@ namespace Mat
       //! derivative of the plastic update tensor w.r.t. the right Cauchy-Green deformation tensor
       //! (Voigt stress form)
       Core::LinAlg::Matrix<9, 6> curr_dEpdC{Core::LinAlg::Initialization::zero};
+      //! derivative of the plastic update tensor w.r.t. the temperature (Voigt
+      //! notation)
+      Core::LinAlg::Matrix<9, 1> curr_dEpdT{Core::LinAlg::Initialization::zero};
 
       //! evaluation type
       StateQuantityDerivEvalType eval_type;
@@ -494,15 +602,188 @@ namespace Mat
     struct PlasticStrainRateDerivs
     {
       //! derivative with respect to the equivalent stress
-      double deriv_equiv_stress;
-
+      double deriv_equiv_stress = 0.0;
 
       //! derivative with respect to the plastic strain
-      double deriv_plastic_strain;
+      double deriv_plastic_strain = 0.0;
 
       //! derivative with respect to the temperature
-      double deriv_temperature;
+      double deriv_temperature = 0.0;
     };
+
+    /// Derivatives of the history variables wrt. the right Cauchy-Green deformation tensor
+    struct HistoryVariablesDerivativesWrtCauchyGreen
+    {
+      //! derivative of the inverse plastic deformation gradient w.r.t. the right Cauchy-Green
+      //! tensor \f$ \frac{\mathrm{d}\boldsymbol{F}_\mathrm{p}^{-1}}{\mathrm{d}\boldsymbol{C}} \f$
+      //! in Voigt notation (second dimension in in stress-form)
+      Core::LinAlg::Matrix<9, 6> inv_plastic_defgrad_wrt_cauchy_green{
+          Core::LinAlg::Initialization::zero};
+      //! derivative of the equivalent plastic strain w.r.t. the right Cauchy-Green tensor
+      //! \f$ \frac{\mathrm{d}\varepsilon_\mathrm{p}}{\mathrm{d}\boldsymbol{C}} \f$ in stress-form
+      Core::LinAlg::Matrix<1, 6> plastic_strain_wrt_cauchy_green{
+          Core::LinAlg::Initialization::zero};
+    };
+
+    /// Derivatives of the history variables wrt. temperature
+    struct HistoryVariablesDerivativesWrtTemperature
+    {
+      //! derivative of the inverse plastic deformation gradient w.r.t. temperature
+      //! \f$ \frac{\mathrm{d}\boldsymbol{F}_\mathrm{p}^{-1}}{\mathrm{d}T} \f$ in Voigt notation
+      Core::LinAlg::Matrix<9, 1> inv_plastic_defgrad_wrt_temperature{
+          Core::LinAlg::Initialization::zero};
+      //! derivative of the equivalent plastic strain w.r.t. temperature
+      //! \f$ \frac{\mathrm{d}\varepsilon_\mathrm{p}}{\mathrm{d}T} \f$
+      double plastic_strain_wrt_temperature{0.0};
+    };
+
+    /**
+     * @brief Subset of the `StateQuantities` struct relevant for thermo-mechanical coupling
+     *
+     * Can be default constructed with all values set to zero, or from a `StateQuantities` struct.
+     */
+    struct ThermoMechanicalCouplingState
+    {
+      /// equivalent stress \f$ \bar{\sigma} \f$
+      double equiv_stress = 0.0;
+      /// equivalent plastic strain rate \f$ \dot{\varepsilon}_\mathrm{p} \f$
+      double plastic_strain_rate = 0.0;
+
+      //! default constructor: Set all values to zero
+      ThermoMechanicalCouplingState() = default;
+
+      //! construct from state_quantities
+      ThermoMechanicalCouplingState(const StateQuantities& state_quantities)
+      {
+        equiv_stress = state_quantities.curr_equiv_stress;
+        plastic_strain_rate = state_quantities.curr_equiv_plastic_strain_rate;
+      }
+    };
+
+    /**
+     * @brief Subset of the `StateQuantityDerivatives` struct relevant for thermo-mechanical
+     * coupling
+     *
+     * Can be default constructed with all values set to zero, or from a `StateQuantityDerivatives`
+     * struct.
+     */
+    struct ThermoMechanicalCouplingStateDerivatives
+    {
+      /// partial derivative of the equivalent stress w.r.t. the inverse plastic deformation
+      /// gradient \f$ \frac{\partial\bar{\sigma}}{\partial\mathbf{F}_\mathrm{p}^{-1}} \f$ in Voigt
+      /// notation
+      Core::LinAlg::Matrix<1, 9> equiv_stress_wrt_inverse_plastic_defgrad{
+          Core::LinAlg::Initialization::zero};
+      /// partial derivative of the equivalent stress w.r.t. the right Cauchy-Green deformation
+      /// tensor \f$ \frac{\partial\bar{\sigma}}{\partial\mathbf{C}} \f$ in Voigt stress form
+      Core::LinAlg::Matrix<1, 6> equiv_stress_wrt_cauchy_green{Core::LinAlg::Initialization::zero};
+      /// partial derivative of the equivalent stress w.r.t. the temperature \f$
+      /// \frac{\partial\bar{\sigma}}{\partial T} \f$
+      double equiv_stress_wrt_temperature = 0.0;
+      /// partial derivatives of the plastic strain rate w.r.t. the equivalent stress, plastic
+      /// strain and temperature
+      PlasticStrainRateDerivs plastic_strain_rate_derivs;
+
+      //! default constructor: Set all values to zero
+      ThermoMechanicalCouplingStateDerivatives() = default;
+
+      //! construct from state_quantity_derivatives
+      ThermoMechanicalCouplingStateDerivatives(
+          const StateQuantityDerivatives& state_quantity_derivatives)
+      {
+        equiv_stress_wrt_inverse_plastic_defgrad =
+            state_quantity_derivatives.curr_dequiv_stress_diFin;
+        equiv_stress_wrt_cauchy_green = state_quantity_derivatives.curr_dequiv_stress_dC;
+        equiv_stress_wrt_temperature = state_quantity_derivatives.curr_dequiv_stress_dT;
+        plastic_strain_rate_derivs = {
+            .deriv_equiv_stress = state_quantity_derivatives.curr_dpsr_dequiv_stress,
+            .deriv_plastic_strain = state_quantity_derivatives.curr_dpsr_depsp,
+            .deriv_temperature = state_quantity_derivatives.curr_dpsr_dT};
+      }
+    };
+
+
+    /**
+     * @brief This struct holds quantities to be cached across public evaluation calls in
+     * thermo-mechanical coupling.
+     *
+     */
+    struct ThermoMechanicalCouplingCache
+    {
+      CachedQuantity<ThermoMechanicalCouplingState> state;
+      CachedQuantity<ThermoMechanicalCouplingStateDerivatives> state_derivatives;
+      CachedQuantity<HistoryVariablesDerivativesWrtCauchyGreen> history_variables_wrt_cauchy_green;
+      CachedQuantity<HistoryVariablesDerivativesWrtTemperature> history_variables_wrt_temperature;
+
+      /// mark the whole cache as not evaluated at the specified gauss points. This should be done
+      /// if the incoming state has changed.
+      void reset(const int gp);
+
+      /// resize all cached quantities to the given number of Gauss points
+      void resize(const unsigned int numgp);
+
+     private:
+      auto quantities()
+      {
+        return std::tie(state, state_derivatives, history_variables_wrt_cauchy_green,
+            history_variables_wrt_temperature);
+      }
+    };
+
+
+    /**
+     * Returns the derivative of the taylor-quinney term wrt. the right Cauchy-Green tensor
+     * \f[\frac{\mathrm{d}}{\mathrm{d}\mathbf{C}}\left(
+     * \xi_\mathrm{TQ}\,\bar{\sigma}\,\dot{\varepsilon}_\mathrm{p}\right)
+     * =\xi_\mathrm{TQ}\left(
+     * \frac{\mathrm{d}\bar{\sigma}}{\mathrm{d}\mathbf{C}}\,\dot{\varepsilon}_\mathrm{p}
+     * +\bar{\sigma}\,\frac{\mathrm{d}\dot{\varepsilon}_\mathrm{p}}
+     * {\mathrm{d}\mathbf{C}}\right)\f]
+     *
+     * with
+     * \f[\frac{\mathrm{d}\bar{\sigma}}{\mathrm{d}\mathbf{C}}
+     * =\frac{\partial \bar{\sigma}}{\partial \mathbf{C}}
+     * +\frac{\partial \bar{\sigma}}{\partial \mathbf{F}_\mathrm{p}^{-1}}
+     * :\frac{\partial \mathbf{F}_\mathrm{p}^{-1}}{\partial \mathbf{C}}\f]
+     *
+     * and
+     * \f[\frac{\mathrm{d}\dot{\varepsilon}_\mathrm{p}}{\mathrm{d}\mathbf{C}}
+     * =\frac{\partial \dot{\varepsilon}_\mathrm{p}}{\partial \varepsilon_\mathrm{p}}
+     * \frac{\partial \varepsilon_\mathrm{p}}{\partial \mathbf{C}}
+     * +\frac{\partial \dot{\varepsilon}_\mathrm{p}}{\partial \bar{\sigma}}
+     * \frac{\mathrm{d}\bar{\sigma}}{\mathrm{d}\mathbf{C}}\f]
+     */
+    Core::LinAlg::Matrix<1, 6> compute_taylor_quinney_wrt_cauchygreen(
+        const double taylor_quinney_coefficient, const ThermoMechanicalCouplingState& state,
+        const ThermoMechanicalCouplingStateDerivatives& state_derivatives,
+        const HistoryVariablesDerivativesWrtCauchyGreen& history_variables_derivatives);
+
+    /**
+     * Returns the derivative of the taylor-quinney term wrt. the temperature
+     * \f[\frac{\mathrm{d}}{\mathrm{d}T}\left(
+     * \xi_\mathrm{TQ}\,\bar{\sigma}\,\dot{\varepsilon}_\mathrm{p}\right)
+     * =\xi_\mathrm{TQ}\left(
+     * \frac{\mathrm{d}\bar{\sigma}}{\mathrm{d}T}\,\dot{\varepsilon}_\mathrm{p}
+     * +\bar{\sigma}\,\frac{\mathrm{d}\dot{\varepsilon}_\mathrm{p}}{\mathrm{d}T}\right)\f]
+     *
+     * with
+     * \f[\frac{\mathrm{d}\bar{\sigma}}{\mathrm{d}T}
+     * =\frac{\partial \bar{\sigma}}{\partial T}
+     * +\frac{\partial \bar{\sigma}}{\partial \mathbf{F}_\mathrm{p}^{-1}}
+     * :\frac{\partial \mathbf{F}_\mathrm{p}^{-1}}{\partial T}\f]
+     *
+     * and
+     * \f[\frac{\mathrm{d}\dot{\varepsilon}_\mathrm{p}}{\mathrm{d}T}
+     * =\frac{\partial \dot{\varepsilon}_\mathrm{p}}{\partial T}
+     * +\frac{\partial \dot{\varepsilon}_\mathrm{p}}{\partial \varepsilon_\mathrm{p}}
+     * \frac{\partial \varepsilon_\mathrm{p}}{\partial T}
+     * +\frac{\partial \dot{\varepsilon}_\mathrm{p}}{\partial \bar{\sigma}}
+     * \frac{\mathrm{d}\bar{\sigma}}{\mathrm{d}T}\f]
+     */
+    double compute_taylor_quinney_wrt_temperature(const double taylor_quinney_coefficient,
+        const ThermoMechanicalCouplingState& state,
+        const ThermoMechanicalCouplingStateDerivatives& state_derivatives,
+        const HistoryVariablesDerivativesWrtTemperature& history_variables_derivatives);
 
 
     /// enum: strategy in dealing with divergence of the Local Newton Loop

--- a/src/mat/4C_mat_inelastic_defgrad_factors_service.hpp
+++ b/src/mat/4C_mat_inelastic_defgrad_factors_service.hpp
@@ -615,12 +615,14 @@ namespace Mat
     struct HistoryVariablesDerivativesWrtCauchyGreen
     {
       //! derivative of the inverse plastic deformation gradient w.r.t. the right Cauchy-Green
-      //! tensor \f$ \frac{\mathrm{d}\boldsymbol{F}_\mathrm{p}^{-1}}{\mathrm{d}\boldsymbol{C}} \f$
-      //! in Voigt notation (second dimension in stress-form)
+      //! tensor \f$
+      //! \frac{\mathrm{d}\boldsymbol{F}_{\mathrm{p},\,n+1}^{-1}}{\mathrm{d}\boldsymbol{C}_{n+1}}
+      //! \f$ in Voigt notation (second dimension in stress-form)
       Core::LinAlg::Matrix<9, 6> inv_plastic_defgrad_wrt_cauchy_green{
           Core::LinAlg::Initialization::zero};
       //! derivative of the equivalent plastic strain w.r.t. the right Cauchy-Green tensor
-      //! \f$ \frac{\mathrm{d}\varepsilon_\mathrm{p}}{\mathrm{d}\boldsymbol{C}} \f$ in stress-form
+      //! \f$ \frac{\mathrm{d}\varepsilon_{\mathrm{p},\,n+1}}{\mathrm{d}\boldsymbol{C}_{n+1}} \f$ in
+      //! stress-form
       Core::LinAlg::Matrix<1, 6> plastic_strain_wrt_cauchy_green{
           Core::LinAlg::Initialization::zero};
     };
@@ -629,11 +631,12 @@ namespace Mat
     struct HistoryVariablesDerivativesWrtTemperature
     {
       //! derivative of the inverse plastic deformation gradient w.r.t. temperature
-      //! \f$ \frac{\mathrm{d}\boldsymbol{F}_\mathrm{p}^{-1}}{\mathrm{d}T} \f$ in Voigt notation
+      //! \f$ \frac{\mathrm{d}\boldsymbol{F}_{\mathrm{p},\,n+1}^{-1}}{\mathrm{d}T_{n+1}} \f$ in
+      //! Voigt notation
       Core::LinAlg::Matrix<9, 1> inv_plastic_defgrad_wrt_temperature{
           Core::LinAlg::Initialization::zero};
       //! derivative of the equivalent plastic strain w.r.t. temperature
-      //! \f$ \frac{\mathrm{d}\varepsilon_\mathrm{p}}{\mathrm{d}T} \f$
+      //! \f$ \frac{\mathrm{d}\varepsilon_{\mathrm{p},\,n+1}}{\mathrm{d}T_{n+1}} \f$
       double plastic_strain_wrt_temperature{0.0};
     };
 
@@ -732,7 +735,7 @@ namespace Mat
 
 
     /**
-     * Returns the derivative of the Taylor-Quinney term wrt. the right Cauchy-Green tensor
+     * Returns the derivative of the Taylor-Quinney term wrt. the right Cauchy-Green tensor at time
      * \f[\frac{\mathrm{d}}{\mathrm{d}\mathbf{C}}\left(
      * \xi_\mathrm{TQ}\,\bar{\sigma}\,\dot{\varepsilon}_\mathrm{p}\right)
      * =\xi_\mathrm{TQ}\left(
@@ -744,12 +747,12 @@ namespace Mat
      * \f[\frac{\mathrm{d}\bar{\sigma}}{\mathrm{d}\mathbf{C}}
      * =\frac{\partial \bar{\sigma}}{\partial \mathbf{C}}
      * +\frac{\partial \bar{\sigma}}{\partial \mathbf{F}_\mathrm{p}^{-1}}
-     * :\frac{\partial \mathbf{F}_\mathrm{p}^{-1}}{\partial \mathbf{C}}\f]
+     * :\frac{\mathrm{d} \mathbf{F}_{\mathrm{p},\,n+1}^{-1}}{\mathrm{d} \mathbf{C}_{n+1}}\f]
      *
      * and
      * \f[\frac{\mathrm{d}\dot{\varepsilon}_\mathrm{p}}{\mathrm{d}\mathbf{C}}
      * =\frac{\partial \dot{\varepsilon}_\mathrm{p}}{\partial \varepsilon_\mathrm{p}}
-     * \frac{\partial \varepsilon_\mathrm{p}}{\partial \mathbf{C}}
+     * \frac{\mathrm{d} \varepsilon_{\mathrm{p},\,n+1}}{\mathrm{d} \mathbf{C}_{n+1}}
      * +\frac{\partial \dot{\varepsilon}_\mathrm{p}}{\partial \bar{\sigma}}
      * \frac{\mathrm{d}\bar{\sigma}}{\mathrm{d}\mathbf{C}}\f]
      */
@@ -770,13 +773,13 @@ namespace Mat
      * \f[\frac{\mathrm{d}\bar{\sigma}}{\mathrm{d}T}
      * =\frac{\partial \bar{\sigma}}{\partial T}
      * +\frac{\partial \bar{\sigma}}{\partial \mathbf{F}_\mathrm{p}^{-1}}
-     * :\frac{\partial \mathbf{F}_\mathrm{p}^{-1}}{\partial T}\f]
+     * :\frac{\mathrm{d} \mathbf{F}_{\mathrm{p},\,n+1}^{-1}}{\mathrm{d} T_{n+1}}\f]
      *
      * and
      * \f[\frac{\mathrm{d}\dot{\varepsilon}_\mathrm{p}}{\mathrm{d}T}
      * =\frac{\partial \dot{\varepsilon}_\mathrm{p}}{\partial T}
      * +\frac{\partial \dot{\varepsilon}_\mathrm{p}}{\partial \varepsilon_\mathrm{p}}
-     * \frac{\partial \varepsilon_\mathrm{p}}{\partial T}
+     * \frac{\mathrm{d} \varepsilon_{\mathrm{p},\,n+1}}{\mathrm{d} T_{n+1}}
      * +\frac{\partial \dot{\varepsilon}_\mathrm{p}}{\partial \bar{\sigma}}
      * \frac{\mathrm{d}\bar{\sigma}}{\mathrm{d}T}\f]
      */

--- a/src/mat/4C_mat_inelastic_defgrad_factors_service.hpp
+++ b/src/mat/4C_mat_inelastic_defgrad_factors_service.hpp
@@ -276,7 +276,7 @@ namespace Mat
        * @param ref_temperature Reference temperature used to set initial values of last/current
        * temperature.
        */
-      void init(const double& ref_temperature);
+      void init(const double ref_temperature);
 
       /*!
        * @brief Resizing based on a given number of Gauss points
@@ -544,8 +544,8 @@ namespace Mat
       //! derivative of the deviatoric, symmetric part of the thermo-elastic Mandel stress tensor
       //! w.r.t. the right Cauchy-Green deformation tensor (Voigt stress-stress form)
       Core::LinAlg::Matrix<6, 6> curr_dMtheta_dev_sym_dC{Core::LinAlg::Initialization::zero};
-      //! derivative of the deviatoric, symmetric part of the Mandel stress tensor w.r.t. the
-      //! temperature (Voigt stress form)
+      //! derivative of the deviatoric, symmetric part of the thermo-elastic Mandel stress tensor
+      //! w.r.t. the temperature (Voigt stress form)
       Core::LinAlg::Matrix<6, 1> curr_dMtheta_dev_sym_dT{Core::LinAlg::Initialization::zero};
 
       //! derivative of the plastic strain rate w.r.t. the equivalent stress
@@ -616,7 +616,7 @@ namespace Mat
     {
       //! derivative of the inverse plastic deformation gradient w.r.t. the right Cauchy-Green
       //! tensor \f$ \frac{\mathrm{d}\boldsymbol{F}_\mathrm{p}^{-1}}{\mathrm{d}\boldsymbol{C}} \f$
-      //! in Voigt notation (second dimension in in stress-form)
+      //! in Voigt notation (second dimension in stress-form)
       Core::LinAlg::Matrix<9, 6> inv_plastic_defgrad_wrt_cauchy_green{
           Core::LinAlg::Initialization::zero};
       //! derivative of the equivalent plastic strain w.r.t. the right Cauchy-Green tensor
@@ -732,7 +732,7 @@ namespace Mat
 
 
     /**
-     * Returns the derivative of the taylor-quinney term wrt. the right Cauchy-Green tensor
+     * Returns the derivative of the Taylor-Quinney term wrt. the right Cauchy-Green tensor
      * \f[\frac{\mathrm{d}}{\mathrm{d}\mathbf{C}}\left(
      * \xi_\mathrm{TQ}\,\bar{\sigma}\,\dot{\varepsilon}_\mathrm{p}\right)
      * =\xi_\mathrm{TQ}\left(

--- a/src/mat/4C_mat_multiplicative_split_defgrad_elasthyper_service.hpp
+++ b/src/mat/4C_mat_multiplicative_split_defgrad_elasthyper_service.hpp
@@ -9,6 +9,7 @@
 #define FOUR_C_MAT_MULTIPLICATIVE_SPLIT_DEFGRAD_ELASTHYPER_SERVICE_HPP
 #include "4C_config.hpp"
 
+#include "4C_comm_pack_helpers.hpp"
 #include "4C_linalg_fixedsizematrix.hpp"
 #include "4C_linalg_fixedsizematrix_tensor_products.hpp"
 #include "4C_linalg_fixedsizematrix_voigt_notation.hpp"
@@ -18,10 +19,39 @@
 #include "4C_mat_elasthyper_service.hpp"
 #include "4C_mat_service.hpp"
 
+#include <vector>
+
 FOUR_C_NAMESPACE_OPEN
 
 namespace Mat
 {
+  /*!
+   * @brief Mechanical heat source contribution produced by the material and the linearizations
+   * needed by thermomechanical coupling. Default constructed with zero values.
+   */
+  struct MechanicalDissipation
+  {
+    double value = 0.0;
+    //! derivative of the mechanical dissipation heat source w.r.t. temperature
+    double derivative_wrt_temperature = 0.0;
+    //! derivative of the mechanical dissipation heat source w.r.t. the right Cauchy-Green tensor
+    //! (stress-form)
+    Core::LinAlg::Matrix<1, 6> derivative_wrt_cauchy_green{Core::LinAlg::Initialization::zero};
+
+    //! pack a vector of MechanicalDissipation
+    static void pack(Core::Communication::PackBuffer& data,
+        const std::vector<MechanicalDissipation>& mech_dissipation)
+    {
+      Core::Communication::add_to_pack(data, static_cast<int>(mech_dissipation.size()));
+
+      for (const auto& md : mech_dissipation)
+      {
+        Core::Communication::add_to_pack(data, md.value);
+        Core::Communication::add_to_pack(data, md.derivative_wrt_temperature);
+        Core::Communication::add_to_pack(data, md.derivative_wrt_cauchy_green);
+      }
+    }
+  };
 
 
   /// Free-energy related stress factors, as presented in Holzapfel - Nonlinear Solid Mechanics.
@@ -253,7 +283,7 @@ namespace Mat
    * @brief Compute thermal stretch quantities for isotropic thermal expansion.
    *
    * @param[in] delta_temperature current absolute temperature minus reference temperature
-   * @param[in] thermal_expansion_fac isotropic thermal expansion factor
+   * @param[in] thermal_expansion_coefficient isotropic thermal expansion coefficient
    * @param[in] iFinM inverse inelastic deformation gradient
    * @param[in] gp Gauss point
    * @param[in] eleGID element global ID
@@ -261,8 +291,9 @@ namespace Mat
    * @return collected thermal kinematic quantities and invariant derivatives
    */
   inline ThermalQuantities evaluate_thermal_quantities(const double delta_temperature,
-      const double thermal_expansion_fac, const Core::LinAlg::Matrix<3, 3>& iFinM, const int gp,
-      const int eleGID, const std::vector<std::shared_ptr<Mat::Elastic::Summand>>& potsumel)
+      const double thermal_expansion_coefficient, const Core::LinAlg::Matrix<3, 3>& iFinM,
+      const int gp, const int eleGID,
+      const std::vector<std::shared_ptr<Mat::Elastic::Summand>>& potsumel)
   {
     ThermalQuantities quantities{};
 
@@ -271,10 +302,10 @@ namespace Mat
     Core::LinAlg::SymmetricTensor<double, 3, 3> thermal_right_cg_tensor{
         Core::LinAlg::TensorGenerators::identity<double, 3, 3>};
     Core::LinAlg::SymmetricTensor<double, 3, 3> thermal_right_cg_temp_deriv_tensor{};
-    thermal_right_cg_tensor += 2 * thermal_expansion_fac * delta_temperature *
+    thermal_right_cg_tensor += 2 * thermal_expansion_coefficient * delta_temperature *
                                Core::LinAlg::TensorGenerators::identity<double, 3, 3>;
     thermal_right_cg_temp_deriv_tensor +=
-        2 * thermal_expansion_fac * Core::LinAlg::TensorGenerators::identity<double, 3, 3>;
+        2 * thermal_expansion_coefficient * Core::LinAlg::TensorGenerators::identity<double, 3, 3>;
 
     // compute inverse of the thermal stretch
     Core::LinAlg::SymmetricTensor<double, 3, 3> inv_thermal_right_cg_tensor =

--- a/src/mat/4C_mat_multiplicative_split_defgrad_elasthyper_service.hpp
+++ b/src/mat/4C_mat_multiplicative_split_defgrad_elasthyper_service.hpp
@@ -29,7 +29,7 @@ namespace Mat
    * @brief Mechanical heat source contribution produced by the material and the linearizations
    * needed by thermomechanical coupling. Default constructed with zero values.
    */
-  struct MechanicalDissipation
+  struct HeatSource
   {
     double value = 0.0;
     //! derivative of the mechanical dissipation heat source w.r.t. temperature
@@ -39,12 +39,12 @@ namespace Mat
     Core::LinAlg::Matrix<1, 6> derivative_wrt_cauchy_green{Core::LinAlg::Initialization::zero};
 
     //! pack a vector of MechanicalDissipation
-    static void pack(Core::Communication::PackBuffer& data,
-        const std::vector<MechanicalDissipation>& mech_dissipation)
+    static void pack(
+        Core::Communication::PackBuffer& data, const std::vector<HeatSource>& heat_source)
     {
-      Core::Communication::add_to_pack(data, static_cast<int>(mech_dissipation.size()));
+      Core::Communication::add_to_pack(data, static_cast<int>(heat_source.size()));
 
-      for (const auto& md : mech_dissipation)
+      for (const auto& md : heat_source)
       {
         Core::Communication::add_to_pack(data, md.value);
         Core::Communication::add_to_pack(data, md.derivative_wrt_temperature);

--- a/unittests/mat/4C_inelastic_defgrad_factors_test.cpp
+++ b/unittests/mat/4C_inelastic_defgrad_factors_test.cpp
@@ -12,12 +12,14 @@
 #include "4C_linalg_fixedsizematrix.hpp"
 #include "4C_linalg_fixedsizematrix_generators.hpp"
 #include "4C_linalg_fixedsizematrix_voigt_notation.hpp"
+#include "4C_linalg_four_tensor.hpp"
 #include "4C_linalg_utils_densematrix_funct.hpp"
 #include "4C_mat_elast_couptransverselyisotropic.hpp"
 #include "4C_mat_electrode.hpp"
 #include "4C_mat_inelastic_defgrad_factors.hpp"
 #include "4C_mat_inelastic_defgrad_factors_service.hpp"
 #include "4C_mat_material_factory.hpp"
+#include "4C_mat_multiplicative_split_defgrad_elasthyper_service.hpp"
 #include "4C_mat_par_bundle.hpp"
 #include "4C_mat_so3_material.hpp"
 #include "4C_mat_vplast_reform_johnsoncook.hpp"
@@ -26,6 +28,12 @@
 #include "4C_utils_exceptions.hpp"
 #include "4C_utils_singleton_owner.hpp"
 
+#include <Teuchos_ParameterList.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <exception>
 #include <memory>
 #include <optional>
 
@@ -68,6 +76,9 @@ namespace
     std::optional<double> yield_cond_b = 2.0;
     std::optional<double> yield_cond_f = 2.5;
     int numgp = 1;
+    double taylor_quinney_coefficient = 0.0;
+    double thermal_expansion_coefficient = 0.1;
+    double ref_temperature = 293.0;
     ReformulatedJohnsonCookParameters viscoplastic_law_params{};
   };
 
@@ -78,6 +89,8 @@ namespace
     // a raw pointer.
     std::shared_ptr<Mat::PAR::InelasticDefgradTransvIsotropElastViscoplast> params;
   };
+
+  static constexpr int problem_id = 0;
 
   int make_unique_viscoplastic_law_id()
   {
@@ -91,15 +104,236 @@ namespace
     return next_structural_tensor_strategy_id++;
   }
 
+  static void expect_near_relative(
+      const double actual, const double expected, const double rel_tol, const double abs_floor)
+  {
+    const double scale = std::max(std::abs(actual), std::abs(expected));
+    EXPECT_LE(std::abs(actual - expected), abs_floor + rel_tol * scale)
+        << "actual: " << actual << ", expected: " << expected;
+  }
+
+  static void expect_near_relative(const Core::LinAlg::Matrix<1, 6>& actual,
+      const Core::LinAlg::Matrix<1, 6>& expected, const double rel_tol, const double abs_floor)
+  {
+    for (int i = 0; i < 6; ++i)
+    {
+      const double scale = std::max(std::abs(actual(0, i)), std::abs(expected(0, i)));
+      EXPECT_LE(std::abs(actual(0, i) - expected(0, i)), abs_floor + rel_tol * scale)
+          << "entry (" << i << ",0), actual: " << actual(0, i) << ", expected: " << expected(0, i);
+    }
+  }
+
+  template <unsigned int rows, unsigned int cols>
+  static void expect_near_relative(const Core::LinAlg::Matrix<rows, cols>& actual,
+      const Core::LinAlg::Matrix<rows, cols>& expected, const double rel_tol,
+      const double abs_floor)
+  {
+    for (unsigned int row = 0; row < rows; ++row)
+    {
+      for (unsigned int col = 0; col < cols; ++col)
+      {
+        const double scale = std::max(std::abs(actual(row, col)), std::abs(expected(row, col)));
+        EXPECT_LE(std::abs(actual(row, col) - expected(row, col)), abs_floor + rel_tol * scale)
+            << "entry (" << row << "," << col << "), actual: " << actual(row, col)
+            << ", expected: " << expected(row, col);
+      }
+    }
+  }
+
+  ViscoplasticTestMaterial set_up_viscoplastic_material(const ViscoplasticMaterialSetup& setup = {})
+  {
+    Global::Problem& problem = (*Global::Problem::instance(problem_id));
+    const int viscoplastic_law_id = make_unique_viscoplastic_law_id();
+    const int structural_tensor_strategy_id = make_unique_structural_tensor_strategy_id();
+
+    Core::IO::InputParameterContainer material_data;
+    material_data.add("FIBER_READER_ID", 5);
+    material_data.add("TAYLOR_QUINNEY_COEFFICIENT", setup.taylor_quinney_coefficient);
+    material_data.add("LINEARIZATION", setup.linearization_type);
+    material_data.add("MATRIX_EXP_CALC_METHOD", Core::LinAlg::MatrixExpCalcMethod::automatic);
+    material_data.add(
+        "MATRIX_EXP_DERIV_CALC_METHOD", Core::LinAlg::GenMatrixExpFirstDerivCalcMethod::automatic);
+    material_data.add("MATRIX_LOG_CALC_METHOD", Core::LinAlg::MatrixLogCalcMethod::inv_scal_square);
+    material_data.add("MATRIX_LOG_DERIV_CALC_METHOD",
+        Core::LinAlg::GenMatrixLogFirstDerivCalcMethod::pade_part_fract);
+    material_data.add("MAT_BEHAVIOR", setup.mat_behavior);
+    material_data.add("MAX_PLASTIC_STRAIN_DERIV_INCR", std::exp(30.0));
+    material_data.add("MAX_PLASTIC_STRAIN_INCR", std::exp(30.0));
+    material_data.add("TIME_INTEGRATION_HIST_VARS",
+        Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::TimIntType::logarithmic);
+    material_data.add("VISCOPLAST_LAW_ID", viscoplastic_law_id);
+    material_data.add<std::optional<double>>("YIELD_COND_A", setup.yield_cond_a);
+    material_data.add<std::optional<double>>("YIELD_COND_B", setup.yield_cond_b);
+    material_data.add<std::optional<double>>("YIELD_COND_F", setup.yield_cond_f);
+    material_data.group("LOCAL_SUBSTEPPING").add("USE_SUBSTEPPING", setup.use_substepping);
+    material_data.group("LOCAL_SUBSTEPPING")
+        .add("MAX_SUBSTEPPING_HALVE_NUM", static_cast<int>(setup.max_substepping_halve_num));
+    material_data.group("LOCAL_NEWTON").add("CONV_CHECK", setup.local_newton_params.conv_check);
+    material_data.group("LOCAL_NEWTON").add("DIVER_CONT", setup.local_newton_params.diver_cont);
+    material_data.group("LOCAL_NEWTON").add("INCR_TOL", setup.local_newton_params.incr_tol);
+    material_data.group("LOCAL_NEWTON").add("RES_TOL", setup.local_newton_params.res_tol);
+    material_data.group("LOCAL_NEWTON")
+        .add("MAX_ITER", static_cast<int>(setup.local_newton_params.max_iter));
+    material_data.group("LOCAL_NEWTON")
+        .add("MAX_EXCEEDANCE_FACT_RES_TOL", setup.local_newton_params.max_exceedance_fact_res_tol);
+    material_data.group("LOCAL_NEWTON")
+        .add(
+            "MAX_EXCEEDANCE_FACT_INCR_TOL", setup.local_newton_params.max_exceedance_fact_incr_tol);
+
+    auto material_params =
+        std::dynamic_pointer_cast<Mat::PAR::InelasticDefgradTransvIsotropElastViscoplast>(
+            std::shared_ptr(Mat::make_parameter(1,
+                Core::Materials::MaterialType::mfi_transv_isotrop_elast_viscoplast,
+                material_data)));
+
+    Core::IO::InputParameterContainer fiber_reader_data;
+    fiber_reader_data.add("ALPHA", 1.0);
+    fiber_reader_data.add("BETA", 1.0);
+    fiber_reader_data.add("GAMMA", 1.0);
+    fiber_reader_data.add("ANGLE", 0.0);
+    fiber_reader_data.add("STR_TENS_ID", structural_tensor_strategy_id);
+    fiber_reader_data.add<std::string>("STRATEGY", "Standard");
+    fiber_reader_data.add<std::string>("DISTR", "none");
+    fiber_reader_data.add("C1", 1.0);
+    fiber_reader_data.add("C2", 0.0);
+    fiber_reader_data.add("C3", 0.0);
+    fiber_reader_data.add("C4", 1.0e16);
+    fiber_reader_data.add("FIBER", 1);
+    fiber_reader_data.add("INIT", 1);
+    problem.materials()->insert(structural_tensor_strategy_id,
+        Mat::make_parameter(structural_tensor_strategy_id,
+            Core::Materials::MaterialType::mes_structuraltensorstratgy, fiber_reader_data));
+
+    auto fiber_reader_params =
+        std::dynamic_pointer_cast<Mat::Elastic::PAR::CoupTransverselyIsotropic>(
+            std::shared_ptr(Mat::make_parameter(1,
+                Core::Materials::MaterialType::mes_couptransverselyisotropic, fiber_reader_data)));
+    Mat::Elastic::CoupTransverselyIsotropic fiber_reader{fiber_reader_params.get()};
+
+    Core::IO::InputParameterContainer viscoplastic_law_data;
+    viscoplastic_law_data.add(
+        "STRAIN_RATE_PREFAC", setup.viscoplastic_law_params.strain_rate_prefac);
+    viscoplastic_law_data.add(
+        "STRAIN_RATE_EXP_FAC", setup.viscoplastic_law_params.strain_rate_exp_fac);
+    viscoplastic_law_data.add(
+        "INIT_YIELD_STRENGTH", setup.viscoplastic_law_params.init_yield_strength);
+    viscoplastic_law_data.add(
+        "ISOTROP_HARDEN_PREFAC", setup.viscoplastic_law_params.isotrop_harden_prefac);
+    viscoplastic_law_data.add(
+        "ISOTROP_HARDEN_EXP", setup.viscoplastic_law_params.isotrop_harden_exp);
+    viscoplastic_law_data.add("REF_TEMPERATURE", setup.viscoplastic_law_params.ref_temperature);
+    viscoplastic_law_data.add("MELT_TEMPERATURE", setup.viscoplastic_law_params.melt_temperature);
+    viscoplastic_law_data.add("TEMPERATURE_SENS", setup.viscoplastic_law_params.temperature_sens);
+    problem.materials()->insert(viscoplastic_law_id,
+        Mat::make_parameter(viscoplastic_law_id,
+            Core::Materials::MaterialType::mvl_reformulated_Johnson_Cook, viscoplastic_law_data));
+
+    auto viscoplastic_law = std::make_shared<Mat::Viscoplastic::ReformulatedJohnsonCook>(
+        problem.materials()->parameter_by_id(viscoplastic_law_id));
+
+    std::vector<std::shared_ptr<Mat::Elastic::Summand>> pot_sum_el;
+    pot_sum_el.emplace_back(Mat::Elastic::Summand::factory(200));
+    std::vector<std::shared_ptr<Mat::Elastic::CoupTransverselyIsotropic>> pot_sum_el_transv_iso;
+
+    // The material stores its parameter object as a raw pointer. Capture the shared parameter
+    // object in the deleter so callers may use the returned material directly when they do not
+    // need to inspect the params.
+    auto viscoplastic_material = std::shared_ptr<Mat::InelasticDefgradTransvIsotropElastViscoplast>(
+        new Mat::InelasticDefgradTransvIsotropElastViscoplast(material_params.get(),
+            viscoplastic_law, fiber_reader, pot_sum_el, pot_sum_el_transv_iso,
+            setup.thermal_expansion_coefficient, setup.ref_temperature),
+        [material_params](Mat::InelasticDefgradTransvIsotropElastViscoplast* material)
+        { delete material; });
+
+    Discret::Elements::Fibers fibers;
+    fibers.element_fibers.emplace_back(Core::LinAlg::Tensor<double, 3>{{0.0, 0.0, 1.0}});
+    viscoplastic_material->setup(setup.numgp, fibers, {});
+    return {.material = viscoplastic_material, .params = material_params};
+  }
+
+  struct ThermoViscoplastLinearizationComparison
+  {
+    ViscoplasticTestMaterial analytic_material;
+    ViscoplasticTestMaterial fd_material;
+    double temperature = 313.0;
+    double total_time = 1.0e-6;
+    double time_step_size = 1.0e-6;
+    Core::LinAlg::Matrix<3, 3> id3x3 = Core::LinAlg::identity_matrix<3>();
+    Core::LinAlg::Matrix<3, 3> FM{Core::LinAlg::Initialization::zero};
+    Core::LinAlg::Matrix<3, 3> iFin_analytic{Core::LinAlg::Initialization::zero};
+    Core::LinAlg::Matrix<3, 3> iFin_fd{Core::LinAlg::Initialization::zero};
+    Core::LinAlg::Matrix<6, 1> iCV{Core::LinAlg::Initialization::zero};
+  };
+
+  ThermoViscoplastLinearizationComparison set_up_thermo_viscoplast_linearization_comparison()
+  {
+    const ReformulatedJohnsonCookParameters viscoplastic_law_params{
+        .strain_rate_prefac = 1.0,
+        .strain_rate_exp_fac = 0.014,
+        .init_yield_strength = 792.0,
+        .isotrop_harden_prefac = 510.0,
+        .isotrop_harden_exp = 0.26,
+        .ref_temperature = 293.0,
+        .melt_temperature = 1793.0,
+        .temperature_sens = 1.03,
+    };
+    const ViscoplastUtils::LocalNewtonParams local_newton_params{
+        .res_tol = 1.0e-14,
+        .incr_tol = 1.0e-14,
+        .conv_check = ViscoplastUtils::LocalNewtonConvCheck::residual_and_increment_ratio,
+        .diver_cont = ViscoplastUtils::LocalNewtonDiverCont::stop,
+        .max_iter = 100,
+        .max_exceedance_fact_res_tol = 1.0e1,
+        .max_exceedance_fact_incr_tol = 1.0e1,
+    };
+
+    ThermoViscoplastLinearizationComparison comparison{
+        .analytic_material =
+            set_up_viscoplastic_material({.local_newton_params = local_newton_params,
+                .linearization_type = ViscoplastUtils::LinearizationType::analytic,
+                .taylor_quinney_coefficient = 0.85,
+                .viscoplastic_law_params = viscoplastic_law_params}),
+        .fd_material = set_up_viscoplastic_material({.local_newton_params = local_newton_params,
+            .linearization_type = ViscoplastUtils::LinearizationType::perturbation_based,
+            .taylor_quinney_coefficient = 0.85,
+            .viscoplastic_law_params = viscoplastic_law_params})};
+
+    Teuchos::ParameterList param_list;
+    param_list.set<double>("temperature", comparison.temperature);
+    Mat::EvaluationContext<3> context{.total_time = &comparison.total_time,
+        .time_step_size = &comparison.time_step_size,
+        .xi = {},
+        .ref_coords = nullptr};
+    comparison.analytic_material.material->pre_evaluate(param_list, context, 0, 0);
+    comparison.fd_material.material->pre_evaluate(param_list, context, 0, 0);
+
+    comparison.FM(0, 0) = 1.55;
+    comparison.FM(1, 1) = 1.0;
+    comparison.FM(2, 2) = 1.0;
+    comparison.FM(0, 1) = 0.15;
+
+    comparison.analytic_material.material->evaluate_inverse_inelastic_def_grad(
+        &comparison.FM, comparison.id3x3, comparison.iFin_analytic);
+    comparison.fd_material.material->evaluate_inverse_inelastic_def_grad(
+        &comparison.FM, comparison.id3x3, comparison.iFin_fd);
+
+    Core::LinAlg::Matrix<3, 3> CM(Core::LinAlg::Initialization::zero);
+    Core::LinAlg::Matrix<3, 3> iCM(Core::LinAlg::Initialization::zero);
+    CM.multiply_tn(1.0, comparison.FM, comparison.FM, 0.0);
+    iCM.invert(CM);
+    Core::LinAlg::Voigt::Stresses::matrix_to_vector(iCM, comparison.iCV);
+
+    return comparison;
+  }
+
+
   class InelasticDefgradFactorsTest : public ::testing::Test
   {
    protected:
-    static constexpr int problemid_ = 0;
-
     void SetUp() override
     {
-      Global::Problem& problem = (*Global::Problem::instance(problemid_));
-      Global::Problem::instance()->materials()->set_read_from_problem(problemid_);
+      Global::Problem& problem = (*Global::Problem::instance(problem_id));
+      Global::Problem::instance()->materials()->set_read_from_problem(problem_id);
 
       // clang-format off
       // set up the deformation gradient
@@ -1034,119 +1268,6 @@ namespace
       iso.curr_dlpdepsp(2, 0) = iso.curr_ddpdepsp(2, 0);
     }
 
-    ViscoplasticTestMaterial set_up_viscoplastic_material(
-        const ViscoplasticMaterialSetup& setup = {})
-    {
-      Global::Problem& problem = (*Global::Problem::instance(problemid_));
-      const int viscoplastic_law_id = make_unique_viscoplastic_law_id();
-      const int structural_tensor_strategy_id = make_unique_structural_tensor_strategy_id();
-
-      Core::IO::InputParameterContainer material_data;
-      material_data.add("FIBER_READER_ID", 5);
-      material_data.add("LINEARIZATION", setup.linearization_type);
-      material_data.add("MATRIX_EXP_CALC_METHOD", Core::LinAlg::MatrixExpCalcMethod::automatic);
-      material_data.add("MATRIX_EXP_DERIV_CALC_METHOD",
-          Core::LinAlg::GenMatrixExpFirstDerivCalcMethod::automatic);
-      material_data.add(
-          "MATRIX_LOG_CALC_METHOD", Core::LinAlg::MatrixLogCalcMethod::inv_scal_square);
-      material_data.add("MATRIX_LOG_DERIV_CALC_METHOD",
-          Core::LinAlg::GenMatrixLogFirstDerivCalcMethod::pade_part_fract);
-      material_data.add("MAT_BEHAVIOR", setup.mat_behavior);
-      material_data.add("MAX_PLASTIC_STRAIN_DERIV_INCR", std::exp(30.0));
-      material_data.add("MAX_PLASTIC_STRAIN_INCR", std::exp(30.0));
-      material_data.add("TIME_INTEGRATION_HIST_VARS",
-          Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::TimIntType::logarithmic);
-      material_data.add("VISCOPLAST_LAW_ID", viscoplastic_law_id);
-      material_data.add<std::optional<double>>("YIELD_COND_A", setup.yield_cond_a);
-      material_data.add<std::optional<double>>("YIELD_COND_B", setup.yield_cond_b);
-      material_data.add<std::optional<double>>("YIELD_COND_F", setup.yield_cond_f);
-      material_data.group("LOCAL_SUBSTEPPING").add("USE_SUBSTEPPING", setup.use_substepping);
-      material_data.group("LOCAL_SUBSTEPPING")
-          .add("MAX_SUBSTEPPING_HALVE_NUM", static_cast<int>(setup.max_substepping_halve_num));
-      material_data.group("LOCAL_NEWTON").add("CONV_CHECK", setup.local_newton_params.conv_check);
-      material_data.group("LOCAL_NEWTON").add("DIVER_CONT", setup.local_newton_params.diver_cont);
-      material_data.group("LOCAL_NEWTON").add("INCR_TOL", setup.local_newton_params.incr_tol);
-      material_data.group("LOCAL_NEWTON").add("RES_TOL", setup.local_newton_params.res_tol);
-      material_data.group("LOCAL_NEWTON")
-          .add("MAX_ITER", static_cast<int>(setup.local_newton_params.max_iter));
-      material_data.group("LOCAL_NEWTON")
-          .add(
-              "MAX_EXCEEDANCE_FACT_RES_TOL", setup.local_newton_params.max_exceedance_fact_res_tol);
-      material_data.group("LOCAL_NEWTON")
-          .add("MAX_EXCEEDANCE_FACT_INCR_TOL",
-              setup.local_newton_params.max_exceedance_fact_incr_tol);
-
-      auto material_params =
-          std::dynamic_pointer_cast<Mat::PAR::InelasticDefgradTransvIsotropElastViscoplast>(
-              std::shared_ptr(Mat::make_parameter(1,
-                  Core::Materials::MaterialType::mfi_transv_isotrop_elast_viscoplast,
-                  material_data)));
-
-      Core::IO::InputParameterContainer fiber_reader_data;
-      fiber_reader_data.add("ALPHA", 1.0);
-      fiber_reader_data.add("BETA", 1.0);
-      fiber_reader_data.add("GAMMA", 1.0);
-      fiber_reader_data.add("ANGLE", 0.0);
-      fiber_reader_data.add("STR_TENS_ID", structural_tensor_strategy_id);
-      fiber_reader_data.add<std::string>("STRATEGY", "Standard");
-      fiber_reader_data.add<std::string>("DISTR", "none");
-      fiber_reader_data.add("C1", 1.0);
-      fiber_reader_data.add("C2", 0.0);
-      fiber_reader_data.add("C3", 0.0);
-      fiber_reader_data.add("C4", 1.0e16);
-      fiber_reader_data.add("FIBER", 1);
-      fiber_reader_data.add("INIT", 1);
-      problem.materials()->insert(structural_tensor_strategy_id,
-          Mat::make_parameter(structural_tensor_strategy_id,
-              Core::Materials::MaterialType::mes_structuraltensorstratgy, fiber_reader_data));
-
-      auto fiber_reader_params =
-          std::dynamic_pointer_cast<Mat::Elastic::PAR::CoupTransverselyIsotropic>(std::shared_ptr(
-              Mat::make_parameter(1, Core::Materials::MaterialType::mes_couptransverselyisotropic,
-                  fiber_reader_data)));
-      Mat::Elastic::CoupTransverselyIsotropic fiber_reader{fiber_reader_params.get()};
-
-      Core::IO::InputParameterContainer viscoplastic_law_data;
-      viscoplastic_law_data.add(
-          "STRAIN_RATE_PREFAC", setup.viscoplastic_law_params.strain_rate_prefac);
-      viscoplastic_law_data.add(
-          "STRAIN_RATE_EXP_FAC", setup.viscoplastic_law_params.strain_rate_exp_fac);
-      viscoplastic_law_data.add(
-          "INIT_YIELD_STRENGTH", setup.viscoplastic_law_params.init_yield_strength);
-      viscoplastic_law_data.add(
-          "ISOTROP_HARDEN_PREFAC", setup.viscoplastic_law_params.isotrop_harden_prefac);
-      viscoplastic_law_data.add(
-          "ISOTROP_HARDEN_EXP", setup.viscoplastic_law_params.isotrop_harden_exp);
-      viscoplastic_law_data.add("REF_TEMPERATURE", setup.viscoplastic_law_params.ref_temperature);
-      viscoplastic_law_data.add("MELT_TEMPERATURE", setup.viscoplastic_law_params.melt_temperature);
-      viscoplastic_law_data.add("TEMPERATURE_SENS", setup.viscoplastic_law_params.temperature_sens);
-      problem.materials()->insert(viscoplastic_law_id,
-          Mat::make_parameter(viscoplastic_law_id,
-              Core::Materials::MaterialType::mvl_reformulated_Johnson_Cook, viscoplastic_law_data));
-
-      auto viscoplastic_law = std::make_shared<Mat::Viscoplastic::ReformulatedJohnsonCook>(
-          problem.materials()->parameter_by_id(viscoplastic_law_id));
-
-      std::vector<std::shared_ptr<Mat::Elastic::Summand>> pot_sum_el;
-      pot_sum_el.emplace_back(Mat::Elastic::Summand::factory(200));
-      std::vector<std::shared_ptr<Mat::Elastic::CoupTransverselyIsotropic>> pot_sum_el_transv_iso;
-
-      // The material stores its parameter object as a raw pointer. Capture the shared parameter
-      // object in the deleter so callers may use the returned material directly when they do not
-      // need to inspect the params.
-      auto viscoplastic_material =
-          std::shared_ptr<Mat::InelasticDefgradTransvIsotropElastViscoplast>(
-              new Mat::InelasticDefgradTransvIsotropElastViscoplast(material_params.get(),
-                  viscoplastic_law, fiber_reader, pot_sum_el, pot_sum_el_transv_iso),
-              [material_params](Mat::InelasticDefgradTransvIsotropElastViscoplast* material)
-              { delete material; });
-
-      Discret::Elements::Fibers fibers;
-      fibers.element_fibers.emplace_back(Core::LinAlg::Tensor<double, 3>{{0.0, 0.0, 1.0}});
-      viscoplastic_material->setup(setup.numgp, fibers, {});
-      return {.material = viscoplastic_material, .params = material_params};
-    }
-
 
     // deformation gradient
     Core::LinAlg::Matrix<3, 3> FM_;
@@ -1598,6 +1719,10 @@ namespace
         set_up_viscoplastic_material({.mat_behavior = ViscoplastUtils::MatBehavior::isotropic})
             .material;
 
+    // reference temperature with which the material was constructed.
+    auto default_setup = ViscoplasticMaterialSetup{};
+    const double ref_temperature = default_setup.ref_temperature;
+
     Teuchos::ParameterList params_list{};
     double total_time = 1.0e-6;
     double time_step_size = 1.0e-6;
@@ -1623,14 +1748,14 @@ namespace
     // compute StateQuantities objects
     Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::StateQuantities
         computed_state_quantities_transv_isotrop =
-            transv_isotropic_material->evaluate_state_quantities(CM,
+            transv_isotropic_material->evaluate_state_quantities(CM, ref_temperature,
                 iFin_transv_isotrop_vplast_refJC_solution_,
                 plastic_strain_transv_isotrop_vplast_refJC_solution_, err_status, 1.0,
                 Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::StateQuantityEvalType::
                     full_eval);
     Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::StateQuantities
         computed_state_quantities_isotrop = isotropic_material->evaluate_state_quantities(CM,
-            iFin_transv_isotrop_vplast_refJC_solution_,
+            ref_temperature, iFin_transv_isotrop_vplast_refJC_solution_,
             plastic_strain_transv_isotrop_vplast_refJC_solution_, err_status, 1.0,
             Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::StateQuantityEvalType::
                 full_eval);
@@ -2228,6 +2353,10 @@ namespace
         set_up_viscoplastic_material({.mat_behavior = ViscoplastUtils::MatBehavior::isotropic})
             .material;
 
+    // reference temperature with which the material was constructed.
+    auto default_setup = ViscoplasticMaterialSetup{};
+    const double ref_temperature = default_setup.ref_temperature;
+
     Teuchos::ParameterList params_list;
     double total_time = 1.0e-6;
     double time_step_size = 1.0e-6;
@@ -2251,7 +2380,7 @@ namespace
     // compute StateQuantityDerivatives objects
     Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::StateQuantityDerivatives
         computed_state_quantity_derivatives_transv_isotrop =
-            transv_isotropic_material->evaluate_state_quantity_derivatives(CM,
+            transv_isotropic_material->evaluate_state_quantity_derivatives(CM, ref_temperature,
                 iFin_transv_isotrop_vplast_refJC_solution_,
                 plastic_strain_transv_isotrop_vplast_refJC_solution_, err_status, 1.0,
                 Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::StateQuantityDerivEvalType::
@@ -2260,7 +2389,7 @@ namespace
 
     Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::StateQuantityDerivatives
         computed_state_quantity_derivatives_isotrop =
-            isotropic_material->evaluate_state_quantity_derivatives(CM,
+            isotropic_material->evaluate_state_quantity_derivatives(CM, ref_temperature,
                 iFin_transv_isotrop_vplast_refJC_solution_,
                 plastic_strain_transv_isotrop_vplast_refJC_solution_, err_status, 1.0,
                 Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::StateQuantityDerivEvalType::
@@ -2334,5 +2463,604 @@ namespace
         computed_state_quantity_derivatives_isotrop.curr_dlpdepsp, 1.0e-6);
   }
 
+  TEST_F(InelasticDefgradFactorsTest, ThermoViscoplastStateQuantitiesAndDerivativesTest)
+  {
+    // This tests evaluate_state_quantities and evaluate_state_quantity_derivatives
+    // if there are temperature contributions, i.e. the temperature is not the reference
+    // temperature.
 
+    //**************************************************
+    const double current_temperature = 313.0;
+    //**************************************************
+    Core::LinAlg::Matrix<3, 3> CM{Core::LinAlg::Initialization::zero};
+    CM(0, 0) = 2.0000000000000000;
+    CM(0, 1) = 0.0000000000000000;
+    CM(0, 2) = 0.0000000000000000;
+    CM(1, 0) = 0.0000000000000000;
+    CM(1, 1) = 1.0000000000000000;
+    CM(1, 2) = 0.0000000000000000;
+    CM(2, 0) = 0.0000000000000000;
+    CM(2, 1) = 0.0000000000000000;
+    CM(2, 2) = 1.0000000000000000;
+    //**************************************************
+    Core::LinAlg::Matrix<3, 3> iFinM{Core::LinAlg::Initialization::zero};
+    iFinM(0, 0) = 1.2771823873225885;
+    iFinM(0, 1) = 3.8315471619677655;
+    iFinM(0, 2) = 1.6603371035193650;
+    iFinM(1, 0) = 0.3831547161967765;
+    iFinM(1, 1) = 1.9157735809838827;
+    iFinM(1, 2) = 0.0000000000000000;
+    iFinM(2, 0) = 0.0000000000000000;
+    iFinM(2, 1) = 0.0000000000000000;
+    iFinM(2, 2) = 1.0217459098580708;
+    //**************************************************
+    double plastic_strain = 0.0100000000000000;
+    //**************************************************
+    Core::LinAlg::Matrix<3, 3> CeM_ref{Core::LinAlg::Initialization::zero};
+    CeM_ref(0, 0) = 3.4091972375178852;
+    CeM_ref(0, 1) = 10.5212067856413203;
+    CeM_ref(0, 2) = 4.2411066112662690;
+    CeM_ref(1, 0) = 10.5212067856413203;
+    CeM_ref(1, 1) = 33.0316957223622865;
+    CeM_ref(1, 2) = 12.7233198337988060;
+    CeM_ref(2, 0) = 4.2411066112662690;
+    CeM_ref(2, 1) = 12.7233198337988060;
+    CeM_ref(2, 2) = 6.5574032989578459;
+    //**************************************************
+    Core::LinAlg::Matrix<3, 3> M_theta_dev_ref_{Core::LinAlg::Initialization::zero};
+    M_theta_dev_ref_(0, 0) = -6038.6293233280339336;
+    M_theta_dev_ref_(0, 1) = 5816.2009659724717494;
+    M_theta_dev_ref_(0, 2) = 2344.5151180664397543;
+    M_theta_dev_ref_(1, 0) = 5816.2009659724717494;
+    M_theta_dev_ref_(1, 1) = 10336.9070397830182628;
+    M_theta_dev_ref_(1, 2) = 7033.5453541996248532;
+    M_theta_dev_ref_(2, 0) = 2344.5151180664397543;
+    M_theta_dev_ref_(2, 1) = 7033.5453541996248532;
+    M_theta_dev_ref_(2, 2) = -4298.2777164549988811;
+    //**************************************************
+    Core::LinAlg::Matrix<3, 3> dM_theta_dev_dT_ref_{Core::LinAlg::Initialization::zero};
+    dM_theta_dev_dT_ref_(0, 0) = 741.8887454374042818;
+    dM_theta_dev_dT_ref_(0, 1) = -714.5618329623580394;
+    dM_theta_dev_dT_ref_(0, 2) = -288.0404287910280345;
+    dM_theta_dev_dT_ref_(1, 0) = -714.5618329623580394;
+    dM_theta_dev_dT_ref_(1, 1) = -1269.9628648876227999;
+    dM_theta_dev_dT_ref_(1, 2) = -864.1212863730841036;
+    dM_theta_dev_dT_ref_(2, 0) = -288.0404287910280345;
+    dM_theta_dev_dT_ref_(2, 1) = -864.1212863730841036;
+    dM_theta_dev_dT_ref_(2, 2) = 528.0741194502180633;
+    //**************************************************
+    Core::LinAlg::Matrix<6, 6> dM_theta_dev_dC_Voigt_ref_{Core::LinAlg::Initialization::zero};
+    dM_theta_dev_dC_Voigt_ref_(0, 0) = -2612.0303046296012326;
+    dM_theta_dev_dC_Voigt_ref_(0, 1) = -622.1982428715837159;
+    dM_theta_dev_dC_Voigt_ref_(0, 2) = -192.3704712255548657;
+    dM_theta_dev_dC_Voigt_ref_(0, 3) = -1172.2575590411943267;
+    dM_theta_dev_dC_Voigt_ref_(0, 4) = 0.0000000001800800;
+    dM_theta_dev_dC_Voigt_ref_(0, 5) = -312.6020157432431006;
+    dM_theta_dev_dC_Voigt_ref_(1, 0) = 4601.8623663998041593;
+    dM_theta_dev_dC_Voigt_ref_(1, 1) = 1325.5527782973986177;
+    dM_theta_dev_dC_Voigt_ref_(1, 2) = -192.3704712263679539;
+    dM_theta_dev_dC_Voigt_ref_(1, 3) = 2615.0360932529874844;
+    dM_theta_dev_dC_Voigt_ref_(1, 4) = -0.0000000007476046;
+    dM_theta_dev_dC_Voigt_ref_(1, 5) = -312.6020157437633316;
+    dM_theta_dev_dC_Voigt_ref_(2, 0) = -1989.8320617701956508;
+    dM_theta_dev_dC_Voigt_ref_(2, 1) = -703.3545354258058069;
+    dM_theta_dev_dC_Voigt_ref_(2, 2) = 384.7409424519319145;
+    dM_theta_dev_dC_Voigt_ref_(2, 3) = -1442.7785342117936125;
+    dM_theta_dev_dC_Voigt_ref_(2, 4) = 0.0000000005676366;
+    dM_theta_dev_dC_Voigt_ref_(2, 5) = 625.2040314869955182;
+    dM_theta_dev_dC_Voigt_ref_(3, 0) = 2705.2097516246067244;
+    dM_theta_dev_dC_Voigt_ref_(3, 1) = 405.7814627492407453;
+    dM_theta_dev_dC_Voigt_ref_(3, 2) = 0.0000000004220055;
+    dM_theta_dev_dC_Voigt_ref_(3, 3) = 1082.0839006570604397;
+    dM_theta_dev_dC_Voigt_ref_(3, 4) = -0.0000000010331860;
+    dM_theta_dev_dC_Voigt_ref_(3, 5) = -0.0000000065338099;
+    dM_theta_dev_dC_Voigt_ref_(4, 0) = 3516.7726770963417948;
+    dM_theta_dev_dC_Voigt_ref_(4, 1) = -0.0000000009968062;
+    dM_theta_dev_dC_Voigt_ref_(4, 2) = -0.0000000001327862;
+    dM_theta_dev_dC_Voigt_ref_(4, 3) = 879.1931692749094509;
+    dM_theta_dev_dC_Voigt_ref_(4, 4) = 541.0419503227003588;
+    dM_theta_dev_dC_Voigt_ref_(4, 5) = 1082.0839006451242312;
+    dM_theta_dev_dC_Voigt_ref_(5, 0) = 1172.2575590275155264;
+    dM_theta_dev_dC_Voigt_ref_(5, 1) = 0.0000000009713403;
+    dM_theta_dev_dC_Voigt_ref_(5, 2) = 0.0000000003201421;
+    dM_theta_dev_dC_Voigt_ref_(5, 3) = 175.8386338541968144;
+    dM_theta_dev_dC_Voigt_ref_(5, 4) = 108.2083900641773653;
+    dM_theta_dev_dC_Voigt_ref_(5, 5) = 360.6946335464308504;
+    //**************************************************
+    Core::LinAlg::Matrix<6, 9> dM_theta_dev_diFp_Voigt_ref_{Core::LinAlg::Initialization::zero};
+    dM_theta_dev_diFp_Voigt_ref_(0, 0) = 1882.7623322118306533;
+    dM_theta_dev_diFp_Voigt_ref_(0, 1) = -706.0358746152960521;
+    dM_theta_dev_diFp_Voigt_ref_(0, 2) = -376.5524664578551892;
+    dM_theta_dev_diFp_Voigt_ref_(0, 3) = -2824.1434984737352352;
+    dM_theta_dev_diFp_Voigt_ref_(0, 4) = 0.0000000007004775;
+    dM_theta_dev_diFp_Voigt_ref_(0, 5) = -1223.7955159961129539;
+    dM_theta_dev_diFp_Voigt_ref_(0, 6) = 282.4143498440244002;
+    dM_theta_dev_diFp_Voigt_ref_(0, 7) = 0.0000000014206307;
+    dM_theta_dev_diFp_Voigt_ref_(0, 8) = -0.0000000027066562;
+    dM_theta_dev_diFp_Voigt_ref_(1, 0) = -941.3811661213476327;
+    dM_theta_dev_diFp_Voigt_ref_(1, 1) = 1412.0717492313815455;
+    dM_theta_dev_diFp_Voigt_ref_(1, 2) = -376.5524664604199643;
+    dM_theta_dev_diFp_Voigt_ref_(1, 3) = 5648.2869969418461551;
+    dM_theta_dev_diFp_Voigt_ref_(1, 4) = -0.0000000021225941;
+    dM_theta_dev_diFp_Voigt_ref_(1, 5) = -1223.7955159952107351;
+    dM_theta_dev_diFp_Voigt_ref_(1, 6) = -141.2071749401075067;
+    dM_theta_dev_diFp_Voigt_ref_(1, 7) = -0.0000000013951649;
+    dM_theta_dev_diFp_Voigt_ref_(1, 8) = -0.0000000009167707;
+    dM_theta_dev_diFp_Voigt_ref_(2, 0) = -941.3811660904320888;
+    dM_theta_dev_diFp_Voigt_ref_(2, 1) = -706.0358746160563896;
+    dM_theta_dev_diFp_Voigt_ref_(2, 2) = 753.1049329183006193;
+    dM_theta_dev_diFp_Voigt_ref_(2, 3) = -2824.1434984681200149;
+    dM_theta_dev_diFp_Voigt_ref_(2, 4) = 0.0000000014221166;
+    dM_theta_dev_diFp_Voigt_ref_(2, 5) = 2447.5910319913241437;
+    dM_theta_dev_diFp_Voigt_ref_(2, 6) = -141.2071749040042050;
+    dM_theta_dev_diFp_Voigt_ref_(2, 7) = -0.0000000000145519;
+    dM_theta_dev_diFp_Voigt_ref_(2, 8) = 0.0000000035215635;
+    dM_theta_dev_diFp_Voigt_ref_(3, 0) = 4236.2152473528403789;
+    dM_theta_dev_diFp_Voigt_ref_(3, 1) = 211.8107623872019758;
+    dM_theta_dev_diFp_Voigt_ref_(3, 2) = 0.0000000032305252;
+    dM_theta_dev_diFp_Voigt_ref_(3, 3) = 1412.0717492136172950;
+    dM_theta_dev_diFp_Voigt_ref_(3, 4) = -0.0000000032487151;
+    dM_theta_dev_diFp_Voigt_ref_(3, 5) = -0.0000000162544893;
+    dM_theta_dev_diFp_Voigt_ref_(3, 6) = 1059.0538118852709886;
+    dM_theta_dev_diFp_Voigt_ref_(3, 7) = 0.0000000021245796;
+    dM_theta_dev_diFp_Voigt_ref_(3, 8) = -0.0000000133986759;
+    dM_theta_dev_diFp_Voigt_ref_(4, 0) = -0.0000000818399712;
+    dM_theta_dev_diFp_Voigt_ref_(4, 1) = 0.0000000022919266;
+    dM_theta_dev_diFp_Voigt_ref_(4, 2) = 0.0000000003856258;
+    dM_theta_dev_diFp_Voigt_ref_(4, 3) = 1835.6932739952317206;
+    dM_theta_dev_diFp_Voigt_ref_(4, 4) = 1059.0538119160482893;
+    dM_theta_dev_diFp_Voigt_ref_(4, 5) = 4236.2152476652117912;
+    dM_theta_dev_diFp_Voigt_ref_(4, 6) = -0.0000000073341653;
+    dM_theta_dev_diFp_Voigt_ref_(4, 7) = 564.8286996881288360;
+    dM_theta_dev_diFp_Voigt_ref_(4, 8) = -0.0000000002328306;
+    dM_theta_dev_diFp_Voigt_ref_(5, 0) = 1835.6932738409377635;
+    dM_theta_dev_diFp_Voigt_ref_(5, 1) = 0.0000000021545929;
+    dM_theta_dev_diFp_Voigt_ref_(5, 2) = 0.0000000008731149;
+    dM_theta_dev_diFp_Voigt_ref_(5, 3) = -0.0000000091458787;
+    dM_theta_dev_diFp_Voigt_ref_(5, 4) = 211.8107623823962058;
+    dM_theta_dev_diFp_Voigt_ref_(5, 5) = 1412.0717492167095770;
+    dM_theta_dev_diFp_Voigt_ref_(5, 6) = -0.0000000102991180;
+    dM_theta_dev_diFp_Voigt_ref_(5, 7) = 0.0000000004365575;
+    dM_theta_dev_diFp_Voigt_ref_(5, 8) = 564.8286996873503085;
+    //**************************************************
+    double equiv_stress_ref_ = 22562.6890921091871860;
+    //**************************************************
+    Core::LinAlg::Matrix<3, 3> Np_ref_{Core::LinAlg::Initialization::zero};
+    Np_ref_(0, 0) = -0.4014567566841964;
+    Np_ref_(0, 1) = 0.3866693997928572;
+    Np_ref_(0, 2) = 0.1558667348002227;
+    Np_ref_(1, 0) = 0.3866693997928572;
+    Np_ref_(1, 1) = 0.6872124371512610;
+    Np_ref_(1, 2) = 0.4676002044006883;
+    Np_ref_(2, 0) = 0.1558667348002227;
+    Np_ref_(2, 1) = 0.4676002044006883;
+    Np_ref_(2, 2) = -0.2857556804670655;
+    //**************************************************
+    double plastic_strain_rate_ref_ = 0.4830914865309823;
+    //**************************************************
+    Core::LinAlg::Matrix<3, 3> lp_ref_{Core::LinAlg::Initialization::zero};
+    lp_ref_(0, 0) = -0.1939403413644753;
+    lp_ref_(0, 1) = 0.1867966951419741;
+    lp_ref_(0, 2) = 0.0752978926153700;
+    lp_ref_(1, 0) = 0.1867966951419741;
+    lp_ref_(1, 1) = 0.3319864778259820;
+    lp_ref_(1, 2) = 0.2258936778461197;
+    lp_ref_(2, 0) = 0.0752978926153700;
+    lp_ref_(2, 1) = 0.2258936778461197;
+    lp_ref_(2, 2) = -0.1380461364615071;
+    //**************************************************
+    Core::LinAlg::Matrix<9, 1> dlp_dT_Voigt_ref_{Core::LinAlg::Initialization::zero};
+    dlp_dT_Voigt_ref_(0) = 0.7562742988211517;
+    dlp_dT_Voigt_ref_(1) = -1.2945880107744234;
+    dlp_dT_Voigt_ref_(2) = 0.5383137119532734;
+    dlp_dT_Voigt_ref_(3) = -0.7284175053353915;
+    dlp_dT_Voigt_ref_(4) = -0.8808769831963305;
+    dlp_dT_Voigt_ref_(5) = -0.2936256610654312;
+    dlp_dT_Voigt_ref_(6) = -0.7284175053353914;
+    dlp_dT_Voigt_ref_(7) = -0.8808769831963305;
+    dlp_dT_Voigt_ref_(8) = -0.2936256610654312;
+
+
+    FOUR_C_ASSERT_ALWAYS(
+        std::abs(iFinM.determinant() - 1) < 1.0e-12, "iFinM is not volume preserving");
+
+    Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::LocalNewtonParams local_newton_params{
+        .res_tol = 1.0e-8,
+        .incr_tol = 1.0e-8,
+        .conv_check = FourC::Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::
+            LocalNewtonConvCheck::residual_and_increment_ratio,
+        .diver_cont = FourC::Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::
+            LocalNewtonDiverCont::stop,
+        .max_iter = 50,
+        .max_exceedance_fact_res_tol = 1.0e1,
+        .max_exceedance_fact_incr_tol = 1.0e1,
+    };
+
+
+    std::shared_ptr<Mat::PAR::InelasticDefgradTransvIsotropElastViscoplast> material_params;
+    auto material =
+        set_up_viscoplastic_material({.local_newton_params = local_newton_params}).material;
+
+    // parameter list for InelasticDefGradTransvIsotropElastViscoplast
+    Teuchos::ParameterList param_list_thermo_vplast{};
+    param_list_thermo_vplast.set<double>("temperature", current_temperature);
+
+
+    double total_time = 4e-5;
+    double time_step_size = 4e-5;
+    Mat::EvaluationContext<3> context{.total_time = &total_time,
+        .time_step_size = &time_step_size,
+        .xi = {},
+        .ref_coords = nullptr};
+    // call pre_evaluate
+    material->pre_evaluate(param_list_thermo_vplast, context, 0, 0);
+
+
+    Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::ErrorType err_status{
+        FourC::Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::ErrorType::no_errors};
+
+    // compute StateQuantities objects
+    Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::StateQuantities
+        computed_state_quantities = material->evaluate_state_quantities(CM, current_temperature,
+            iFinM, plastic_strain, err_status, 1.0,
+            Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::StateQuantityEvalType::
+                full_eval);
+
+    EXPECT_NEAR(
+        computed_state_quantities.curr_equiv_plastic_strain_rate, plastic_strain_rate_ref_, 1e-8);
+    EXPECT_NEAR(computed_state_quantities.curr_equiv_stress, equiv_stress_ref_, 1e-8);
+    FOUR_C_EXPECT_NEAR(computed_state_quantities.curr_CeM, CeM_ref, 1e-8);
+    FOUR_C_EXPECT_NEAR(computed_state_quantities.curr_lpM, lp_ref_, 1e-8);
+    FOUR_C_EXPECT_NEAR(computed_state_quantities.curr_Mtheta_dev_sym_M, M_theta_dev_ref_, 1e-8);
+    FOUR_C_EXPECT_NEAR(computed_state_quantities.curr_NpM, Np_ref_, 1e-8);
+
+
+    // compute StateQuantityDerivatives objects
+    Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::StateQuantityDerivatives
+        computed_state_quantity_derivatives = material->evaluate_state_quantity_derivatives(CM,
+            current_temperature, iFinM, plastic_strain, err_status, 1.0,
+            Mat::InelasticDefgradTransvIsotropElastViscoplastUtils::StateQuantityDerivEvalType::
+                full_eval,
+            true);
+
+    // postprocessing for comparison
+    Core::LinAlg::Matrix<3, 3> curr_dMe_dev_sym_dT{Core::LinAlg::Initialization::zero};
+    Core::LinAlg::Voigt::Stresses::vector_to_matrix(
+        computed_state_quantity_derivatives.curr_dMtheta_dev_sym_dT, curr_dMe_dev_sym_dT);
+
+    // assert equality
+    FOUR_C_EXPECT_NEAR(curr_dMe_dev_sym_dT, dM_theta_dev_dT_ref_, 1e-6);
+    FOUR_C_EXPECT_NEAR(computed_state_quantity_derivatives.curr_dMtheta_dev_sym_dC,
+        dM_theta_dev_dC_Voigt_ref_, 1e-6);
+    FOUR_C_EXPECT_NEAR(computed_state_quantity_derivatives.curr_dMtheta_dev_sym_diFin,
+        dM_theta_dev_diFp_Voigt_ref_, 1e-6);
+    FOUR_C_EXPECT_NEAR(computed_state_quantity_derivatives.curr_dlpdT, dlp_dT_Voigt_ref_, 1e-6);
+  }
+
+  TEST_F(InelasticDefgradFactorsTest, ThermoViscoplastAdditionalCmatLinearizationMatchesFD)
+  {
+    auto comparison = set_up_thermo_viscoplast_linearization_comparison();
+    FOUR_C_EXPECT_NEAR(comparison.iFin_analytic, comparison.iFin_fd, 1.0e-10);
+
+    Core::LinAlg::Matrix<6, 6> cmatadd_analytic(Core::LinAlg::Initialization::zero);
+    Core::LinAlg::Matrix<6, 6> cmatadd_fd(Core::LinAlg::Initialization::zero);
+    comparison.analytic_material.material->evaluate_additional_cmat(&comparison.FM,
+        comparison.id3x3, comparison.iFin_analytic, comparison.iCV, dSdiFin_, cmatadd_analytic);
+    comparison.fd_material.material->evaluate_additional_cmat(
+        &comparison.FM, comparison.id3x3, comparison.iFin_fd, comparison.iCV, dSdiFin_, cmatadd_fd);
+
+    ASSERT_GT(cmatadd_analytic.norm2(), 0.0);
+    expect_near_relative(cmatadd_analytic, cmatadd_fd, 1.0e-6, 1.0e-9);
+  }
+
+  TEST_F(InelasticDefgradFactorsTest, ThermoViscoplastODStiffMatLinearizationMatchesFD)
+  {
+    auto comparison = set_up_thermo_viscoplast_linearization_comparison();
+    FOUR_C_EXPECT_NEAR(comparison.iFin_analytic, comparison.iFin_fd, 1.0e-10);
+
+    Core::LinAlg::Matrix<6, 1> dstressdT_analytic(Core::LinAlg::Initialization::zero);
+    Core::LinAlg::Matrix<6, 1> dstressdT_fd(Core::LinAlg::Initialization::zero);
+    comparison.analytic_material.material->evaluate_od_stiff_mat(
+        &comparison.FM, comparison.id3x3, comparison.iFin_analytic, dSdiFin_, dstressdT_analytic);
+    comparison.fd_material.material->evaluate_od_stiff_mat(
+        &comparison.FM, comparison.id3x3, comparison.iFin_fd, dSdiFin_, dstressdT_fd);
+
+    ASSERT_GT(dstressdT_analytic.norm2(), 0.0);
+    expect_near_relative(dstressdT_analytic, dstressdT_fd, 1.0e-6, 1.0e-9);
+  }
+
+  TEST_F(InelasticDefgradFactorsTest, ThermoViscoplastMechanicalDissipationLinearizationMatchesFD)
+  {
+    auto comparison = set_up_thermo_viscoplast_linearization_comparison();
+    FOUR_C_EXPECT_NEAR(comparison.iFin_analytic, comparison.iFin_fd, 1.0e-10);
+
+    const Mat::MechanicalDissipation analytic_dissipation =
+        comparison.analytic_material.material->evaluate_mechanical_dissipation(
+            0, &comparison.FM, comparison.id3x3, comparison.temperature);
+    const Mat::MechanicalDissipation fd_dissipation =
+        comparison.fd_material.material->evaluate_mechanical_dissipation(
+            0, &comparison.FM, comparison.id3x3, comparison.temperature);
+
+    ASSERT_GT(std::abs(analytic_dissipation.value), 0.0);
+    ASSERT_GT(analytic_dissipation.derivative_wrt_cauchy_green.norm2(), 0.0);
+    ASSERT_GT(std::abs(analytic_dissipation.derivative_wrt_temperature), 0.0);
+
+    ASSERT_DOUBLE_EQ(analytic_dissipation.value, fd_dissipation.value);
+    expect_near_relative(analytic_dissipation.derivative_wrt_cauchy_green,
+        fd_dissipation.derivative_wrt_cauchy_green, 1.0e-7, 1.0e-16);
+    expect_near_relative(analytic_dissipation.derivative_wrt_temperature,
+        fd_dissipation.derivative_wrt_temperature, 1.0e-8, 1.0e-16);
+  }
+
+  TEST_F(InelasticDefgradFactorsTest, ThermoViscoplastPublicEvaluationsCanBeCalledInAnyOrder)
+  {
+    const double requested_temperature = 313.0;
+    const double stale_temperature = 312.0;
+
+    const Core::LinAlg::Matrix<3, 3> id3x3 = Core::LinAlg::identity_matrix<3>();
+
+    const int requested_gp = 0;
+    const int next_gp = 1;
+    const int numgp = 2;
+
+    double total_time = 1.0e-6;
+    double time_step_size = 1.0e-6;
+    Mat::EvaluationContext<3> context{.total_time = &total_time,
+        .time_step_size = &time_step_size,
+        .xi = {},
+        .ref_coords = nullptr};
+
+    const ReformulatedJohnsonCookParameters viscoplastic_law_params{.strain_rate_prefac = 1.0,
+        .strain_rate_exp_fac = 0.014,
+        .init_yield_strength = 792.0,
+        .isotrop_harden_prefac = 510.0,
+        .isotrop_harden_exp = 0.26,
+        .ref_temperature = 293.0,
+        .melt_temperature = 1793.0,
+        .temperature_sens = 1.03};
+
+    Core::LinAlg::Matrix<3, 3> requested_FM(Core::LinAlg::Initialization::zero);
+    requested_FM(0, 0) = 1.55;
+    requested_FM(0, 1) = 0.15;
+    requested_FM(1, 1) = 1.0;
+    requested_FM(2, 2) = 1.0;
+
+    Core::LinAlg::Matrix<3, 3> stale_FM(Core::LinAlg::Initialization::zero);
+    stale_FM(0, 0) = 1.50;
+    stale_FM(0, 1) = 0.10;
+    stale_FM(1, 1) = 1.0;
+    stale_FM(2, 2) = 1.0;
+
+    auto make_material_and_pre_evaluate =
+        [&context, &viscoplastic_law_params](
+            const double material_temperature, const int material_gp)
+    {
+      auto material =
+          set_up_viscoplastic_material({.numgp = numgp,
+                                           .taylor_quinney_coefficient = 0.85,
+                                           .viscoplastic_law_params = viscoplastic_law_params})
+              .material;
+      Teuchos::ParameterList param_list;
+      param_list.set<double>("temperature", material_temperature);
+      material->pre_evaluate(param_list, context, material_gp, 0);
+      return material;
+    };
+
+    auto evaluate_inverse_inelastic_defgrad =
+        [&](const auto& material, const Core::LinAlg::Matrix<3, 3>& defgrad)
+    {
+      Core::LinAlg::Matrix<3, 3> iFin(Core::LinAlg::Initialization::zero);
+      try
+      {
+        material->evaluate_inverse_inelastic_def_grad(&defgrad, id3x3, iFin);
+      }
+      catch (const std::exception& exception)
+      {
+        ADD_FAILURE() << "evaluate_inverse_inelastic_def_grad threw an exception:\n"
+                      << exception.what();
+      }
+      return iFin;
+    };
+
+    auto evaluate_additional_cmat = [&](const auto& material,
+                                        const Core::LinAlg::Matrix<3, 3>& defgrad,
+                                        const Core::LinAlg::Matrix<3, 3>& iFin)
+    {
+      Core::LinAlg::Matrix<3, 3> CM(Core::LinAlg::Initialization::zero);
+      Core::LinAlg::Matrix<3, 3> iCM(Core::LinAlg::Initialization::zero);
+      Core::LinAlg::Matrix<6, 1> iCV(Core::LinAlg::Initialization::zero);
+      CM.multiply_tn(1.0, defgrad, defgrad, 0.0);
+      iCM.invert(CM);
+      Core::LinAlg::Voigt::Stresses::matrix_to_vector(iCM, iCV);
+
+      Core::LinAlg::Matrix<6, 6> cmatadd(Core::LinAlg::Initialization::zero);
+      material->evaluate_additional_cmat(&defgrad, id3x3, iFin, iCV, dSdiFin_, cmatadd);
+
+      EXPECT_GT(cmatadd.norm2(), 0.0);
+      return cmatadd;
+    };
+
+    auto evaluate_od_stiff_mat = [&](const auto& material,
+                                     const Core::LinAlg::Matrix<3, 3>& defgrad,
+                                     const Core::LinAlg::Matrix<3, 3>& iFin)
+    {
+      Core::LinAlg::Matrix<6, 1> dstressdT(Core::LinAlg::Initialization::zero);
+      try
+      {
+        material->evaluate_od_stiff_mat(&defgrad, id3x3, iFin, dSdiFin_, dstressdT);
+      }
+      catch (const std::exception& exception)
+      {
+        ADD_FAILURE() << "evaluate_od_stiff_mat threw an exception:\n" << exception.what();
+      }
+
+      EXPECT_GT(dstressdT.norm2(), 0.0);
+
+      return dstressdT;
+    };
+
+    struct EvaluationResults
+    {
+      Core::LinAlg::Matrix<3, 3> iFin;
+      Core::LinAlg::Matrix<6, 6> cmatadd;
+      Core::LinAlg::Matrix<6, 1> dstressdT;
+      Mat::MechanicalDissipation dissipation;
+    };
+
+    const auto full_evaluation = [&](const auto& material, const int gp,
+                                     const Core::LinAlg::Matrix<3, 3>& defgrad,
+                                     const double temperature) -> EvaluationResults
+    {
+      Teuchos::ParameterList param_list;
+      param_list.set<double>("temperature", temperature);
+      material->pre_evaluate(param_list, context, gp, 0);
+      const Core::LinAlg::Matrix<3, 3> iFin = evaluate_inverse_inelastic_defgrad(material, defgrad);
+      EvaluationResults results;
+      results.iFin = iFin;
+      results.cmatadd = evaluate_additional_cmat(material, defgrad, iFin);
+      results.dstressdT = evaluate_od_stiff_mat(material, defgrad, iFin);
+      results.dissipation =
+          material->evaluate_mechanical_dissipation(gp, &defgrad, id3x3, temperature);
+      return results;
+    };
+
+    auto expect_results_match =
+        [&](const EvaluationResults& actual, const EvaluationResults& expected)
+    {
+      FOUR_C_EXPECT_NEAR(actual.iFin, expected.iFin, 1.0e-16);
+      FOUR_C_EXPECT_NEAR(actual.cmatadd, expected.cmatadd, 1.0e-16);
+      FOUR_C_EXPECT_NEAR(actual.dstressdT, expected.dstressdT, 1.0e-16);
+      EXPECT_NEAR(actual.dissipation.value, expected.dissipation.value, 1.0e-16);
+      FOUR_C_EXPECT_NEAR(actual.dissipation.derivative_wrt_cauchy_green,
+          expected.dissipation.derivative_wrt_cauchy_green, 1.0e-16);
+      EXPECT_NEAR(actual.dissipation.derivative_wrt_temperature,
+          expected.dissipation.derivative_wrt_temperature, 1.0e-16);
+    };
+
+    EvaluationResults expected;
+    {
+      SCOPED_TRACE("reference full evaluation");
+      auto eager_material = make_material_and_pre_evaluate(requested_temperature, requested_gp);
+      expected = full_evaluation(eager_material, requested_gp, requested_FM, requested_temperature);
+      ASSERT_GT(expected.cmatadd.norm2(), 0.0);
+      ASSERT_GT(expected.dstressdT.norm2(), 0.0);
+      ASSERT_GT(std::abs(expected.dissipation.value), 0.0);
+      ASSERT_GT(expected.dissipation.derivative_wrt_cauchy_green.norm2(), 0.0);
+      ASSERT_GT(std::abs(expected.dissipation.derivative_wrt_temperature), 0.0);
+    }
+
+    {
+      SCOPED_TRACE("mechanical dissipation is evaluated first");
+      auto material = make_material_and_pre_evaluate(requested_temperature, requested_gp);
+      EvaluationResults actual;
+      actual.dissipation = material->evaluate_mechanical_dissipation(
+          requested_gp, &requested_FM, id3x3, requested_temperature);
+
+      // only for comparison
+      actual.iFin = evaluate_inverse_inelastic_defgrad(material, requested_FM);
+      actual.cmatadd = evaluate_additional_cmat(material, requested_FM, actual.iFin);
+      actual.dstressdT = evaluate_od_stiff_mat(material, requested_FM, actual.iFin);
+      expect_results_match(actual, expected);
+    }
+
+    {
+      SCOPED_TRACE("mechanical dissipation is evaluated after inverse inelastic defgrad");
+      auto material = make_material_and_pre_evaluate(requested_temperature, requested_gp);
+      EvaluationResults actual;
+      actual.iFin = evaluate_inverse_inelastic_defgrad(material, requested_FM);
+      // evaluate the dissipation while using the cached inverse inelastic defgrad
+      actual.dissipation = material->evaluate_mechanical_dissipation(
+          requested_gp, &requested_FM, id3x3, requested_temperature);
+
+      // only for comparison
+      actual.cmatadd = evaluate_additional_cmat(material, requested_FM, actual.iFin);
+      actual.dstressdT = evaluate_od_stiff_mat(material, requested_FM, actual.iFin);
+      expect_results_match(actual, expected);
+    }
+
+    {
+      SCOPED_TRACE("mechanical dissipation is evaluated after additional cmat");
+      auto material = make_material_and_pre_evaluate(requested_temperature, requested_gp);
+      EvaluationResults actual;
+      actual.iFin = evaluate_inverse_inelastic_defgrad(material, requested_FM);
+      actual.cmatadd = evaluate_additional_cmat(material, requested_FM, actual.iFin);
+      // evaluate the dissipation while using the cached inverse inelastic defgrad and solid
+      // linearization
+      actual.dissipation = material->evaluate_mechanical_dissipation(
+          requested_gp, &requested_FM, id3x3, requested_temperature);
+      actual.dstressdT = evaluate_od_stiff_mat(material, requested_FM, actual.iFin);
+      expect_results_match(actual, expected);
+    }
+
+    {
+      SCOPED_TRACE("mechanical dissipation is evaluated after od stiff mat");
+      auto material = make_material_and_pre_evaluate(requested_temperature, requested_gp);
+      EvaluationResults actual;
+      actual.iFin = evaluate_inverse_inelastic_defgrad(material, requested_FM);
+      actual.dstressdT = evaluate_od_stiff_mat(material, requested_FM, actual.iFin);
+      // evaluate the dissipation while using the cached inverse inelastic defgrad and od stiff mat
+      actual.dissipation = material->evaluate_mechanical_dissipation(
+          requested_gp, &requested_FM, id3x3, requested_temperature);
+      actual.cmatadd = evaluate_additional_cmat(material, requested_FM, actual.iFin);
+      expect_results_match(actual, expected);
+    }
+
+    {
+      SCOPED_TRACE("mechanical dissipation is evaluated after another defgrad was current");
+
+      // setup material with stale defgrad
+      auto material = make_material_and_pre_evaluate(requested_temperature, requested_gp);
+      evaluate_inverse_inelastic_defgrad(material, stale_FM);
+
+      EvaluationResults actual;
+      // evaluate the dissipation. This re-runs the return mapping for the new state
+      actual.dissipation = material->evaluate_mechanical_dissipation(
+          requested_gp, &requested_FM, id3x3, requested_temperature);
+      // only for comparison
+      actual.iFin = evaluate_inverse_inelastic_defgrad(material, requested_FM);
+      actual.cmatadd = evaluate_additional_cmat(material, requested_FM, actual.iFin);
+      actual.dstressdT = evaluate_od_stiff_mat(material, requested_FM, actual.iFin);
+      expect_results_match(actual, expected);
+    }
+
+    {
+      SCOPED_TRACE("mechanical dissipation is evaluated after another temperature was current");
+
+      // setup material with stale temperature
+      auto material = make_material_and_pre_evaluate(stale_temperature, requested_gp);
+      evaluate_inverse_inelastic_defgrad(material, requested_FM);
+
+      EvaluationResults actual;
+      // evaluate the dissipation. This re-runs the return mapping for the new state
+      actual.dissipation = material->evaluate_mechanical_dissipation(
+          requested_gp, &requested_FM, id3x3, requested_temperature);
+      actual.iFin = evaluate_inverse_inelastic_defgrad(material, requested_FM);
+      actual.cmatadd = evaluate_additional_cmat(material, requested_FM, actual.iFin);
+      actual.dstressdT = evaluate_od_stiff_mat(material, requested_FM, actual.iFin);
+      expect_results_match(actual, expected);
+    }
+
+    {
+      SCOPED_TRACE("mechanical dissipation is requested for a different gp than previous calls");
+
+      auto material = make_material_and_pre_evaluate(requested_temperature, next_gp);
+
+      // evaluate at the requested gauss point
+      auto actual = full_evaluation(material, requested_gp, requested_FM, requested_temperature);
+
+      // evaluate at the next gauss point with stale state
+      full_evaluation(material, next_gp, stale_FM, stale_temperature);
+
+      Teuchos::ParameterList params;
+      params.set<double>("temperature", requested_temperature);
+      material->pre_evaluate(params, context, requested_gp, 0);
+
+      // evaluate the dissipation at the requested gauss point, using the cache stored at the last
+      // requested gauss point.
+      actual.dissipation = material->evaluate_mechanical_dissipation(
+          requested_gp, &requested_FM, id3x3, requested_temperature);
+
+      expect_results_match(actual, expected);
+    }
+  }
 }  // namespace

--- a/unittests/mat/4C_inelastic_defgrad_factors_test.cpp
+++ b/unittests/mat/4C_inelastic_defgrad_factors_test.cpp
@@ -2770,27 +2770,28 @@ namespace
     expect_near_relative(dstressdT_analytic, dstressdT_fd, 1.0e-6, 1.0e-9);
   }
 
-  TEST_F(InelasticDefgradFactorsTest, ThermoViscoplastMechanicalDissipationLinearizationMatchesFD)
+  TEST_F(InelasticDefgradFactorsTest, ThermoViscoplastTaylorQuinneyHeatSourceLinearizationMatchesFD)
   {
     auto comparison = set_up_thermo_viscoplast_linearization_comparison();
     FOUR_C_EXPECT_NEAR(comparison.iFin_analytic, comparison.iFin_fd, 1.0e-10);
 
-    const Mat::MechanicalDissipation analytic_dissipation =
-        comparison.analytic_material.material->evaluate_mechanical_dissipation(comparison.context,
-            0, 0, &comparison.FM, Core::LinAlg::identity_matrix<3>(), comparison.temperature);
-    const Mat::MechanicalDissipation fd_dissipation =
-        comparison.fd_material.material->evaluate_mechanical_dissipation(comparison.context, 0, 0,
-            &comparison.FM, Core::LinAlg::identity_matrix<3>(), comparison.temperature);
+    const Mat::HeatSource tq_heat_analytic =
+        comparison.analytic_material.material->evaluate_taylor_quinney_heat_source(
+            comparison.context, 0, 0, &comparison.FM, Core::LinAlg::identity_matrix<3>(),
+            comparison.temperature);
+    const Mat::HeatSource tq_heat_fd =
+        comparison.fd_material.material->evaluate_taylor_quinney_heat_source(comparison.context, 0,
+            0, &comparison.FM, Core::LinAlg::identity_matrix<3>(), comparison.temperature);
 
-    ASSERT_GT(std::abs(analytic_dissipation.value), 0.0);
-    ASSERT_GT(analytic_dissipation.derivative_wrt_cauchy_green.norm2(), 0.0);
-    ASSERT_GT(std::abs(analytic_dissipation.derivative_wrt_temperature), 0.0);
+    ASSERT_GT(std::abs(tq_heat_analytic.value), 0.0);
+    ASSERT_GT(tq_heat_analytic.derivative_wrt_cauchy_green.norm2(), 0.0);
+    ASSERT_GT(std::abs(tq_heat_analytic.derivative_wrt_temperature), 0.0);
 
-    ASSERT_DOUBLE_EQ(analytic_dissipation.value, fd_dissipation.value);
-    expect_near_relative(analytic_dissipation.derivative_wrt_cauchy_green,
-        fd_dissipation.derivative_wrt_cauchy_green, 1.0e-7, 1.0e-16);
-    expect_near_relative(analytic_dissipation.derivative_wrt_temperature,
-        fd_dissipation.derivative_wrt_temperature, 1.0e-8, 1.0e-16);
+    ASSERT_DOUBLE_EQ(tq_heat_analytic.value, tq_heat_fd.value);
+    expect_near_relative(tq_heat_analytic.derivative_wrt_cauchy_green,
+        tq_heat_fd.derivative_wrt_cauchy_green, 1.0e-7, 1.0e-16);
+    expect_near_relative(tq_heat_analytic.derivative_wrt_temperature,
+        tq_heat_fd.derivative_wrt_temperature, 1.0e-8, 1.0e-16);
   }
 
   TEST_F(InelasticDefgradFactorsTest, ThermoViscoplastPublicEvaluationsCanBeCalledInAnyOrder)
@@ -2875,15 +2876,15 @@ namespace
 
     struct ThermoEvaluationResults
     {
-      Mat::MechanicalDissipation dissipation;
+      Mat::HeatSource heat_source;
       static void assert_equal(
           const ThermoEvaluationResults& actual, const ThermoEvaluationResults& expected)
       {
-        ASSERT_DOUBLE_EQ(actual.dissipation.value, expected.dissipation.value);
-        FOUR_C_EXPECT_NEAR(actual.dissipation.derivative_wrt_cauchy_green,
-            expected.dissipation.derivative_wrt_cauchy_green, 1.0e-16);
-        ASSERT_DOUBLE_EQ(actual.dissipation.derivative_wrt_temperature,
-            expected.dissipation.derivative_wrt_temperature);
+        ASSERT_DOUBLE_EQ(actual.heat_source.value, expected.heat_source.value);
+        FOUR_C_EXPECT_NEAR(actual.heat_source.derivative_wrt_cauchy_green,
+            expected.heat_source.derivative_wrt_cauchy_green, 1.0e-16);
+        ASSERT_DOUBLE_EQ(actual.heat_source.derivative_wrt_temperature,
+            expected.heat_source.derivative_wrt_temperature);
       }
     };
 
@@ -2966,16 +2967,16 @@ namespace
         reference.solid_results =
             solid_evaluation(material, requested_gp, requested_FM, requested_temperature);
         // 2.: thermo evaluation
-        reference.thermo_results.dissipation = material->evaluate_mechanical_dissipation(
+        reference.thermo_results.heat_source = material->evaluate_taylor_quinney_heat_source(
             context, requested_gp, 0, &requested_FM, id3x3, requested_temperature);
 
         // Since we are using this result as reference,assert that all values are non-zero to ensure
         // full evaluation paths (no early returns due to no plastic strain)
         ASSERT_GT(reference.solid_results.cmatadd.norm2(), 0.0);
         ASSERT_GT(reference.solid_results.dstressdT.norm2(), 0.0);
-        ASSERT_GT(std::abs(reference.thermo_results.dissipation.value), 0.0);
-        ASSERT_GT(reference.thermo_results.dissipation.derivative_wrt_cauchy_green.norm2(), 0.0);
-        ASSERT_GT(std::abs(reference.thermo_results.dissipation.derivative_wrt_temperature), 0.0);
+        ASSERT_GT(std::abs(reference.thermo_results.heat_source.value), 0.0);
+        ASSERT_GT(reference.thermo_results.heat_source.derivative_wrt_cauchy_green.norm2(), 0.0);
+        ASSERT_GT(std::abs(reference.thermo_results.heat_source.derivative_wrt_temperature), 0.0);
       }
       {
         SCOPED_TRACE(
@@ -2986,7 +2987,7 @@ namespace
         // 1.: solid evaluation with stale temperature
         solid_evaluation(material, requested_gp, requested_FM, stale_temperature);
         // 2.: thermo evaluation with the requested temperature
-        current.dissipation = material->evaluate_mechanical_dissipation(
+        current.heat_source = material->evaluate_taylor_quinney_heat_source(
             context, requested_gp, 0, &requested_FM, id3x3, requested_temperature);
 
         ThermoEvaluationResults::assert_equal(current, reference.thermo_results);
@@ -3000,7 +3001,7 @@ namespace
         // 1.: solid evaluation with stale deformation gradient
         solid_evaluation(material, requested_gp, stale_FM, requested_temperature);
         // 2.: thermo evaluation with the requested deformation gradient
-        current.dissipation = material->evaluate_mechanical_dissipation(
+        current.heat_source = material->evaluate_taylor_quinney_heat_source(
             context, requested_gp, 0, &requested_FM, id3x3, requested_temperature);
         ThermoEvaluationResults::assert_equal(current, reference.thermo_results);
       }
@@ -3019,7 +3020,7 @@ namespace
                                  // gauss point caches are not leaking into each other
         // 2.: thermo evaluation at the requested gauss point (should use the cache filled by the
         // first solid evaluation)
-        current.thermo_results.dissipation = material->evaluate_mechanical_dissipation(
+        current.thermo_results.heat_source = material->evaluate_taylor_quinney_heat_source(
             context, requested_gp, 0, &requested_FM, id3x3, requested_temperature);
         EvaluationResults::assert_equal(current, reference);
       }
@@ -3035,7 +3036,7 @@ namespace
         auto material = make_material();
         EvaluationResults current;
         // 1.: thermo evaluation
-        current.thermo_results.dissipation = material->evaluate_mechanical_dissipation(
+        current.thermo_results.heat_source = material->evaluate_taylor_quinney_heat_source(
             context, requested_gp, 0, &requested_FM, id3x3, requested_temperature);
         // 2.: solid evaluation
         current.solid_results =
@@ -3049,7 +3050,7 @@ namespace
             "evaluation.");
         auto material = make_material();
         // 1.: thermo evaluation with stale temperature
-        (void)material->evaluate_mechanical_dissipation(
+        (void)material->evaluate_taylor_quinney_heat_source(
             context, requested_gp, 0, &requested_FM, id3x3, stale_temperature);
         // 2.: solid evaluation with the requested temperature
         const auto current =
@@ -3063,7 +3064,7 @@ namespace
             "evaluation.");
         auto material = make_material();
         // 1.: thermo evaluation with stale deformation gradient
-        (void)material->evaluate_mechanical_dissipation(
+        (void)material->evaluate_taylor_quinney_heat_source(
             context, requested_gp, 0, &stale_FM, id3x3, requested_temperature);
         // 2.: solid evaluation with the requested deformation gradient
         const auto current =
@@ -3078,9 +3079,9 @@ namespace
         EvaluationResults current;
         // 1.: thermo evaluation at two different gauss points, the most previous one with stale
         // values
-        current.thermo_results.dissipation = material->evaluate_mechanical_dissipation(
+        current.thermo_results.heat_source = material->evaluate_taylor_quinney_heat_source(
             context, requested_gp, 0, &requested_FM, id3x3, requested_temperature);
-        (void)material->evaluate_mechanical_dissipation(context, stale_gp, 0, &stale_FM, id3x3,
+        (void)material->evaluate_taylor_quinney_heat_source(context, stale_gp, 0, &stale_FM, id3x3,
             stale_temperature);  // evaluate the next gauss point with different values to test that
                                  // gauss point caches are not leaking into each other
         // 2.: solid evaluation at the requested gauss point (should use the cache filled by the

--- a/unittests/mat/4C_inelastic_defgrad_factors_test.cpp
+++ b/unittests/mat/4C_inelastic_defgrad_factors_test.cpp
@@ -258,7 +258,10 @@ namespace
     double temperature = 313.0;
     double total_time = 1.0e-6;
     double time_step_size = 1.0e-6;
-    Core::LinAlg::Matrix<3, 3> id3x3 = Core::LinAlg::identity_matrix<3>();
+    Mat::EvaluationContext<3> context{.total_time = &total_time,
+        .time_step_size = &time_step_size,
+        .xi = {},
+        .ref_coords = nullptr};
     Core::LinAlg::Matrix<3, 3> FM{Core::LinAlg::Initialization::zero};
     Core::LinAlg::Matrix<3, 3> iFin_analytic{Core::LinAlg::Initialization::zero};
     Core::LinAlg::Matrix<3, 3> iFin_fd{Core::LinAlg::Initialization::zero};
@@ -300,12 +303,8 @@ namespace
 
     Teuchos::ParameterList param_list;
     param_list.set<double>("temperature", comparison.temperature);
-    Mat::EvaluationContext<3> context{.total_time = &comparison.total_time,
-        .time_step_size = &comparison.time_step_size,
-        .xi = {},
-        .ref_coords = nullptr};
-    comparison.analytic_material.material->pre_evaluate(param_list, context, 0, 0);
-    comparison.fd_material.material->pre_evaluate(param_list, context, 0, 0);
+    comparison.analytic_material.material->pre_evaluate(param_list, comparison.context, 0, 0);
+    comparison.fd_material.material->pre_evaluate(param_list, comparison.context, 0, 0);
 
     comparison.FM(0, 0) = 1.55;
     comparison.FM(1, 1) = 1.0;
@@ -313,9 +312,9 @@ namespace
     comparison.FM(0, 1) = 0.15;
 
     comparison.analytic_material.material->evaluate_inverse_inelastic_def_grad(
-        &comparison.FM, comparison.id3x3, comparison.iFin_analytic);
+        &comparison.FM, Core::LinAlg::identity_matrix<3>(), comparison.iFin_analytic);
     comparison.fd_material.material->evaluate_inverse_inelastic_def_grad(
-        &comparison.FM, comparison.id3x3, comparison.iFin_fd);
+        &comparison.FM, Core::LinAlg::identity_matrix<3>(), comparison.iFin_fd);
 
     Core::LinAlg::Matrix<3, 3> CM(Core::LinAlg::Initialization::zero);
     Core::LinAlg::Matrix<3, 3> iCM(Core::LinAlg::Initialization::zero);
@@ -2745,9 +2744,11 @@ namespace
     Core::LinAlg::Matrix<6, 6> cmatadd_analytic(Core::LinAlg::Initialization::zero);
     Core::LinAlg::Matrix<6, 6> cmatadd_fd(Core::LinAlg::Initialization::zero);
     comparison.analytic_material.material->evaluate_additional_cmat(&comparison.FM,
-        comparison.id3x3, comparison.iFin_analytic, comparison.iCV, dSdiFin_, cmatadd_analytic);
-    comparison.fd_material.material->evaluate_additional_cmat(
-        &comparison.FM, comparison.id3x3, comparison.iFin_fd, comparison.iCV, dSdiFin_, cmatadd_fd);
+        Core::LinAlg::identity_matrix<3>(), comparison.iFin_analytic, comparison.iCV, dSdiFin_,
+        cmatadd_analytic);
+    comparison.fd_material.material->evaluate_additional_cmat(&comparison.FM,
+        Core::LinAlg::identity_matrix<3>(), comparison.iFin_fd, comparison.iCV, dSdiFin_,
+        cmatadd_fd);
 
     ASSERT_GT(cmatadd_analytic.norm2(), 0.0);
     expect_near_relative(cmatadd_analytic, cmatadd_fd, 1.0e-6, 1.0e-9);
@@ -2760,10 +2761,10 @@ namespace
 
     Core::LinAlg::Matrix<6, 1> dstressdT_analytic(Core::LinAlg::Initialization::zero);
     Core::LinAlg::Matrix<6, 1> dstressdT_fd(Core::LinAlg::Initialization::zero);
-    comparison.analytic_material.material->evaluate_od_stiff_mat(
-        &comparison.FM, comparison.id3x3, comparison.iFin_analytic, dSdiFin_, dstressdT_analytic);
-    comparison.fd_material.material->evaluate_od_stiff_mat(
-        &comparison.FM, comparison.id3x3, comparison.iFin_fd, dSdiFin_, dstressdT_fd);
+    comparison.analytic_material.material->evaluate_od_stiff_mat(&comparison.FM,
+        Core::LinAlg::identity_matrix<3>(), comparison.iFin_analytic, dSdiFin_, dstressdT_analytic);
+    comparison.fd_material.material->evaluate_od_stiff_mat(&comparison.FM,
+        Core::LinAlg::identity_matrix<3>(), comparison.iFin_fd, dSdiFin_, dstressdT_fd);
 
     ASSERT_GT(dstressdT_analytic.norm2(), 0.0);
     expect_near_relative(dstressdT_analytic, dstressdT_fd, 1.0e-6, 1.0e-9);
@@ -2775,11 +2776,11 @@ namespace
     FOUR_C_EXPECT_NEAR(comparison.iFin_analytic, comparison.iFin_fd, 1.0e-10);
 
     const Mat::MechanicalDissipation analytic_dissipation =
-        comparison.analytic_material.material->evaluate_mechanical_dissipation(
-            0, &comparison.FM, comparison.id3x3, comparison.temperature);
+        comparison.analytic_material.material->evaluate_mechanical_dissipation(comparison.context,
+            0, 0, &comparison.FM, Core::LinAlg::identity_matrix<3>(), comparison.temperature);
     const Mat::MechanicalDissipation fd_dissipation =
-        comparison.fd_material.material->evaluate_mechanical_dissipation(
-            0, &comparison.FM, comparison.id3x3, comparison.temperature);
+        comparison.fd_material.material->evaluate_mechanical_dissipation(comparison.context, 0, 0,
+            &comparison.FM, Core::LinAlg::identity_matrix<3>(), comparison.temperature);
 
     ASSERT_GT(std::abs(analytic_dissipation.value), 0.0);
     ASSERT_GT(analytic_dissipation.derivative_wrt_cauchy_green.norm2(), 0.0);
@@ -2794,21 +2795,51 @@ namespace
 
   TEST_F(InelasticDefgradFactorsTest, ThermoViscoplastPublicEvaluationsCanBeCalledInAnyOrder)
   {
+    // The viscoplastic factor has two public evaluation paths: one from the solid field (through
+    // pre_evaluate, evaluate_inverse_inelastic_def_grad, evaluate_additional_cmat and (for
+    // monolithic solvers) evaluate_od_stiff_mat) and one from the thermo field (through
+    // evaluate_mechanical_dissipation).
+
+    // This test tests that both evaluation paths are independent of each other, i.e. they can be
+    // called in arbitrary order.
+
+    // Since internally, both evaluation paths are coupled via Gauss point caches, we must also
+    // ensure that either evaluation path uses wrong caches. This is done by letting the second
+    // public evaluation request results at a different gauss point, temperature or deformation
+    // gradient respectively.
+
+    // requested_* values are the values we actually test on. stale_* values are used to show that
+    // those values are not leaking into the evaluations with the requested_* values.
+
     const double requested_temperature = 313.0;
     const double stale_temperature = 312.0;
 
-    const Core::LinAlg::Matrix<3, 3> id3x3 = Core::LinAlg::identity_matrix<3>();
+    Core::LinAlg::Matrix<3, 3> requested_FM(Core::LinAlg::Initialization::zero);
+    requested_FM(0, 0) = 1.55;
+    requested_FM(0, 1) = 0.15;
+    requested_FM(1, 1) = 1.0;
+    requested_FM(2, 2) = 1.0;
+
+    Core::LinAlg::Matrix<3, 3> stale_FM(Core::LinAlg::Initialization::zero);
+    stale_FM(0, 0) = 1.50;
+    stale_FM(0, 1) = 0.15;
+    stale_FM(1, 1) = 1.3;
+    stale_FM(2, 2) = 0.8;
 
     const int requested_gp = 0;
-    const int next_gp = 1;
+    const int stale_gp = 1;
     const int numgp = 2;
 
     double total_time = 1.0e-6;
     double time_step_size = 1.0e-6;
-    Mat::EvaluationContext<3> context{.total_time = &total_time,
+    const Mat::EvaluationContext<3> context{.total_time = &total_time,
         .time_step_size = &time_step_size,
         .xi = {},
         .ref_coords = nullptr};
+
+    // auxiliaries
+    const Core::LinAlg::Matrix<3, 3> id3x3 = Core::LinAlg::identity_matrix<3>();
+    using ViscoPlastMaterial = std::shared_ptr<Mat::InelasticDefgradTransvIsotropElastViscoplast>;
 
     const ReformulatedJohnsonCookParameters viscoplastic_law_params{.strain_rate_prefac = 1.0,
         .strain_rate_exp_fac = 0.014,
@@ -2819,248 +2850,245 @@ namespace
         .melt_temperature = 1793.0,
         .temperature_sens = 1.03};
 
-    Core::LinAlg::Matrix<3, 3> requested_FM(Core::LinAlg::Initialization::zero);
-    requested_FM(0, 0) = 1.55;
-    requested_FM(0, 1) = 0.15;
-    requested_FM(1, 1) = 1.0;
-    requested_FM(2, 2) = 1.0;
-
-    Core::LinAlg::Matrix<3, 3> stale_FM(Core::LinAlg::Initialization::zero);
-    stale_FM(0, 0) = 1.50;
-    stale_FM(0, 1) = 0.10;
-    stale_FM(1, 1) = 1.0;
-    stale_FM(2, 2) = 1.0;
-
-    auto make_material_and_pre_evaluate =
-        [&context, &viscoplastic_law_params](
-            const double material_temperature, const int material_gp)
+    // create a new clean material instance
+    auto make_material = [&viscoplastic_law_params]()
     {
-      auto material =
-          set_up_viscoplastic_material({.numgp = numgp,
-                                           .taylor_quinney_coefficient = 0.85,
-                                           .viscoplastic_law_params = viscoplastic_law_params})
-              .material;
-      Teuchos::ParameterList param_list;
-      param_list.set<double>("temperature", material_temperature);
-      material->pre_evaluate(param_list, context, material_gp, 0);
-      return material;
+      return set_up_viscoplastic_material({.numgp = numgp,
+                                              .taylor_quinney_coefficient = 0.85,
+                                              .viscoplastic_law_params = viscoplastic_law_params})
+          .material;
     };
 
-    auto evaluate_inverse_inelastic_defgrad =
-        [&](const auto& material, const Core::LinAlg::Matrix<3, 3>& defgrad)
-    {
-      Core::LinAlg::Matrix<3, 3> iFin(Core::LinAlg::Initialization::zero);
-      try
-      {
-        material->evaluate_inverse_inelastic_def_grad(&defgrad, id3x3, iFin);
-      }
-      catch (const std::exception& exception)
-      {
-        ADD_FAILURE() << "evaluate_inverse_inelastic_def_grad threw an exception:\n"
-                      << exception.what();
-      }
-      return iFin;
-    };
-
-    auto evaluate_additional_cmat = [&](const auto& material,
-                                        const Core::LinAlg::Matrix<3, 3>& defgrad,
-                                        const Core::LinAlg::Matrix<3, 3>& iFin)
-    {
-      Core::LinAlg::Matrix<3, 3> CM(Core::LinAlg::Initialization::zero);
-      Core::LinAlg::Matrix<3, 3> iCM(Core::LinAlg::Initialization::zero);
-      Core::LinAlg::Matrix<6, 1> iCV(Core::LinAlg::Initialization::zero);
-      CM.multiply_tn(1.0, defgrad, defgrad, 0.0);
-      iCM.invert(CM);
-      Core::LinAlg::Voigt::Stresses::matrix_to_vector(iCM, iCV);
-
-      Core::LinAlg::Matrix<6, 6> cmatadd(Core::LinAlg::Initialization::zero);
-      material->evaluate_additional_cmat(&defgrad, id3x3, iFin, iCV, dSdiFin_, cmatadd);
-
-      EXPECT_GT(cmatadd.norm2(), 0.0);
-      return cmatadd;
-    };
-
-    auto evaluate_od_stiff_mat = [&](const auto& material,
-                                     const Core::LinAlg::Matrix<3, 3>& defgrad,
-                                     const Core::LinAlg::Matrix<3, 3>& iFin)
-    {
-      Core::LinAlg::Matrix<6, 1> dstressdT(Core::LinAlg::Initialization::zero);
-      try
-      {
-        material->evaluate_od_stiff_mat(&defgrad, id3x3, iFin, dSdiFin_, dstressdT);
-      }
-      catch (const std::exception& exception)
-      {
-        ADD_FAILURE() << "evaluate_od_stiff_mat threw an exception:\n" << exception.what();
-      }
-
-      EXPECT_GT(dstressdT.norm2(), 0.0);
-
-      return dstressdT;
-    };
-
-    struct EvaluationResults
+    struct SolidEvaluationResults
     {
       Core::LinAlg::Matrix<3, 3> iFin;
       Core::LinAlg::Matrix<6, 6> cmatadd;
       Core::LinAlg::Matrix<6, 1> dstressdT;
-      Mat::MechanicalDissipation dissipation;
+      static void assert_equal(
+          const SolidEvaluationResults& actual, const SolidEvaluationResults& expected)
+      {
+        FOUR_C_EXPECT_NEAR(actual.iFin, expected.iFin, 1.0e-16);
+        FOUR_C_EXPECT_NEAR(actual.cmatadd, expected.cmatadd, 1.0e-16);
+        FOUR_C_EXPECT_NEAR(actual.dstressdT, expected.dstressdT, 1.0e-16);
+      }
     };
 
-    const auto full_evaluation = [&](const auto& material, const int gp,
-                                     const Core::LinAlg::Matrix<3, 3>& defgrad,
-                                     const double temperature) -> EvaluationResults
+    struct ThermoEvaluationResults
     {
+      Mat::MechanicalDissipation dissipation;
+      static void assert_equal(
+          const ThermoEvaluationResults& actual, const ThermoEvaluationResults& expected)
+      {
+        ASSERT_DOUBLE_EQ(actual.dissipation.value, expected.dissipation.value);
+        FOUR_C_EXPECT_NEAR(actual.dissipation.derivative_wrt_cauchy_green,
+            expected.dissipation.derivative_wrt_cauchy_green, 1.0e-16);
+        ASSERT_DOUBLE_EQ(actual.dissipation.derivative_wrt_temperature,
+            expected.dissipation.derivative_wrt_temperature);
+      }
+    };
+
+    // helper to store a full evaluation result
+    struct EvaluationResults
+    {
+      SolidEvaluationResults solid_results;
+      ThermoEvaluationResults thermo_results;
+
+      // assert that two EvaluationResults are near each other (used for comparing results from
+      // different evaluation orders)
+      static void assert_equal(const EvaluationResults& actual, const EvaluationResults& expected)
+      {
+        SolidEvaluationResults::assert_equal(actual.solid_results, expected.solid_results);
+        ThermoEvaluationResults::assert_equal(actual.thermo_results, expected.thermo_results);
+      };
+    };
+
+    // perform a full solid evaluation of the material
+    const auto solid_evaluation = [&context, this](const ViscoPlastMaterial& material, const int gp,
+                                      const Core::LinAlg::Matrix<3, 3>& defgrad,
+                                      const double temperature) -> SolidEvaluationResults
+    {
+      // pre-evaluate (sets the gauss point index and temperature)
       Teuchos::ParameterList param_list;
       param_list.set<double>("temperature", temperature);
       material->pre_evaluate(param_list, context, gp, 0);
-      const Core::LinAlg::Matrix<3, 3> iFin = evaluate_inverse_inelastic_defgrad(material, defgrad);
-      EvaluationResults results;
-      results.iFin = iFin;
-      results.cmatadd = evaluate_additional_cmat(material, defgrad, iFin);
-      results.dstressdT = evaluate_od_stiff_mat(material, defgrad, iFin);
-      results.dissipation =
-          material->evaluate_mechanical_dissipation(gp, &defgrad, id3x3, temperature);
+
+      SolidEvaluationResults results;
+
+      try
+      {
+        // evaluate and return the inverse inelastic defgrad (relies on pre_evaluate being called
+        // first)
+        material->evaluate_inverse_inelastic_def_grad(
+            &defgrad, Core::LinAlg::identity_matrix<3>(), results.iFin);
+
+        // evaluate the additional cmat contribution (relies on
+        // evaluate_inverse_inelastic_defgrad being called first).
+        // We simply use dSiFin_ from the SetUp(), it does not matter here
+        Core::LinAlg::Matrix<3, 3> CM(Core::LinAlg::Initialization::zero);
+        Core::LinAlg::Matrix<3, 3> iCM(Core::LinAlg::Initialization::zero);
+        Core::LinAlg::Matrix<6, 1> iCV(Core::LinAlg::Initialization::zero);
+        CM.multiply_tn(1.0, defgrad, defgrad, 0.0);
+        iCM.invert(CM);
+        Core::LinAlg::Voigt::Stresses::matrix_to_vector(iCM, iCV);
+        material->evaluate_additional_cmat(&defgrad, Core::LinAlg::identity_matrix<3>(),
+            results.iFin, iCV, dSdiFin_, results.cmatadd);
+        EXPECT_GT(results.cmatadd.norm2(), 0.0);
+
+        // evaluate the off-diagonal stiffness matrix contribution (relies on
+        // evaluate_inverse_inelastic_defgrad being called first)
+        material->evaluate_od_stiff_mat(&defgrad, Core::LinAlg::identity_matrix<3>(), results.iFin,
+            dSdiFin_, results.dstressdT);
+        EXPECT_GT(results.dstressdT.norm2(), 0.0);
+      }
+      catch (const std::exception& exception)
+      {
+        ADD_FAILURE() << "Solid evaluation failed:\n" << exception.what();
+      }
+
       return results;
     };
 
-    auto expect_results_match =
-        [&](const EvaluationResults& actual, const EvaluationResults& expected)
-    {
-      FOUR_C_EXPECT_NEAR(actual.iFin, expected.iFin, 1.0e-16);
-      FOUR_C_EXPECT_NEAR(actual.cmatadd, expected.cmatadd, 1.0e-16);
-      FOUR_C_EXPECT_NEAR(actual.dstressdT, expected.dstressdT, 1.0e-16);
-      EXPECT_NEAR(actual.dissipation.value, expected.dissipation.value, 1.0e-16);
-      FOUR_C_EXPECT_NEAR(actual.dissipation.derivative_wrt_cauchy_green,
-          expected.dissipation.derivative_wrt_cauchy_green, 1.0e-16);
-      EXPECT_NEAR(actual.dissipation.derivative_wrt_temperature,
-          expected.dissipation.derivative_wrt_temperature, 1.0e-16);
-    };
 
-    EvaluationResults expected;
+    //************************* Actual test starts here *************************
+
+    // container to hold the reference evaluation result obtained from solid first
+    EvaluationResults reference;
+
     {
-      SCOPED_TRACE("reference full evaluation");
-      auto eager_material = make_material_and_pre_evaluate(requested_temperature, requested_gp);
-      expected = full_evaluation(eager_material, requested_gp, requested_FM, requested_temperature);
-      ASSERT_GT(expected.cmatadd.norm2(), 0.0);
-      ASSERT_GT(expected.dstressdT.norm2(), 0.0);
-      ASSERT_GT(std::abs(expected.dissipation.value), 0.0);
-      ASSERT_GT(expected.dissipation.derivative_wrt_cauchy_green.norm2(), 0.0);
-      ASSERT_GT(std::abs(expected.dissipation.derivative_wrt_temperature), 0.0);
+      SCOPED_TRACE("Solid evaluation first, thermo evaluation second.");
+
+      {
+        SCOPED_TRACE(
+            "Thermo evaluation requests same temperature and deformation gradient as the solid "
+            "evaluation.");
+        auto material = make_material();
+        // 1.: solid evaluation
+        reference.solid_results =
+            solid_evaluation(material, requested_gp, requested_FM, requested_temperature);
+        // 2.: thermo evaluation
+        reference.thermo_results.dissipation = material->evaluate_mechanical_dissipation(
+            context, requested_gp, 0, &requested_FM, id3x3, requested_temperature);
+
+        // Since we are using this result as reference,assert that all values are non-zero to ensure
+        // full evaluation paths (no early returns due to no plastic strain)
+        ASSERT_GT(reference.solid_results.cmatadd.norm2(), 0.0);
+        ASSERT_GT(reference.solid_results.dstressdT.norm2(), 0.0);
+        ASSERT_GT(std::abs(reference.thermo_results.dissipation.value), 0.0);
+        ASSERT_GT(reference.thermo_results.dissipation.derivative_wrt_cauchy_green.norm2(), 0.0);
+        ASSERT_GT(std::abs(reference.thermo_results.dissipation.derivative_wrt_temperature), 0.0);
+      }
+      {
+        SCOPED_TRACE(
+            "Thermo evaluation requests a different temperature than the previous solid "
+            "evaluation.");
+        auto material = make_material();
+        ThermoEvaluationResults current;
+        // 1.: solid evaluation with stale temperature
+        solid_evaluation(material, requested_gp, requested_FM, stale_temperature);
+        // 2.: thermo evaluation with the requested temperature
+        current.dissipation = material->evaluate_mechanical_dissipation(
+            context, requested_gp, 0, &requested_FM, id3x3, requested_temperature);
+
+        ThermoEvaluationResults::assert_equal(current, reference.thermo_results);
+      }
+      {
+        SCOPED_TRACE(
+            "Thermo evaluation requests a different deformation gradient than the previous solid "
+            "evaluation.");
+        auto material = make_material();
+        ThermoEvaluationResults current;
+        // 1.: solid evaluation with stale deformation gradient
+        solid_evaluation(material, requested_gp, stale_FM, requested_temperature);
+        // 2.: thermo evaluation with the requested deformation gradient
+        current.dissipation = material->evaluate_mechanical_dissipation(
+            context, requested_gp, 0, &requested_FM, id3x3, requested_temperature);
+        ThermoEvaluationResults::assert_equal(current, reference.thermo_results);
+      }
+      {
+        SCOPED_TRACE(
+            "Thermo evaluation requests a different gauss point than the previous solid "
+            "evaluation.");
+        auto material = make_material();
+        EvaluationResults current;
+        // 1.: solid evaluation at two different gauss points, the most previous one with stale
+        // values
+        current.solid_results =
+            solid_evaluation(material, requested_gp, requested_FM, requested_temperature);
+        solid_evaluation(material, stale_gp, stale_FM,
+            stale_temperature);  // evaluate the next gauss point with different values to test that
+                                 // gauss point caches are not leaking into each other
+        // 2.: thermo evaluation at the requested gauss point (should use the cache filled by the
+        // first solid evaluation)
+        current.thermo_results.dissipation = material->evaluate_mechanical_dissipation(
+            context, requested_gp, 0, &requested_FM, id3x3, requested_temperature);
+        EvaluationResults::assert_equal(current, reference);
+      }
     }
 
     {
-      SCOPED_TRACE("mechanical dissipation is evaluated first");
-      auto material = make_material_and_pre_evaluate(requested_temperature, requested_gp);
-      EvaluationResults actual;
-      actual.dissipation = material->evaluate_mechanical_dissipation(
-          requested_gp, &requested_FM, id3x3, requested_temperature);
+      SCOPED_TRACE("Thermo evaluation first, solid evaluation second.");
 
-      // only for comparison
-      actual.iFin = evaluate_inverse_inelastic_defgrad(material, requested_FM);
-      actual.cmatadd = evaluate_additional_cmat(material, requested_FM, actual.iFin);
-      actual.dstressdT = evaluate_od_stiff_mat(material, requested_FM, actual.iFin);
-      expect_results_match(actual, expected);
-    }
+      {
+        SCOPED_TRACE(
+            "Thermo evaluation requests same temperature and deformation gradient as the solid "
+            "evaluation.");
+        auto material = make_material();
+        EvaluationResults current;
+        // 1.: thermo evaluation
+        current.thermo_results.dissipation = material->evaluate_mechanical_dissipation(
+            context, requested_gp, 0, &requested_FM, id3x3, requested_temperature);
+        // 2.: solid evaluation
+        current.solid_results =
+            solid_evaluation(material, requested_gp, requested_FM, requested_temperature);
 
-    {
-      SCOPED_TRACE("mechanical dissipation is evaluated after inverse inelastic defgrad");
-      auto material = make_material_and_pre_evaluate(requested_temperature, requested_gp);
-      EvaluationResults actual;
-      actual.iFin = evaluate_inverse_inelastic_defgrad(material, requested_FM);
-      // evaluate the dissipation while using the cached inverse inelastic defgrad
-      actual.dissipation = material->evaluate_mechanical_dissipation(
-          requested_gp, &requested_FM, id3x3, requested_temperature);
+        EvaluationResults::assert_equal(current, reference);
+      }
+      {
+        SCOPED_TRACE(
+            "Solid evaluation requests a different temperature than the previous thermo "
+            "evaluation.");
+        auto material = make_material();
+        // 1.: thermo evaluation with stale temperature
+        (void)material->evaluate_mechanical_dissipation(
+            context, requested_gp, 0, &requested_FM, id3x3, stale_temperature);
+        // 2.: solid evaluation with the requested temperature
+        const auto current =
+            solid_evaluation(material, requested_gp, requested_FM, requested_temperature);
 
-      // only for comparison
-      actual.cmatadd = evaluate_additional_cmat(material, requested_FM, actual.iFin);
-      actual.dstressdT = evaluate_od_stiff_mat(material, requested_FM, actual.iFin);
-      expect_results_match(actual, expected);
-    }
-
-    {
-      SCOPED_TRACE("mechanical dissipation is evaluated after additional cmat");
-      auto material = make_material_and_pre_evaluate(requested_temperature, requested_gp);
-      EvaluationResults actual;
-      actual.iFin = evaluate_inverse_inelastic_defgrad(material, requested_FM);
-      actual.cmatadd = evaluate_additional_cmat(material, requested_FM, actual.iFin);
-      // evaluate the dissipation while using the cached inverse inelastic defgrad and solid
-      // linearization
-      actual.dissipation = material->evaluate_mechanical_dissipation(
-          requested_gp, &requested_FM, id3x3, requested_temperature);
-      actual.dstressdT = evaluate_od_stiff_mat(material, requested_FM, actual.iFin);
-      expect_results_match(actual, expected);
-    }
-
-    {
-      SCOPED_TRACE("mechanical dissipation is evaluated after od stiff mat");
-      auto material = make_material_and_pre_evaluate(requested_temperature, requested_gp);
-      EvaluationResults actual;
-      actual.iFin = evaluate_inverse_inelastic_defgrad(material, requested_FM);
-      actual.dstressdT = evaluate_od_stiff_mat(material, requested_FM, actual.iFin);
-      // evaluate the dissipation while using the cached inverse inelastic defgrad and od stiff mat
-      actual.dissipation = material->evaluate_mechanical_dissipation(
-          requested_gp, &requested_FM, id3x3, requested_temperature);
-      actual.cmatadd = evaluate_additional_cmat(material, requested_FM, actual.iFin);
-      expect_results_match(actual, expected);
-    }
-
-    {
-      SCOPED_TRACE("mechanical dissipation is evaluated after another defgrad was current");
-
-      // setup material with stale defgrad
-      auto material = make_material_and_pre_evaluate(requested_temperature, requested_gp);
-      evaluate_inverse_inelastic_defgrad(material, stale_FM);
-
-      EvaluationResults actual;
-      // evaluate the dissipation. This re-runs the return mapping for the new state
-      actual.dissipation = material->evaluate_mechanical_dissipation(
-          requested_gp, &requested_FM, id3x3, requested_temperature);
-      // only for comparison
-      actual.iFin = evaluate_inverse_inelastic_defgrad(material, requested_FM);
-      actual.cmatadd = evaluate_additional_cmat(material, requested_FM, actual.iFin);
-      actual.dstressdT = evaluate_od_stiff_mat(material, requested_FM, actual.iFin);
-      expect_results_match(actual, expected);
-    }
-
-    {
-      SCOPED_TRACE("mechanical dissipation is evaluated after another temperature was current");
-
-      // setup material with stale temperature
-      auto material = make_material_and_pre_evaluate(stale_temperature, requested_gp);
-      evaluate_inverse_inelastic_defgrad(material, requested_FM);
-
-      EvaluationResults actual;
-      // evaluate the dissipation. This re-runs the return mapping for the new state
-      actual.dissipation = material->evaluate_mechanical_dissipation(
-          requested_gp, &requested_FM, id3x3, requested_temperature);
-      actual.iFin = evaluate_inverse_inelastic_defgrad(material, requested_FM);
-      actual.cmatadd = evaluate_additional_cmat(material, requested_FM, actual.iFin);
-      actual.dstressdT = evaluate_od_stiff_mat(material, requested_FM, actual.iFin);
-      expect_results_match(actual, expected);
-    }
-
-    {
-      SCOPED_TRACE("mechanical dissipation is requested for a different gp than previous calls");
-
-      auto material = make_material_and_pre_evaluate(requested_temperature, next_gp);
-
-      // evaluate at the requested gauss point
-      auto actual = full_evaluation(material, requested_gp, requested_FM, requested_temperature);
-
-      // evaluate at the next gauss point with stale state
-      full_evaluation(material, next_gp, stale_FM, stale_temperature);
-
-      Teuchos::ParameterList params;
-      params.set<double>("temperature", requested_temperature);
-      material->pre_evaluate(params, context, requested_gp, 0);
-
-      // evaluate the dissipation at the requested gauss point, using the cache stored at the last
-      // requested gauss point.
-      actual.dissipation = material->evaluate_mechanical_dissipation(
-          requested_gp, &requested_FM, id3x3, requested_temperature);
-
-      expect_results_match(actual, expected);
+        SolidEvaluationResults::assert_equal(current, reference.solid_results);
+      }
+      {
+        SCOPED_TRACE(
+            "Solid evaluation requests a different deformation gradient than the previous thermo "
+            "evaluation.");
+        auto material = make_material();
+        // 1.: thermo evaluation with stale deformation gradient
+        (void)material->evaluate_mechanical_dissipation(
+            context, requested_gp, 0, &stale_FM, id3x3, requested_temperature);
+        // 2.: solid evaluation with the requested deformation gradient
+        const auto current =
+            solid_evaluation(material, requested_gp, requested_FM, requested_temperature);
+        SolidEvaluationResults::assert_equal(current, reference.solid_results);
+      }
+      {
+        SCOPED_TRACE(
+            "Solid evaluation requests a different gauss point than the previous thermo "
+            "evaluation.");
+        auto material = make_material();
+        EvaluationResults current;
+        // 1.: thermo evaluation at two different gauss points, the most previous one with stale
+        // values
+        current.thermo_results.dissipation = material->evaluate_mechanical_dissipation(
+            context, requested_gp, 0, &requested_FM, id3x3, requested_temperature);
+        (void)material->evaluate_mechanical_dissipation(context, stale_gp, 0, &stale_FM, id3x3,
+            stale_temperature);  // evaluate the next gauss point with different values to test that
+                                 // gauss point caches are not leaking into each other
+        // 2.: solid evaluation at the requested gauss point (should use the cache filled by the
+        // first thermo evaluation)
+        current.solid_results =
+            solid_evaluation(material, requested_gp, requested_FM, requested_temperature);
+        EvaluationResults::assert_equal(current, reference);
+      }
     }
   }
 }  // namespace


### PR DESCRIPTION
## Description

This PR adds thermal effects to the viscoplastic inelastic deformation-gradient factor, including thermal expansion and Taylor-Quinney mechanical dissipation.

The new `evaluate_mechanical_dissipation` method returns the Taylor-Quinney heat source

$$
R_\mathrm{TQ} = \xi_\mathrm{TQ}\cdot\sigma_\mathrm{eq}\cdot\dot{\varepsilon}_\mathrm{p}
$$

together with its linearizations with respect to temperature and the right Cauchy-Green tensor. In the viscoplastic state evaluation, the mechanical driving stress is changed from the elastic Mandel stress to the thermo-elastic Mandel stress, i.e. the thermal-expansion stress contribution is subtracted.

The main challenge is that `evaluate_mechanical_dissipation` adds another public evaluation path to the material, called from the thermo field. Depending on the coupling algorithm, for example monolithic vs. partitioned, this call may happen before or after the solid-side evaluations and may be requested for a different deformation-gradient/temperature state. Therefore, the thermo-side evaluation must be independent of the solid-side call order. At the same time, re-running return mapping or the history-variable linearization for an unchanged state would be wasteful.

To handle this, the PR adds a `ThermoMechanicalCouplingCache` that stores all quantities needed for thermo-mechanical linearization per Gauss point. A changed incoming state invalidates the cache, and both solid-side and thermo-side evaluations can populate it. The new `evaluate_history_variables_wrt*` helpers either fill the cache or return cached values if they are already valid. `evaluate_additional_cmat`, `evaluate_od_stiff_mat`, and `evaluate_mechanical_dissipation` all use this shared path.

The new `ThermoViscoplastPublicEvaluationsCanBeCalledInAnyOrder` test checks that solid and thermo evaluations can be called in arbitrary order, and that `evaluate_mechanical_dissipation` safely reruns return mapping when the incoming state requires it.

All relevant new linearizations are covered by unit tests against finite differences. For this comparison, `evaluate_additional_cmat` was switched to central finite differences in the perturbation-based path. The thermo-viscoplastic `state_quantities` and `state_quantity_derivatives` are also tested against analytically obtained reference values.

### Current limitation
- thermoelastic coupling with transversely isotropic elastic summands is not supported yet for non-reference temperatures (it throws).
- So far, these are only changes to the factor, it is not wired into the parent material yet. This will be the next PR.

Thanks to @dragos-ana for providing especially the linearizations of the history variables wrt temperature.