### PR TITLE
Introduce output verbosity levels in reduced lung

### DIFF
--- a/src/reduced_lung/src/4C_reduced_lung_helpers.cpp
+++ b/src/reduced_lung/src/4C_reduced_lung_helpers.cpp
@@ -661,12 +661,19 @@ namespace ReducedLung
       Core::IO::DiscretizationVisualizationWriterMesh& visualization_writer,
       const AirwayContainer& airways, const TerminalUnitContainer& terminal_units,
       const Core::LinAlg::Vector<double>& locally_relevant_dofs,
-      const Core::LinAlg::Map* element_row_map)
+      const Core::LinAlg::Map* element_row_map, ReducedLungParameters::OutputVerbosity verbosity)
   {
     Core::LinAlg::Vector<double> pressure_in(*element_row_map, true);
     Core::LinAlg::Vector<double> pressure_out(*element_row_map, true);
     Core::LinAlg::Vector<double> flow_in(*element_row_map, true);
     Core::LinAlg::Vector<double> flow_out(*element_row_map, true);
+
+    const double nan = std::numeric_limits<double>::quiet_NaN();
+    pressure_in.put_scalar(nan);
+    pressure_out.put_scalar(nan);
+    flow_in.put_scalar(nan);
+    flow_out.put_scalar(nan);
+
     for (const auto& model : airways.models)
     {
       const bool has_q_out = model.data.n_state_equations == 2;
@@ -693,8 +700,6 @@ namespace ReducedLung
             locally_relevant_dofs.local_values_as_span()[model.data.lid_p2[i]]);
         flow_in.replace_local_value(model.data.local_element_id[i],
             locally_relevant_dofs.local_values_as_span()[model.data.lid_q[i]]);
-        flow_out.replace_local_value(model.data.local_element_id[i],
-            locally_relevant_dofs.local_values_as_span()[model.data.lid_q[i]]);
       }
     }
     visualization_writer.append_result_data_vector_with_context(
@@ -705,6 +710,33 @@ namespace ReducedLung
         flow_in, Core::IO::OutputEntity::element, {"q_in"});
     visualization_writer.append_result_data_vector_with_context(
         flow_out, Core::IO::OutputEntity::element, {"q_out"});
+
+    if (verbosity > ReducedLungParameters::OutputVerbosity::minimal)
+    {
+      RuntimeOutputCollector collector(*element_row_map);
+
+      for (const auto& model : airways.models)
+      {
+        if (model.output_evaluator)
+        {
+          model.output_evaluator(model.data, collector, verbosity);
+        }
+      }
+
+      for (const auto& model : terminal_units.models)
+      {
+        if (model.output_evaluator)
+        {
+          model.output_evaluator(model.data, collector, verbosity);
+        }
+      }
+
+      for (const auto& [name, vector] : collector.vectors)
+      {
+        visualization_writer.append_result_data_vector_with_context(
+            vector, Core::IO::OutputEntity::element, {name});
+      }
+    }
   }
 }  // namespace ReducedLung
 

--- a/src/reduced_lung/src/4C_reduced_lung_helpers.hpp
+++ b/src/reduced_lung/src/4C_reduced_lung_helpers.hpp
@@ -22,8 +22,12 @@
 #include <Teuchos_ParameterList.hpp>
 
 #include <functional>
+#include <limits>
 #include <map>
 #include <optional>
+#include <string>
+#include <tuple>
+#include <utility>
 #include <vector>
 
 FOUR_C_NAMESPACE_OPEN
@@ -93,6 +97,32 @@ namespace ReducedLung
     Core::LinAlg::Vector<double>& locally_relevant_dofs;  ///< Ghosted dof vector.
     Core::LinAlg::Vector<double>& x;                      ///< NOX solution vector.
     Core::LinAlg::SparseOperator& jacobian;               ///< NOX Jacobian operator.
