### PR TITLE
Remove custom implemented functions: Part 3

### DIFF
--- a/src/elch/4C_elch_input.cpp
+++ b/src/elch/4C_elch_input.cpp
@@ -17,6 +17,7 @@ FOUR_C_NAMESPACE_OPEN
 std::vector<Core::IO::InputSpec> ElCh::valid_parameters()
 {
   using namespace Core::IO::InputSpecBuilders;
+  using namespace Core::IO::InputSpecBuilders::Validators;
 
   std::vector<Core::IO::InputSpec> specs;
   specs.push_back(group("ELCH CONTROL",
@@ -30,8 +31,9 @@ std::vector<Core::IO::InputSpec> ElCh::valid_parameters()
               "MOVBOUNDARYCONVTOL", {.description = "Convergence check tolerance for outer loop in "
                                                     "electrode shape change computations",
                                         .default_value = 1e-6}),
-          parameter<double>("TEMPERATURE",
-              {.description = "Constant temperature (Kelvin)", .default_value = 298.0}),
+          parameter<double>("TEMPERATURE", {.description = "Constant temperature (Kelvin)",
+                                               .default_value = 298.0,
+                                               .validator = positive_or_zero<double>()}),
           parameter<int>("TEMPERATURE_FROM_FUNCT",
               {.description =
                       "Homogeneous temperature within electrochemistry field that can be time "
@@ -39,10 +41,12 @@ std::vector<Core::IO::InputSpec> ElCh::valid_parameters()
                   .default_value = -1}),
           parameter<double>("FARADAY_CONSTANT",
               {.description = "Faraday constant (in unit system as chosen in input file)",
-                  .default_value = 9.64853399e4}),
+                  .default_value = 9.64853399e4,
+                  .validator = positive<double>()}),
           parameter<double>("GAS_CONSTANT",
               {.description = "(universal) gas constant (in unit system as chosen in input file)",
-                  .default_value = 8.314472}),
+                  .default_value = 8.314472,
+                  .validator = positive<double>()}),
           // parameter for possible types of ELCH algorithms for deforming meshes
           deprecated_selection<ElCh::ElchMovingBoundary>("MOVINGBOUNDARY",
               {

--- a/src/mat/4C_mat_elchsinglemat.cpp
+++ b/src/mat/4C_mat_elchsinglemat.cpp
@@ -37,8 +37,7 @@ Mat::PAR::ElchSingleMat::ElchSingleMat(const Core::Mat::PAR::Parameter::Data& ma
       number_conductivity_temp_scale_funct_params_(
           matdata.parameters.get<int>("COND_TEMP_SCALE_FUNCT_PARA_NUM")),
       conductivity_temp_scale_funct_params_(
-          matdata.parameters.get<std::vector<double>>("COND_TEMP_SCALE_FUNCT_PARA")),
-      R_(Global::Problem::instance()->elch_control_params().get<double>("GAS_CONSTANT"))
+          matdata.parameters.get<std::vector<double>>("COND_TEMP_SCALE_FUNCT_PARA"))
 {
   // safety checks
   if (number_diffusion_coefficient_params_ !=
@@ -83,17 +82,6 @@ void Mat::PAR::ElchSingleMat::check_provided_params(
       {
         // constant value: functval=functparams[0];
         functionname = "'constant function'";
-        nfunctparams = 1;
-        break;
-      }
-      case Mat::ElchSingleMat::ARRHENIUS:
-      {
-        // Arrhenius Ansatz for temperature dependent diffusion coefficient in solids D0 *
-        // exp(-Q/(R*T)) Q: activation energy, R: universal gas constant, T: temperature, D0: max
-        // diffusion coefficient D0 is provided by DIFF PARA and R is a constant which is already
-        // defined
-        functionname =
-            "'Arrhenius Ansatz for temperature dependent diffusion coefficient in solids'";
         nfunctparams = 1;
         break;
       }
@@ -403,16 +391,6 @@ double Mat::ElchSingleMat::eval_pre_defined_funct(
       functval = functparams[0];
       break;
 
-    case ARRHENIUS:
-    {
-      // Arrhenius Ansatz for temperature dependent diffusion coefficient in solids D0 *
-      // exp(-Q/(R*T)) Q: activation energy, R: universal gas constant, T:temperature, D0: max
-      // diffusion coefficient D0 is provided by DIFF PARA
-      // functval = exp(-a0/(R * T)
-      const double R = static_cast<Mat::PAR::ElchSingleMat*>(parameter())->R_;
-      functval = std::exp(-functparams[0] / (R * scalar));
-      break;
-    }
     default:
     {
       FOUR_C_THROW("Curve number {} is not implemented!", functnr);
@@ -437,16 +415,6 @@ double Mat::ElchSingleMat::eval_first_deriv_pre_defined_funct(
       firstderivfunctval = 0.0;
       break;
 
-    case ARRHENIUS:
-    {
-      // Arrhenius Ansatz for temperature dependent diffusion coefficient in solids D0 *
-      // exp(-Q/(R*T)) Q: activation energy, R: universal gasconstant, T:temperature, D0: max
-      // diffusioncoefficient D0 is provided by DIFF PARA
-      const double R = static_cast<Mat::PAR::ElchSingleMat*>(parameter())->R_;
-      firstderivfunctval = std::exp(-functparams[0] / (R * scalar)) * functparams[0] / R * 1.0 /
-                           std::pow(scalar, 2.0);
-      break;
-    }
     default:
     {
       FOUR_C_THROW("Curve number {} is not implemented!", functnr);

--- a/src/mat/4C_mat_elchsinglemat.hpp
+++ b/src/mat/4C_mat_elchsinglemat.hpp
@@ -62,10 +62,6 @@ namespace Mat
 
       //! parameters for scaling function describing temperature dependence conductivity
       const std::vector<double> conductivity_temp_scale_funct_params_;
-
-      //! universal gas constant for evaluation of diffusion coefficient by means of
-      //! Arrhenius-ansatz
-      const double R_;
       ///@}
 
      protected:
@@ -126,7 +122,6 @@ namespace Mat
     //! abbreviations for pre-defined functions
     ///@{
     static constexpr int CONSTANT_FUNCTION = -1;
-    static constexpr int ARRHENIUS = -14;
     ///@}
 
    protected:

--- a/src/mat/4C_mat_scl.cpp
+++ b/src/mat/4C_mat_scl.cpp
@@ -33,6 +33,7 @@ Mat::PAR::Scl::Scl(const Core::Mat::PAR::Parameter::Data& matdata)
       susceptibility_(matdata.parameters.get<double>("SUSCEPT")),
       delta_nu_(matdata.parameters.get<double>("DELTA_NU")),
       faraday_(Global::Problem::instance()->elch_control_params().get<double>("FARADAY_CONSTANT")),
+      R_(Global::Problem::instance()->elch_control_params().get<double>("GAS_CONSTANT")),
       epsilon_0_(Global::Problem::instance()
               ->elch_control_params()
               .sublist("DIFFCOND")

--- a/src/mat/4C_mat_scl.hpp
+++ b/src/mat/4C_mat_scl.hpp
@@ -78,7 +78,7 @@ namespace Mat
   class SclType : public Core::Communication::ParObjectType
   {
    public:
-    std::string name() const override { return "SclType"; }
+    [[nodiscard]] std::string name() const override { return "SclType"; }
 
     static SclType& instance() { return instance_; }
 
@@ -99,96 +99,68 @@ namespace Mat
     /// construct the material object given material parameters
     explicit Scl(Mat::PAR::Scl* params);
 
-    //! @name Packing and Unpacking
+    [[nodiscard]] int unique_par_object_id() const override
+    {
+      return SclType::instance().unique_par_object_id();
+    }
 
-    /*!
-      \brief Return unique ParObject id
-
-      every class implementing ParObject needs a unique id defined at the
-      top of drt_parobject.H (this file) and should return it in this method.
-    */
-    int unique_par_object_id() const override { return SclType::instance().unique_par_object_id(); }
-
-    /*!
-      \brief Pack this class so it can be communicated
-
-      Resizes the vector data and stores all information of a class in it.
-      The first information to be stored in data has to be the
-      unique parobject id delivered by unique_par_object_id() which will then
-      identify the exact class on the receiving processor.
-
-      \param data (in/out): char vector to store class information
-    */
     void pack(Core::Communication::PackBuffer& data) const override;
 
-    /*!
-      \brief Unpack data from a char vector into this class
-
-      The vector data contains all information to rebuild the
-      exact copy of an instance of a class on a different processor.
-      The first entry in data has to be an integer which is the unique
-      parobject id defined at the top of this file and delivered by
-      unique_par_object_id().
-
-      \param data (in) : vector storing all data to be unpacked into this
-      instance.
-    */
     void unpack(Core::Communication::UnpackBuffer& buffer) override;
 
-    //@}
+    [[nodiscard]] Core::Materials::MaterialType material_type() const override
+    {
+      return Core::Materials::m_scl;
+    }
 
-    /// material type
-    Core::Materials::MaterialType material_type() const override { return Core::Materials::m_scl; }
-
-    /// return copy of this material object
-    std::shared_ptr<Core::Mat::Material> clone() const override
+    [[nodiscard]] std::shared_ptr<Core::Mat::Material> clone() const override
     {
       return std::make_shared<Scl>(*this);
     }
 
     /// valence (= charge number)
-    double valence() const { return params_->valence_; }
+    [[nodiscard]] double valence() const { return params_->valence_; }
 
     /// computation of the transference number based on the defined curve
-    double compute_transference_number(const double cint) const;
+    [[nodiscard]] double compute_transference_number(double cint) const;
 
     /// computation of the first derivative of the transference number based on the defined curve
-    double compute_first_deriv_trans(const double cint) const;
+    [[nodiscard]] double compute_first_deriv_trans(double cint) const;
 
-    double compute_diffusion_coefficient(
-        const double concentration, const double temperature) const override;
+    [[nodiscard]] double compute_diffusion_coefficient(
+        double concentration, double temperature) const override;
 
-    double compute_concentration_derivative_of_diffusion_coefficient(
-        const double concentration, const double temperature) const override;
+    [[nodiscard]] double compute_concentration_derivative_of_diffusion_coefficient(
+        double concentration, double temperature) const override;
 
     /// computation of dielectric susceptibility (currently a constant)
-    double compute_susceptibility() const { return params_->susceptibility_; }
+    [[nodiscard]] double compute_susceptibility() const { return params_->susceptibility_; }
 
     /// computation of 1/(z^2F^2) with valence of cations
-    double inv_val_valence_faraday_squared() const;
+    [[nodiscard]] double inv_val_valence_faraday_squared() const;
 
-    /// Computation of dielectric permittivity based on dieelectric susceptibility
-    double compute_permittivity() const;
+    /// Computation of dielectric permittivity based on dielectric susceptibility
+    [[nodiscard]] double compute_permittivity() const;
 
     /// Returns Value of cation concentration in the neutral bulk (= anion concentration)
-    double bulk_concentration() const { return params_->cbulk_; }
+    [[nodiscard]] double bulk_concentration() const { return params_->cbulk_; }
 
     /// computation of mobility factor in linear onsager ansatz
-    double compute_onsager_coefficient(const double concentration, const double temperature) const;
+    [[nodiscard]] double compute_onsager_coefficient(
+        double concentration, double temperature) const;
 
     /// computation of the derivative of the mobility factor w.r.t to cation concentration
-    double compute_concentration_derivative_of_onsager_coefficient(
-        const double concentration, const double temperature) const;
+    [[nodiscard]] double compute_concentration_derivative_of_onsager_coefficient(
+        double concentration, double temperature) const;
+
+    [[nodiscard]] Core::Mat::PAR::Parameter* parameter() const override { return params_; }
 
    private:
     /// return curve defining the transference number
-    int trans_nr_curve() const { return params_->transnrcurve_; }
+    [[nodiscard]] int trans_nr_curve() const { return params_->transnrcurve_; }
 
     /// parameter needed for implemented concentration dependence
-    const std::vector<double>& trans_nr_params() const { return params_->transnr_; }
-
-    /// Return quick accessible material parameter data
-    Core::Mat::PAR::Parameter* parameter() const override { return params_; }
+    [[nodiscard]] const std::vector<double>& trans_nr_params() const { return params_->transnr_; }
 
     /// my material parameters
     Mat::PAR::Scl* params_;

--- a/src/mat/4C_mat_scl.hpp
+++ b/src/mat/4C_mat_scl.hpp
@@ -24,7 +24,7 @@ namespace Mat
     class Scl : public ElchSingleMat
     {
      public:
-      Scl(const Core::Mat::PAR::Parameter::Data& matdata);
+      explicit Scl(const Core::Mat::PAR::Parameter::Data& matdata);
 
       /// @name material parameters
       //@{
@@ -53,7 +53,7 @@ namespace Mat
       //! bulk concentration i.e. anion concentration for equal transference numbers
       const double cbulk_;
 
-      //! dieelectric susceptibility of electrolyte material
+      //! dielectric susceptibility of electrolyte material
       const double susceptibility_;
 
       //! difference in partial molar volumes (vacancy <=> interstitial)
@@ -61,6 +61,9 @@ namespace Mat
 
       //! Faraday constant
       const double faraday_;
+
+      //! universal gas constant
+      const double R_;
 
       //! vacuum Permittivity
       const double epsilon_0_;

--- a/src/scatra/4C_scatra_functions.cpp
+++ b/src/scatra/4C_scatra_functions.cpp
@@ -9,6 +9,7 @@
 
 #include "4C_global_data.hpp"
 #include "4C_io_input_spec_builders.hpp"
+#include "4C_utils_function_manager.hpp"
 
 #include <cmath>
 
@@ -70,6 +71,32 @@ FOUR_C_NAMESPACE_OPEN namespace
     }
     return std::shared_ptr<Core::Utils::FunctionOfSpaceTime>(nullptr);
   }
+
+  std::shared_ptr<Core::Utils::FunctionOfTime> create_arrhenius_function(
+      const Core::IO::InputParameterContainer& container)
+  {
+    const auto input_container = container.group("ARRHENIUS_FUNCTION");
+    const auto arrhenius_parameters = ScaTra::ArrheniusParameters{
+        .activation_energy = input_container.get<double>("activation_energy"),
+        .universal_gas_constant =
+            Global::Problem::instance()->elch_control_params().get<double>("GAS_CONSTANT")};
+
+    return std::make_shared<ScaTra::ArrheniusFunction>(arrhenius_parameters);
+  }
+
+
+  std::shared_ptr<Core::Utils::FunctionOfTime> try_create_arrhenius_function(
+      const std::vector<Core::IO::InputParameterContainer>& parameters)
+  {
+    if (parameters.size() != 1) return nullptr;
+
+    if (const auto& container = parameters.front(); container.has_group("ARRHENIUS_FUNCTION"))
+    {
+      return create_arrhenius_function(container);
+    }
+    return std::shared_ptr<Core::Utils::FunctionOfTime>(nullptr);
+  }
+
 
 }  // namespace
 
@@ -183,6 +210,38 @@ void ScaTra::add_valid_scatra_functions(Core::Utils::FunctionManager& function_m
       });
 
   function_manager.add_function_definition(std::move(spec), try_create_scatra_function);
+
+  auto arrhenius_spec = group("ARRHENIUS_FUNCTION",
+      {
+          parameter<double>("activation_energy",
+              {.description = "Activation energy 'Q'", .validator = positive<double>()}),
+      },
+      {.description = "Arrhenius function exp(-Q/(R*T)) for temperature-dependent reaction rates "
+                      "using the universal gas constant 'R' from the ELCH_CONTROL section and the "
+                      "activation energy 'Q'."});
+
+  function_manager.add_function_definition(
+      std::move(arrhenius_spec), try_create_arrhenius_function);
+}
+
+
+ScaTra::ArrheniusFunction::ArrheniusFunction(const ArrheniusParameters& parameters)
+    : parameters_(parameters)
+{
+}
+
+double ScaTra::ArrheniusFunction::evaluate(const double time, const std::size_t component) const
+{
+  // note that the time is the temperature
+  return std::exp(-parameters_.activation_energy / (parameters_.universal_gas_constant * time));
+}
+
+double ScaTra::ArrheniusFunction::evaluate_derivative(
+    const double time, const std::size_t component) const
+{
+  // derivative with respect to time (temperature)
+  const double value = evaluate(time, component);
+  return value * parameters_.activation_energy / (parameters_.universal_gas_constant * time * time);
 }
 
 
@@ -193,7 +252,7 @@ ScaTra::CylinderMagnetFunction::CylinderMagnetFunction(const CylinderMagnetParam
 
 
 double ScaTra::CylinderMagnetFunction::evaluate(
-    std::span<const double> x, double t, std::size_t component) const
+    const std::span<const double> x, const double t, const std::size_t component) const
 {
   FOUR_C_ASSERT(x.size() == 3, "Input position must be a 3D point");
   const auto force_vector = evaluate_magnetic_force(x);
@@ -202,7 +261,7 @@ double ScaTra::CylinderMagnetFunction::evaluate(
 
 
 void ScaTra::CylinderMagnetFunction::evaluate_vector(
-    const std::span<const double> x, double t, std::span<double> values) const
+    const std::span<const double> x, const double t, std::span<double> values) const
 {
   auto force = evaluate_magnetic_force(x);
   FOUR_C_ASSERT(force.size() == 3, "Internal error: force vector has wrong size");

--- a/src/scatra/4C_scatra_functions.hpp
+++ b/src/scatra/4C_scatra_functions.hpp
@@ -11,6 +11,7 @@
 #include "4C_config.hpp"
 
 #include "4C_utils_function.hpp"
+#include "4C_utils_function_of_time.hpp"
 
 
 FOUR_C_NAMESPACE_OPEN
@@ -26,13 +27,13 @@ namespace ScaTra
   /**
    * Type of the Scatra function
    */
-  enum class ScatraFunctionType
+  enum class ScatraFunctionType : std::uint8_t
   {
     cylinder_magnet,
   };
 
 
-  enum class ParticleMagnetizationModelType
+  enum class ParticleMagnetizationModelType : std::uint8_t
   {
     linear,
     linear_with_saturation,
@@ -95,7 +96,7 @@ namespace ScaTra
   class CylinderMagnetFunction : public Core::Utils::FunctionOfSpaceTime
   {
    public:
-    CylinderMagnetFunction(const CylinderMagnetParameters& parameters);
+    explicit CylinderMagnetFunction(const CylinderMagnetParameters& parameters);
 
     /**
      * Evaluate the function at a given position x and time t for a given component
@@ -105,7 +106,8 @@ namespace ScaTra
      * @param component index of the function-component which should be evaluated
      * @return function value
      */
-    double evaluate(std::span<const double> x, double t, std::size_t component) const override;
+    [[nodiscard]] double evaluate(
+        std::span<const double> x, double t, std::size_t component) const override;
 
     /**
      * Evaluate the function at a given position x and time t and return the vector of all
@@ -123,7 +125,7 @@ namespace ScaTra
      *
      * @return 3
      */
-    [[nodiscard]] std::size_t number_components() const override { return (3); };
+    [[nodiscard]] std::size_t number_components() const override { return 3; }
 
    private:
     /*!
@@ -193,6 +195,35 @@ namespace ScaTra
     /// parameters of the cylinder magnet
     const CylinderMagnetParameters parameters_;
   };
+
+  /**
+   * Parameters of the Arrhenius function
+   */
+  struct ArrheniusParameters
+  {
+    double activation_energy{};
+    double universal_gas_constant{};
+  };
+
+  /*!
+   * @brief Arrhenius function exp(-Q/(R*T)) for temperature-dependent reaction rates using the
+   * activation energy 'Q' and universal gas constant 'R'.
+   *
+   * @note the 'time' is misused to communicate the temperature value
+   */
+  class ArrheniusFunction : public Core::Utils::FunctionOfTime
+  {
+   public:
+    explicit ArrheniusFunction(const ArrheniusParameters& parameters);
+
+    [[nodiscard]] double evaluate(double time, std::size_t component = 0) const override;
+
+    [[nodiscard]] double evaluate_derivative(double time, std::size_t component = 0) const override;
+
+   private:
+    const ArrheniusParameters parameters_;
+  };
+
 
   /*!
    * Evaluate the complete elliptic integral of the third kind

--- a/tests/input_files/ssti_mono_3D_2blocks_elch_temp_dep_diff.4C.yaml
+++ b/tests/input_files/ssti_mono_3D_2blocks_elch_temp_dep_diff.4C.yaml
@@ -8,7 +8,6 @@ TITLE:
   - '- arbitrary conductivity in electrolyte using the function framework'
   - '- stationary elch problem'
   - '- flux of species (phi1) and charge (phi2) in'
-  - '- diffusion coefficient: Arrhenius ansatz (function: -14)'
 PROBLEM TYPE:
   PROBLEMTYPE: "Structure_Scalar_Thermo_Interaction"
 IO:
@@ -69,13 +68,11 @@ MATERIALS:
   - MAT: 5
     MAT_electrode:
       DIFF_COEF_CONC_DEP_FUNCT: -1
-      DIFF_COEF_TEMP_SCALE_FUNCT: -14
+      DIFF_COEF_TEMP_SCALE_FUNCT: 7
       COND_CONC_DEP_FUNCT: -1
       COND_TEMP_SCALE_FUNCT: 6
       DIFF_PARA_NUM: 1
       DIFF_PARA: [1]
-      DIFF_COEF_TEMP_SCALE_FUNCT_PARA_NUM: 1
-      DIFF_COEF_TEMP_SCALE_FUNCT_PARA: [5]
       COND_PARA_NUM: 1
       COND_PARA: [1]
       C_MAX: 50000
@@ -154,6 +151,9 @@ FUNCT5:
       COEFF: [0]
 FUNCT6:
   - SYMBOLIC_FUNCTION_OF_TIME: "1.0/(1.0+1.0*(t-0.5))"
+FUNCT7:
+  - ARRHENIUS_FUNCTION:
+      activation_energy: 5.0
 RESULT DESCRIPTION:
   - STRUCTURE:
       DIS: "structure"


### PR DESCRIPTION
## Description and Context
This PR is the third step toward removing custom-implemented functions from elchsinglemat. Different functions can be chosen by „magic“ negative numbers in the function definition, along with a combination of parameters, which is a nightmare to use. The commits of this PR are structured as:

1. Replaces the Arrhenius function with an implementation in scatra functions that is now available for all scatra problems with a nicer user interface
2. Some minor cleanup of the scl material as a byproduct, as I had to touch it within the first commit anyway

Now, only the most useless but most used function (the constant function) is left, which will be removed in the next PR with some restructuring.

## Related Issues and Pull Requests
Follows #2042 #2061