### PR TITLE
Monolithic non-local stimulus

### DIFF
--- a/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
+++ b/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
@@ -4368,6 +4368,11 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
                 {.description = "Index of the non-local stimulus scalar in the scatra matlist "
                                 "(leave unset to disable)",
                     .validator = null_or(positive_or_zero<int>())}),
+            parameter<bool>("IMPLICIT_INTEGRATION",
+                {.description =
+                        "Integrate growth_scalar and lambda_r implicitly at each Newton iteration. "
+                        "Default: false.",
+                    .default_value = false}),
         },
         {.description =
                 "A 1D constituent where the g&r evolution ODEs can be solved either as own scatra "

--- a/src/mat/4C_mat_mixture.cpp
+++ b/src/mat/4C_mat_mixture.cpp
@@ -11,7 +11,6 @@
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
 #include "4C_mat_service.hpp"
-#include "4C_mixture_constituent_remodelfiber_ssi.hpp"
 #include "4C_utils_enum.hpp"
 
 #include <memory>
@@ -342,4 +341,14 @@ const Mixture::MixtureConstituentRemodelFiberSsi* Mat::Mixture::ssi_constituent_
   }
   return nullptr;
 }
+std::vector<Core::LinAlg::SymmetricTensor<double, 3, 3>> Mat::Mixture::evaluate_d_stress_d_scalars(
+    const Core::LinAlg::Tensor<double, 3, 3>& defgrad,
+    const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
+    const Teuchos::ParameterList& params, const EvaluationContext<3>& context, int num_scalars,
+    int gp, int eleGID)
+{
+  return mixture_rule_->evaluate_d_stress_d_scalars(
+      defgrad, glstrain, params, context, num_scalars, gp, eleGID);
+}
+
 FOUR_C_NAMESPACE_CLOSE

--- a/src/mat/4C_mat_mixture.hpp
+++ b/src/mat/4C_mat_mixture.hpp
@@ -14,6 +14,7 @@
 #include "4C_comm_parobjectfactory.hpp"
 #include "4C_mat_anisotropy.hpp"
 #include "4C_mat_elast_summand.hpp"
+#include "4C_mat_monolithic_solid_scalar_material.hpp"
 #include "4C_mat_so3_material.hpp"
 #include "4C_material_parameter_base.hpp"
 #include "4C_mixture_constituent.hpp"
@@ -77,7 +78,7 @@ namespace Mat
    * the mixture rule and the constituents defining an clear interface if an extension of the
    * mixture framework is needed.
    */
-  class Mixture : public So3Material
+  class Mixture : public So3Material, public MonolithicSolidScalarMaterial
   {
    public:
     /// Constructor for an empty material object
@@ -230,6 +231,21 @@ namespace Mat
     {
       return *constituents_;
     }
+
+    Core::LinAlg::SymmetricTensor<double, 3, 3> evaluate_d_stress_d_scalar(
+        const Core::LinAlg::Tensor<double, 3, 3>& defgrad,
+        const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
+        const Teuchos::ParameterList& params, const EvaluationContext<3>& context, int gp,
+        int eleGID) override
+    {
+      return evaluate_d_stress_d_scalars(defgrad, glstrain, params, context, 1, gp, eleGID).front();
+    }
+
+    std::vector<Core::LinAlg::SymmetricTensor<double, 3, 3>> evaluate_d_stress_d_scalars(
+        const Core::LinAlg::Tensor<double, 3, 3>& defgrad,
+        const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
+        const Teuchos::ParameterList& params, const EvaluationContext<3>& context, int num_scalars,
+        int gp, int eleGID) override;
 
    private:
     /// Material parameters

--- a/src/mat/4C_mat_monolithic_solid_scalar_material.hpp
+++ b/src/mat/4C_mat_monolithic_solid_scalar_material.hpp
@@ -13,7 +13,10 @@
 #include "4C_linalg_fixedsizematrix.hpp"
 #include "4C_linalg_symmetric_tensor.hpp"
 #include "4C_mat_so3_material.hpp"
+#include "4C_utils_exceptions.hpp"
 #include "4C_utils_parameter_list.fwd.hpp"
+
+#include <vector>
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -39,6 +42,27 @@ namespace Mat
         const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
         const Teuchos::ParameterList& params, const EvaluationContext<3>& context, int gp,
         int eleGID) = 0;
+
+    /*!
+     * @brief Evaluates dS/dc_k for all scalar DOFs per node.
+     *
+     * Returns a vector of num_scalars tensors. Entry k holds dS/dc_k.
+     * The default wraps evaluate_d_stress_d_scalar and places the result in entry 0;
+     * all other entries are zero (scalars not affecting the stress).
+     * Override for materials where the stress is affected by more than one scalar.
+     */
+    [[nodiscard]] virtual std::vector<Core::LinAlg::SymmetricTensor<double, 3, 3>>
+    evaluate_d_stress_d_scalars(const Core::LinAlg::Tensor<double, 3, 3>& defgrad,
+        const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
+        const Teuchos::ParameterList& params, const EvaluationContext<3>& context, int num_scalars,
+        int gp, int eleGID)
+    {
+      FOUR_C_ASSERT(num_scalars > 0, "num_scalars must be positive");
+      std::vector<Core::LinAlg::SymmetricTensor<double, 3, 3>> result(num_scalars);
+      for (auto& t : result) t.fill(0.0);
+      result[0] = evaluate_d_stress_d_scalar(defgrad, glstrain, params, context, gp, eleGID);
+      return result;
+    }
   };
 }  // namespace Mat
 

--- a/src/mixture/src/4C_mixture_constituent_remodelfiber_ssi.cpp
+++ b/src/mixture/src/4C_mixture_constituent_remodelfiber_ssi.cpp
@@ -57,7 +57,8 @@ Mixture::PAR::MixtureConstituentRemodelFiberSsi::MixtureConstituentRemodelFiberS
       growth_scalar_id_(matdata.parameters.get<std::optional<int>>("GROWTH_SCALAR_ID")),
       remodeling_scalar_id_(matdata.parameters.get<std::optional<int>>("REMODELING_SCALAR_ID")),
       nonlocal_stimulus_scalar_id_(
-          matdata.parameters.get<std::optional<int>>("NONLOCAL_STIMULUS_SCALAR_ID"))
+          matdata.parameters.get<std::optional<int>>("NONLOCAL_STIMULUS_SCALAR_ID")),
+      implicit_integration_(matdata.parameters.get<bool>("IMPLICIT_INTEGRATION"))
 {
 }
 