+  };
+
+  /**
+   * @brief Collector for runtime output data vectors.
+   *
+   * Manages creation and storage of output vectors for different verbosity levels.
+   */
+  struct RuntimeOutputCollector
+  {
+    const Core::LinAlg::Map& element_row_map;
+    std::map<std::string, Core::LinAlg::Vector<double>> vectors;
+
+    explicit RuntimeOutputCollector(const Core::LinAlg::Map& map) : element_row_map(map) {}
+
+    Core::LinAlg::Vector<double>& get_or_create_vector(const std::string& name)
+    {
+      auto it = vectors.find(name);
+      if (it == vectors.end())
+      {
+        auto res = vectors.emplace(std::piecewise_construct, std::forward_as_tuple(name),
+            std::forward_as_tuple(element_row_map, true));
+        res.first->second.put_scalar(std::numeric_limits<double>::quiet_NaN());
+        return res.first->second;
+      }
+      return it->second;
+    }
   };
 
   /**
@@ -302,7 +332,8 @@ namespace ReducedLung
       const Airways::AirwayContainer& airways,
       const TerminalUnits::TerminalUnitContainer& terminal_units,
       const Core::LinAlg::Vector<double>& locally_relevant_dofs,
-      const Core::LinAlg::Map* element_row_map);
+      const Core::LinAlg::Map* element_row_map, ReducedLungParameters::OutputVerbosity verbosity);
+
 }  // namespace ReducedLung
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/reduced_lung/src/4C_reduced_lung_input.cpp
+++ b/src/reduced_lung/src/4C_reduced_lung_input.cpp
@@ -402,6 +402,12 @@ Core::IO::InputSpec ReducedLung::valid_parameters()
                           .store = in_struct(
                               &ReducedLungParameters::Dynamics::nonlinear_increment_tolerance),
                       }),
+                  parameter<ReducedLungParameters::OutputVerbosity>("output_verbosity",
+                      {
+                          .description = "Output verbosity level.",
+                          .default_value = ReducedLungParameters::OutputVerbosity::minimal,
+                          .store = in_struct(&ReducedLungParameters::Dynamics::output_verbosity),
+                      }),
               },
               {
                   .required = true,

--- a/src/reduced_lung/src/4C_reduced_lung_input.hpp
+++ b/src/reduced_lung/src/4C_reduced_lung_input.hpp
@@ -13,6 +13,7 @@
 #include "4C_io_input_field.hpp"
 #include "4C_io_input_spec.hpp"
 
+#include <cstdint>
 #include <vector>
 
 
@@ -22,6 +23,17 @@ namespace ReducedLung
 {
   struct ReducedLungParameters
   {
+    enum class OutputVerbosity : std::uint8_t
+    {
+      //  write only core fields (p_1, p_2, q_in, q_out)
+      minimal,
+      //  include minimal + advanced model outputs (currently e.g. area, volume where available).
+      medium,
+      // include medium + model-internal diagnostic quantities (e.g. flow_k_turb, elastic_pressure,
+      // maxwell_pressure).
+      high
+    };
+
     struct Dynamics
     {
       double time_increment;
@@ -32,6 +44,7 @@ namespace ReducedLung
       int max_nonlinear_iterations;
       double nonlinear_residual_tolerance;
       double nonlinear_increment_tolerance;
+      OutputVerbosity output_verbosity = OutputVerbosity::minimal;
     } dynamics;
     struct LungTree
     {

--- a/src/reduced_lung/src/4C_reduced_lung_main.cpp
+++ b/src/reduced_lung/src/4C_reduced_lung_main.cpp
@@ -286,7 +286,8 @@ namespace ReducedLung
 
         visualization_writer_->reset();
         collect_runtime_output_data(*visualization_writer_, airways_, terminal_units_,
-            *locally_relevant_dofs_, actdis_->element_row_map());
+            *locally_relevant_dofs_, actdis_->element_row_map(),
+            context_.parameters.dynamics.output_verbosity);
         visualization_writer_->write_to_disk(current_time_, step);
       }
 

--- a/src/reduced_lung/src/airways/4C_reduced_lung_airways.cpp
+++ b/src/reduced_lung/src/airways/4C_reduced_lung_airways.cpp
@@ -113,6 +113,16 @@ namespace ReducedLung::Airways
       model.internal_state_updater = WallMechanics::make_internal_state_updater(
           model.wall_model, FlowResistance::make_internal_state_updater(model.flow_model));
       model.end_of_timestep_routine = WallMechanics::make_end_of_timestep_routine(model.wall_model);
+      auto flow_output_evaluator = FlowResistance::make_output_evaluator(model.flow_model);
+      auto wall_output_evaluator = WallMechanics::make_output_evaluator(model.wall_model);
+      model.output_evaluator = [flow_output_evaluator, wall_output_evaluator](
+                                   const AirwayData& data,
+                                   ReducedLung::RuntimeOutputCollector& collector,
+                                   ReducedLungParameters::OutputVerbosity verbosity)
+      {
+        flow_output_evaluator(data, collector, verbosity);
+        wall_output_evaluator(data, collector, verbosity);
+      };
     }
   }
 }  // namespace ReducedLung::Airways

--- a/src/reduced_lung/src/airways/4C_reduced_lung_airways.hpp
+++ b/src/reduced_lung/src/airways/4C_reduced_lung_airways.hpp
@@ -32,6 +32,7 @@ namespace ReducedLung::Airways
     JacobianEvaluator jacobian_evaluator;
     InternalStateUpdater internal_state_updater;
     EndOfTimestepRoutine end_of_timestep_routine;
+    OutputEvaluator output_evaluator;
   };
 
   /**

--- a/src/reduced_lung/src/airways/4C_reduced_lung_airways_common.hpp
+++ b/src/reduced_lung/src/airways/4C_reduced_lung_airways_common.hpp
@@ -12,6 +12,7 @@
 
 #include "4C_linalg_sparsematrix.hpp"
 #include "4C_linalg_vector.hpp"
+#include "4C_reduced_lung_input.hpp"
 
 #include <cstddef>
 #include <functional>
@@ -19,6 +20,10 @@
 
 FOUR_C_NAMESPACE_OPEN
 
+namespace ReducedLung
+{
+  struct RuntimeOutputCollector;
+}
 namespace ReducedLung::Airways
 {
   /**
@@ -90,6 +95,10 @@ namespace ReducedLung::Airways
   ///< Callback type for end-of-timestep history updates.
   using EndOfTimestepRoutine = std::function<void(AirwayData& data,
       const Core::LinAlg::Vector<double>& locally_relevant_dofs, double time_step_size_dt)>;
+
+  ///< Callback type for collecting additional runtime output.
+  using OutputEvaluator = std::function<void(const AirwayData& data,
+      RuntimeOutputCollector& collector, ReducedLungParameters::OutputVerbosity verbosity)>;
 }  // namespace ReducedLung::Airways
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/reduced_lung/src/airways/4C_reduced_lung_airways_flow_resistance.cpp
+++ b/src/reduced_lung/src/airways/4C_reduced_lung_airways_flow_resistance.cpp
@@ -8,6 +8,7 @@
 #include "4C_reduced_lung_airways_flow_resistance.hpp"
 
 #include "4C_reduced_lung_airways_wall_mechanics.hpp"
+#include "4C_reduced_lung_helpers.hpp"
 
 #include <cmath>
 #include <numbers>
@@ -430,6 +431,36 @@ namespace ReducedLung::Airways::FlowResistance
           {
             FOUR_C_THROW("Unknown airway flow model.");
           }
+        },
+        flow_model);
+  }
+
+  void append_flow_output(const LinearResistive& /*model*/, const AirwayData& /*data*/,
+      RuntimeOutputCollector& /*collector*/, ReducedLungParameters::OutputVerbosity /*verbosity*/)
+  {
+  }
+
+  void append_flow_output(const NonLinearResistive& model, const AirwayData& data,
+      RuntimeOutputCollector& collector, ReducedLungParameters::OutputVerbosity verbosity)
+  {
+    if (verbosity >= ReducedLungParameters::OutputVerbosity::high)
+    {
+      auto& k_turb = collector.get_or_create_vector("flow_k_turb");
+      for (size_t i = 0; i < data.number_of_elements(); ++i)
+      {
+        k_turb.replace_local_value(data.local_element_id[i], model.k_turb[i]);
+      }
+    }
+  }
+
+  OutputEvaluator make_output_evaluator(FlowModel& flow_model)
+  {
+    return std::visit(
+        [](auto& model) -> OutputEvaluator
+        {
+          return [&model](const AirwayData& data, RuntimeOutputCollector& collector,
+                     ReducedLungParameters::OutputVerbosity verbosity)
+          { append_flow_output(model, data, collector, verbosity); };
         },
         flow_model);
   }

