### PR TITLE
Add benchmark result badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 [![docs/doxygen](./utilities/assets/badges/documentation_doxygen.svg)](https://4c-multiphysics.github.io/4C/doxygen/)
 [![coverage report](https://4c-multiphysics.github.io/4C/coverage_report/badge_coverage.svg)](https://4c-multiphysics.github.io/4C/coverage_report)
 [![performance_results](./utilities/assets/badges/performance_results.svg)](https://4c-multiphysics.github.io/4C/performance_report/report.html)
+[![benchmark_results](./utilities/assets/badges/benchmark_results.svg)](https://4c-multiphysics.github.io/4C/benchmark_test_report/report.html)
 
 </div>
 

--- a/utilities/assets/badges/benchmark_results.svg
+++ b/utilities/assets/badges/benchmark_results.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="122"
+    height="20" role="img" aria-label="benchmark: results">
+    <title>benchmark: results</title>
+    <linearGradient id="s" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
+        <stop offset="1" stop-opacity=".1" />
+    </linearGradient>
+    <clipPath id="r">
+        <rect width="122" height="20" rx="3" fill="#fff" />
+    </clipPath>
+    <g clip-path="url(#r)">
+        <rect width="67" height="20" fill="#555" />
+        <rect x="67" width="55" height="20" fill="#007ec6" />
+        <rect width="122" height="20" fill="url(#s)" />
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif"
+        text-rendering="geometricPrecision" font-size="110">
+        <text aria-hidden="true" x="335" y="150" fill="#010101" fill-opacity=".3"
+            transform="scale(.1)" textLength="570">benchmark</text>
+        <text x="335" y="140" transform="scale(.1)" fill="#fff" textLength="570">benchmark</text>
+        <text aria-hidden="true" x="945" y="150" fill="#010101" fill-opacity=".3"
+            transform="scale(.1)" textLength="390">results</text>
+        <text x="945" y="140" transform="scale(.1)" fill="#fff" textLength="390">results</text>
+    </g>
+</svg>


### PR DESCRIPTION
## Description and Context
As the title states, a badge to easily access the benchmark results from the README is added.

## Related Issues and Pull Requests
Follows #2039
