### PR TITLE
Adapt the workflow schedules

### DIFF
--- a/.github/workflows/checkcode.yml
+++ b/.github/workflows/checkcode.yml
@@ -6,7 +6,9 @@ on:
     branches:
       - 'main'
   schedule:
-    - cron: '0 22 * * *'
+    # GitHub recommends avoiding scheduling at the start of the hour to avoid delays; thus, a random minute is set.
+    - cron: '44 20 * * *'
+      timezone: "Europe/Berlin"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,7 +2,9 @@ name: coverage
 
 on:
   schedule:
-    - cron: '0 1 * * *'
+    # GitHub recommends avoiding scheduling at the start of the hour to avoid delays; thus, a random minute is set.
+    - cron: '29 0 * * *'
+      timezone: "Europe/Berlin"
 
 jobs:
   clang18_coverage_build:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -8,7 +8,9 @@ on:
     branches:
       - "main"
   schedule:
-    - cron: "0 22 * * *"
+    # GitHub recommends avoiding scheduling at the start of the hour to avoid delays; thus, a random minute is set.
+    - cron: "54 20 * * *"
+      timezone: "Europe/Berlin"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -2,7 +2,9 @@ name: nightly_tests
 
 on:
   schedule:
-    - cron: "0 22 * * *"
+    # GitHub recommends avoiding scheduling at the start of the hour to avoid delays; thus, a random minute is set.
+    - cron: "11 20 * * *"
+      timezone: "Europe/Berlin"
 
 jobs:
   gcc13_assertions_build:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,6 +5,7 @@ name: "Close stale PRs"
 on:
   schedule:
     - cron: '30 12 * * *'
+      timezone: "Europe/Berlin"
 
 env:
   PR_INACTIVITY_AFTER: 180 # days

--- a/.github/workflows/trilinos-develop.yml
+++ b/.github/workflows/trilinos-develop.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 8 * * 6'
+      timezone: "Europe/Berlin"
 
 env:
   IMAGE_NAME: ghcr.io/4c-multiphysics/4c-dependencies-trilinos


### PR DESCRIPTION
## Description and Context
I realized recently that our nightly workflows finish rather late (around 10 - 11 a.m.), which interferes with PR pipelines when a PR is opened in the morning.
Thus, I suggest triggering the nightly workflows earlier and explicitly setting the timezone so one does not need to read the documentation to find the default time zone.
With these changes, the pipeline should be triggered around 4 hours earlier, i.e., the estimated starting time would be 9 p.m., and the estimated finish time would be 6-7 a.m.

See here why the workflows are usually triggered later than set in the definition (https://github.com/orgs/community/discussions/147369), thank you @davidrudlstorfer.

And here is the doc on how to set the timezone: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#schedule