--- a/src/reduced_lung/src/airways/4C_reduced_lung_airways_flow_resistance.hpp
+++ b/src/reduced_lung/src/airways/4C_reduced_lung_airways_flow_resistance.hpp
@@ -191,6 +191,11 @@ namespace ReducedLung::Airways::FlowResistance
   InternalStateUpdaterFlowModel make_internal_state_updater(FlowModel& flow_model);
 
   /**
+   * @brief Build output evaluator callback for the concrete flow-model variant.
+   */
+  OutputEvaluator make_output_evaluator(FlowModel& flow_model);
+
+  /**
    * @brief Append element parameters and initialize vectors for a concrete flow model.
    */
   void append_model_parameters(FlowModel& flow_model, int global_element_id,

--- a/src/reduced_lung/src/airways/4C_reduced_lung_airways_model_registry.cpp
+++ b/src/reduced_lung/src/airways/4C_reduced_lung_airways_model_registry.cpp
@@ -103,8 +103,10 @@ namespace ReducedLung
       {
         AirwayFactoryMap factories;
 
-        for (const auto& [flow_model_type, wall_model_type] : compatible_airway_model_pairs())
+        for (const auto& compatible_pair : compatible_airway_model_pairs())
         {
+          const FlowModelType flow_model_type = compatible_pair.first;
+          const WallModelType wall_model_type = compatible_pair.second;
           const auto [it, inserted] = factories.emplace(
               AirwayModelKey{flow_model_type, wall_model_type},
               [flow_model_type, wall_model_type](Airways::AirwayContainer& airways,

--- a/src/reduced_lung/src/airways/4C_reduced_lung_airways_wall_mechanics.cpp
+++ b/src/reduced_lung/src/airways/4C_reduced_lung_airways_wall_mechanics.cpp
@@ -7,6 +7,8 @@
 
 #include "4C_reduced_lung_airways_wall_mechanics.hpp"
 
+#include "4C_reduced_lung_helpers.hpp"
+
 #include <array>
 #include <cmath>
 #include <type_traits>
@@ -310,6 +312,36 @@ namespace ReducedLung::Airways::WallMechanics
           {
             FOUR_C_THROW("Unknown airway wall model.");
           }
+        },
+        wall_model);
+  }
+
+  void append_wall_output(const RigidWall& /*wall_model_data*/, const AirwayData& /*data*/,
+      RuntimeOutputCollector& /*collector*/, ReducedLungParameters::OutputVerbosity /*verbosity*/)
+  {
+  }
+
+  void append_wall_output(const KelvinVoigtWall& wall_model_data, const AirwayData& data,
+      RuntimeOutputCollector& collector, ReducedLungParameters::OutputVerbosity verbosity)
+  {
+    if (verbosity >= ReducedLungParameters::OutputVerbosity::medium)
+    {
+      auto& area = collector.get_or_create_vector("area");
+      for (size_t i = 0; i < data.number_of_elements(); i++)
+      {
+        area.replace_local_value(data.local_element_id[i], wall_model_data.area[i]);
+      }
+    }
+  }
+
+  OutputEvaluator make_output_evaluator(WallModel& wall_model)
+  {
+    return std::visit(
+        [](auto& wall_model_data) -> OutputEvaluator
+        {
+          return [&wall_model_data](const AirwayData& data, RuntimeOutputCollector& collector,
+                     ReducedLungParameters::OutputVerbosity verbosity)
+          { append_wall_output(wall_model_data, data, collector, verbosity); };
         },
         wall_model);
   }

--- a/src/reduced_lung/src/airways/4C_reduced_lung_airways_wall_mechanics.hpp
+++ b/src/reduced_lung/src/airways/4C_reduced_lung_airways_wall_mechanics.hpp
@@ -132,6 +132,11 @@ namespace ReducedLung::Airways::WallMechanics
       WallModel& wall_model, FlowModelInternalStateUpdater flow_state_updater);
 
   /**
+   * @brief Build output evaluator callback for the concrete wall-model variant.
+   */
+  OutputEvaluator make_output_evaluator(WallModel& wall_model);
+
+  /**
    * @brief Build end-of-timestep callback for the concrete wall-model variant.
    */
   EndOfTimestepRoutine make_end_of_timestep_routine(WallModel& wall_model);

--- a/src/reduced_lung/src/terminal_units/4C_reduced_lung_terminal_unit.cpp
+++ b/src/reduced_lung/src/terminal_units/4C_reduced_lung_terminal_unit.cpp
@@ -9,6 +9,7 @@
 
 #include "4C_reduced_lung_terminal_unit.hpp"
 
+#include "4C_reduced_lung_helpers.hpp"
 #include "4C_reduced_lung_terminal_unit_elasticity.hpp"
 #include "4C_reduced_lung_terminal_unit_rheology.hpp"
 
@@ -114,6 +115,23 @@ namespace ReducedLung
     }
 
     /**
+     * Emit terminal-unit volume output.
+     */
+    void append_volume_output(const TerminalUnitData& data,
+        ReducedLung::RuntimeOutputCollector& collector,
+        ReducedLungParameters::OutputVerbosity verbosity)
+    {
+      if (verbosity >= ReducedLungParameters::OutputVerbosity::medium)
+      {
+        auto& volume_vec = collector.get_or_create_vector("volume");
+        for (size_t i = 0; i < data.number_of_elements(); ++i)
+        {
+          volume_vec.replace_local_value(data.local_element_id[i], data.volume_v[i]);
+        }
+      }
+    }
+
+    /**
      * Compose elasticity and rheology callbacks into final model evaluators.
      */
     void create_evaluators(TerminalUnitContainer& terminal_units)
