### PR TITLE
Enable inelastic growth in impl-fiber

### DIFF
--- a/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
+++ b/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
@@ -4428,6 +4428,9 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
                 {.description = "Id of the time function to scale the deposition stretch "
                                 "(Default: 0=None)",
                     .default_value = 0}),
+            parameter<bool>("INELASTIC_GROWTH",
+                {.description = "Mixture rule has inelastic growth (default false)",
+                    .default_value = false}),
         },
         {.description = "A 1D constituent that remodels"});
   }

--- a/src/mixture/src/4C_mixture_constituent.hpp
+++ b/src/mixture/src/4C_mixture_constituent.hpp
@@ -200,6 +200,19 @@ namespace Mixture
     }
 
     /*!
+     * @brief Provides the d_iFg_d_growth_scalar for the inelastic growth tangent.
+     *
+     * Called by the mixture rule before evaluate_elastic_part to allow constituents that depend on
+     * lambda_ext (through Fg(growth_scalar)) to pre-compute and store
+     * d_lambda_ext_d_growth_scalar per GP.
+     */
+    virtual void prepare_inelastic_growth_tangent(const Core::LinAlg::Tensor<double, 3, 3>& iFg,
+        const Core::LinAlg::Tensor<double, 3, 3>& d_iFg_d_growth_scalar,
+        const Mat::EvaluationContext<3>& context, int gp, int eleGID)
+    {
+    }
+
+    /*!
      * \brief Returns the scalar indicating the growth scale from the reference configuration
      *
      * \return double

--- a/src/mixture/src/4C_mixture_constituent_remodelfiber_impl.cpp
+++ b/src/mixture/src/4C_mixture_constituent_remodelfiber_impl.cpp
@@ -34,6 +34,12 @@ namespace
   {
     return Core::LinAlg::assume_symmetry(Core::LinAlg::transpose(F) * F);
   }
+
+  [[nodiscard]] Core::LinAlg::SymmetricTensor<double, 3, 3> evaluate_inelastic_inv_cauchy_green(
+      const Core::LinAlg::Tensor<double, 3, 3>& iFext)
+  {
+    return Core::LinAlg::assume_symmetry(iFext * Core::LinAlg::transpose(iFext));
+  }
 }  // namespace
 
 Mixture::PAR::MixtureConstituentRemodelFiberImpl::MixtureConstituentRemodelFiberImpl(
@@ -49,7 +55,8 @@ Mixture::PAR::MixtureConstituentRemodelFiberImpl::MixtureConstituentRemodelFiber
       poisson_decay_time_(matdata.parameters.get<double>("DECAY_TIME")),
       growth_constant_(matdata.parameters.get<double>("GROWTH_CONSTANT")),
       deposition_stretch_(matdata.parameters.get<double>("DEPOSITION_STRETCH")),
-      deposition_stretch_timefunc_num_(matdata.parameters.get<int>("DEPOSITION_STRETCH_TIMEFUNCT"))
+      deposition_stretch_timefunc_num_(matdata.parameters.get<int>("DEPOSITION_STRETCH_TIMEFUNCT")),
+      inelastic_external_deformation_(matdata.parameters.get<bool>("INELASTIC_GROWTH"))
 {
 }
 
@@ -210,13 +217,26 @@ Mixture::MixtureConstituentRemodelFiberImpl::evaluate_current_cmat(
   // additional linearization from implicit integration
   if (params_->enable_growth_)
   {
-    Core::LinAlg::SymmetricTensor<double, 3, 3> d_lambda_r_d_cauchy_green =
-        remodel_fiber_[gp].evaluate_d_current_lambda_r_d_lambda_f_sq() *
+    const Core::LinAlg::SymmetricTensor<double, 3, 3> d_lambdafsq_dc =
         evaluate_d_lambdafsq_dc(gp, eleGID);
+
+    Core::LinAlg::SymmetricTensor<double, 3, 3> d_lambda_r_d_cauchy_green =
+        remodel_fiber_[gp].evaluate_d_current_lambda_r_d_lambda_f_sq() * d_lambdafsq_dc;
 
     const double dpk2dlambdar = remodel_fiber_[gp].evaluate_d_current_fiber_pk2_stress_d_lambda_r();
     cmat += 2.0 * dpk2dlambdar *
             Core::LinAlg::dyadic(structural_tensors_[gp], d_lambda_r_d_cauchy_green);
+
+    // additional linearization in case of inelastic growth laws
+    if (params_->inelastic_external_deformation_)
+    {
+      const double dpk2dlambdaext =
+          remodel_fiber_[gp].evaluate_d_current_fiber_pk2_stress_d_lambda_ext();
+      const Core::LinAlg::SymmetricTensor<double, 3, 3> d_growth_scalar_d_cauchy_green =
+          remodel_fiber_[gp].evaluate_d_current_growth_scalar_d_lambda_f_sq() * d_lambdafsq_dc;
+      cmat += 2.0 * dpk2dlambdaext * remodel_fiber_[gp].get_d_lambda_ext_d_growth_scalar() *
+              Core::LinAlg::dyadic(structural_tensors_[gp], d_growth_scalar_d_cauchy_green);
+    }
   }
 
   return cmat;
@@ -271,10 +291,66 @@ void Mixture::MixtureConstituentRemodelFiberImpl::evaluate_elastic_part(
     Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
     Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID)
 {
-  FOUR_C_THROW(
-      "The implicit remodel fiber cannot be evaluated with an additional inelastic deformation. "
-      "You can either use the explicit remodel fiber or use a growth strategy without an inelastic "
-      "external deformation.");
+  if (!params_->inelastic_external_deformation_)
+  {
+    FOUR_C_THROW(
+        "You specified that there is no inelastic external deformation in the input file, but this "
+        "method is only called if there is one. Probably, you are using a mixture rule with "
+        "inelastic growth. You have to set INELASTIC_GROWTH to true or use a different growth "
+        "rule.");
+  }
+
+  FOUR_C_ASSERT(context.time_step_size, "Time step size not given in evaluation context.");
+  const double dt = *context.time_step_size;
+
+  FOUR_C_ASSERT(std::cmp_greater_equal(structural_tensors_.size(), gp + 1),
+      "structural_tensors_ must be initialized by prepare_inelastic_growth_tangent before "
+      "evaluate_elastic_part is called.");
+
+  Core::LinAlg::SymmetricTensor<double, 3, 3> C = evaluate_cauchy_green(FM);
+
+  const double lambda_f = evaluate_lambdaf(C, gp, eleGID);
+  const double lambda_ext = evaluate_lambda_ext(iFextin, gp, eleGID);
+  remodel_fiber_[gp].set_state(lambda_f, lambda_ext);
+
+  if (params_->enable_growth_) integrate_local_evolution_equations(dt, gp, eleGID);
+
+  S_stress = evaluate_current_pk2(gp, eleGID);
+  cmat = evaluate_current_cmat(gp, eleGID);
+}
+
+double Mixture::MixtureConstituentRemodelFiberImpl::evaluate_lambda_ext(
+    const Core::LinAlg::Tensor<double, 3, 3>& iFext, const int gp, const int eleGID) const
+{
+  return 1.0 / std::sqrt(Core::LinAlg::ddot(
+                   evaluate_inelastic_inv_cauchy_green(iFext), structural_tensors_[gp]));
+}
+
+void Mixture::MixtureConstituentRemodelFiberImpl::prepare_inelastic_growth_tangent(
+    const Core::LinAlg::Tensor<double, 3, 3>& iFg,
+    const Core::LinAlg::Tensor<double, 3, 3>& d_iFg_d_growth_scalar,
+    const Mat::EvaluationContext<3>& context, int gp, int eleGID)
+{
+  if (!params_->inelastic_external_deformation_) return;
+
+  if (static_cast<int>(structural_tensors_.size()) < gp + 1)
+  {
+    FOUR_C_ASSERT(std::cmp_equal(structural_tensors_.size(), gp),
+        "Expecting the Gauss points to be called in order!");
+    Core::LinAlg::Tensor<double, 3> orientation =
+        params_->fiber_orientation.interpolate(eleGID, context.xi->as_span());
+    structural_tensors_.emplace_back(Core::LinAlg::self_dyadic(orientation));
+  }
+
+  const double lambda_ext = evaluate_lambda_ext(iFg, gp, eleGID);
+
+  // d_lambda_ext_d_growth_scalar = -lambda_ext^3 * (iFg * A_fiber) : d_iFg_d_growth_scalar
+  const double d_lambda_ext_d_growth_scalar =
+      -std::pow(lambda_ext, 3) *
+      Core::LinAlg::ddot(
+          iFg * Core::LinAlg::get_full(structural_tensors_[gp]), d_iFg_d_growth_scalar);
+
+  remodel_fiber_[gp].set_d_lambda_ext_d_growth_scalar(d_lambda_ext_d_growth_scalar);
 }
 
 double Mixture::MixtureConstituentRemodelFiberImpl::get_growth_scalar(int gp) const

--- a/src/mixture/src/4C_mixture_constituent_remodelfiber_impl.hpp
+++ b/src/mixture/src/4C_mixture_constituent_remodelfiber_impl.hpp
@@ -51,6 +51,7 @@ namespace Mixture
 
       const double deposition_stretch_;
       const int deposition_stretch_timefunc_num_;
+      const bool inelastic_external_deformation_;
     };
   }  // namespace PAR
 
@@ -90,6 +91,10 @@ namespace Mixture
         Core::LinAlg::SymmetricTensor<double, 3, 3>& S_stress,
         Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat, int gp, int eleGID) override;
 
+    void prepare_inelastic_growth_tangent(const Core::LinAlg::Tensor<double, 3, 3>& iFg,
+        const Core::LinAlg::Tensor<double, 3, 3>& d_iFg_d_growth_scalar,
+        const Mat::EvaluationContext<3>& context, int gp, int eleGID) override;
+
     [[nodiscard]] double get_growth_scalar(int gp) const override;
     [[nodiscard]] Core::LinAlg::SymmetricTensor<double, 3, 3> get_d_growth_scalar_d_cg(
         int gp, int eleGID) const override;
@@ -104,6 +109,8 @@ namespace Mixture
     void integrate_local_evolution_equations(double dt, int gp, int eleGID);
     [[nodiscard]] double evaluate_lambdaf(
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& C, int gp, int eleGID) const;
+    [[nodiscard]] double evaluate_lambda_ext(
+        const Core::LinAlg::Tensor<double, 3, 3>& iFext, int gp, int eleGID) const;
     [[nodiscard]] Core::LinAlg::SymmetricTensor<double, 3, 3> evaluate_d_lambdafsq_dc(
         int gp, int eleGID) const;
 

--- a/src/mixture/src/4C_mixture_growth_strategy.hpp
+++ b/src/mixture/src/4C_mixture_growth_strategy.hpp
@@ -96,6 +96,22 @@ namespace Mixture
         int eleGID) const = 0;
 
     /*!
+     * @brief Returns d_iFg_/d_growth_scalar - derivative of the inverse inelastic deformation
+     * gradient with respect to the growth scalar. Used to assemble the consistent tangent
+     * when lambda_ext depends on growth_scalar (inelastic growth strategies).
+     *
+     * Default implementation returns the zero tensor (no inelastic deformation, e.g. stiffness
+     * strategy).
+     */
+    [[nodiscard]] virtual Core::LinAlg::Tensor<double, 3, 3>
+    evaluate_d_inverse_growth_deformation_gradient_d_growth_scalar(
+        double currentReferenceGrowthScalar, const Mat::EvaluationContext<3>& context, int gp,
+        int eleGID) const
+    {
+      return {};
+    }
+
+    /*!
      * @brief Evaluates the contribution of the growth strategy to the stress tensor and the
      * linearization.
      *

--- a/src/mixture/src/4C_mixture_growth_strategy_anisotropic.cpp
+++ b/src/mixture/src/4C_mixture_growth_strategy_anisotropic.cpp
@@ -74,6 +74,22 @@ void Mixture::AnisotropicGrowthStrategy::evaluate_inverse_growth_deformation_gra
                              Core::LinAlg::TensorGenerators::identity<double, 3, 3>);
 }
 
+Core::LinAlg::Tensor<double, 3, 3>
+Mixture::AnisotropicGrowthStrategy::evaluate_d_inverse_growth_deformation_gradient_d_growth_scalar(
+    const double currentReferenceGrowthScalar, const Mat::EvaluationContext<3>& context,
+    const int gp, const int eleGID) const
+{
+  if (gp >= static_cast<int>(structural_tensors_.size()))
+  {
+    Core::LinAlg::Tensor<double, 3> growth_direction =
+        params_->growth_direction.interpolate(eleGID, context.xi->as_span());
+    structural_tensors_.emplace_back(Core::LinAlg::self_dyadic(growth_direction));
+  }
+  return Core::LinAlg::get_full(-1.0 /
+                                (currentReferenceGrowthScalar * currentReferenceGrowthScalar) *
+                                structural_tensors_[gp]);
+}
+
 void Mixture::AnisotropicGrowthStrategy::evaluate_growth_stress_cmat(
     const Mixture::MixtureRule& mixtureRule, double currentReferenceGrowthScalar,
     const Core::LinAlg::SymmetricTensor<double, 3, 3>& dCurrentReferenceGrowthScalarDC,

--- a/src/mixture/src/4C_mixture_growth_strategy_anisotropic.hpp
+++ b/src/mixture/src/4C_mixture_growth_strategy_anisotropic.hpp
@@ -62,6 +62,11 @@ namespace Mixture
         const Mixture::MixtureRule& mixtureRule, double currentReferenceGrowthScalar,
         const Mat::EvaluationContext<3>& context, int gp, int eleGID) const override;
 
+    [[nodiscard]] Core::LinAlg::Tensor<double, 3, 3>
+    evaluate_d_inverse_growth_deformation_gradient_d_growth_scalar(
+        double currentReferenceGrowthScalar, const Mat::EvaluationContext<3>& context, int gp,
+        int eleGID) const override;
+
     void evaluate_growth_stress_cmat(const Mixture::MixtureRule& mixtureRule,
         double currentReferenceGrowthScalar,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& dCurrentReferenceGrowthScalarDC,

--- a/src/mixture/src/4C_mixture_growth_strategy_isotropic.cpp
+++ b/src/mixture/src/4C_mixture_growth_strategy_isotropic.cpp
@@ -33,6 +33,15 @@ void Mixture::IsotropicGrowthStrategy::evaluate_inverse_growth_deformation_gradi
          Core::LinAlg::get_full(Core::LinAlg::TensorGenerators::identity<double, 3, 3>);
 }
 
+Core::LinAlg::Tensor<double, 3, 3>
+Mixture::IsotropicGrowthStrategy::evaluate_d_inverse_growth_deformation_gradient_d_growth_scalar(
+    const double currentReferenceGrowthScalar, const Mat::EvaluationContext<3>& context,
+    const int gp, const int eleGID) const
+{
+  return (-1.0 / 3.0) * std::pow(currentReferenceGrowthScalar, -4.0 / 3.0) *
+         Core::LinAlg::get_full(Core::LinAlg::TensorGenerators::identity<double, 3, 3>);
+}
+
 void Mixture::IsotropicGrowthStrategy::evaluate_growth_stress_cmat(
     const Mixture::MixtureRule& mixtureRule, double currentReferenceGrowthScalar,
     const Core::LinAlg::SymmetricTensor<double, 3, 3>& dCurrentReferenceGrowthScalarDC,

--- a/src/mixture/src/4C_mixture_growth_strategy_isotropic.hpp
+++ b/src/mixture/src/4C_mixture_growth_strategy_isotropic.hpp
@@ -41,6 +41,11 @@ namespace Mixture
         const Mixture::MixtureRule& mixtureRule, double currentReferenceGrowthScalar,
         const Mat::EvaluationContext<3>& context, int gp, int eleGID) const override;
 
+    [[nodiscard]] Core::LinAlg::Tensor<double, 3, 3>
+    evaluate_d_inverse_growth_deformation_gradient_d_growth_scalar(
+        double currentReferenceGrowthScalar, const Mat::EvaluationContext<3>& context, int gp,
+        int eleGID) const override;
+
     void evaluate_growth_stress_cmat(const Mixture::MixtureRule& mixtureRule,
         double currentReferenceGrowthScalar,
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& dCurrentReferenceGrowthScalarDC,

--- a/src/mixture/src/4C_mixture_remodelfiber-internal.hpp
+++ b/src/mixture/src/4C_mixture_remodelfiber-internal.hpp
@@ -140,6 +140,8 @@ namespace Mixture
           T lambda_f, T lambda_r, T lambda_ext, T growth_scalar) const;
       [[nodiscard]] T evaluate_d_growth_evolution_equation_dt_d_remodel(
           T lambda_f, T lambda_r, T lambda_ext, T growth_scalar) const;
+      [[nodiscard]] T evaluate_d_growth_evolution_equation_dt_d_lambda_ext(
+          T lambda_f, T lambda_r, T lambda_ext, T growth_scalar) const;
 
       [[nodiscard]] T evaluate_remodel_evolution_equation_dt(
           T lambda_f, T lambda_r, T lambda_ext) const;
@@ -156,6 +158,8 @@ namespace Mixture
       [[nodiscard]] T evaluate_d_remodel_evolution_equation_dt_d_growth(
           T lambda_f, T lambda_r, T lambda_ext) const;
       [[nodiscard]] T evaluate_d_remodel_evolution_equation_dt_d_remodel(
+          T lambda_f, T lambda_r, T lambda_ext) const;
+      [[nodiscard]] T evaluate_d_remodel_evolution_equation_dt_d_lambda_ext(
           T lambda_f, T lambda_r, T lambda_ext) const;
 
       [[nodiscard]] T evaluate_fiber_cauchy_stress(T lambda_f, T lambda_r, T lambda_ext) const;
@@ -208,6 +212,9 @@ namespace Mixture
       [[nodiscard]] T evaluate_current_fiber_pk2_stress() const;
       [[nodiscard]] T evaluate_d_current_fiber_pk2_stress_d_lambda_f_sq() const;
       [[nodiscard]] T evaluate_d_current_fiber_pk2_stress_d_lambda_r() const;
+      [[nodiscard]] T evaluate_d_current_fiber_pk2_stress_d_lambda_ext() const;
+      void set_d_lambda_ext_d_growth_scalar(T value);
+      [[nodiscard]] T get_d_lambda_ext_d_growth_scalar() const;
       [[nodiscard]] T
       evaluate_d_current_growth_evolution_implicit_time_integration_residuum_d_lambda_f_sq(
           T dt) const;
@@ -232,6 +239,10 @@ namespace Mixture
       T d_growth_scalar_d_lambda_f_sq_ = 0.0;
       T d_lambda_r_d_lambda_f_sq_ = 0.0;
       /// @}
+
+      /// d_lambda_ext_d_growth_scalar_ - set from outside (growth strategy via mixture rule).
+      /// Non-zero only for inelastic growth strategies where Fg depends on growth_scalar.
+      T d_lambda_ext_d_growth_scalar_ = 0.0;
 
       /// homeostatic quantities
       /// @{

--- a/src/mixture/src/4C_mixture_remodelfiber.cpp
+++ b/src/mixture/src/4C_mixture_remodelfiber.cpp
@@ -56,6 +56,12 @@ namespace
   {
     return 1.0 / std::pow(lambda_r * lambda_ext, 2);
   }
+
+  template <typename T>
+  [[nodiscard]] T evaluate_di4_dlambda_ext(T lambda_f, T lambda_r, T lambda_ext)
+  {
+    return -2.0 * std::pow(lambda_f, 2) / (std::pow(lambda_r * lambda_ext, 2) * lambda_ext);
+  }
 }  // namespace
 
 template <int numstates, typename T>
@@ -177,6 +183,20 @@ void Mixture::Implementation::RemodelFiberImplementation<numstates, T>::set_lamb
 }
 
 template <int numstates, typename T>
+void Mixture::Implementation::RemodelFiberImplementation<numstates,
+    T>::set_d_lambda_ext_d_growth_scalar(const T value)
+{
+  d_lambda_ext_d_growth_scalar_ = value;
+}
+
+template <int numstates, typename T>
+T Mixture::Implementation::RemodelFiberImplementation<numstates,
+    T>::get_d_lambda_ext_d_growth_scalar() const
+{
+  return d_lambda_ext_d_growth_scalar_;
+}
+
+template <int numstates, typename T>
 Mixture::Implementation::IntegrationState<numstates, T>
 Mixture::Implementation::RemodelFiberImplementation<numstates,
     T>::get_integration_state_growth_scalar_with_nonlocal_stimulus(const T psi) const
@@ -274,6 +294,16 @@ void Mixture::Implementation::RemodelFiberImplementation<numstates,
         ImplicitIntegration<numstates, T>::get_partial_derivative_xnp(remodel_state, dt) +
         ImplicitIntegration<numstates, T>::get_partial_derivative_fnp(remodel_state, dt) *
             evaluate_d_remodel_evolution_equation_dt_d_remodel(lambda_f, lambda_r_np, lambda_ext);
+
+    // d_lambda_ext/d_growth_scalar contribution
+    drdx(0, 0) += ImplicitIntegration<numstates, T>::get_partial_derivative_fnp(growth_state, dt) *
+                  evaluate_d_growth_evolution_equation_dt_d_lambda_ext(
+                      lambda_f, lambda_r_np, lambda_ext, growth_scalar_np) *
+                  d_lambda_ext_d_growth_scalar_;
+    drdx(1, 0) +=
+        ImplicitIntegration<numstates, T>::get_partial_derivative_fnp(remodel_state, dt) *
+        evaluate_d_remodel_evolution_equation_dt_d_lambda_ext(lambda_f, lambda_r_np, lambda_ext) *
+        d_lambda_ext_d_growth_scalar_;
 
     return std::make_tuple(drdx, residuum);
   };
@@ -461,6 +491,26 @@ T Mixture::Implementation::RemodelFiberImplementation<numstates,
 
 template <int numstates, typename T>
 T Mixture::Implementation::RemodelFiberImplementation<numstates,
+    T>::evaluate_d_growth_evolution_equation_dt_d_lambda_ext(const T lambda_f, const T lambda_r,
+    const T lambda_ext, const T growth_scalar) const
+{
+  return evaluate_d_growth_evolution_equation_dt_d_sig(
+             lambda_f, lambda_r, lambda_ext, growth_scalar) *
+         evaluate_d_fiber_cauchy_stress_partial_d_i4(lambda_f, lambda_r, lambda_ext) *
+         evaluate_di4_dlambda_ext(lambda_f, lambda_r, lambda_ext);
+}
+
+template <int numstates, typename T>
+T Mixture::Implementation::RemodelFiberImplementation<numstates,
+    T>::evaluate_d_remodel_evolution_equation_dt_d_lambda_ext(const T lambda_f, const T lambda_r,
+    const T lambda_ext) const
+{
+  return evaluate_d_remodel_evolution_equation_dt_d_i4(lambda_f, lambda_r, lambda_ext) *
+         evaluate_di4_dlambda_ext(lambda_f, lambda_r, lambda_ext);
+}
+
+template <int numstates, typename T>
+T Mixture::Implementation::RemodelFiberImplementation<numstates,
     T>::evaluate_remodeling_reaction_coefficient(const T lambda_f, const T lambda_r,
     const T lambda_ext) const
 {
@@ -635,6 +685,21 @@ T Mixture::Implementation::RemodelFiberImplementation<numstates,
 
 template <int numstates, typename T>
 T Mixture::Implementation::RemodelFiberImplementation<numstates,
+    T>::evaluate_d_current_fiber_pk2_stress_d_lambda_ext() const
+{
+  FOUR_C_ASSERT(state_is_set_, "You have to call set_state() before!");
+  const T lambda_f = states_.back().lambda_f;
+  const T lambda_r = states_.back().lambda_r;
+  const T lambda_ext = states_.back().lambda_ext;
+  const T I4 = evaluate_i4<T>(lambda_f, lambda_r, lambda_ext);
+
+  const T dI4dlambdaext = evaluate_di4_dlambda_ext(lambda_f, lambda_r, lambda_ext);
+
+  return fiber_material_->get_d_cauchy_stress_d_i4(I4) * dI4dlambdaext / std::pow(lambda_f, 2);
+}
+
+template <int numstates, typename T>
+T Mixture::Implementation::RemodelFiberImplementation<numstates,
     T>::evaluate_d_current_growth_evolution_implicit_time_integration_residuum_d_lambda_f_sq(T dt)
     const
 {
@@ -740,9 +805,11 @@ T Mixture::Implementation::RemodelFiberImplementation<numstates,
 
   const T d_i4_d_lambda_f_sq = evaluate_di4_dlambda_f_sq(lambda_f, lambda_r, lambda_ext);
   const T d_i4_d_lambda_r = evaluate_di4_dlambda_r(lambda_f, lambda_r, lambda_ext);
+  const T d_i4_d_lambda_ext = evaluate_di4_dlambda_ext(lambda_f, lambda_r, lambda_ext);
 
   return fiber_material_->get_d_cauchy_stress_d_i4(I4) *
-         (d_i4_d_lambda_f_sq + d_i4_d_lambda_r * d_lambda_r_d_lambda_f_sq_);
+         (d_i4_d_lambda_f_sq + d_i4_d_lambda_r * d_lambda_r_d_lambda_f_sq_ +
+             d_i4_d_lambda_ext * d_lambda_ext_d_growth_scalar_ * d_growth_scalar_d_lambda_f_sq_);
 }
 
 template <int numstates, typename T>
@@ -823,6 +890,18 @@ void Mixture::RemodelFiber<numstates>::set_lambda_r(const double lambda_r)
 }
 
 template <int numstates>
+void Mixture::RemodelFiber<numstates>::set_d_lambda_ext_d_growth_scalar(const double value)
+{
+  impl_->set_d_lambda_ext_d_growth_scalar(value);
+}
+
+template <int numstates>
+double Mixture::RemodelFiber<numstates>::get_d_lambda_ext_d_growth_scalar() const
+{
+  return impl_->get_d_lambda_ext_d_growth_scalar();
+}
+
+template <int numstates>
 void Mixture::RemodelFiber<numstates>::integrate_local_evolution_equations_implicit(const double dt)
 {
   impl_->integrate_local_evolution_equations_implicit(dt);
@@ -870,6 +949,12 @@ template <int numstates>
 double Mixture::RemodelFiber<numstates>::evaluate_d_current_fiber_pk2_stress_d_lambda_r() const
 {
   return impl_->evaluate_d_current_fiber_pk2_stress_d_lambda_r();
+};
+
+template <int numstates>
+double Mixture::RemodelFiber<numstates>::evaluate_d_current_fiber_pk2_stress_d_lambda_ext() const
+{
+  return impl_->evaluate_d_current_fiber_pk2_stress_d_lambda_ext();
 };
 
 template <int numstates>

--- a/src/mixture/src/4C_mixture_remodelfiber.hpp
+++ b/src/mixture/src/4C_mixture_remodelfiber.hpp
@@ -87,6 +87,8 @@ namespace Mixture
     void set_state(double lambda_f, double lambda_ext);
     void set_growth_scalar(double growth_scalar);
     void set_lambda_r(double lambda_r);
+    void set_d_lambda_ext_d_growth_scalar(double value);
+    [[nodiscard]] double get_d_lambda_ext_d_growth_scalar() const;
 
    public:
     /// @brief Evaluation methods
@@ -127,6 +129,7 @@ namespace Mixture
     [[nodiscard]] double evaluate_current_fiber_pk2_stress() const;
     [[nodiscard]] double evaluate_d_current_fiber_pk2_stress_d_lambda_f_sq() const;
     [[nodiscard]] double evaluate_d_current_fiber_pk2_stress_d_lambda_r() const;
+    [[nodiscard]] double evaluate_d_current_fiber_pk2_stress_d_lambda_ext() const;
     [[nodiscard]] double
     evaluate_d_current_growth_evolution_implicit_time_integration_residuum_d_lambda_f_sq(
         double dt) const;

--- a/src/mixture/src/4C_mixture_rule_growthremodel.cpp
+++ b/src/mixture/src/4C_mixture_rule_growthremodel.cpp
@@ -126,6 +126,16 @@ void Mixture::GrowthRemodelMixtureRule::evaluate(const Core::LinAlg::Tensor<doub
 
     growth_strategy_->evaluate_inverse_growth_deformation_gradient(
         iF_gM, *this, currentReferenceGrowthScalar, context, gp, eleGID);
+
+    const Core::LinAlg::Tensor<double, 3, 3> d_iFg_d_growth_scalar =
+        growth_strategy_->evaluate_d_inverse_growth_deformation_gradient_d_growth_scalar(
+            currentReferenceGrowthScalar, context, gp, eleGID);
+
+    // d_iFg_d_growth_scalar w.r.t. the mixture reference growth scalar and additional
+    // chain factor d_growth_scalar_mix_d_growth_scalar_i = w_i per constituent
+    for (std::size_t i = 0; i < constituents().size(); ++i)
+      constituents()[i]->prepare_inelastic_growth_tangent(
+          iF_gM, params_->mass_fractions_[i] * d_iFg_d_growth_scalar, context, gp, eleGID);
   }
 
   // define temporary matrices

--- a/src/mixture/tests/4C_mixture_remodelfiber_test.cpp
+++ b/src/mixture/tests/4C_mixture_remodelfiber_test.cpp
@@ -234,6 +234,42 @@ namespace
     EXPECT_FLOAT_EQ(cauchy_stress.dx(0), d_cauchy_stress_d_lambda_f_sq.val() * 2 * lambda_f.val());
   }
 
+  TEST_F(RemodelFiberTest, TestEvaluateDGrowthEvolutionEquationDtDLambdaExt)
+  {
+    Mixture::Implementation::RemodelFiberImplementation<2, FADdouble> fiber =
+        generate_fiber<FADdouble>();
+
+    const double lambda_f = 1.02;
+    const FADdouble lambda_ext = FADdouble(1, 0, 1.014);
+    const FADdouble growth_scalar = 1.12;
+    const FADdouble lambda_r = 1.05;
+
+    const FADdouble y =
+        fiber.evaluate_growth_evolution_equation_dt(lambda_f, lambda_r, lambda_ext, growth_scalar);
+    const FADdouble d_growth_d_lambda_ext =
+        fiber.evaluate_d_growth_evolution_equation_dt_d_lambda_ext(
+            lambda_f, lambda_r, lambda_ext, growth_scalar);
+
+    EXPECT_FLOAT_EQ(y.dx(0), d_growth_d_lambda_ext.val());
+  }
+
+  TEST_F(RemodelFiberTest, TestEvaluateDRemodelEvolutionEquationDtDLambdaExt)
+  {
+    Mixture::Implementation::RemodelFiberImplementation<2, FADdouble> fiber =
+        generate_fiber<FADdouble>();
+
+    const double lambda_f = 1.02;
+    const FADdouble lambda_ext = FADdouble(1, 0, 1.014);
+    const FADdouble lambda_r = 1.05;
+
+    const FADdouble y =
+        fiber.evaluate_remodel_evolution_equation_dt(lambda_f, lambda_r, lambda_ext);
+    const FADdouble d_remodel_d_lambda_ext =
+        fiber.evaluate_d_remodel_evolution_equation_dt_d_lambda_ext(lambda_f, lambda_r, lambda_ext);
+
+    EXPECT_FLOAT_EQ(y.dx(0), d_remodel_d_lambda_ext.val());
+  }
+
   TEST_F(RemodelFiberTest, test_evaluate_d_current_growth_scalar_d_lambda_f_sq)
   {
     Mixture::Implementation::RemodelFiberImplementation<2, FADdouble> fiber =

--- a/tests/input_files/homogenized-constrained-mixture-cube-aniso-impl.4C.yaml
+++ b/tests/input_files/homogenized-constrained-mixture-cube-aniso-impl.4C.yaml
@@ -1,0 +1,458 @@
+TITLE:
+  - "Growth simulation with anisotropic growth law"
+PROBLEM TYPE:
+  PROBLEMTYPE: "Structure"
+IO:
+  OUTPUT_SPRING: true
+  STRUCT_STRESS: "Cauchy"
+  STRUCT_STRAIN: "GL"
+  WRITE_INITIAL_STATE: false
+  VERBOSITY: "Standard"
+IO/RUNTIME VTK OUTPUT:
+  INTERVAL_STEPS: 1
+  OUTPUT_DATA_FORMAT: ascii
+IO/RUNTIME VTK OUTPUT/STRUCTURE:
+  OUTPUT_STRUCTURE: true
+  DISPLACEMENT: true
+  STRESS_STRAIN: true
+  GAUSS_POINT_DATA_OUTPUT_TYPE: nodes
+SOLVER 1:
+  SOLVER: "MUMPS"
+  NAME: "Structure_Solver"
+STRUCTURAL DYNAMIC:
+  RESTARTEVERY: 5
+  DYNAMICTYPE: "Statics"
+  TIMESTEP: 1
+  NUMSTEP: 10
+  MAXTIME: 10
+  TOLDISP: 1e-09
+  TOLRES: 1e-09
+  LOADLIN: true
+  LINEAR_SOLVER: 1
+STRUCT NOX/Printing:
+  Inner Iteration: false
+  Outer Iteration StatusTest: false
+MATERIALS:
+  - MAT: 1
+    MAT_Mixture:
+      MATIDMIXTURERULE: 10
+      MATIDSCONST: [11, 12]
+  - MAT: 10
+    MIX_GrowthRemodelMixtureRule:
+      GROWTH_STRATEGY: 100
+      DENS: 1
+      MASSFRAC: [0.1, 0.9]
+  - MAT: 100
+    MIX_GrowthStrategy_Anisotropic:
+      GROWTH_DIRECTION:
+        constant: [0.0, 1.0, 0.0]
+  - MAT: 11
+    MIX_Constituent_ImplicitRemodelFiber:
+      ORIENTATION:
+        constant: [1.0, 0.0, 0.0]
+      FIBER_MATERIAL_ID: 110
+      DECAY_TIME: 10
+      GROWTH_CONSTANT: 0.1
+      DEPOSITION_STRETCH: 1.1783669297169928
+      INELASTIC_GROWTH: true
+  - MAT: 110
+    MIX_Constituent_RemodelFiber_Material_Exponential:
+      K1: 10
+      K2: 30
+      COMPRESSION: false
+  - MAT: 12
+    MIX_Constituent_ElastHyper:
+      NUMMAT: 2
+      MATIDS: [121, 122]
+      PRESTRESS_STRATEGY: 129
+  - MAT: 121
+    ELAST_IsoExpoPow:
+      K1: 10
+      K2: 10
+      C: 1
+  - MAT: 122
+    ELAST_VolSussmanBathe:
+      KAPPA: 100
+  - MAT: 129
+    MIX_Prestress_Strategy_Prescribed:
+      PRESTRETCH:
+        constant: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+DESIGN SURF ROBIN SPRING DASHPOT CONDITIONS:
+  - E: 1
+    NUMDOF: 3
+    ONOFF: [1, 1, 1]
+    STIFF: [100, 100, 100]
+    TIMEFUNCTSTIFF: [0, 0, 0]
+    VISCO: [0, 0, 0]
+    TIMEFUNCTVISCO: [0, 0, 0]
+    DISPLOFFSET: [-1, 0, 0]
+    TIMEFUNCTDISPLOFFSET: [0, 0, 0]
+    FUNCTNONLINSTIFF: [0, 0, 0]
+    DIRECTION: "xyz"
+DESIGN SURF NEUMANN CONDITIONS:
+  - E: 2
+    NUMDOF: 6
+    ONOFF: [1, 0, 0, 0, 0, 0]
+    VAL: [150, 0, 0, 0, 0, 0]
+    FUNCT: [0, 0, 0, 0, 0, 0]
+RESULT DESCRIPTION:
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 5
+      QUANTITY: "dispx"
+      VALUE: 5.05457604065251864e-01
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 5
+      QUANTITY: "dispy"
+      VALUE: -1.35468630209276859e-02
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 5
+      QUANTITY: "dispz"
+      VALUE: 3.66425990077496851e-04
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 6
+      QUANTITY: "dispx"
+      VALUE: 5.05457604065251420e-01
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 6
+      QUANTITY: "dispy"
+      VALUE: 1.35468630209277414e-02
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 6
+      QUANTITY: "dispz"
+      VALUE: 3.66425990077524552e-04
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 7
+      QUANTITY: "dispx"
+      VALUE: 5.05457604065251975e-01
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 7
+      QUANTITY: "dispy"
+      VALUE: -1.35468630209275905e-02
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 7
+      QUANTITY: "dispz"
+      VALUE: -3.66425990077483786e-04
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 8
+      QUANTITY: "dispx"
+      VALUE: 5.05457604065251309e-01
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 8
+      QUANTITY: "dispy"
+      VALUE: 1.35468630209276512e-02
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 8
+      QUANTITY: "dispz"
+      VALUE: -3.66425990077504061e-04
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 9
+      QUANTITY: "dispx"
+      VALUE: 5.10906536671683953e-01
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 9
+      QUANTITY: "dispy"
+      VALUE: -1.40057084590583924e-02
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 9
+      QUANTITY: "dispz"
+      VALUE: 9.90266519328804199e-04
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 10
+      QUANTITY: "dispx"
+      VALUE: 5.10906536671683176e-01
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 10
+      QUANTITY: "dispy"
+      VALUE: 1.40057084590585121e-02
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 10
+      QUANTITY: "dispz"
+      VALUE: 9.90266519328836725e-04
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 11
+      QUANTITY: "dispx"
+      VALUE: 5.10906536671683953e-01
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 11
+      QUANTITY: "dispy"
+      VALUE: -1.40057084590585017e-02
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 11
+      QUANTITY: "dispz"
+      VALUE: -9.90266519328795742e-04
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 12
+      QUANTITY: "dispx"
+      VALUE: 5.10906536671683398e-01
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 12
+      QUANTITY: "dispy"
+      VALUE: 1.40057084590586335e-02
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 12
+      QUANTITY: "dispz"
+      VALUE: -9.90266519328809620e-04
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 41
+      QUANTITY: "dispx"
+      VALUE: 5.02364088249494078e-01
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 41
+      QUANTITY: "dispy"
+      VALUE: 1.18478503104976918e-02
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 41
+      QUANTITY: "dispz"
+      VALUE: 0.0
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 47
+      QUANTITY: "dispx"
+      VALUE: 5.02451989884588390e-01
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 47
+      QUANTITY: "dispy"
+      VALUE: 1.23247176351692651e-02
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 47
+      QUANTITY: "dispz"
+      VALUE: 4.52496454762252174e-05
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 50
+      QUANTITY: "dispx"
+      VALUE: 5.02764818802887037e-01
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 50
+      QUANTITY: "dispy"
+      VALUE: 5.72037452580472297e-03
+      TOLERANCE: 1e-08
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 50
+      QUANTITY: "dispz"
+      VALUE: -4.12258800240201560e-04
+      TOLERANCE: 1e-08
+PROBLEM SIZE:
+  ELEMENTS: 31
+  NODES: 85
+  MATERIALS: 9999
+DNODE-NODE TOPOLOGY:
+  - "NODE 13 DNODE 1"
+  - "NODE 14 DNODE 2"
+  - "NODE 20 DNODE 1"
+  - "NODE 40 DNODE 2"
+DSURF-NODE TOPOLOGY:
+  - "NODE 4 DSURFACE 1"
+  - "NODE 3 DSURFACE 1"
+  - "NODE 1 DSURFACE 1"
+  - "NODE 2 DSURFACE 1"
+  - "NODE 14 DSURFACE 2"
+  - "NODE 15 DSURFACE 2"
+  - "NODE 13 DSURFACE 2"
+  - "NODE 16 DSURFACE 2"
+  - "NODE 43 DSURFACE 1"
+  - "NODE 19 DSURFACE 1"
+  - "NODE 26 DSURFACE 1"
+  - "NODE 42 DSURFACE 1"
+  - "NODE 53 DSURFACE 1"
+  - "NODE 18 DSURFACE 1"
+  - "NODE 39 DSURFACE 1"
+  - "NODE 17 DSURFACE 1"
+  - "NODE 30 DSURFACE 1"
+  - "NODE 23 DSURFACE 1"
+  - "NODE 24 DSURFACE 1"
+  - "NODE 25 DSURFACE 1"
+  - "NODE 31 DSURFACE 1"
+  - "NODE 63 DSURFACE 2"
+  - "NODE 79 DSURFACE 2"
+  - "NODE 61 DSURFACE 2"
+  - "NODE 67 DSURFACE 2"
+  - "NODE 83 DSURFACE 2"
+  - "NODE 20 DSURFACE 2"
+  - "NODE 84 DSURFACE 2"
+  - "NODE 85 DSURFACE 2"
+  - "NODE 66 DSURFACE 2"
+  - "NODE 64 DSURFACE 2"
+  - "NODE 51 DSURFACE 2"
+  - "NODE 62 DSURFACE 2"
+  - "NODE 40 DSURFACE 2"
+NODE COORDS:
+  - "NODE 1 COORD 0.0 0.0 0.0"
+  - "NODE 2 COORD 0.0 1.0 0.0"
+  - "NODE 3 COORD 0.0 0.0 1.0"
+  - "NODE 4 COORD 0.0 1.0 1.0"
+  - "NODE 5 COORD 1.0 0.0 0.0"
+  - "NODE 6 COORD 1.0 1.0 0.0"
+  - "NODE 7 COORD 1.0 0.0 1.0"
+  - "NODE 8 COORD 1.0 1.0 1.0"
+  - "NODE 9 COORD 2.0 0.0 0.0"
+  - "NODE 10 COORD 2.0 1.0 0.0"
+  - "NODE 11 COORD 2.0 0.0 1.0"
+  - "NODE 12 COORD 2.0 1.0 1.0"
+  - "NODE 13 COORD 3.0 0.0 0.0"
+  - "NODE 14 COORD 3.0 1.0 0.0"
+  - "NODE 15 COORD 3.0 0.0 1.0"
+  - "NODE 16 COORD 3.0 1.0 1.0"
+  - "NODE 17 COORD 0.0 1.5 0.0"
+  - "NODE 18 COORD 0.0 2.5 0.0"
+  - "NODE 19 COORD 0.0 1.5 1.0"
+  - "NODE 20 COORD 1.0 1.5 0.0"
+  - "NODE 21 COORD 0.5 2.0 0.0"
+  - "NODE 22 COORD 0.5 1.5 0.5"
+  - "NODE 23 COORD 0.0 2.0 0.5"
+  - "NODE 24 COORD 0.0 1.5 0.5"
+  - "NODE 25 COORD 0.0 1.75 0.25"
+  - "NODE 26 COORD 0.0 1.75 0.75"
+  - "NODE 27 COORD 0.25 1.5 0.75"
+  - "NODE 28 COORD 0.25 1.5 0.25"
+  - "NODE 29 COORD 0.25 1.75 0.5"
+  - "NODE 30 COORD 0.0 2.0 0.0"
+  - "NODE 31 COORD 0.0 2.25 0.25"
+  - "NODE 32 COORD 0.25 1.75 0.0"
+  - "NODE 33 COORD 0.25 2.25 0.0"
+  - "NODE 34 COORD 0.25 2.0 0.25"
+  - "NODE 35 COORD 0.5 1.5 0.0"
+  - "NODE 36 COORD 0.75 1.75 0.0"
+  - "NODE 37 COORD 0.75 1.5 0.25"
+  - "NODE 38 COORD 0.5 1.75 0.25"
+  - "NODE 39 COORD 0.0 2.5 1.0"
+  - "NODE 40 COORD 1.0 2.5 0.0"
+  - "NODE 41 COORD 0.5 2.5 0.5"
+  - "NODE 42 COORD 0.0 2.5 0.5"
+  - "NODE 43 COORD 0.0 2.25 0.75"
+  - "NODE 44 COORD 0.25 2.5 0.25"
+  - "NODE 45 COORD 0.25 2.5 0.75"
+  - "NODE 46 COORD 0.25 2.25 0.5"
+  - "NODE 47 COORD 0.5 2.5 0.0"
+  - "NODE 48 COORD 0.75 2.5 0.25"
+  - "NODE 49 COORD 0.75 2.25 0.0"
+  - "NODE 50 COORD 0.5 2.25 0.25"
+  - "NODE 51 COORD 1.0 1.5 1.0"
+  - "NODE 52 COORD 0.5 2.0 1.0"
+  - "NODE 53 COORD 0.0 2.0 1.0"
+  - "NODE 54 COORD 0.25 2.25 1.0"
+  - "NODE 55 COORD 0.25 1.75 1.0"
+  - "NODE 56 COORD 0.25 2.0 0.75"
+  - "NODE 57 COORD 0.5 1.5 1.0"
+  - "NODE 58 COORD 0.75 1.5 0.75"
+  - "NODE 59 COORD 0.75 1.75 1.0"
+  - "NODE 60 COORD 0.5 1.75 0.75"
+  - "NODE 61 COORD 1.0 2.0 0.5"
+  - "NODE 62 COORD 1.0 1.5 0.5"
+  - "NODE 63 COORD 1.0 1.75 0.75"
+  - "NODE 64 COORD 1.0 1.75 0.25"
+  - "NODE 65 COORD 0.75 1.75 0.5"
+  - "NODE 66 COORD 1.0 2.0 0.0"
+  - "NODE 67 COORD 1.0 2.25 0.25"
+  - "NODE 68 COORD 0.75 2.0 0.25"
+  - "NODE 69 COORD 0.5 2.0 0.5"
+  - "NODE 70 COORD 0.75 2.25 0.5"
+  - "NODE 71 COORD 0.25 2.0 0.5"
+  - "NODE 72 COORD 0.5 1.75 0.5"
+  - "NODE 73 COORD 0.5 2.0 0.25"
+  - "NODE 74 COORD 0.5 2.25 0.5"
+  - "NODE 75 COORD 0.75 2.0 0.5"
+  - "NODE 76 COORD 0.75 2.0 0.75"
+  - "NODE 77 COORD 0.5 2.0 0.75"
+  - "NODE 78 COORD 0.5 2.25 0.75"
+  - "NODE 79 COORD 1.0 2.5 1.0"
+  - "NODE 80 COORD 0.5 2.5 1.0"
+  - "NODE 81 COORD 0.75 2.25 1.0"
+  - "NODE 82 COORD 0.75 2.5 0.75"
+  - "NODE 83 COORD 1.0 2.5 0.5"
+  - "NODE 84 COORD 1.0 2.25 0.75"
+  - "NODE 85 COORD 1.0 2.0 1.0"
+STRUCTURE ELEMENTS:
+  - "1 SOLID HEX8 1 5 6 2 3 7 8 4 MAT 1 KINEM nonlinear"
+  - "2 SOLID HEX8 5 9 10 6 7 11 12 8 MAT 1 KINEM nonlinear"
+  - "3 SOLID HEX8 9 13 14 10 11 15 16 12 MAT 1 KINEM nonlinear"
+  - "4 SOLID TET10 19 17 23 22 24 25 26 27 28 29 MAT 1 KINEM nonlinear"
+  - "5 SOLID TET10 17 18 23 21 30 31 25 32 33 34 MAT 1 KINEM nonlinear"
+  - "6 SOLID TET10 18 39 23 41 42 43 31 44 45 46 MAT 1 KINEM nonlinear"
+  - "7 SOLID TET10 39 19 23 52 53 26 43 54 55 56 MAT 1 KINEM nonlinear"
+  - "8 SOLID TET10 19 51 22 52 57 58 27 55 59 60 MAT 1 KINEM nonlinear"
+  - "9 SOLID TET10 17 20 21 22 35 36 32 28 37 38 MAT 1 KINEM nonlinear"
+  - "10 SOLID TET10 18 40 41 21 47 48 44 33 49 50 MAT 1 KINEM nonlinear"
+  - "11 SOLID TET10 39 79 52 41 80 81 54 45 82 78 MAT 1 KINEM nonlinear"
+  - "12 SOLID TET10 51 20 22 61 62 37 58 63 64 65 MAT 1 KINEM nonlinear"
+  - "13 SOLID TET10 20 40 21 61 66 49 36 64 67 68 MAT 1 KINEM nonlinear"
+  - "14 SOLID TET10 40 79 41 61 83 82 48 67 84 70 MAT 1 KINEM nonlinear"
+  - "15 SOLID TET10 79 51 52 61 85 59 81 84 63 76 MAT 1 KINEM nonlinear"
+  - "16 SOLID TET10 23 22 52 19 29 60 56 26 27 55 MAT 1 KINEM nonlinear"
+  - "17 SOLID TET10 23 21 22 17 34 38 29 25 32 28 MAT 1 KINEM nonlinear"
+  - "18 SOLID TET10 23 41 21 18 46 50 34 31 44 33 MAT 1 KINEM nonlinear"
+  - "19 SOLID TET10 23 52 41 39 56 78 46 43 54 45 MAT 1 KINEM nonlinear"
+  - "20 SOLID TET10 61 52 22 51 76 60 65 63 59 58 MAT 1 KINEM nonlinear"
+  - "21 SOLID TET10 61 22 21 20 65 38 68 64 37 36 MAT 1 KINEM nonlinear"
+  - "22 SOLID TET10 61 21 41 40 68 50 70 67 49 48 MAT 1 KINEM nonlinear"
+  - "23 SOLID TET10 61 41 52 79 70 78 76 84 82 81 MAT 1 KINEM nonlinear"
+  - "24 SOLID TET10 23 52 22 69 56 60 29 71 77 72 MAT 1 KINEM nonlinear"
+  - "25 SOLID TET10 23 22 21 69 29 38 34 71 72 73 MAT 1 KINEM nonlinear"
+  - "26 SOLID TET10 23 21 41 69 34 50 46 71 73 74 MAT 1 KINEM nonlinear"
+  - "27 SOLID TET10 23 41 52 69 46 78 56 71 74 77 MAT 1 KINEM nonlinear"
+  - "28 SOLID TET10 61 22 52 69 65 60 76 75 72 77 MAT 1 KINEM nonlinear"
+  - "29 SOLID TET10 61 21 22 69 68 38 65 75 73 72 MAT 1 KINEM nonlinear"
+  - "30 SOLID TET10 61 41 21 69 70 50 68 75 74 73 MAT 1 KINEM nonlinear"
+  - "31 SOLID TET10 61 52 41 69 76 78 70 75 77 74 MAT 1 KINEM nonlinear"

--- a/tests/list_of_tests.cmake
+++ b/tests/list_of_tests.cmake
@@ -825,6 +825,8 @@ four_c_test(TEST_FILE hdg_weakly_compressible_poiseuille.4C.yaml NP 2 REQUIRED_D
 four_c_test(TEST_FILE hdg_weakly_compressible_poiseuille.4C.yaml REQUIRED_DEPENDENCIES TRILINOS_MUMPS)
 four_c_test(TEST_FILE homogenized-constrained-mixture-cube-aniso-expl.4C.yaml NP 2 RETURN_AS current REQUIRED_DEPENDENCIES TRILINOS_MUMPS)
 __four_c_test_restart(BASED_ON ${current} SAME_FILE NP 2 RESTART_STEP 5 REQUIRED_DEPENDENCIES TRILINOS_MUMPS)
+four_c_test(TEST_FILE homogenized-constrained-mixture-cube-aniso-impl.4C.yaml NP 2 RETURN_AS current REQUIRED_DEPENDENCIES TRILINOS_MUMPS)
+__four_c_test_restart(BASED_ON ${current} SAME_FILE NP 2 RESTART_STEP 5 REQUIRED_DEPENDENCIES TRILINOS_MUMPS)
 four_c_test(TEST_FILE homogenized-constrained-mixture-cube-iso-expl.4C.yaml NP 2 RETURN_AS current REQUIRED_DEPENDENCIES TRILINOS_MUMPS)
 __four_c_test_restart(BASED_ON ${current} SAME_FILE NP 2 RESTART_STEP 5 REQUIRED_DEPENDENCIES TRILINOS_MUMPS)
 four_c_test(TEST_FILE homogenized-constrained-mixture-cube-stiffness-expl.4C.yaml NP 2 RETURN_AS current REQUIRED_DEPENDENCIES TRILINOS_MUMPS)


### PR DESCRIPTION
## Enable inelastic growth for implicit remodel fiber

### Summary

- The implicit remodel fiber (`MIX_Constituent_ImplicitRemodelFiber`) previously couldn't be used
  with inelastic growth strategies (`MIX_GrowthStrategy_Anisotropic`,
  `MIX_GrowthStrategy_Isotropic`). This PR implements the support.
- A new input parameter `INELASTIC_GROWTH` (default: `false`) guards the inelastic code paths,
  mirroring the existing explicit fiber.
- Two additional derivative contributions are added: one to the global material tangent (`cmat`)
  and one to the local Newton Jacobian inside `integrate_local_evolution_equations_implicit`.

### Background

For inelastic growth strategies, the inverse growth deformation gradient $\mathbf{F}_g^{-1}$
depends on the growth scalar $\phi_g$. This introduces an additional inelastic fiber stretch

$$\lambda_\text{ext}^2 = \frac{1}{\mathbf{A} : \mathbf{F}_g^{-T}\mathbf{F}_g^{-1}}$$

whose sensitivity to $\phi_g$ is

$$\frac{\partial \lambda_\text{ext}}{\partial \phi_g}
= -\lambda_\text{ext}^3 \left(\mathbf{F}_g^{-1}\mathbf{A}\right)
  : \frac{\partial \mathbf{F}_g^{-1}}{\partial \phi_g},$$

computed in `prepare_inelastic_growth_tangent` and stored per Gauss point.

### Additional tangent term in `cmat`

The $\lambda_\text{ext}(\phi_g(\lambda_f^2))$ chain contributes an extra term to the material
tangent:

$$\mathbb{C}^{(\text{ext})} = 2\cdot\frac{\partial \hat{S}}{\partial \lambda_\text{ext}}\cdot
\frac{\partial \lambda_\text{ext}}{\partial \phi_g}\cdot\frac{d\phi_g}{d\lambda_f^2}
\;\mathbf{A} \otimes \mathbf{A}$$

### Additional terms in the local Newton Jacobian

To the Jacobean of the local Newton for $(\phi_g^{n+1}, \lambda_r^{n+1})$ two new partial derivatives of the evolution equations w.r.t. $\lambda_\text{ext}$ were added.

$$\frac{\partial f_g}{\partial \lambda_\text{ext}}
= \frac{\partial f_g}{\partial \sigma}
\cdot \frac{\partial \sigma}{\partial I_4^{el}}
\cdot \frac{\partial I_4^{el}}{\partial \lambda_\text{ext}},
\qquad
\frac{\partial f_r}{\partial \lambda_\text{ext}}
= \frac{\partial f_r}{\partial I_4^{el}}
\cdot \frac{\partial I_4^{el}}{\partial \lambda_\text{ext}}$$

Both derivatives are verified by FAD tests in `4C_mixture_remodelfiber_test.cpp`.

### Test plan

- New unit tests `TestEvaluateDGrowthEvolutionEquationDtDLambdaExt` and
      `TestEvaluateDRemodelEvolutionEquationDtDLambdaExt` pass (FAD verification of the two new
      derivatives)
- New `homogenized-constrained-mixture-cube-aniso-impl` which renders similar solutions as the explicit test case (deviation 1e-5)