### PR TITLE
[Particle] Cache senders and receivers of the refreshed particles

### DIFF
--- a/src/particle/src/engine/4C_particle_engine.cpp
+++ b/src/particle/src/engine/4C_particle_engine.cpp
@@ -362,8 +362,8 @@ void Particle::ParticleEngine::refresh_particles() const
   // determine particles that need to be refreshed
   determine_particles_to_be_refreshed(particlestosend);
 
-  // communicate particles
-  communicate_particles(particlestosend, particlestoinsert);
+  // communicate refreshed particles using cached communication graph
+  communicate_refreshed_particles(particlestosend, particlestoinsert);
 
   // insert refreshed particles received from other processors
   insert_refreshed_particles(particlestoinsert);
@@ -383,8 +383,8 @@ void Particle::ParticleEngine::refresh_particles_of_specific_states_and_types(
   determine_specific_states_of_particles_of_specific_types_to_be_refreshed(
       particlestatestotypes, particlestosend);
 
-  // communicate particles
-  communicate_particles(particlestosend, particlestoinsert);
+  // communicate refreshed particles using cached communication graph
+  communicate_refreshed_particles(particlestosend, particlestoinsert);
 
   // insert refreshed particles received from other processors
   insert_refreshed_particles(particlestoinsert);
@@ -1727,6 +1727,113 @@ void Particle::ParticleEngine::communicate_particles(
   }
 }
 