@@ -133,8 +151,22 @@ namespace ReducedLung
             Rheology::make_internal_state_updater(model.rheological_model);
         model.end_of_timestep_routine =
             Rheology::make_end_of_timestep_routine(model.rheological_model);
+        auto elasticity_output_evaluator =
+            Elasticity::make_output_evaluator(model.elasticity_model);
+        auto rheology_output_evaluator = Rheology::make_output_evaluator(model.rheological_model);
+        const OutputEvaluator volume_output_evaluator = append_volume_output;
+        model.output_evaluator = [elasticity_output_evaluator, rheology_output_evaluator,
+                                     volume_output_evaluator](const TerminalUnitData& data,
+                                     ReducedLung::RuntimeOutputCollector& collector,
+                                     ReducedLungParameters::OutputVerbosity verbosity)
+        {
+          elasticity_output_evaluator(data, collector, verbosity);
+          rheology_output_evaluator(data, collector, verbosity);
+          volume_output_evaluator(data, collector, verbosity);
+        };
       }
     }
+
   }  // namespace TerminalUnits
 }  // namespace ReducedLung
 

--- a/src/reduced_lung/src/terminal_units/4C_reduced_lung_terminal_unit.hpp
+++ b/src/reduced_lung/src/terminal_units/4C_reduced_lung_terminal_unit.hpp
@@ -33,6 +33,7 @@ namespace ReducedLung::TerminalUnits
     JacobianEvaluator jacobian_evaluator;
     InternalStateUpdater internal_state_updater;
     EndOfTimestepRoutine end_of_timestep_routine;
