### PR TITLE
[Particle] Fix probe for the message with the size tag

### DIFF
--- a/src/particle/src/engine/4C_particle_engine_communication_utils.cpp
+++ b/src/particle/src/engine/4C_particle_engine_communication_utils.cpp
@@ -41,6 +41,7 @@ void Particle::ParticleUtils::immediate_recv_blocking_send(
   // ---- send size of messages to receiving processors ----
   std::vector<MPI_Request> sizerequest(numsendtoprocs);
   std::vector<int> sizetargets(numsendtoprocs);
+  std::vector<int> msgsizestosend(numsendtoprocs);
   int counter = 0;
   for (const auto& p : sdata)
   {
@@ -50,14 +51,15 @@ void Particle::ParticleUtils::immediate_recv_blocking_send(
 
     sizetargets[counter] = torank;
 
-    int msgsizetosend = static_cast<int>((p.second).size());
+    msgsizestosend[counter] = static_cast<int>((p.second).size());
 
     // check sending size of message
-    if (not(msgsizetosend > 0))
-      FOUR_C_THROW("sending non-positive message size {} to proc {}!", msgsizetosend, torank);
+    if (not(msgsizestosend[counter] > 0))
+      FOUR_C_THROW(
+          "sending non-positive message size {} to proc {}!", msgsizestosend[counter], torank);
 
     // perform non-blocking send operation
-    MPI_Isend(&msgsizetosend, 1, MPI_INT, torank, 1234, comm, &sizerequest[counter]);
+    MPI_Isend(&msgsizestosend[counter], 1, MPI_INT, torank, 1234, comm, &sizerequest[counter]);
 
     ++counter;
   }
@@ -67,17 +69,12 @@ void Particle::ParticleUtils::immediate_recv_blocking_send(
   std::vector<MPI_Request> recvrequest(numrecvfromprocs);
   for (int rec = 0; rec < numrecvfromprocs; ++rec)
   {
-    // probe for any message to come
+    // probe for message with size tag to come
     MPI_Status status;
-    MPI_Probe(MPI_ANY_SOURCE, MPI_ANY_TAG, comm, &status);
+    MPI_Probe(MPI_ANY_SOURCE, 1234, comm, &status);
 
-    // get message sender and tag
+    // get message sender
     int const msgsource = status.MPI_SOURCE;
-    int const msgtag = status.MPI_TAG;
-
-    // check message tag
-    if (msgtag != 1234)
-      FOUR_C_THROW("received data on proc {} with wrong tag from proc {}", myrank, msgsource);
 
     // get message size
     int msgsize = -1;
@@ -88,7 +85,7 @@ void Particle::ParticleUtils::immediate_recv_blocking_send(
 
     // perform blocking receive operation
     int msgsizetorecv = -1;
-    MPI_Recv(&msgsizetorecv, msgsize, MPI_INT, msgsource, msgtag, comm, MPI_STATUS_IGNORE);
+    MPI_Recv(&msgsizetorecv, msgsize, MPI_INT, msgsource, 1234, comm, MPI_STATUS_IGNORE);
 
     // check received size of message
     if (not(msgsizetorecv > 0))


### PR DESCRIPTION
## Description and Context
I observed a very strange bug on a system with 2 EPYC 7713 processors. When running on 32 ranks, the SPH simulation worked fine, but it crashes for larger numbers with the following errors:
```
[a0sv2300080:231845] *** An error occurred in MPI_Waitall
[a0sv2300080:231845] *** reported by process [3095068673,11]
[a0sv2300080:231845] *** on communicator MPI COMMUNICATOR 3 SPLIT FROM 0
[a0sv2300080:231845] *** MPI_ERR_TRUNCATE: message truncated
[a0sv2300080:231845] *** MPI_ERRORS_ARE_FATAL (processes in this communicator will now abort,
[a0sv2300080:231845] ***    and potentially your MPI job)
```

It turned out the bug was related to `MPI_Probe` race condition.

The size-reception loop used `MPI_ANY_TAG` when probing for size messages (tag 1234). With 64 ranks spanning 2 NUMA domains, execution speeds diverge significantly. A fast rank can complete its size reception, post `MPI_Irecv`s, and begin sending data (tag 5678) back to a slow rank — while that slow rank is still probing for size messages. MPI does not guarantee inter-tag ordering, so the data message can be matched by the probe before all size messages arrive. This corrupts the communication protocol and causes cascading `MPI_ERR_TRUNCATE` errors on other ranks during `MPI_Waitall`.

With 32 ranks on a single socket, execution speeds are more uniform, making this race too unlikely to trigger.

Additionally, there was a UB with `msgsizetosend` variable that goes out of scope for a non-blocking `MPI_Isend`.

@georghammerl, @slfuchs, @ppraegla