@@ -174,8 +175,11 @@ void Mixture::MixtureConstituentRemodelFiberSsi::update_elastic_part(
       const auto& scalars = *params.get<std::shared_ptr<std::vector<double>>>("scalars");
       const double psi =
           scalars[static_cast<std::size_t>(params_->nonlocal_stimulus_scalar_id_.value())];
-      remodel_fiber_[gp].integrate_local_evolution_equations_explicit_with_nonlocal_stimulus(
-          psi, dt);
+      if (!params_->implicit_integration_)
+      {
+        remodel_fiber_[gp].integrate_local_evolution_equations_explicit_with_nonlocal_stimulus(
+            psi, dt);
+      }
     }
     else
     {
@@ -209,8 +213,11 @@ void Mixture::MixtureConstituentRemodelFiberSsi::update(const Core::LinAlg::Tens
         const auto& scalars = *params.get<std::shared_ptr<std::vector<double>>>("scalars");
         const double psi =
             scalars[static_cast<std::size_t>(params_->nonlocal_stimulus_scalar_id_.value())];
-        remodel_fiber_[gp].integrate_local_evolution_equations_explicit_with_nonlocal_stimulus(
-            psi, dt);
+        if (!params_->implicit_integration_)
+        {
+          remodel_fiber_[gp].integrate_local_evolution_equations_explicit_with_nonlocal_stimulus(
+              psi, dt);
+        }
       }
       else
       {
@@ -318,6 +325,16 @@ void Mixture::MixtureConstituentRemodelFiberSsi::evaluate(
   const double lambda_f = evaluate_lambdaf(C, gp, eleGID);
   remodel_fiber_[gp].set_state(lambda_f, 1.0);
 
+  if (params_->enable_growth_ && is_nonlocal_stimulus_mode() && params_->implicit_integration_)
+  {
+    FOUR_C_ASSERT(context.time_step_size, "Time step size not given in evaluation context.");
+    const double dt = *context.time_step_size;
+    const auto& scalars = *params.get<std::shared_ptr<std::vector<double>>>("scalars");
+    const double psi =
+        scalars[static_cast<std::size_t>(params_->nonlocal_stimulus_scalar_id_.value())];
+    remodel_fiber_[gp].integrate_local_evolution_equations_implicit_with_nonlocal_stimulus(psi, dt);
+  }
+
   S_stress = evaluate_current_pk2(gp, eleGID);
   cmat = evaluate_current_cmat(gp, eleGID);
 }
@@ -353,6 +370,16 @@ void Mixture::MixtureConstituentRemodelFiberSsi::evaluate_elastic_part(
   const double lambda_f = evaluate_lambdaf(C, gp, eleGID);
   const double lambda_ext = evaluate_lambda_ext(iFextin, gp, eleGID);
   remodel_fiber_[gp].set_state(lambda_f, lambda_ext);
+
+  if (params_->enable_growth_ && is_nonlocal_stimulus_mode() && params_->implicit_integration_)
+  {
+    FOUR_C_ASSERT(context.time_step_size, "Time step size not given in evaluation context.");
+    const double dt = *context.time_step_size;
+    const auto& scalars = *params.get<std::shared_ptr<std::vector<double>>>("scalars");
+    const double psi =
+        scalars[static_cast<std::size_t>(params_->nonlocal_stimulus_scalar_id_.value())];
+    remodel_fiber_[gp].integrate_local_evolution_equations_implicit_with_nonlocal_stimulus(psi, dt);
+  }
 
   S_stress = evaluate_current_pk2(gp, eleGID);
   cmat = evaluate_current_cmat(gp, eleGID);
@@ -390,6 +417,23 @@ double Mixture::MixtureConstituentRemodelFiberSsi::evaluate_growth_reaction_coef
 {
   if (params_->enable_growth_) return remodel_fiber_[gp].evaluate_growth_reaction_coefficient();
   return 0.0;
+}
+
+double Mixture::MixtureConstituentRemodelFiberSsi::evaluate_current_fiber_pk2_stress(int gp) const
+{
+  return remodel_fiber_[gp].evaluate_current_fiber_pk2_stress();
+}
+
+double Mixture::MixtureConstituentRemodelFiberSsi::evaluate_d_growth_scalar_d_nonlocal_stimulus(
+    int gp) const
+{
+  return remodel_fiber_[gp].evaluate_d_growth_scalar_d_nonlocal_stimulus();
+}
+
+double Mixture::MixtureConstituentRemodelFiberSsi::evaluate_d_cauchy_stress_d_lambda_f_sq(
+    int gp) const
+{
+  return remodel_fiber_[gp].evaluate_d_current_cauchy_stress_d_lambda_f_sq();
 }
 
 double Mixture::MixtureConstituentRemodelFiberSsi::evaluate_local_stimulus(int gp) const

--- a/src/mixture/src/4C_mixture_constituent_remodelfiber_ssi.hpp
+++ b/src/mixture/src/4C_mixture_constituent_remodelfiber_ssi.hpp
@@ -59,6 +59,8 @@ namespace Mixture
       const std::optional<int> growth_scalar_id_;
       const std::optional<int> remodeling_scalar_id_;
       const std::optional<int> nonlocal_stimulus_scalar_id_;
+
+      const bool implicit_integration_;
     };
   }  // namespace PAR
 
@@ -118,6 +120,17 @@ namespace Mixture
     {
       return params_->nonlocal_stimulus_scalar_id_.has_value();
     }
+
+    [[nodiscard]] bool is_implicit_integration() const { return params_->implicit_integration_; }
+
+    [[nodiscard]] int nonlocal_stimulus_scalar_id() const
+    {
+      return params_->nonlocal_stimulus_scalar_id_.value();
+    }
+
+    [[nodiscard]] double evaluate_current_fiber_pk2_stress(int gp) const;
+    [[nodiscard]] double evaluate_d_growth_scalar_d_nonlocal_stimulus(int gp) const;
+    [[nodiscard]] double evaluate_d_cauchy_stress_d_lambda_f_sq(int gp) const;
 
     void set_current_growth_scalar(const Teuchos::ParameterList& params, int gp);
     void set_current_lambda_r(const Teuchos::ParameterList& params, int gp);

--- a/src/mixture/src/4C_mixture_remodelfiber-internal.hpp
+++ b/src/mixture/src/4C_mixture_remodelfiber-internal.hpp
@@ -201,6 +201,17 @@ namespace Mixture
        * @param dt (in) : timestep
        */
       void integrate_local_evolution_equations_explicit_with_nonlocal_stimulus(T psi, T dt);
+
+      /*!
+       * @brief Integrate the local evolution equations implicitly, driven by a non-local stimulus
+       * \psi.
+       *
+       * @param psi (in) : non-local stimulus \psi
+       * @param dt (in) : timestep
+       */
+      void integrate_local_evolution_equations_implicit_with_nonlocal_stimulus(
+          const T psi, const T dt);
+
       /// @}
       /// @brief Evaluation methods
       ///
@@ -229,6 +240,9 @@ namespace Mixture
       [[nodiscard]] T evaluate_d_current_growth_scalar_d_lambda_f_sq() const;
       [[nodiscard]] T evaluate_d_current_lambda_r_d_lambda_f_sq() const;
       [[nodiscard]] T evaluate_d_current_cauchy_stress_d_lambda_f_sq() const;
+      [[nodiscard]] T evaluate_d_growth_scalar_d_nonlocal_stimulus() const;
+
+
       /// @}
 
       /// array of G&R states (the last state in the array is the current state)
@@ -239,6 +253,10 @@ namespace Mixture
       T d_growth_scalar_d_lambda_f_sq_ = 0.0;
       T d_lambda_r_d_lambda_f_sq_ = 0.0;
       /// @}
+
+      /// d_growth_scalar^{n+1}_d_psi - stored during integrate_..._with_nonlocal_stimulus calls.
+      /// Used for K_u_psi assembly without recomputing from scratch.
+      T d_growth_scalar_d_stimulus_ = 0.0;
 
       /// d_lambda_ext_d_growth_scalar_ - set from outside (growth strategy via mixture rule).
       /// Non-zero only for inelastic growth strategies where Fg depends on growth_scalar.

--- a/src/mixture/src/4C_mixture_remodelfiber.cpp
+++ b/src/mixture/src/4C_mixture_remodelfiber.cpp
@@ -338,16 +338,16 @@ void Mixture::Implementation::RemodelFiberImplementation<numstates,
   const Core::LinAlg::Matrix<2, 1, T> d_residuum_d_lambda_f_sq = std::invoke(
       [&]()
       {
-        Core::LinAlg::Matrix<2, 1, T> d_residuum_d_lambfa_f_sq;
+        Core::LinAlg::Matrix<2, 1, T> d_residuum_d_lambda_f_sq;
 
-        d_residuum_d_lambfa_f_sq(0, 0) =
+        d_residuum_d_lambda_f_sq(0, 0) =
             evaluate_d_current_growth_evolution_implicit_time_integration_residuum_d_lambda_f_sq(
                 dt);
-        d_residuum_d_lambfa_f_sq(1, 0) =
+        d_residuum_d_lambda_f_sq(1, 0) =
             evaluate_d_current_remodel_evolution_implicit_time_integration_residuum_d_lambda_f_sq(
                 dt);
 
-        return d_residuum_d_lambfa_f_sq;
+        return d_residuum_d_lambda_f_sq;
       });
 
 
@@ -382,6 +382,71 @@ void Mixture::Implementation::RemodelFiberImplementation<numstates,
 
   d_growth_scalar_d_lambda_f_sq_ = 0.0;
   d_lambda_r_d_lambda_f_sq_ = 0.0;
+}
+
+template <int numstates, typename T>
+void Mixture::Implementation::RemodelFiberImplementation<numstates,
+    T>::integrate_local_evolution_equations_implicit_with_nonlocal_stimulus(const T psi, const T dt)
+{
+  FOUR_C_ASSERT(state_is_set_, "You have to call set_state() before!");
+  const T lambda_f = states_.back().lambda_f;
+  const T lambda_ext = states_.back().lambda_ext;
+
+  // get linear ODE coefficient c
+  const T c = evaluate_growth_evolution_equation_dt_with_nonlocal_stimulus(
+      psi, lambda_f, states_[0].lambda_r, lambda_ext, T(1.0));
+
+  // growth_scalar^{n+1} = growth_scalar^n * (1 + dt*(1-theta)*c) / (1 - dt*theta*c)
+  constexpr double theta = ImplicitIntegration<numstates, T>::theta;
+  const T denominator = T(1.0) - dt * theta * c;
+  states_.back().growth_scalar =
+      states_[0].growth_scalar * (T(1.0) + dt * (1.0 - theta) * c) / denominator;
+
+  // d_growth_scalar^{n+1}/d_psi = growth_scalar^n * dt * d_c/d_psi / B^2
+  const T dsig = psi / sig_h_;
+  const T dc_dpsi = (growth_evolution_.evaluate_d_true_mass_production_rate_d_sig(dsig) +
+                        growth_evolution_.evaluate_d_true_mass_removal_rate_d_sig(dsig)) /
+                    sig_h_;
+  d_growth_scalar_d_stimulus_ =
+      states_[0].growth_scalar * dt * dc_dpsi / (denominator * denominator);
+
+
+  // --- lambda_r: 1D implicit Newton ---
+  const auto EvaluateLocalNewton = [&]()
+  {
+    const IntegrationState<numstates, T> remodel_state = get_integration_state_lambda_r();
+    const T res = ImplicitIntegration<numstates, T>::get_residuum(remodel_state, dt);
+    const T lambda_r_np = states_.back().lambda_r;
+    const T drdr =
+        ImplicitIntegration<numstates, T>::get_partial_derivative_xnp(remodel_state, dt) +
+        ImplicitIntegration<numstates, T>::get_partial_derivative_fnp(remodel_state, dt) *
+            evaluate_d_remodel_evolution_equation_dt_d_remodel(lambda_f, lambda_r_np, lambda_ext);
+    return std::make_pair(drdr, res);
+  };
+
+  auto [K_r, b_r] = EvaluateLocalNewton();
+  unsigned iteration = 0;
+  while (std::abs(Core::FADUtils::cast_to_double(b_r)) > 1e-10)
+  {
+    if (iteration >= 500)
+    {
+      FOUR_C_THROW(
+          "The local newton didn't converge within 500 iterations. Residuum is {:.3e} > {:.3e}",
+          std::abs(Core::FADUtils::cast_to_double(b_r)), 1e-10);
+    }
+    states_.back().lambda_r -= b_r / K_r;
+    std::tie(K_r, b_r) = EvaluateLocalNewton();
+    ++iteration;
+  }
+
+  // d_lambda_r^{n+1}/d_lambda_f^2
+  const T d_residuum_d_lambda_f_sq =
+      evaluate_d_current_remodel_evolution_implicit_time_integration_residuum_d_lambda_f_sq(dt);
+  d_lambda_r_d_lambda_f_sq_ = -d_residuum_d_lambda_f_sq / K_r;
+
+  // growth_scalar depends on the stimulus psi, which has its own linearization w.r.t. lambda_f_sq
+  // in the OD-block
+  d_growth_scalar_d_lambda_f_sq_ = T(0.0);
 }
 
 template <int numstates, typename T>