+    OutputEvaluator output_evaluator;
   };
 
   /**

--- a/src/reduced_lung/src/terminal_units/4C_reduced_lung_terminal_unit_common.hpp
+++ b/src/reduced_lung/src/terminal_units/4C_reduced_lung_terminal_unit_common.hpp
@@ -12,11 +12,17 @@
 
 #include "4C_linalg_sparsematrix.hpp"
 #include "4C_linalg_vector.hpp"
+#include "4C_reduced_lung_input.hpp"
 
 #include <functional>
 #include <vector>
 
 FOUR_C_NAMESPACE_OPEN
+
+namespace ReducedLung
+{
+  struct RuntimeOutputCollector;
+}
 
 namespace ReducedLung::TerminalUnits
 {
@@ -75,6 +81,11 @@ namespace ReducedLung::TerminalUnits
   ///< Callback type for end-of-timestep history updates.
   using EndOfTimestepRoutine = std::function<void(TerminalUnitData& model_data,
       const Core::LinAlg::Vector<double>& locally_relevant_dof_vector, double time_step_size_dt)>;
+
+  ///< Callback type for collecting additional runtime output.
+  using OutputEvaluator = std::function<void(const TerminalUnitData& model_data,
+      RuntimeOutputCollector& collector, ReducedLungParameters::OutputVerbosity verbosity)>;
+
 }  // namespace ReducedLung::TerminalUnits
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/reduced_lung/src/terminal_units/4C_reduced_lung_terminal_unit_elasticity.cpp
+++ b/src/reduced_lung/src/terminal_units/4C_reduced_lung_terminal_unit_elasticity.cpp
@@ -9,6 +9,8 @@
 
 #include "4C_reduced_lung_terminal_unit_elasticity.hpp"
 
+#include "4C_reduced_lung_helpers.hpp"
+
 #include <cmath>
 
 FOUR_C_NAMESPACE_OPEN
@@ -91,6 +93,21 @@ namespace ReducedLung::TerminalUnits::Elasticity
       }
       return ogden_hyperelastic_model.elastic_pressure_grad_dp_el;
     }
+
+    template <typename Model>
+    void append_elastic_pressure_output(const Model& model, const TerminalUnitData& data,
+        RuntimeOutputCollector& collector, ReducedLungParameters::OutputVerbosity verbosity)
+    {
+      if (verbosity >= ReducedLungParameters::OutputVerbosity::high)
+      {
+        auto& elastic_pressure_vec = collector.get_or_create_vector("elastic_pressure");
+        for (size_t i = 0; i < data.number_of_elements(); i++)
+        {
+          elastic_pressure_vec.replace_local_value(
+              data.local_element_id[i], model.elastic_pressure_p_el[i]);
+        }
+      }
+    }
   }  // namespace
 
   /**
@@ -156,6 +173,21 @@ namespace ReducedLung::TerminalUnits::Elasticity
           {
             FOUR_C_THROW("Unknown terminal-unit elasticity model.");
           }
+        },
+        elasticity_model);
+  }
+
+  /**
+   * Resolve variant-based output evaluator.
+   */
+  OutputEvaluator make_output_evaluator(ElasticityModel& elasticity_model)
+  {
+    return std::visit(
+        [&](auto& model) -> OutputEvaluator
+        {
+          return [&model](const TerminalUnitData& data, RuntimeOutputCollector& collector,
+                     ReducedLungParameters::OutputVerbosity verbosity)
+          { append_elastic_pressure_output(model, data, collector, verbosity); };
         },
         elasticity_model);
   }