+void Particle::ParticleEngine::communicate_refreshed_particles(
+    std::vector<std::vector<ParticleObjShrdPtr>>& particlestosend,
+    std::vector<std::vector<std::pair<int, ParticleObjShrdPtr>>>& particlestoreceive) const
+{
+  // prepare buffer for sending
+  std::map<int, std::vector<char>> sdata;
+
+  // pack data for sending (only to known refresh targets)
+  for (int torank : refresh_send_procs_)
+  {
+    if (particlestosend[torank].empty()) continue;
+
+    for (const auto& iter : particlestosend[torank])
+    {
+      Core::Communication::PackBuffer data;
+      iter->pack(data);
+      sdata[torank].insert(sdata[torank].end(), data().begin(), data().end());
+    }
+  }
+
+  // clear after all particles are packed
+  particlestosend.clear();
+
+  const int numsendtoprocs = static_cast<int>(refresh_send_procs_.size());
+  const int numrecvfromprocs = static_cast<int>(refresh_recv_procs_.size());
+
+  // send size of messages to ALL known refresh targets (0 if no data)
+  std::vector<MPI_Request> sizesendrequest(numsendtoprocs);
+  std::vector<int> msgsizestosend(numsendtoprocs);
+  {
+    int counter = 0;
+    for (int torank : refresh_send_procs_)
+    {
+      auto it = sdata.find(torank);
+      msgsizestosend[counter] = (it != sdata.end()) ? static_cast<int>(it->second.size()) : 0;
+      MPI_Isend(
+          &msgsizestosend[counter], 1, MPI_INT, torank, 1234, comm_, &sizesendrequest[counter]);
+      ++counter;
+    }
+  }
+
+  // receive size of messages from ALL known senders
+  std::vector<int> recvsources(refresh_recv_procs_.begin(), refresh_recv_procs_.end());
+  std::vector<int> msgsizestorecv(numrecvfromprocs);
+  std::vector<MPI_Request> sizerecvrequest(numrecvfromprocs);
+  for (int i = 0; i < numrecvfromprocs; ++i)
+  {
+    MPI_Irecv(&msgsizestorecv[i], 1, MPI_INT, recvsources[i], 1234, comm_, &sizerecvrequest[i]);
+  }
+
+  // wait for all size receives to complete
+  MPI_Waitall(numrecvfromprocs, sizerecvrequest.data(), MPI_STATUSES_IGNORE);
+
+  // post receives for actual data from senders with non-zero size
+  std::map<int, std::vector<char>> rdata;
+  std::vector<MPI_Request> recvrequest(numrecvfromprocs);
+  for (int i = 0; i < numrecvfromprocs; ++i)
+  {
+    if (msgsizestorecv[i] > 0)
+    {
+      rdata[recvsources[i]].resize(msgsizestorecv[i]);
+      MPI_Irecv(rdata[recvsources[i]].data(), msgsizestorecv[i], MPI_CHAR, recvsources[i], 5678,
+          comm_, &recvrequest[i]);
+    }
+    else
+    {
+      recvrequest[i] = MPI_REQUEST_NULL;
+    }
+  }
+
+  // wait for size sends to complete, then send data
+  MPI_Waitall(numsendtoprocs, sizesendrequest.data(), MPI_STATUSES_IGNORE);
+
+  std::vector<MPI_Request> sendrequest;
+  sendrequest.reserve(sdata.size());
+  for (auto& p : sdata)
+  {
+    sendrequest.emplace_back();
+    MPI_Isend(p.second.data(), static_cast<int>(p.second.size()), MPI_CHAR, p.first, 5678, comm_,
+        &sendrequest.back());
+  }
+
+  // wait for completion
+  if (!sendrequest.empty())
+    MPI_Waitall(static_cast<int>(sendrequest.size()), sendrequest.data(), MPI_STATUSES_IGNORE);
+  sdata.clear();
+  MPI_Waitall(numrecvfromprocs, recvrequest.data(), MPI_STATUSES_IGNORE);
+
+  // unpack and store received data
+  for (const auto& p : rdata)
+  {
+    const int msgsource = p.first;
+    const std::vector<char>& rmsg = p.second;
+
+    Core::Communication::UnpackBuffer buffer(rmsg);
+    while (!buffer.at_end())
+    {
+      std::shared_ptr<Core::Communication::ParObject> object(Core::Communication::factory(buffer));
+      ParticleObjShrdPtr particleobject = std::dynamic_pointer_cast<ParticleObject>(object);
+      FOUR_C_ASSERT(particleobject, "received object is not a particle object!");
+
+      particlestoreceive[particleobject->return_particle_type()].push_back(
+          std::make_pair(msgsource, particleobject));
+    }
+  }
+}
+
 void Particle::ParticleEngine::communicate_direct_ghosting_map(
     std::map<int, std::map<ParticleType, std::map<int, std::pair<int, int>>>>& directghosting)
 {
@@ -1736,6 +1843,11 @@ void Particle::ParticleEngine::communicate_direct_ghosting_map(
 
   // invalidate flags denoting validity of direct ghosting
   validdirectghosting_ = false;
+
+  // cache procs from which we receive refreshed particle data: these are the procs that sent
+  // ghost particles to us (keys of directghosting map)
+  refresh_recv_procs_.clear();
+  for (const auto& p : directghosting) refresh_recv_procs_.insert(p.first);
 
   // prepare buffer for sending and receiving
   std::map<int, std::vector<char>> sdata;
@@ -1788,6 +1900,12 @@ void Particle::ParticleEngine::communicate_direct_ghosting_map(
 
   // validate flags denoting validity of direct ghosting
   validdirectghosting_ = true;
+
+  // cache procs to which we send refreshed particle data
+  refresh_send_procs_.clear();
+  for (const auto& type : particlecontainerbundle_->get_particle_types())
+    for (const auto& [ownedindex, targets] : directghostingtargets_[type])
+      for (const auto& [proc, ghostedindex] : targets) refresh_send_procs_.insert(proc);
 }
 
 void Particle::ParticleEngine::insert_owned_particles(

--- a/src/particle/src/engine/4C_particle_engine.cpp
+++ b/src/particle/src/engine/4C_particle_engine.cpp
@@ -362,8 +362,9 @@ void Particle::ParticleEngine::refresh_particles() const
   // determine particles that need to be refreshed
   determine_particles_to_be_refreshed(particlestosend);
 
-  // communicate refreshed particles using cached communication graph
-  communicate_refreshed_particles(particlestosend, particlestoinsert);
+  // communicate particles using cached communication graph
+  communicate_particles(particlestosend, particlestoinsert, &cached_procs_send_ghost_data_to_,
+      &cached_procs_receive_ghost_data_from_);
 
   // insert refreshed particles received from other processors
   insert_refreshed_particles(particlestoinsert);
@@ -383,8 +384,9 @@ void Particle::ParticleEngine::refresh_particles_of_specific_states_and_types(
   determine_specific_states_of_particles_of_specific_types_to_be_refreshed(
       particlestatestotypes, particlestosend);
 
-  // communicate refreshed particles using cached communication graph
-  communicate_refreshed_particles(particlestosend, particlestoinsert);
+  // communicate particles using cached communication graph
+  communicate_particles(particlestosend, particlestoinsert, &cached_procs_send_ghost_data_to_,
+      &cached_procs_receive_ghost_data_from_);
 
   // insert refreshed particles received from other processors
   insert_refreshed_particles(particlestoinsert);
@@ -1680,78 +1682,44 @@ void Particle::ParticleEngine::
 
 void Particle::ParticleEngine::communicate_particles(
     std::vector<std::vector<ParticleObjShrdPtr>>& particlestosend,
-    std::vector<std::vector<std::pair<int, ParticleObjShrdPtr>>>& particlestoreceive) const
+    std::vector<std::vector<std::pair<int, ParticleObjShrdPtr>>>& particlestoreceive,
+    const std::set<int>* send_to_procs, const std::set<int>* receive_from_procs) const
 {
+  FOUR_C_ASSERT_ALWAYS(
+      (send_to_procs && receive_from_procs) || (!send_to_procs && !receive_from_procs),
+      "Either both senders and receivers must be specified or none of them!");
+
   // prepare buffer for sending and receiving
   std::map<int, std::vector<char>> sdata;
   std::map<int, std::vector<char>> rdata;
 
   // pack data for sending
-  for (int torank = 0; torank < Core::Communication::num_mpi_ranks(comm_); ++torank)
+  auto pack_for_rank = [&](int torank)
   {
-    if (particlestosend[torank].empty()) continue;
-
+    if (particlestosend[torank].empty()) return;
     for (const auto& iter : particlestosend[torank])
     {
       Core::Communication::PackBuffer data;
       iter->pack(data);
       sdata[torank].insert(sdata[torank].end(), data().begin(), data().end());
     }
-  }
+  };
+
+  if (send_to_procs)
+    for (int torank : *send_to_procs) pack_for_rank(torank);
+  else
+    for (int torank = 0; torank < Core::Communication::num_mpi_ranks(comm_); ++torank)
+      pack_for_rank(torank);
 
   // clear after all particles are packed
   particlestosend.clear();
 
-  // communicate data via non-buffered send from proc to proc
-  ParticleUtils::immediate_recv_blocking_send(comm_, sdata, rdata);
-
-  // unpack and store received data
-  for (const auto& p : rdata)
-  {
-    const int msgsource = p.first;
-    const std::vector<char>& rmsg = p.second;
-
-    Core::Communication::UnpackBuffer buffer(rmsg);
-    while (!buffer.at_end())
-    {
-      std::shared_ptr<Core::Communication::ParObject> object(Core::Communication::factory(buffer));
-      ParticleObjShrdPtr particleobject = std::dynamic_pointer_cast<ParticleObject>(object);
-      if (particleobject == nullptr) FOUR_C_THROW("received object is not a particle object!");
-
-      // store received particle
-      particlestoreceive[particleobject->return_particle_type()].push_back(
-          std::make_pair(msgsource, particleobject));
-    }
-  }
-}
-
-void Particle::ParticleEngine::communicate_refreshed_particles(
-    std::vector<std::vector<ParticleObjShrdPtr>>& particlestosend,
-    std::vector<std::vector<std::pair<int, ParticleObjShrdPtr>>>& particlestoreceive) const
-{
-  // prepare buffer for sending
-  std::map<int, std::vector<char>> sdata;
-
-  // pack data for sending (only to known refresh targets)
-  for (int torank : cached_procs_send_ghost_data_to_)
-  {
-    if (particlestosend[torank].empty()) continue;
-
-    for (const auto& iter : particlestosend[torank])
-    {
-      Core::Communication::PackBuffer data;
-      iter->pack(data);
-      sdata[torank].insert(sdata[torank].end(), data().begin(), data().end());
-    }
-  }
-
-  // clear after all particles are packed
-  particlestosend.clear();
-
-  // communicate data via cached send/receive graph
-  std::map<int, std::vector<char>> rdata;
-  ParticleUtils::immediate_send_recv_known_procs(
-      comm_, sdata, rdata, cached_procs_send_ghost_data_to_, cached_procs_receive_ghost_data_from_);
+  // communicate data
+  if (send_to_procs && receive_from_procs)
+    ParticleUtils::immediate_send_recv_known_procs(
+        comm_, sdata, rdata, *send_to_procs, *receive_from_procs);
+  else
+    ParticleUtils::immediate_recv_blocking_send(comm_, sdata, rdata);
 
   // unpack and store received data
   for (const auto& p : rdata)
@@ -1766,6 +1734,7 @@ void Particle::ParticleEngine::communicate_refreshed_particles(
       ParticleObjShrdPtr particleobject = std::dynamic_pointer_cast<ParticleObject>(object);
       FOUR_C_ASSERT_ALWAYS(particleobject, "received object is not a particle object!");
 
+      // store received particle
       particlestoreceive[particleobject->return_particle_type()].push_back(
           std::make_pair(msgsource, particleobject));
     }
@@ -1782,8 +1751,8 @@ void Particle::ParticleEngine::communicate_direct_ghosting_map(
   // invalidate flags denoting validity of direct ghosting
   validdirectghosting_ = false;
 
-  // cache procs from which we receive refreshed particle data: these are the procs that sent
-  // ghost particles to us (keys of directghosting map)
+  // cache procs from which this proc receives refreshed particle data: these are the procs that
+  // sent ghost particles to us (keys of directghosting map)
   cached_procs_receive_ghost_data_from_.clear();
   for (const auto& p : directghosting) cached_procs_receive_ghost_data_from_.insert(p.first);
 
@@ -1839,7 +1808,7 @@ void Particle::ParticleEngine::communicate_direct_ghosting_map(
   // validate flags denoting validity of direct ghosting
   validdirectghosting_ = true;
 
-  // cache procs to which we send refreshed particle data
+  // cache procs to which this proc sends refreshed particle data
   cached_procs_send_ghost_data_to_.clear();
   for (const auto& type : particlecontainerbundle_->get_particle_types())
     for (const auto& [ownedindex, targets] : directghostingtargets_[type])

--- a/src/particle/src/engine/4C_particle_engine.cpp
+++ b/src/particle/src/engine/4C_particle_engine.cpp
@@ -1711,8 +1711,6 @@ void Particle::ParticleEngine::communicate_particles(
     const int msgsource = p.first;
     const std::vector<char>& rmsg = p.second;
 
-
-
     Core::Communication::UnpackBuffer buffer(rmsg);
     while (!buffer.at_end())
     {
@@ -1735,7 +1733,7 @@ void Particle::ParticleEngine::communicate_refreshed_particles(
   std::map<int, std::vector<char>> sdata;
 
   // pack data for sending (only to known refresh targets)
-  for (int torank : refresh_send_procs_)
+  for (int torank : cached_procs_send_ghost_data_to_)
   {
     if (particlestosend[torank].empty()) continue;
 
@@ -1750,70 +1748,10 @@ void Particle::ParticleEngine::communicate_refreshed_particles(
   // clear after all particles are packed
   particlestosend.clear();
 
-  const int numsendtoprocs = static_cast<int>(refresh_send_procs_.size());
-  const int numrecvfromprocs = static_cast<int>(refresh_recv_procs_.size());
-
-  // send size of messages to ALL known refresh targets (0 if no data)
-  std::vector<MPI_Request> sizesendrequest(numsendtoprocs);
-  std::vector<int> msgsizestosend(numsendtoprocs);
-  {
-    int counter = 0;
-    for (int torank : refresh_send_procs_)
-    {
-      auto it = sdata.find(torank);
-      msgsizestosend[counter] = (it != sdata.end()) ? static_cast<int>(it->second.size()) : 0;
-      MPI_Isend(
-          &msgsizestosend[counter], 1, MPI_INT, torank, 1234, comm_, &sizesendrequest[counter]);
-      ++counter;
-    }
-  }
-
-  // receive size of messages from ALL known senders
-  std::vector<int> recvsources(refresh_recv_procs_.begin(), refresh_recv_procs_.end());
-  std::vector<int> msgsizestorecv(numrecvfromprocs);
-  std::vector<MPI_Request> sizerecvrequest(numrecvfromprocs);
-  for (int i = 0; i < numrecvfromprocs; ++i)
-  {
-    MPI_Irecv(&msgsizestorecv[i], 1, MPI_INT, recvsources[i], 1234, comm_, &sizerecvrequest[i]);
-  }
-
-  // wait for all size receives to complete
-  MPI_Waitall(numrecvfromprocs, sizerecvrequest.data(), MPI_STATUSES_IGNORE);
-
-  // post receives for actual data from senders with non-zero size
+  // communicate data via cached send/receive graph
   std::map<int, std::vector<char>> rdata;
-  std::vector<MPI_Request> recvrequest(numrecvfromprocs);
-  for (int i = 0; i < numrecvfromprocs; ++i)
-  {
-    if (msgsizestorecv[i] > 0)
-    {
-      rdata[recvsources[i]].resize(msgsizestorecv[i]);
-      MPI_Irecv(rdata[recvsources[i]].data(), msgsizestorecv[i], MPI_CHAR, recvsources[i], 5678,
-          comm_, &recvrequest[i]);
-    }
-    else
-    {
-      recvrequest[i] = MPI_REQUEST_NULL;
-    }
-  }
-
-  // wait for size sends to complete, then send data
-  MPI_Waitall(numsendtoprocs, sizesendrequest.data(), MPI_STATUSES_IGNORE);
-
-  std::vector<MPI_Request> sendrequest;
-  sendrequest.reserve(sdata.size());
-  for (auto& p : sdata)
-  {
-    sendrequest.emplace_back();
-    MPI_Isend(p.second.data(), static_cast<int>(p.second.size()), MPI_CHAR, p.first, 5678, comm_,
-        &sendrequest.back());
-  }
-
-  // wait for completion
-  if (!sendrequest.empty())
-    MPI_Waitall(static_cast<int>(sendrequest.size()), sendrequest.data(), MPI_STATUSES_IGNORE);
-  sdata.clear();
-  MPI_Waitall(numrecvfromprocs, recvrequest.data(), MPI_STATUSES_IGNORE);
+  ParticleUtils::immediate_send_recv_known_procs(
+      comm_, sdata, rdata, cached_procs_send_ghost_data_to_, cached_procs_receive_ghost_data_from_);
 
   // unpack and store received data
   for (const auto& p : rdata)
@@ -1826,7 +1764,7 @@ void Particle::ParticleEngine::communicate_refreshed_particles(
     {
       std::shared_ptr<Core::Communication::ParObject> object(Core::Communication::factory(buffer));
       ParticleObjShrdPtr particleobject = std::dynamic_pointer_cast<ParticleObject>(object);
-      FOUR_C_ASSERT(particleobject, "received object is not a particle object!");
+      FOUR_C_ASSERT_ALWAYS(particleobject, "received object is not a particle object!");
 
       particlestoreceive[particleobject->return_particle_type()].push_back(
           std::make_pair(msgsource, particleobject));
@@ -1846,8 +1784,8 @@ void Particle::ParticleEngine::communicate_direct_ghosting_map(
 
   // cache procs from which we receive refreshed particle data: these are the procs that sent
   // ghost particles to us (keys of directghosting map)
-  refresh_recv_procs_.clear();
-  for (const auto& p : directghosting) refresh_recv_procs_.insert(p.first);
+  cached_procs_receive_ghost_data_from_.clear();
+  for (const auto& p : directghosting) cached_procs_receive_ghost_data_from_.insert(p.first);
 
   // prepare buffer for sending and receiving
   std::map<int, std::vector<char>> sdata;
@@ -1902,10 +1840,11 @@ void Particle::ParticleEngine::communicate_direct_ghosting_map(
   validdirectghosting_ = true;
 
   // cache procs to which we send refreshed particle data
-  refresh_send_procs_.clear();
+  cached_procs_send_ghost_data_to_.clear();
   for (const auto& type : particlecontainerbundle_->get_particle_types())
     for (const auto& [ownedindex, targets] : directghostingtargets_[type])
-      for (const auto& [proc, ghostedindex] : targets) refresh_send_procs_.insert(proc);
+      for (const auto& [proc, ghostedindex] : targets)
+        cached_procs_send_ghost_data_to_.insert(proc);
 }
 
 void Particle::ParticleEngine::insert_owned_particles(

--- a/src/particle/src/engine/4C_particle_engine.hpp
+++ b/src/particle/src/engine/4C_particle_engine.hpp
@@ -605,6 +605,20 @@ namespace Particle
         std::vector<std::vector<std::pair<int, ParticleObjShrdPtr>>>& particlestoreceive) const;
 
     /*!
+     * \brief communicate refreshed particles using cached communication graph
+     *
+     * Uses the pre-computed refresh_send_procs_ and refresh_recv_procs_ to exchange refreshed
+     * particle data without an MPI_Allreduce for target discovery.
+     *
+     *
+     * \param[in]  particlestosend    particles to be send to other processors
+     * \param[out] particlestoreceive particles to be received on this processor
+     */
+    void communicate_refreshed_particles(
+        std::vector<std::vector<ParticleObjShrdPtr>>& particlestosend,
+        std::vector<std::vector<std::pair<int, ParticleObjShrdPtr>>>& particlestoreceive) const;
+
+    /*!
      * \brief communicate and build map for direct ghosting
      *
      * Communicate the information at which local index in the particle container a particle at the
@@ -739,6 +753,12 @@ namespace Particle
 
     //! flag denoting validity of direct ghosting
     bool validdirectghosting_;
+
+    //! cached set of procs to send refreshed particle data to
+    std::set<int> refresh_send_procs_;
+
+    //! cached set of procs to receive refreshed particle data from
+    std::set<int> refresh_recv_procs_;
   };
 
 }  // namespace Particle

--- a/src/particle/src/engine/4C_particle_engine.hpp
+++ b/src/particle/src/engine/4C_particle_engine.hpp
@@ -595,28 +595,20 @@ namespace Particle
      * \brief communicate particles
      *
      * This method communicates particles to be send to other processors and receives particles from
-     * other processors.
+     * other processors. When send_to_procs and receive_from_procs are provided, the communication
+     * uses the known graph directly without collective communication. Otherwise a collective
+     * communication is used to determine the number of incoming messages.
      *
      *
-     * \param[in]  particlestosend    particles to be send to other processors
-     * \param[out] particlestoreceive particles to be received on this processor
+     * \param[in]  particlestosend      particles to be send to other processors
+     * \param[out] particlestoreceive   particles to be received on this processor
+     * \param[in]  send_to_procs        optional set of processors to send data to
+     * \param[in]  receive_from_procs   optional set of processors to receive data from
      */
     void communicate_particles(std::vector<std::vector<ParticleObjShrdPtr>>& particlestosend,
-        std::vector<std::vector<std::pair<int, ParticleObjShrdPtr>>>& particlestoreceive) const;
-
-    /*!
-     * \brief communicate refreshed particles using cached communication graph
-     *
-     * Uses the pre-computed cached_procs_send_ghost_data_to_ and
-     * cached_procs_receive_ghost_data_from_ to exchange refreshed particle.
-     *
-     *
-     * \param[in]  particlestosend    particles to be send to other processors
-     * \param[out] particlestoreceive particles to be received on this processor
-     */
-    void communicate_refreshed_particles(
-        std::vector<std::vector<ParticleObjShrdPtr>>& particlestosend,
-        std::vector<std::vector<std::pair<int, ParticleObjShrdPtr>>>& particlestoreceive) const;
+        std::vector<std::vector<std::pair<int, ParticleObjShrdPtr>>>& particlestoreceive,
+        const std::set<int>* send_to_procs = nullptr,
+        const std::set<int>* receive_from_procs = nullptr) const;
 
     /*!
      * \brief communicate and build map for direct ghosting

--- a/src/particle/src/engine/4C_particle_engine.hpp
+++ b/src/particle/src/engine/4C_particle_engine.hpp
@@ -607,8 +607,8 @@ namespace Particle
     /*!
      * \brief communicate refreshed particles using cached communication graph
      *
-     * Uses the pre-computed refresh_send_procs_ and refresh_recv_procs_ to exchange refreshed
-     * particle data without an MPI_Allreduce for target discovery.
+     * Uses the pre-computed cached_procs_send_ghost_data_to_ and
+     * cached_procs_receive_ghost_data_from_ to exchange refreshed particle.
      *
      *
      * \param[in]  particlestosend    particles to be send to other processors
@@ -755,10 +755,10 @@ namespace Particle
     bool validdirectghosting_;
 
     //! cached set of procs to send refreshed particle data to
-    std::set<int> refresh_send_procs_;
+    std::set<int> cached_procs_send_ghost_data_to_;
 
     //! cached set of procs to receive refreshed particle data from
-    std::set<int> refresh_recv_procs_;
+    std::set<int> cached_procs_receive_ghost_data_from_;
   };
 
 }  // namespace Particle

--- a/src/particle/src/engine/4C_particle_engine_communication_utils.cpp
+++ b/src/particle/src/engine/4C_particle_engine_communication_utils.cpp
@@ -10,6 +10,8 @@
 #include "4C_comm_mpi_utils.hpp"
 #include "4C_utils_exceptions.hpp"
 
+#include <set>
+
 FOUR_C_NAMESPACE_OPEN
 
 /*---------------------------------------------------------------------------*
@@ -131,6 +133,77 @@ void Particle::ParticleUtils::immediate_recv_blocking_send(
   MPI_Waitall(numsendtoprocs, sendrequest.data(), MPI_STATUSES_IGNORE);
 
   // clear send buffer after successful communication
+  sdata.clear();
+
+  // ---- wait for completion of receive operations ----
+  MPI_Waitall(numrecvfromprocs, recvrequest.data(), MPI_STATUSES_IGNORE);
+}
+
+void Particle::ParticleUtils::immediate_send_recv_known_procs(MPI_Comm comm,
+    std::map<int, std::vector<char>>& sdata, std::map<int, std::vector<char>>& rdata,
+    const std::set<int>& send_to_procs, const std::set<int>& receive_from_procs)
+{
+  const int numsendtoprocs = static_cast<int>(send_to_procs.size());
+  const int numrecvfromprocs = static_cast<int>(receive_from_procs.size());
+
+  // ---- send size of messages to ALL known targets (0 if no data) ----
+  std::vector<MPI_Request> sizesendrequest(numsendtoprocs);
+  std::vector<int> msgsizestosend(numsendtoprocs);
+  {
+    int counter = 0;
+    for (int torank : send_to_procs)
+    {
+      auto it = sdata.find(torank);
+      msgsizestosend[counter] = (it != sdata.end()) ? static_cast<int>(it->second.size()) : 0;
+      MPI_Isend(
+          &msgsizestosend[counter], 1, MPI_INT, torank, 1234, comm, &sizesendrequest[counter]);
+      ++counter;
+    }
+  }
+
+  // ---- receive size of messages from ALL known senders ----
+  std::vector<int> recvsources(receive_from_procs.begin(), receive_from_procs.end());
+  std::vector<int> msgsizestorecv(numrecvfromprocs);
+  std::vector<MPI_Request> sizerecvrequest(numrecvfromprocs);
+  for (int i = 0; i < numrecvfromprocs; ++i)
+  {
+    MPI_Irecv(&msgsizestorecv[i], 1, MPI_INT, recvsources[i], 1234, comm, &sizerecvrequest[i]);
+  }
+
+  // ---- wait for all size receives to complete ----
+  MPI_Waitall(numrecvfromprocs, sizerecvrequest.data(), MPI_STATUSES_IGNORE);
+
+  // ---- post receives for actual data from senders with non-zero size ----
+  std::vector<MPI_Request> recvrequest(numrecvfromprocs);
+  for (int i = 0; i < numrecvfromprocs; ++i)
+  {
+    if (msgsizestorecv[i] > 0)
+    {
+      rdata[recvsources[i]].resize(msgsizestorecv[i]);
+      MPI_Irecv(rdata[recvsources[i]].data(), msgsizestorecv[i], MPI_CHAR, recvsources[i], 5678,
+          comm, &recvrequest[i]);
+    }
+    else
+    {
+      recvrequest[i] = MPI_REQUEST_NULL;
+    }
+  }
+
+  // ---- wait for size sends to complete, then send data ----
+  MPI_Waitall(numsendtoprocs, sizesendrequest.data(), MPI_STATUSES_IGNORE);
+
+  std::vector<MPI_Request> sendrequest;
+  sendrequest.reserve(sdata.size());
+  for (auto& p : sdata)
+  {
+    sendrequest.emplace_back();
+    MPI_Isend(p.second.data(), static_cast<int>(p.second.size()), MPI_CHAR, p.first, 5678, comm,
+        &sendrequest.back());
+  }
+
+  // ---- wait for completion of send operations ----
+  if (!sendrequest.empty())
+    MPI_Waitall(static_cast<int>(sendrequest.size()), sendrequest.data(), MPI_STATUSES_IGNORE);
   sdata.clear();
 
   // ---- wait for completion of receive operations ----

--- a/src/particle/src/engine/4C_particle_engine_communication_utils.hpp
+++ b/src/particle/src/engine/4C_particle_engine_communication_utils.hpp
@@ -13,6 +13,7 @@
 #include <mpi.h>
 
 #include <map>
+#include <set>
 #include <vector>
 
 FOUR_C_NAMESPACE_OPEN
@@ -40,6 +41,29 @@ namespace Particle::ParticleUtils
    */
   void immediate_recv_blocking_send(MPI_Comm comm, std::map<int, std::vector<char>>& sdata,
       std::map<int, std::vector<char>>& rdata);
+
+  /*!
+   * \brief communicate data using a cached communication graph
+   *
+   * Communicate data via non-buffered send from processor to processor using pre-computed sets of
+   * send and receive partners. Unlike immediate_recv_blocking_send, this avoids collective
+   * communication by using the known communication graph. Size-zero messages are sent to all
+   * processors in send_to_procs that have no data, so that every receiver in receive_from_procs
+   * always gets a size message.
+   *
+   * \note This method does NOT require collective communication and is safe to call with
+   * asymmetric data (some ranks sending zero-size messages).
+   *
+   *
+   * \param[in]  comm                communicator
+   * \param[in]  sdata               send buffers related to corresponding target processors
+   * \param[out] rdata               receive buffers related to corresponding source processors
+   * \param[in]  send_to_procs       set of processors to send data to
+   * \param[in]  receive_from_procs  set of processors to receive data from
+   */
+  void immediate_send_recv_known_procs(MPI_Comm comm, std::map<int, std::vector<char>>& sdata,
+      std::map<int, std::vector<char>>& rdata, const std::set<int>& send_to_procs,
+      const std::set<int>& receive_from_procs);
 
   //@}
 


### PR DESCRIPTION
When performing the scalability studies I have identified a few places which can be optimized in order to improve performance. Most of those changes are related to optimizing the MPI communications: mainly reducing their number and the amount of data to be transferred.

As the result of this study, multiple modifications are proposed and split into 6 PRs. This whole sequence of optimizations was performed using Opus 4.6 assisting in reasoning about the bottlenecks.

This PR (and the follow-up PRs too) is tested using the ~5,000,000 particles SPH-PD simulation previously studied in #2063. The tests were again performed on a system with 2 AMD EPYC 7713 processors.

### 1. Cache senders and receivers to reuse the ghosts topology when communicating particles

This PR eliminates the per-step target-discovery collective inside the refresh path by reusing the directed-ghosting topology already known at ghost-rebuild time.

It also replaces an expensive `Allreduce` communication with small fixed point-to-point exchanges over a peer set.

The caches are updated every time `communicate_direct_ghosting_map()` runs.

This is the effect of this modification:

<img width="1286" height="484" alt="image" src="https://github.com/user-attachments/assets/26850cb8-31fd-4dcb-adad-5ccf1aa07ada" />