@@ -814,6 +879,13 @@ T Mixture::Implementation::RemodelFiberImplementation<numstates,
 
 template <int numstates, typename T>
 T Mixture::Implementation::RemodelFiberImplementation<numstates,
+    T>::evaluate_d_growth_scalar_d_nonlocal_stimulus() const
+{
+  return d_growth_scalar_d_stimulus_;
+}
+
+template <int numstates, typename T>
+T Mixture::Implementation::RemodelFiberImplementation<numstates,
     T>::evaluate_growth_reaction_coefficient() const
 {
   FOUR_C_ASSERT(state_is_set_, "You have to call set_state() before!");
@@ -922,6 +994,14 @@ void Mixture::RemodelFiber<numstates>::
 }
 
 template <int numstates>
+void Mixture::RemodelFiber<numstates>::
+    integrate_local_evolution_equations_implicit_with_nonlocal_stimulus(
+        const double psi, const double dt)
+{
+  impl_->integrate_local_evolution_equations_implicit_with_nonlocal_stimulus(psi, dt);
+}
+
+template <int numstates>
 double Mixture::RemodelFiber<numstates>::evaluate_current_homeostatic_fiber_cauchy_stress() const
 {
   return impl_->evaluate_current_homeostatic_fiber_cauchy_stress();
@@ -1015,6 +1095,12 @@ template <int numstates>
 double Mixture::RemodelFiber<numstates>::evaluate_d_current_cauchy_stress_d_lambda_f_sq() const
 {
   return impl_->evaluate_d_current_cauchy_stress_d_lambda_f_sq();
+}
+
+template <int numstates>
+double Mixture::RemodelFiber<numstates>::evaluate_d_growth_scalar_d_nonlocal_stimulus() const
+{
+  return impl_->evaluate_d_growth_scalar_d_nonlocal_stimulus();
 }
 
 template class Mixture::RemodelFiber<2>;

--- a/src/mixture/src/4C_mixture_remodelfiber.hpp
+++ b/src/mixture/src/4C_mixture_remodelfiber.hpp
@@ -123,6 +123,16 @@ namespace Mixture
      * @param dt (in) : timestep
      */
     void integrate_local_evolution_equations_explicit_with_nonlocal_stimulus(double psi, double dt);
+    /*!
+     * @brief Integrate the local evolution equations implicitly, driven by a non-local stimulus
+     * \psi. The growth_scalar is solved analytically (ODE is linear in growth_scalar), while
+     * lambda_r is solved via a 1D local Newton. Stores d_growth_scalar_d_stimulus_ and
+     * d_lambda_r_d_lambda_f_sq_ for monolithic tangent assembly.
+     *
+     * @param psi (in) : non-local stimulus \psi (from Scatra DOF)
+     * @param dt (in) : timestep
+     */
+    void integrate_local_evolution_equations_implicit_with_nonlocal_stimulus(double psi, double dt);
     /// @}
     [[nodiscard]] double evaluate_current_homeostatic_fiber_cauchy_stress() const;
     [[nodiscard]] double evaluate_current_fiber_cauchy_stress() const;
@@ -143,6 +153,7 @@ namespace Mixture
     [[nodiscard]] double evaluate_d_current_growth_scalar_d_lambda_f_sq() const;
     [[nodiscard]] double evaluate_d_current_lambda_r_d_lambda_f_sq() const;
     [[nodiscard]] double evaluate_d_current_cauchy_stress_d_lambda_f_sq() const;
+    [[nodiscard]] double evaluate_d_growth_scalar_d_nonlocal_stimulus() const;
     /// @}
 
    private:

--- a/src/mixture/src/4C_mixture_rule.hpp
+++ b/src/mixture/src/4C_mixture_rule.hpp
@@ -231,6 +231,31 @@ namespace Mixture
     }
 
     /*!
+     * @brief Evaluates the derivative of the stress w.r.t. the scalar DOFs of the mixture
+     * constituents
+     *
+     * @param defgrad (in) : Deformation gradient
+     * @param glstrain (in) : Green-Lagrange strain
+     * @param params (in) : ParameterList for additional parameters
+     * @param context (in) : Evaluation context
+     * @param num_scalars (in) : Number of scalar DOFs
+     * @param gp (in) : Gauss point id
+     * @param eleGID (in) : global element id
+     * @return vector of length num_scalars containing the derivatives of the stress w.r.t. the
+     * scalar DOFs
+     */
+    [[nodiscard]] virtual std::vector<Core::LinAlg::SymmetricTensor<double, 3, 3>>
+    evaluate_d_stress_d_scalars(const Core::LinAlg::Tensor<double, 3, 3>& defgrad,
+        const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
+        const Teuchos::ParameterList& params, const Mat::EvaluationContext<3>& context,
+        int num_scalars, int gp, int eleGID) const
+    {
+      std::vector<Core::LinAlg::SymmetricTensor<double, 3, 3>> result(num_scalars);
+      for (auto& t : result) t.fill(0.0);
+      return result;
+    }
+
+    /*!
      * \brief Register names of the internal data that should be saved during runtime output
      *
      * \param name_and_size [out] : unordered map of names of the data with the respective vector

--- a/src/mixture/src/4C_mixture_rule_growthremodel.cpp
+++ b/src/mixture/src/4C_mixture_rule_growthremodel.cpp
@@ -11,6 +11,7 @@
 #include "4C_linalg_serialdensematrix.hpp"
 #include "4C_material_parameter_base.hpp"
 #include "4C_mixture_constituent.hpp"
+#include "4C_mixture_constituent_remodelfiber_ssi.hpp"
 #include "4C_mixture_growth_strategy.hpp"
 #include "4C_utils_exceptions.hpp"
 
@@ -245,4 +246,40 @@ bool Mixture::GrowthRemodelMixtureRule::evaluate_output_data(
   }
   return false;
 }
+std::vector<Core::LinAlg::SymmetricTensor<double, 3, 3>>
+Mixture::GrowthRemodelMixtureRule::evaluate_d_stress_d_scalars(
+    const Core::LinAlg::Tensor<double, 3, 3>& defgrad,
+    const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
+    const Teuchos::ParameterList& params, const Mat::EvaluationContext<3>& context, int num_scalars,
+    int gp, int eleGID) const
+{
+  std::vector<Core::LinAlg::SymmetricTensor<double, 3, 3>> result(num_scalars);
+  for (auto& t : result) t.fill(0.0);
+
+  for (const auto& constituent_ptr : constituents())
+  {
+    const auto* ssi = dynamic_cast<const FourC::Mixture::MixtureConstituentRemodelFiberSsi*>(
+        constituent_ptr.get());
+    if (ssi == nullptr) continue;
+    if (!ssi->is_nonlocal_stimulus_mode()) continue;
+
+    FOUR_C_ASSERT_ALWAYS(ssi->is_implicit_integration(),
+        "MIX_Constituent_SsiRemodelFiber with NONLOCAL_STIMULUS_SCALAR_ID is used in a "
+        "monolithic SSI solver, but IMPLICIT is set to false. Please set IMPLICIT true for "
+        "consistent linearization.");
+
+    const int psi_id = ssi->nonlocal_stimulus_scalar_id();
+    FOUR_C_ASSERT(psi_id < num_scalars, "nonlocal_stimulus_scalar_id {} >= num_scalars {}", psi_id,
+        num_scalars);
+
+    const double rho0 = get_constituent_initial_reference_mass_density(*constituent_ptr);
+    const double S_pk2 = ssi->evaluate_current_fiber_pk2_stress(gp);
+    const double d_growth_scalar_d_stimulus = ssi->evaluate_d_growth_scalar_d_nonlocal_stimulus(gp);
+
+    result[psi_id] += rho0 * S_pk2 * ssi->get_structural_tensor(gp) * d_growth_scalar_d_stimulus;
+  }
+
+  return result;
+}
+
 FOUR_C_NAMESPACE_CLOSE

--- a/src/mixture/src/4C_mixture_rule_growthremodel.hpp
+++ b/src/mixture/src/4C_mixture_rule_growthremodel.hpp
@@ -115,6 +115,12 @@ namespace Mixture
     [[nodiscard]] double get_constituent_initial_reference_mass_density(
         const Mixture::MixtureConstituent& constituent) const;
 
+    [[nodiscard]] std::vector<Core::LinAlg::SymmetricTensor<double, 3, 3>>
+    evaluate_d_stress_d_scalars(const Core::LinAlg::Tensor<double, 3, 3>& defgrad,
+        const Core::LinAlg::SymmetricTensor<double, 3, 3>& glstrain,
+        const Teuchos::ParameterList& params, const Mat::EvaluationContext<3>& context,
+        int num_scalars, int gp, int eleGID) const override;
+
     void register_output_data_names(
         std::unordered_map<std::string, int>& names_and_size) const override;
 

--- a/src/scatra_ele/4C_scatra_ele_calc_nonlocal_stimulus.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_nonlocal_stimulus.cpp
@@ -9,10 +9,12 @@
 
 #include "4C_fem_discretization.hpp"
 #include "4C_fem_general_element.hpp"
+#include "4C_linalg_tensor_conversion.hpp"
 #include "4C_mat_list.hpp"
 #include "4C_mat_mixture.hpp"
 #include "4C_mat_scatra_nonlocal_stimulus.hpp"
 #include "4C_mixture_constituent_remodelfiber_ssi.hpp"
+#include "4C_scatra_ele_action.hpp"
 #include "4C_scatra_ele_calc.hpp"
 #include "4C_utils_exceptions.hpp"
 #include "4C_utils_singleton_owner.hpp"
@@ -190,6 +192,107 @@ Discret::Elements::ScaTraEleCalcNonlocalStimulus<distype, probdim>::get_struct_m
   return mixture;
 }
 
+
+template <Core::FE::CellType distype, int probdim>
+int Discret::Elements::ScaTraEleCalcNonlocalStimulus<distype, probdim>::evaluate_action_od(
+    Core::Elements::Element* ele, Teuchos::ParameterList& params,
+    Core::FE::Discretization& discretization, const ScaTra::Action& action,
+    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+    Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+    Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3)
+{
+  // base class call
+  const int result = my::evaluate_action_od(
+      ele, params, discretization, action, la, elemat1, elemat2, elevec1, elevec2, elevec3);
+
+  // nonlocal stimulus specific contribution to the off-diagonal block
+  if (action == ScaTra::Action::calc_scatra_mono_odblock_mesh)
+    sysmat_od_mesh_nls(elemat1, my::nsd_);
+
+  return result;
+}
+
+template <Core::FE::CellType distype, int probdim>
+void Discret::Elements::ScaTraEleCalcNonlocalStimulus<distype, probdim>::sysmat_od_mesh_nls(
+    Core::LinAlg::SerialDenseMatrix& emat, const int ndofpernodemesh)
+{
+  if constexpr (probdim == 3 && Core::FE::dim<distype> == 3)
+  {
+    Core::FE::IntPointsAndWeights<Core::FE::dim<distype>> intpoints(
+        ScaTra::DisTypeToOptGaussRule<distype>::rule);
+
+    for (int iquad = 0; iquad < intpoints.ip().nquad; ++iquad)
+    {
+      const double fac = my::eval_shape_func_and_derivs_at_int_point(intpoints, iquad);
+      my::set_internal_variables_for_mat_and_rhs();
+
+      // Reference coordinates: xyze_ - edispnp_
+      Core::LinAlg::Matrix<my::nsd_, my::nen_> nodal_reference_coords(my::xyze_);
+      nodal_reference_coords.update(-1.0, my::edispnp_, 1.0);
+
+      // Reference Jacobian J = dX/dxi and its inverse
+      Core::LinAlg::Matrix<my::nsd_, my::nsd_> xjm0;
+      xjm0.multiply_nt(nodal_reference_coords, my::deriv_);
+      Core::LinAlg::Matrix<my::nsd_, my::nsd_> xji0(Core::LinAlg::Initialization::zero);
+      xji0.invert(xjm0);
+
+      // Reference shape derivatives dN_i/dX_r: chain rule dN/dxi * dxi/dX
+      Core::LinAlg::Matrix<my::nen_, my::nsd_> dN_dX;
+      dN_dX.multiply_tn(my::deriv_, xji0);
+
+      // Deformation gradient F = dx/dX
+      Core::LinAlg::Matrix<my::nsd_, my::nsd_> defgrd;
+      defgrd.multiply(my::xyze_, dN_dX);
+
+      // loop over all scalars
+      for (int k = 0; k < my::numscal_; ++k)
+      {
+        if (constituent_[k] == nullptr) continue;
+
+        const double d_sigma_d_lf2 = constituent_[k]->evaluate_d_cauchy_stress_d_lambda_f_sq(iquad);
+
+        if (d_sigma_d_lf2 == 0.0) continue;
+
+        // Eulerian structural tensor: b_alpha = F * A_alpha * F^T
+        const Core::LinAlg::Matrix<my::nsd_, my::nsd_> A_alpha_mat = Core::LinAlg::make_matrix(
+            Core::LinAlg::get_full(constituent_[k]->get_structural_tensor(iquad)));
+        Core::LinAlg::Matrix<my::nsd_, my::nsd_> FA;
+        FA.multiply(defgrd, A_alpha_mat);
+        Core::LinAlg::Matrix<my::nsd_, my::nsd_> b_alpha;
+        b_alpha.multiply_nt(FA, defgrd);
+
+        // K_psi_u^{vi*numdof+k, ui*ndofmesh+d}
+        //   += -fac * d_sigma_d_lf2 * funct_(vi) * 2 * (b_alpha_{d,c} * derxy_(c,ui))
+
+        // loop over the scatra nodes with usually one numdofpernode_
+        for (int vi = 0; vi < static_cast<int>(my::nen_); ++vi)
+        {
+          const int fvi = vi * my::numdofpernode_ + k;
+          const double val = -fac * d_sigma_d_lf2 * my::funct_(vi);
+
+          // loop over the mesh nodes
+          for (int ui = 0; ui < static_cast<int>(my::nen_); ++ui)
+          {
+            // loop over the spatial dimensions of the mesh node
+            for (unsigned int d = 0; d < my::nsd_; ++d)
+            {
+              double b_dot_derxy = 0.0;
+              // compute scalar product
+              for (unsigned int c = 0; c < my::nsd_; ++c)
+                b_dot_derxy += b_alpha(d, c) * my::derxy_(c, ui);
+
+              emat(fvi, ui * ndofpernodemesh + d) += val * 2.0 * b_dot_derxy;
+            }
+          }
+        }
+      }
+    }
+  }
+  else
+  {
+    FOUR_C_THROW("sysmat_od_mesh_nls is only implemented for 3D elements.");
+  }
+}
 
 // template classes
 

--- a/src/scatra_ele/4C_scatra_ele_calc_nonlocal_stimulus.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_nonlocal_stimulus.hpp
@@ -66,7 +66,15 @@ namespace Discret::Elements
 
     void get_rhs_int(double& rhsint, const double densnp, const int k) override;
 
+    int evaluate_action_od(Core::Elements::Element* ele, Teuchos::ParameterList& params,
+        Core::FE::Discretization& discretization, const ScaTra::Action& action,
+        Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+        Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+        Core::LinAlg::SerialDenseVector& elevec2,
+        Core::LinAlg::SerialDenseVector& elevec3) override;
+
    private:
+    void sysmat_od_mesh_nls(Core::LinAlg::SerialDenseMatrix& emat, int ndofpernodemesh);
     static std::shared_ptr<Mat::Mixture> get_struct_material(const Core::Elements::Element* ele);
 
     /// SSI RemodelFiber constituents per scalar (set in setup_calc)

--- a/src/solid_scatra_ele/4C_solid_scatra_ele_calc.cpp
+++ b/src/solid_scatra_ele/4C_solid_scatra_ele_calc.cpp
@@ -50,8 +50,9 @@ namespace
   }
 
   template <Core::FE::CellType celltype>
-  Core::LinAlg::SymmetricTensor<double, Core::FE::dim<celltype>, Core::FE::dim<celltype>>
-  evaluate_d_material_stress_d_scalar(Mat::So3Material& solid_material,
+  std::vector<
+      Core::LinAlg::SymmetricTensor<double, Core::FE::dim<celltype>, Core::FE::dim<celltype>>>
+  evaluate_d_material_stress_d_scalars(Mat::So3Material& solid_material,
       const Discret::Elements::ElementProperties<celltype>& element_properties,
       const Core::LinAlg::Tensor<double, Core::FE::dim<celltype>, Core::FE::dim<celltype>>&
           deformation_gradient,
@@ -59,7 +60,7 @@ namespace
           gl_strain,
       Teuchos::ParameterList& params,
       const Mat::EvaluationContext<Core::FE::dim<celltype>>& context, const int gp,
-      const int eleGID)
+      const int eleGID, const int num_scalars)
   {
     auto* monolithic_material = dynamic_cast<Mat::MonolithicSolidScalarMaterial*>(&solid_material);
 
@@ -70,27 +71,33 @@ namespace
     {
       // The derivative of the solid stress w.r.t. the scalar is implemented in the normal
       // material Evaluate call by not passing the linearization matrix.
-      return monolithic_material->evaluate_d_stress_d_scalar(
-          deformation_gradient, gl_strain, params, context, gp, eleGID);
+      return monolithic_material->evaluate_d_stress_d_scalars(
+          deformation_gradient, gl_strain, params, context, num_scalars, gp, eleGID);
     }
     else
     {
-      Core::LinAlg::SymmetricTensor<double, 3, 3> d_stress_d_scalar_3d{};
+      std::vector<Core::LinAlg::SymmetricTensor<double, 3, 3>> d_stress_d_scalars_3d;
       Discret::Elements::transform_to_3d(solid_material, element_properties, deformation_gradient,
           gl_strain, params, context, gp, eleGID,
           [&](const Core::LinAlg::Tensor<double, 3, 3>& defgrd_3d,
               const Core::LinAlg::SymmetricTensor<double, 3, 3>& gl_strain_3d,
               const Mat::EvaluationContext<3>& context_3d)
           {
-            d_stress_d_scalar_3d = monolithic_material->evaluate_d_stress_d_scalar(
-                defgrd_3d, gl_strain_3d, params, context_3d, gp, eleGID);
+            d_stress_d_scalars_3d = monolithic_material->evaluate_d_stress_d_scalars(
+                defgrd_3d, gl_strain_3d, params, context_3d, num_scalars, gp, eleGID);
           });
 
       // only return the 2D part of the tensor
-      return Core::LinAlg::assume_symmetry(Core::LinAlg::Tensor<double, 2, 2>{{
-          {d_stress_d_scalar_3d(0, 0), d_stress_d_scalar_3d(0, 1)},
-          {d_stress_d_scalar_3d(1, 0), d_stress_d_scalar_3d(1, 1)},
-      }});
+      std::vector<
+          Core::LinAlg::SymmetricTensor<double, Core::FE::dim<celltype>, Core::FE::dim<celltype>>>
+          d_stress_d_scalars_2d(num_scalars);
+      for (int k = 0; k < num_scalars; ++k)
+      {
+        d_stress_d_scalars_2d[k] = Core::LinAlg::assume_symmetry(Core::LinAlg::Tensor<double, 2, 2>{
+            {{d_stress_d_scalars_3d[k](0, 0), d_stress_d_scalars_3d[k](0, 1)},
+                {d_stress_d_scalars_3d[k](1, 0), d_stress_d_scalars_3d[k](1, 1)}}});
+      }
+      return d_stress_d_scalars_2d;
     }
   }
 
@@ -521,11 +528,9 @@ void Discret::Elements::SolidScatraEleCalc<celltype, SolidFormulation>::evaluate
                   .xi = &xi,
                   .ref_coords = &gp_ref_coord};
 
-              Core::LinAlg::SymmetricTensor<double, Core::FE::dim<celltype>,
-                  Core::FE::dim<celltype>>
-                  dSdc = evaluate_d_material_stress_d_scalar<celltype>(solid_material,
-                      element_properties_, deformation_gradient, gl_strain, params, context, gp,
-                      ele.id());
+              const auto dSdc = evaluate_d_material_stress_d_scalars<celltype>(solid_material,
+                  element_properties_, deformation_gradient, gl_strain, params, context, gp,
+                  ele.id(), scatra_column_stride);
 
               constexpr int num_dof_per_ele =
                   Core::FE::dim<celltype> * Core::FE::num_nodes(celltype);
@@ -533,18 +538,20 @@ void Discret::Elements::SolidScatraEleCalc<celltype, SolidFormulation>::evaluate
               // Assemble matrix
               // k_dS = dNdxi . F . dS/dc * detJ * N * w(gp) (analogous to force vector)
               Core::LinAlg::Matrix<num_dof_per_ele, 1> BdSdc(Core::LinAlg::Initialization::zero);
-              Discret::Elements::add_internal_force_vector(
-                  jacobian_mapping, deformation_gradient, dSdc, integration_factor, BdSdc);
-
-              // loop over rows
-              for (int rowi = 0; rowi < num_dof_per_ele; ++rowi)
+              for (int k = 0; k < scatra_column_stride; ++k)
               {
-                const double BdSdc_rowi = BdSdc(rowi, 0);
-                // loop over columns
-                for (int coli = 0; coli < Core::FE::num_nodes(celltype); ++coli)
+                BdSdc.put_scalar(0.0);
+                Discret::Elements::add_internal_force_vector(
+                    jacobian_mapping, deformation_gradient, dSdc[k], integration_factor, BdSdc);
+
+                for (int row = 0; row < num_dof_per_ele; ++row)
                 {
-                  stiffness_matrix_dScalar(rowi, coli * scatra_column_stride) +=
-                      BdSdc_rowi * shape_functions.shapefunctions_(coli, 0);
+                  const double BdSdc_row = BdSdc(row, 0);
+                  for (int col = 0; col < Core::FE::num_nodes(celltype); ++col)
+                  {
+                    stiffness_matrix_dScalar(row, col * scatra_column_stride + k) +=
+                        BdSdc_row * shape_functions.shapefunctions_(col, 0);
+                  }
                 }
               }
             });

--- a/src/ssi/4C_ssi_monolithic.cpp
+++ b/src/ssi/4C_ssi_monolithic.cpp
@@ -664,16 +664,6 @@ void SSI::SsiMono::setup()
   // call base class routine
   SSIBase::setup();
 
-  // safety checks
-  if (scatra_field()->num_scal() != 1)
-  {
-    FOUR_C_THROW(
-        "Since the ssi_monolithic framework is only implemented for usage in combination with "
-        "volume change laws 'MAT_InelasticDefgradLinScalarIso' or "
-        "'MAT_InelasticDefgradLinScalarAniso' so far and these laws are implemented for only "
-        "one transported scalar at the moment it is not reasonable to use them with more than one "
-        "transported scalar. So you need to cope with it or change implementation! ;-)");
-  }
   const auto ssi_params = SSI::Utils::problem_from_instance()->ssi_control_params();
 
   const bool calc_initial_pot_elch =

--- a/tests/input_files/ssi_homogenized_constraint_mixture_qcyl_nonlocal_mono.4C.yaml
+++ b/tests/input_files/ssi_homogenized_constraint_mixture_qcyl_nonlocal_mono.4C.yaml
@@ -1,0 +1,342 @@
+TITLE:
+  - "Test case for monolithic SSI coupling with non-local stimulus driven growth and remodeling:"
+  - "- non-local stimulus psi from stationary Helmholtz ScaTra field"
+  - "- K_u_psi and K_psi_u off-diagonal blocks assembled"
+  - "- quarter cylinder with four fiber directions"
+PROBLEM TYPE:
+  PROBLEMTYPE: "Structure_Scalar_Interaction"
+CLONING MATERIAL MAP:
+  - SRC_FIELD: "structure"
+    SRC_MAT: 1
+    TAR_FIELD: "scatra"
+    TAR_MAT: 101
+fields:
+  - name: "fiber5"
+    discretization: "structure"
+    source:
+      from_mesh:
+        basis: "points"
+  - name: "fiber4"
+    discretization: "structure"
+    source:
+      from_mesh:
+        basis: "points"
+  - name: "fiber3"
+    discretization: "structure"
+    source:
+      from_mesh:
+        basis: "points"
+  - name: "fiber2"
+    discretization: "structure"
+    source:
+      from_mesh:
+        basis: "points"
+  - name: "fiber1"
+    discretization: "structure"
+    source:
+      from_mesh:
+        basis: "points"
+IO:
+  VERBOSITY: "Standard"
+  STRUCT_STRAIN: "gl"
+  STRUCT_STRESS: "cauchy"
+  WRITE_FINAL_STATE: true
+  WRITE_INITIAL_STATE: false
+IO/RUNTIME VTK OUTPUT:
+  OUTPUT_DATA_FORMAT: "ascii"
+  INTERVAL_STEPS: 1
+IO/RUNTIME VTK OUTPUT/STRUCTURE:
+  OUTPUT_STRUCTURE: true
+  DISPLACEMENT: true
+  STRESS_STRAIN: true
+SCALAR TRANSPORT DYNAMIC:
+  SOLVERTYPE: "linear_incremental"
+  TIMEINTEGR: "Stationary"
+  THETA: 1.0
+  SKIPINITDER: true
+  RESULTSEVERY: 1
+  MATID: 101
+  VELOCITYFIELD: "Navier_Stokes"
+  INITIALFIELD: "zero_field"
+  CONVFORM: "convective"
+  IS_INTENSIVE_SCALAR: true
+  LINEAR_SOLVER: 1
+SCALAR TRANSPORT DYNAMIC/NONLINEAR:
+  ITEMAX: 20
+  CONVTOL: 1e-09
+SCALAR TRANSPORT DYNAMIC/STABILIZATION:
+  STABTYPE: "no_stabilization"
+  DEFINITION_TAU: "Zero"
+  EVALUATION_TAU: "integration_point"
+  EVALUATION_MAT: "integration_point"
+SOLVER 1:
+  NAME: "Monolithic_Solver"
+  SOLVER: "MUMPS"
+SSI CONTROL:
+  NUMSTEP: 40
+  MAXTIME: 1000.0000000001
+  TIMESTEP: 10.0
+  RESULTSEVERY: 1
+  ITEMAX: 20
+  COUPALGO: ssi_Monolithic
+SSI CONTROL/MONOLITHIC:
+  LINEAR_SOLVER: 1
+  MATRIXTYPE: "sparse"
+STRUCT NOX/Direction:
+  Method: "Newton"
+STRUCT NOX/Printing:
+  Outer Iteration: true
+  Inner Iteration: false
+  Outer Iteration StatusTest: false
+STRUCTURAL DYNAMIC:
+  DYNAMICTYPE: "OneStepTheta"
+  NEGLECTINERTIA: true
+  TOLDISP: 1e-12
+  TOLRES: 1e-12
+  LINEAR_SOLVER: 1
+  NLNSOL: "noxnln"
+  LOADLIN: true
+STRUCTURAL DYNAMIC/ONESTEPTHETA:
+  THETA: 1.0
+STRUCTURE GEOMETRY:
+  FILE: "vtu/homogenized-constrained-mixture-qcyl.vtu"
+  ELEMENT_BLOCKS:
+    - ID: 1
+      SOLIDSCATRA:
+        HEX8:
+          MAT: 1
+          KINEM: "nonlinear"
+          TYPE: "NLS"
+MATERIALS:
+  - MAT: 1
+    MAT_Mixture:
+      MATIDSCONST: [11, 12, 13, 14, 15]
+      MATIDMIXTURERULE: 10
+  - MAT: 10
+    MIX_GrowthRemodelMixtureRule:
+      GROWTH_STRATEGY: 100
+      MASSFRAC: [0.8, 0.05, 0.05, 0.05, 0.05]
+      DENS: 10.500000000000002
+  - MAT: 100
+    MIX_GrowthStrategy_Anisotropic:
+      GROWTH_DIRECTION:
+        from_mesh: "fiber5"
+  - MAT: 11
+    MIX_Constituent_ElastHyper:
+      NUMMAT: 2
+      MATIDS: [111, 112]
+      PRESTRESS_STRATEGY: 119
+  - MAT: 111
+    ELAST_IsoNeoHooke:
+      MUE:
+        constant: 0.09769999999999998
+  - MAT: 112
+    ELAST_VolSussmanBathe:
+      KAPPA: 0.09999999999999999
+  - MAT: 119
+    MIX_Prestress_Strategy_Prescribed:
+      PRESTRETCH:
+        constant: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+  - MAT: 12
+    MIX_Constituent_SsiRemodelFiber:
+      FIBER_MATERIAL_ID: 120
+      DECAY_TIME: 101.0
+      GROWTH_CONSTANT: 0.0009900990099009901
+      DEPOSITION_STRETCH: 0.0
+      DEPOSITION_STRETCH_TIMEFUNCT: 2
+      ORIENTATION:
+        from_mesh: "fiber1"
+      INELASTIC_GROWTH: true
+      ENABLE_GROWTH: true
+      NONLOCAL_STIMULUS_SCALAR_ID: 0
+      IMPLICIT_INTEGRATION: true
+  - MAT: 120
+    MIX_Constituent_RemodelFiber_Material_Exponential:
+      K1: 0.22009519999999996
+      K2: 1.23
+      COMPRESSION: false
+  - MAT: 13
+    MIX_Constituent_SsiRemodelFiber:
+      FIBER_MATERIAL_ID: 130
+      DECAY_TIME: 101.0
+      GROWTH_CONSTANT: 0.0009900990099009901
+      DEPOSITION_STRETCH: 0.0
+      DEPOSITION_STRETCH_TIMEFUNCT: 3
+      ORIENTATION:
+        from_mesh: "fiber2"
+      INELASTIC_GROWTH: true
+      ENABLE_GROWTH: true
+      NONLOCAL_STIMULUS_SCALAR_ID: 1
+      IMPLICIT_INTEGRATION: true
+  - MAT: 130
+    MIX_Constituent_RemodelFiber_Material_Exponential:
+      K1: 0.22009519999999996
+      K2: 1.23
+      COMPRESSION: false
+  - MAT: 14
+    MIX_Constituent_SsiRemodelFiber:
+      FIBER_MATERIAL_ID: 140
+      DECAY_TIME: 101.0
+      GROWTH_CONSTANT: 0.0009900990099009901
+      DEPOSITION_STRETCH: 0.0
+      DEPOSITION_STRETCH_TIMEFUNCT: 4
+      ORIENTATION:
+        from_mesh: "fiber3"
+      INELASTIC_GROWTH: true
+      ENABLE_GROWTH: true
+      NONLOCAL_STIMULUS_SCALAR_ID: 2
+      IMPLICIT_INTEGRATION: true
+  - MAT: 140
+    MIX_Constituent_RemodelFiber_Material_Exponential:
+      K1: 0.22009519999999996
+      K2: 1.23
+      COMPRESSION: false
+  - MAT: 15
+    MIX_Constituent_SsiRemodelFiber:
+      FIBER_MATERIAL_ID: 150
+      DECAY_TIME: 101.0
+      GROWTH_CONSTANT: 0.0009900990099009901
+      DEPOSITION_STRETCH: 0.0
+      DEPOSITION_STRETCH_TIMEFUNCT: 5
+      ORIENTATION:
+        from_mesh: "fiber4"
+      INELASTIC_GROWTH: true
+      ENABLE_GROWTH: true
+      NONLOCAL_STIMULUS_SCALAR_ID: 3
+      IMPLICIT_INTEGRATION: true
+  - MAT: 150
+    MIX_Constituent_RemodelFiber_Material_Exponential:
+      K1: 0.22009519999999996
+      K2: 1.23
+      COMPRESSION: false
+  - MAT: 1000
+    MAT_scatra_nl_stimulus:
+      CHAR_LENGTH_SQ: 1.0e-6
+      STRUCTURE_MAT_ID: 12
+  - MAT: 1001
+    MAT_scatra_nl_stimulus:
+      CHAR_LENGTH_SQ: 1.0e-6
+      STRUCTURE_MAT_ID: 13
+  - MAT: 1002
+    MAT_scatra_nl_stimulus:
+      CHAR_LENGTH_SQ: 1.0e-6
+      STRUCTURE_MAT_ID: 14
+  - MAT: 1003
+    MAT_scatra_nl_stimulus:
+      CHAR_LENGTH_SQ: 1.0e-6
+      STRUCTURE_MAT_ID: 15
+  - MAT: 101
+    MAT_matlist:
+      LOCAL: false
+      NUMMAT: 4
+      MATIDS: [1000, 1001, 1002, 1003]
+DESIGN SURF DIRICH CONDITIONS:
+  - E: 4
+    ENTITY_TYPE: "node_set_id"
+    NUMDOF: 3
+    ONOFF: [0, 1, 0]
+    VAL: [0.0, 0.0, 0.0]
+    FUNCT: [0, 0, 0]
+  - E: 6
+    ENTITY_TYPE: "node_set_id"
+    NUMDOF: 3
+    ONOFF: [1, 0, 0]
+    VAL: [0.0, 0.0, 0.0]
+    FUNCT: [0, 0, 0]
+  - E: 5
+    ENTITY_TYPE: "node_set_id"
+    NUMDOF: 3
+    ONOFF: [0, 0, 1]
+    VAL: [0.0, 0.0, 0.0]
+    FUNCT: [0, 0, 0]
+  - E: 3
+    ENTITY_TYPE: "node_set_id"
+    NUMDOF: 3
+    ONOFF: [0, 0, 1]
+    VAL: [0.0, 0.0, 0.0]
+    FUNCT: [0, 0, 0]
+DESIGN SURF NEUMANN CONDITIONS:
+  - E: 1
+    ENTITY_TYPE: "node_set_id"
+    NUMDOF: 3
+    ONOFF: [1, 0, 0]
+    VAL: [-1.0, 0.0, 0.0]
+    FUNCT: [1, 0, 0]
+    TYPE: "orthopressure"
+FUNCT1:
+  - SYMBOLIC_FUNCTION_OF_SPACE_TIME: "v"
+  - VARIABLE: 0
+    NAME: "v"
+    TYPE: "linearinterpolation"
+    NUMPOINTS: 3
+    TIMES: [0, 1, 1010.0000000001]
+    VALUES: [0.0, 0.11999779932000001, 0.11999779932000001]
+FUNCT2:
+  - SYMBOLIC_FUNCTION_OF_TIME: "v"
+  - VARIABLE: 0
+    NAME: "v"
+    TYPE: "linearinterpolation"
+    NUMPOINTS: 3
+    TIMES: [0.0, 1.0, 1010.0000000001]
+    VALUES: [1.1, 1.1, 1.1]
+FUNCT3:
+  - SYMBOLIC_FUNCTION_OF_TIME: "v"
+  - VARIABLE: 0
+    NAME: "v"
+    TYPE: "linearinterpolation"
+    NUMPOINTS: 3
+    TIMES: [0.0, 1.0, 1010.0000000001]
+    VALUES: [1.1, 1.1, 1.1]
+FUNCT4:
+  - SYMBOLIC_FUNCTION_OF_TIME: "v"
+  - VARIABLE: 0
+    NAME: "v"
+    TYPE: "linearinterpolation"
+    NUMPOINTS: 3
+    TIMES: [0.0, 1.0, 1010.0000000001]
+    VALUES: [1.1, 1.1, 1.1]
+FUNCT5:
+  - SYMBOLIC_FUNCTION_OF_TIME: "v"
+  - VARIABLE: 0
+    NAME: "v"
+    TYPE: "linearinterpolation"
+    NUMPOINTS: 3
+    TIMES: [0.0, 1.0, 1010.0000000001]
+    VALUES: [1.1, 1.1, 1.1]
+RESULT DESCRIPTION:
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 24
+      QUANTITY: "dispx"
+      VALUE: 8.10017536621499695e-03
+      TOLERANCE: 1e-10
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 24
+      QUANTITY: "dispy"
+      VALUE: 1.84881216875441650e-03
+      TOLERANCE: 1e-10
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 24
+      QUANTITY: "dispz"
+      VALUE: 0.0
+      TOLERANCE: 1e-12
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 40
+      QUANTITY: "dispx"
+      VALUE: 7.94728148983169999e-03
+      TOLERANCE: 1e-10
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 40
+      QUANTITY: "dispy"
+      VALUE: 3.82720905402183153e-03
+      TOLERANCE: 1e-10
+  - STRUCTURE:
+      DIS: "structure"
+      NODE: 40
+      QUANTITY: "dispz"
+      VALUE: 0.0
+      TOLERANCE: 1e-12

--- a/tests/list_of_tests.cmake
+++ b/tests/list_of_tests.cmake
@@ -2686,6 +2686,7 @@ four_c_test(TEST_FILE xfsi_push_1D_2nd_order.4C.yaml)
 
 # Tests requiring VTK
 four_c_test(TEST_FILE ssi_homogenized_constraint_mixture_qcyl_nonlocal.4C.yaml NP 2 REQUIRED_DEPENDENCIES VTK TRILINOS_MUMPS)
+four_c_test(TEST_FILE ssi_homogenized_constraint_mixture_qcyl_nonlocal_mono.4C.yaml NP 1 REQUIRED_DEPENDENCIES VTK TRILINOS_MUMPS)
 four_c_test(TEST_FILE mixture_prestress_iterative_prescribed.4C.yaml NP 2 REQUIRED_DEPENDENCIES VTK TRILINOS_MUMPS)
 four_c_test(TEST_FILE ssi_homogenized_constraint_mixture_qcyl.4C.yaml NP 2 REQUIRED_DEPENDENCIES VTK TRILINOS_MUMPS)
 four_c_test(TEST_FILE ssi_homogenized_constraint_mixture_prestress_qcyl.4C.yaml NP 2 REQUIRED_DEPENDENCIES VTK TRILINOS_MUMPS)


### PR DESCRIPTION
## Monolithic SSI for non-local stimulus growth and remodeling

Enables the monolithic coupling for the non-local stimulus (NLS) hCMM variant introduced in #2019. 

### What this PR adds

**Implicit local ODE integration** (`MixtureConstituentRemodelFiberSsi`, `RemodelFiberImplementation`)

- New `integrate_local_evolution_equations_implicit_with_nonlocal_stimulus(psi, dt)`: integrates growth_scalar $\kappa$ in closed form (Crank-Nicolson exact because the ODE is linear in $\kappa$) and $\lambda_r$ via a scalar Newton. Stores the sensitivities $\partial\kappa_g^{n+1}/\partial\psi$ and $\partial\lambda_r^{n+1}/\partial\lambda_f^2$ needed for the off-diagonal blocks.
- New `IMPLICIT` input parameter on `MIX_Constituent_SsiRemodelFiber` (default `false`). Implicit mode is required for a consistent monolithic tangent; explicit mode remains available for staggered solvers.
- Coressponding integration call sites: implicit integration is called inside `evaluate`/`evaluate_elastic_part` (every Newton iteration), explicit only inside `update`/`update_elastic_part` (after convergence).
- `FOUR_C_ASSERT_ALWAYS` in `GrowthRemodelMixtureRule::evaluate_d_stress_d_scalars` enforces implicit mode when the monolithic $K_{u\psi}$ path is entered.

**Off-diagonal block** $K_{\psi u}$ (`ScaTraEleCalcNonlocalStimulus`)

New `sysmat_od_mesh_nls` assembles the ScaTra–displacement block from the source-term linearization:

$$-N_{v_i} \cdot \frac{d\sigma}{d\lambda_f^2} \cdot 2\mathbf{b}_\alpha \nabla_x N_{u_j}$$

The Eulerian structural tensor is:

$$\mathbf{b}_\alpha = \mathbf{F}\mathbf{A}_\alpha\mathbf{F}^T$$

which needed the construction of the deformation gradient $F$ in `ScaTraEleCalcNonlocalStimulus`.

Here $d\sigma/d\lambda_f^2$ includes the implicit $\lambda_r$ sensitivity via the stored `d_lambda_r_d_lambda_f_sq_`.

**Off-diagonal block $K_{u\psi}$** (`SolidScatraEleCalc`, `GrowthRemodelMixtureRule`)

- `evaluate_d_stress_d_scalars` extended to the multi-scalar case (previously single-scalar only) 
- Located in `Mat::Mixture` to `GrowthRemodelMixtureRule`, as the evaluate call for $K_{uu}$
- `MonolithicSolidScalarMaterial::evaluate_d_stress_d_scalars` added as the multi-scalar virtual interface; the default wraps the existing single-scalar `evaluate_d_stress_d_scalar` for backward compatibility.

**Monolithic solver**

- Removed the single-scalar restriction in `SsiMono::setup` that prevented NLS (which uses one ScaTra DOF per fiber).

**Test**

- New test `ssi_homogenized_constraint_mixture_qcyl_nonlocal_mono`: quarter-cylinder hCMM with NLS, monolithic SSI.

### Related
- #2019 -- non-local stimulus staggered variant (base implementation)