--- a/src/reduced_lung/src/terminal_units/4C_reduced_lung_terminal_unit_elasticity.hpp
+++ b/src/reduced_lung/src/terminal_units/4C_reduced_lung_terminal_unit_elasticity.hpp
@@ -121,6 +121,11 @@ namespace ReducedLung::TerminalUnits::Elasticity
       ElasticityModel& elasticity_model);
 
   /**
+   * @brief Build output evaluator callback for the concrete elasticity variant.
+   */
+  OutputEvaluator make_output_evaluator(ElasticityModel& elasticity_model);
+
+  /**
    * @brief Append element parameters and initialize internal vectors for a concrete elasticity
    * model.
    */

--- a/src/reduced_lung/src/terminal_units/4C_reduced_lung_terminal_unit_rheology.cpp
+++ b/src/reduced_lung/src/terminal_units/4C_reduced_lung_terminal_unit_rheology.cpp
@@ -9,6 +9,8 @@
 
 #include "4C_reduced_lung_terminal_unit_rheology.hpp"
 
+#include "4C_reduced_lung_helpers.hpp"
+
 #include <array>
 
 FOUR_C_NAMESPACE_OPEN
@@ -131,6 +133,25 @@ namespace ReducedLung::TerminalUnits::Rheology
                                             four_element_maxwell_model.viscosity_eta_m[i])) /
                                     data.reference_volume_v0[i];
           target.replace_my_values(data.local_row_id[i], 1, &grad_q, &data.lid_q[i]);
