### PR TITLE
[Particle] Reduce complexity of `Particle::PDNeighborPairs::communicate_bond_list()`

### DIFF
--- a/src/particle/src/interaction/4C_particle_interaction_pd_neighbor_pairs.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_pd_neighbor_pairs.cpp
@@ -495,6 +495,15 @@ void Particle::PDNeighborPairs::communicate_bond_list(
   std::vector<std::set<std::pair<int, int>>> communicated_bonds_per_target(
       Core::Communication::num_mpi_ranks(comm_));
 
+  // build an index mapping particle global id -> bond indices for O(1) lookup
+  std::unordered_map<int, std::vector<std::size_t>> particle_to_bond_indices;
+  for (std::size_t bond_idx = 0; bond_idx < bondlist_->size(); ++bond_idx)
+  {
+    const auto& bond = (*bondlist_)[bond_idx];
+    particle_to_bond_indices[std::get<3>(bond.first)].push_back(bond_idx);
+    particle_to_bond_indices[std::get<3>(bond.second)].push_back(bond_idx);
+  }
+
   // pack bond pair information
   // do not delete information on proc just add bond information while receiving
   // during later evaluation if any particle of that bond is not available remove the bond
@@ -505,26 +514,26 @@ void Particle::PDNeighborPairs::communicate_bond_list(
 
     for (int globalid : particletargets[torank])
     {
-      for (const auto& pair : *bondlist_)
+      auto it = particle_to_bond_indices.find(globalid);
+      if (it == particle_to_bond_indices.end()) continue;
+
+      for (std::size_t bond_idx : it->second)
       {
-        const int globalid_i = std::get<3>(pair.first);
-        const int globalid_j = std::get<3>(pair.second);
+        const auto& bond = (*bondlist_)[bond_idx];
+        const int globalid_i = std::get<3>(bond.first);
+        const int globalid_j = std::get<3>(bond.second);
 
-        // if particle to be sent is in the bond list also send the bond list information
-        if (globalid_i == globalid or globalid_j == globalid)
-        {
-          const auto canonical_bond_ids = canonical_pd_bond_ids(globalid_i, globalid_j);
-          // A bond can be matched twice when both particles move to the same rank.
-          // Send each canonical bond at most once per target rank.
-          const bool inserted =
-              communicated_bonds_per_target[torank].insert(canonical_bond_ids).second;
-          if (!inserted) continue;
+        const auto canonical_bond_ids = canonical_pd_bond_ids(globalid_i, globalid_j);
+        // A bond can be matched twice when both particles move to the same rank.
+        // Send each canonical bond at most once per target rank.
+        const bool inserted =
+            communicated_bonds_per_target[torank].insert(canonical_bond_ids).second;
+        if (!inserted) continue;
 
-          Core::Communication::PackBuffer data;
-          data.add_to_pack(canonical_bond_ids.first);
-          data.add_to_pack(canonical_bond_ids.second);
-          sdata[torank].insert(sdata[torank].end(), data().begin(), data().end());
-        }
+        Core::Communication::PackBuffer data;
+        data.add_to_pack(canonical_bond_ids.first);
+        data.add_to_pack(canonical_bond_ids.second);
+        sdata[torank].insert(sdata[torank].end(), data().begin(), data().end());
       }
     }
   }


### PR DESCRIPTION
## Description and Context
The original implementation used 3 nested loops with the resultant complexity of $O(P \times M \times B)$. Prebuilding the bond indices and storing them in an `unordered_map` significantly reduced the time spent in this function, see the table with the timing results I obtained when running the scalability studies of an SPH-PD simulation with ~5,000,000 particles. Observe the spike in time spent in `Particle::ParticleAlgorithm::distribute_load_among_procs` for 8 ranks which calls `Particle::PDNeighborPairs::communicate_bond_list()`. This is the time measured from the restart point that was computed running a simulation on 24 ranks. The table shows the maximum time over all ranks in seconds. The tests were performed on a system with 2 AMD EPYC 7713 processors, the same as used in #2058.

| ranks  | old version, s | new version, s |
| -- | -- | -- |
| 2 | 3.7 | 3.7 |
| 4 | 2.1 | 2.4 |
| 8 | 1827 | 3.3 |
| 16 | 486 | 1.6 |
| 32 | 463 | 1.2 |
| 64 | 234 | 1.1 |
| 128 | 109 | 3.5 |

For reference, here are the original job timings:
[2ranks-job-timings.yaml](https://github.com/user-attachments/files/28483745/2ranks-job-timings.yaml)
[4ranks-job-timings.yaml](https://github.com/user-attachments/files/28483754/4ranks-job-timings.yaml)
[8ranks-job-timings.yaml](https://github.com/user-attachments/files/28483757/8ranks-job-timings.yaml)
[16ranks-job-timings.yaml](https://github.com/user-attachments/files/28483752/16ranks-job-timings.yaml)
[32ranks-job-timings.yaml](https://github.com/user-attachments/files/28483753/32ranks-job-timings.yaml)
[64ranks-job-timings.yaml](https://github.com/user-attachments/files/28483756/64ranks-job-timings.yaml)
[128ranks-job-timings.yaml](https://github.com/user-attachments/files/28483751/128ranks-job-timings.yaml)

@georghammerl, @slfuchs, @ppraegla

