### PR TITLE
Modify vtu vector storage for 2D node output

### DIFF
--- a/src/core/io/src/4C_io_element_append_visualization.hpp
+++ b/src/core/io/src/4C_io_element_append_visualization.hpp
@@ -209,7 +209,7 @@ namespace Core::IO
         // We have to make sure that this dof is actually available at this node. It can happen that
         // this is not the case e.g. in multi-scale simulations where different nodes in the mesh
         // have a different number of dofs.
-        // Since this is not supported by vtu, we add a NaN in this case, see else branch
+        // Keep the requested vector size and pad missing components with 0.0, see else branch
         if (nodedofs.size() > read_result_data_from_dofindex + idof)
         {
           const int lid =
@@ -218,7 +218,7 @@ namespace Core::IO
         }
         else
         {
-          vtu_point_result_data.push_back(std::numeric_limits<double>::quiet_NaN());
+          vtu_point_result_data.push_back(0.0);
         }
       }
     }


### PR DESCRIPTION
# Description

For 2D solid analyses, the  displacements, velocities, etc., was stored as 3-component vectors, and the third component was saved as "NaN". The reason was given in a comment:

```
        // We have to make sure that this dof is actually available at this node. It can happen that
        // this is not the case e.g. in multi-scale simulations where different nodes in the mesh
        // have a different number of dofs.
        // Since this is not supported by vtu, we add a NaN in this case, see else branch

```

Since a Warp filter cannot be applied in Paraview, if the third component is NaN, I changed it to 0.0. I hope there are no other side effects.

## Related issues, PR, etc.
#2027

## Interested parties:
@bennoschoenstein 