+        }
+      }
+    }
+
+    void append_rheology_output(const KelvinVoigt& /*model*/, const TerminalUnitData& /*data*/,
+        RuntimeOutputCollector& /*collector*/, ReducedLungParameters::OutputVerbosity /*verbosity*/)
+    {
+    }
+
+    void append_rheology_output(const FourElementMaxwell& model, const TerminalUnitData& data,
+        RuntimeOutputCollector& collector, ReducedLungParameters::OutputVerbosity verbosity)
+    {
+      if (verbosity >= ReducedLungParameters::OutputVerbosity::high)
+      {
+        auto& maxwell_pressure_vec = collector.get_or_create_vector("maxwell_pressure");
+        for (size_t i = 0; i < data.number_of_elements(); i++)
+        {
+          maxwell_pressure_vec.replace_local_value(
+              data.local_element_id[i], model.maxwell_pressure_p_m[i]);
         }
       }
     }
@@ -281,6 +302,21 @@ namespace ReducedLung::TerminalUnits::Rheology
           {
             FOUR_C_THROW("Unknown terminal-unit rheological model.");
           }
+        },
+        rheological_model);
+  }
+
+  /**
+   * Resolve variant-based output evaluator.
+   */
+  OutputEvaluator make_output_evaluator(RheologicalModel& rheological_model)
+  {
+    return std::visit(
+        [&](auto& model) -> OutputEvaluator
+        {
+          return [&model](const TerminalUnitData& data, RuntimeOutputCollector& collector,
+                     ReducedLungParameters::OutputVerbosity verbosity)
+          { append_rheology_output(model, data, collector, verbosity); };
         },
         rheological_model);
   }

--- a/src/reduced_lung/src/terminal_units/4C_reduced_lung_terminal_unit_rheology.hpp
+++ b/src/reduced_lung/src/terminal_units/4C_reduced_lung_terminal_unit_rheology.hpp
@@ -120,6 +120,11 @@ namespace ReducedLung::TerminalUnits::Rheology
   EndOfTimestepRoutine make_end_of_timestep_routine(RheologicalModel& rheological_model);
 
   /**
+   * @brief Build output evaluator callback for the concrete rheology variant.
+   */
+  OutputEvaluator make_output_evaluator(RheologicalModel& rheological_model);
+
+  /**
    * @brief Append element parameters and initialize internal vectors for a concrete rheology model.
    */
   void append_model_parameters(RheologicalModel& rheological_model, int global_element_id,


### PR DESCRIPTION

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
This PR adds configurable runtime output verbosity for the `reduced_lung` module with three modes: `minimal`, `medium`, and `high`.
Core solution fields are always written. If a quantity is not defined for a given element/model pair (for example `q_out` in terminal units), we now write `NaN` explicitly so missing values are clear.
Additional model-specific outputs are handled directly in model-level output evaluators. This keeps minimal output compact, while detailed output can include internal model quantities when needed for analysis/debugging.

