### PR TITLE
Futher renaming of master/slave to source/target

### DIFF
--- a/src/contact_constitutivelaw/src/4C_contact_constitutivelaw_interface.cpp
+++ b/src/contact_constitutivelaw/src/4C_contact_constitutivelaw_interface.cpp
@@ -32,7 +32,7 @@ CONTACT::ConstitutivelawInterface::ConstitutivelawInterface(
 void CONTACT::ConstitutivelawInterface::assemble_reg_normal_forces(
     bool& localisincontact, bool& localactivesetchange)
 {
-  // loop over all slave row nodes on the current interface
+  // loop over all source row nodes on the current interface
   for (int i = 0; i < source_row_nodes()->num_my_elements(); ++i)
   {
     const int gid = source_row_nodes()->gid(i);
@@ -126,7 +126,7 @@ void CONTACT::ConstitutivelawInterface::assemble_reg_normal_forces(
       cnode->data().get_deriv_z().clear();
 
     }  // Macauley-Bracket
-  }  // loop over slave nodes
+  }  // loop over source nodes
 }
 
 /*----------------------------------------------------------------------*

--- a/src/contact_constitutivelaw/src/4C_contact_constitutivelaw_interface.hpp
+++ b/src/contact_constitutivelaw/src/4C_contact_constitutivelaw_interface.hpp
@@ -43,7 +43,7 @@ namespace CONTACT
         bool selfcontact, const int contactconstitutivelawid);
 
     /**
-     * \brief Evaluate regularized normal forces at slave nodes
+     * \brief Evaluate regularized normal forces at source nodes
      *
      * Assemble gap-computed lagrange multipliers and nodal linlambda derivatives into nodal
      * quantities using the Macauley bracket
@@ -72,7 +72,7 @@ namespace CONTACT
     void assemble_reg_normal_forces(bool& localisincontact, bool& localactivesetchange) override;
 
     /**
-     * \brief Evaluate regularized normal forces at slave nodes
+     * \brief Evaluate regularized normal forces at source nodes
      *
      * Throws an error since frictional contact is not implemented, yet.
      */

--- a/src/core/comm/src/4C_comm_utils_factory.hpp
+++ b/src/core/comm/src/4C_comm_utils_factory.hpp
@@ -171,7 +171,7 @@ namespace Core::Communication
       int nnode,                  ///< number of nodes
       const int* nodeids,         ///< node ids
       Core::Nodes::Node** nodes,  ///< nodes of surface
-      ParentEle* target_ele,      ///< pointer on the master parent element
+      ParentEle* target_ele,      ///< pointer on the target parent element
       ParentEle* source_ele,      ///< pointer on the source parent element
       const int lsurface_target,  ///< local surface index with respect to target parent element
       const int lsurface_source,  ///< local surface index with respect to source parent element

--- a/src/core/fem/src/discretization/4C_fem_discretization_faces.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_faces.cpp
@@ -73,8 +73,6 @@ void Core::FE::DiscretizationFaces::create_internal_faces_extension(const bool v
     if (Core::Communication::my_mpi_rank(comm_) == 0)
       std::cout << "number of created faces:   " << summall << "\n" << std::endl;
   }
-
-  return;
 }
 
 
@@ -372,14 +370,6 @@ void Core::FE::DiscretizationFaces::build_faces(const bool verbose)
 
         if (my_target_node_ids.size() > 0)
         {
-          //          std::cout << "current sets" << std::endl;
-          //          std::cout << "target nodes" << std::endl;
-          //          for (std::size_t rr=0; rr < my_target_node_ids.size(); rr++)
-          //            std::cout << my_target_node_ids[rr] << std::endl;
-          //          std::cout << "further target nodes" << std::endl;
-          //          for (std::size_t rr=0; rr < further_target_node_ids.size(); rr++)
-          //            std::cout << further_target_node_ids[rr] << std::endl;
-
           // check if all nodes of the face are targets of pbcs
           // -> this is a target face
           if ((my_target_node_ids.size() + further_target_node_ids.size()) == mynodeids.size())
@@ -681,26 +671,6 @@ void Core::FE::DiscretizationFaces::build_faces(const bool verbose)
                   }
                 }
 
-                //                std::cout << "further_target_cond " <<further_target_cond<<
-                //                std::endl; std::cout << "source_cond_1 " <<source_cond_1<<
-                //                std::endl;
-
-                //                std::cout<< "target 1 \n" << target_pbc_id << std::endl;
-                //                std::set<int>::iterator myiter;
-                //                for
-                //                (myiter=target_to_pbc_set[remaining_source_pbc_ids[0]].begin();
-                //                myiter!=target_to_pbc_set[remaining_source_pbc_ids[0]].end();
-                //                myiter++)
-                //                {
-                //                  std::cout<< *myiter << std::endl;
-                //                }
-                //                std::cout<< "target 2 \n" << target_pbc_id << std::endl;
-                //                for
-                //                (myiter=target_to_pbc_set[remaining_source_pbc_ids[1]].begin();
-                //                myiter!=target_to_pbc_set[remaining_source_pbc_ids[1]].end();
-                //                myiter++)
-                //                  std::cout<< *myiter << std::endl;
-
                 // loop all source nodes of the current target and
                 // check which node fulfills above conditions
                 int act_source_id = -999;
@@ -782,7 +752,7 @@ void Core::FE::DiscretizationFaces::build_faces(const bool verbose)
           // add source element to the patch
           if (add_source_ele_to_face)
           {
-            // get master element
+            // get target element
             Core::Elements::Element* target_ele = elecolptr_[0];
             for (fool = elecolptr_.begin(); fool != elecolptr_.end(); ++fool)
             {
@@ -842,32 +812,6 @@ void Core::FE::DiscretizationFaces::build_faces(const bool verbose)
             }
             // set in face
             face_it->second.set_local_numbering_map(localtrafomap);
-
-            //            if (Core::Communication::my_mpi_rank(comm_)==1)
-            //            {
-            //            std::cout << "\n added pbc face "  << std::endl;
-            //
-            //            std::cout << "target nodes" << std::endl;
-            //            for (std::size_t rr=0; rr < my_target_node_ids.size(); rr++)
-            //              std::cout << my_target_node_ids[rr] << std::endl;
-            //
-            //            std::cout << "further target nodes" << std::endl;
-            //            for (std::size_t rr=0; rr < further_target_node_ids.size(); rr++)
-            //              std::cout << further_target_node_ids[rr] << std::endl;
-            //
-            //              std::cout << "source node ids "  << std::endl;
-            //            for (std::size_t kk=0; kk<my_source_node_ids.size(); kk++)
-            //               std::cout << my_source_node_ids[kk] << std::endl;
-            //
-            ////            std::cout << "local trafo map  " << std::endl;
-            ////            for (std::size_t kk=0; kk<localtrafomap.size(); kk++)
-            ////            {
-            ////              std::cout << "target node id " << nodes_face_target[kk]->Id() <<
-            /// std::endl; /              std::cout << "source node id " << source_nodes[kk]->Id()
-            /// << std::endl; /              std::cout << "source node position " <<
-            /// localtrafomap[kk]
-            /// << std::endl; /            }
-            //            }
           }
         }
       }
@@ -942,8 +886,6 @@ void Core::FE::DiscretizationFaces::build_faces(const bool verbose)
   {
     std::cout << "... done!" << std::endl;
   }
-
-  return;
 }  // Core::FE::DiscretizationFaces::BuildInternalFaces
 
 
@@ -970,7 +912,6 @@ void Core::FE::DiscretizationFaces::build_face_row_map()
     }
   if (count != nummyeles) FOUR_C_THROW("Mismatch in no. of internal faces");
   facerowmap_ = std::make_shared<Core::LinAlg::Map>(-1, nummyeles, eleids.data(), 0, get_comm());
-  return;
 }
 
 
@@ -993,7 +934,6 @@ void Core::FE::DiscretizationFaces::build_face_col_map()
   }
   if (count != nummyeles) FOUR_C_THROW("Mismatch in no. of elements");
   facecolmap_ = std::make_shared<Core::LinAlg::Map>(-1, nummyeles, eleids.data(), 0, get_comm());
-  return;
 }
 
 
@@ -1114,8 +1054,6 @@ void Core::FE::DiscretizationFaces::print_faces(std::ostream& os) const
     }
     Core::Communication::barrier(get_comm());
   }
-
-  return;
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/coupling/src/volmortar/4C_coupling_volmortar.cpp
+++ b/src/coupling/src/volmortar/4C_coupling_volmortar.cpp
@@ -120,8 +120,6 @@ Coupling::VolMortar::VolMortarCoupl::VolMortarCoupl(int dim,
   cellcounter_ = 0;
   inteles_ = 0;
   volume_ = 0.0;
-
-  return;
 }
 
 /*----------------------------------------------------------------------*
@@ -165,8 +163,6 @@ void Coupling::VolMortar::VolMortarCoupl::build_maps(std::shared_ptr<Core::FE::D
   }
   // dof map is the original, unpermuted distribution of dofs
   dofmap = std::make_shared<Core::LinAlg::Map>(-1, dofmapvec.size(), dofmapvec.data(), 0, comm_);
-
-  return;
 }
 
 /*----------------------------------------------------------------------*
@@ -247,9 +243,6 @@ void Coupling::VolMortar::VolMortarCoupl::evaluate_volmortar()
   cellcounter_ = 0;
   inteles_ = 0;
   volume_ = 0.0;
-
-  // coupling done
-  return;
 }
 
 /*----------------------------------------------------------------------*
@@ -292,8 +285,6 @@ void Coupling::VolMortar::VolMortarCoupl::init_dop_normals()
   dopnormals_(8, 0) = 0.0;
   dopnormals_(8, 1) = 1.0;
   dopnormals_(8, 2) = -1.0;
-
-  return;
 }
 /*----------------------------------------------------------------------*
  |  Init search tree                                         farah 05/14|
@@ -306,12 +297,12 @@ std::shared_ptr<Core::Geo::SearchTree> Coupling::VolMortar::VolMortarCoupl::init
 
   for (int lid = 0; lid < searchdis->num_my_col_elements(); ++lid)
   {
-    Core::Elements::Element* sele = searchdis->l_col_element(lid);
+    Core::Elements::Element* source_ele = searchdis->l_col_element(lid);
 
     // calculate slabs for every node on every element
-    for (int k = 0; k < sele->num_node(); k++)
+    for (int k = 0; k < source_ele->num_node(); k++)
     {
-      Core::Nodes::Node* node = sele->nodes()[k];
+      Core::Nodes::Node* node = source_ele->nodes()[k];
       Core::LinAlg::Matrix<3, 1> currpos;
 
       const auto x = node->x();
@@ -344,9 +335,9 @@ std::map<int, Core::LinAlg::Matrix<9, 2>> Coupling::VolMortar::VolMortarCoupl::c
 
   for (int lid = 0; lid < searchdis->num_my_col_elements(); ++lid)
   {
-    Core::Elements::Element* sele = searchdis->l_col_element(lid);
+    Core::Elements::Element* source_ele = searchdis->l_col_element(lid);
 
-    currentKDOPs[sele->id()] = calc_dop(*sele);
+    currentKDOPs[source_ele->id()] = calc_dop(*source_ele);
   }
 
   return currentKDOPs;
@@ -470,8 +461,6 @@ void Coupling::VolMortar::VolMortarCoupl::assign_materials()
      ***********************************************************/
     materialstrategy_->assign_material1_to2(this, Bele, found, dis1_, dis2_);
   }
-
-  return;
 }
 
 /*----------------------------------------------------------------------*
@@ -643,10 +632,10 @@ void Coupling::VolMortar::VolMortarCoupl::create_trafo_operator(Core::Elements::
     // corner nodes
     if (i >= corner_min and i <= corner_max)
     {
-      int nsdof = searchdis->num_dof(1, cnode);
+      int nsource_dof = searchdis->num_dof(1, cnode);
 
       // loop over source dofs
-      for (int jdof = 0; jdof < nsdof; ++jdof)
+      for (int jdof = 0; jdof < nsource_dof; ++jdof)
       {
         int row = searchdis->dof(1, cnode, jdof);
 
@@ -663,10 +652,10 @@ void Coupling::VolMortar::VolMortarCoupl::create_trafo_operator(Core::Elements::
       // get ids
       std::vector<int> ids = get_adjacent_nodes(ele.shape(), i);
 
-      int nsdof = searchdis->num_dof(1, cnode);
+      int nsource_dof = searchdis->num_dof(1, cnode);
 
       // loop over dofs
-      for (int jdof = 0; jdof < nsdof; ++jdof)
+      for (int jdof = 0; jdof < nsource_dof; ++jdof)
       {
         int row = searchdis->dof(1, cnode, jdof);
 
@@ -699,8 +688,6 @@ void Coupling::VolMortar::VolMortarCoupl::create_trafo_operator(Core::Elements::
       }
     }
   }
-
-  return;
 }
 
 /*----------------------------------------------------------------------*
@@ -767,8 +754,6 @@ void Coupling::VolMortar::VolMortarCoupl::evaluate_consistent_interpolation()
    ***********************************************************/
   p12_->complete(*p12_dofdomainmap_, *p12_dofrowmap_);
   p21_->complete(*p21_dofdomainmap_, *p21_dofrowmap_);
-
-  return;
 }
 
 /*----------------------------------------------------------------------*
@@ -960,17 +945,17 @@ void Coupling::VolMortar::VolMortarCoupl::evaluate_segments_2d(
 void Coupling::VolMortar::VolMortarCoupl::evaluate_segments_3d(
     Core::Elements::Element* Aele, Core::Elements::Element* Bele)
 {
-  // check need element-based integration over sele:
+  // check need element-based integration over source_ele:
   bool integrateA = check_ele_integration(*Aele, *Bele);
 
-  // check need element-based integration over mele:
+  // check need element-based integration over target_ele:
   bool integrateB = check_ele_integration(*Bele, *Aele);
 
   // check need for cut:
   bool performcut = check_cut(*Aele, *Bele);
 
   /**************************************************
-   * Integrate element-based Sele                   *
+   * Integrate element-based source_ele                   *
    **************************************************/
   if (integrateA)
   {
@@ -978,7 +963,7 @@ void Coupling::VolMortar::VolMortarCoupl::evaluate_segments_3d(
     integrate_3d(*Aele, *Bele, 0);
   }
   /**************************************************
-   * Integrate element-based Mele                   *
+   * Integrate element-based target_ele                   *
    **************************************************/
   else if (integrateB)
   {
@@ -1013,8 +998,6 @@ void Coupling::VolMortar::VolMortarCoupl::evaluate_segments_3d(
   {
     // do nothing...
   }
-
-  return;
 }
 
 /*----------------------------------------------------------------------*
@@ -1080,10 +1063,10 @@ void Coupling::VolMortar::VolMortarCoupl::check_initial_residuum()
     for (int j = 0; j < Aele->num_node(); ++j)
     {
       Core::Nodes::Node* cnode = Aele->nodes()[j];
-      int nsdof = discret1()->num_dof(0, cnode);
+      int nsource_dof = discret1()->num_dof(0, cnode);
 
       // loop over source dofs
-      for (int jdof = 0; jdof < nsdof; ++jdof)
+      for (int jdof = 0; jdof < nsource_dof; ++jdof)
       {
         int id = discret1()->dof(0, cnode, jdof);
         double val = cnode->x()[jdof];
@@ -1100,10 +1083,10 @@ void Coupling::VolMortar::VolMortarCoupl::check_initial_residuum()
     for (int j = 0; j < Bele->num_node(); ++j)
     {
       Core::Nodes::Node* cnode = Bele->nodes()[j];
-      int nsdof = discret2()->num_dof(1, cnode);
+      int nsource_dof = discret2()->num_dof(1, cnode);
 
       // loop over source dofs
-      for (int jdof = 0; jdof < nsdof; ++jdof)
+      for (int jdof = 0; jdof < nsource_dof; ++jdof)
       {
         int id = discret2()->dof(1, cnode, jdof);
         double val = cnode->x()[jdof];
@@ -1113,15 +1096,6 @@ void Coupling::VolMortar::VolMortarCoupl::check_initial_residuum()
     }
   }
 
-  // std::cout << "vector of source positions " << *var_B << std::endl;
-
-  // do: D*db - M*da
-  // int err1 = dmatrixB_->Multiply(false, *var_B, *result_B);
-  // int err2 = mmatrixB_->Multiply(false, *var_A, *result_A);
-
-  // if(err1!=0 or err2!=0)
-  //  FOUR_C_THROW("error");
-
   p21_->multiply(false, *var_A, *result_A);
 
   // subtract both results
@@ -1129,8 +1103,6 @@ void Coupling::VolMortar::VolMortarCoupl::check_initial_residuum()
 
   std::cout << "Result of init check= " << std::endl;
   result_A->print(std::cout);
-
-  return;
 }
 
 /*----------------------------------------------------------------------*
@@ -1408,11 +1380,11 @@ void Coupling::VolMortar::VolMortarCoupl::mesh_init()
       for (int j = 0; j < Aele->num_node(); ++j)
       {
         Core::Nodes::Node* cnode = Aele->nodes()[j];
-        int nsdof = discret1()->num_dof(dofseta, cnode);
+        int nsource_dof = discret1()->num_dof(dofseta, cnode);
         std::vector<double> nvector(3);
 
         // loop over source dofs
-        for (int jdof = 0; jdof < nsdof; ++jdof)
+        for (int jdof = 0; jdof < nsource_dof; ++jdof)
         {
           const int lid = sola->get_map().lid(discret1()->dof(dofseta, cnode, jdof));
           nvector[jdof] = sola->local_values_as_span()[lid] - cnode->x()[jdof];
@@ -1427,11 +1399,11 @@ void Coupling::VolMortar::VolMortarCoupl::mesh_init()
       for (int j = 0; j < Bele->num_node(); ++j)
       {
         Core::Nodes::Node* cnode = Bele->nodes()[j];
-        int nsdof = discret2()->num_dof(dofsetb, cnode);
+        int nsource_dof = discret2()->num_dof(dofsetb, cnode);
         std::vector<double> nvector(3);
 
         // loop over source dofs
-        for (int jdof = 0; jdof < nsdof; ++jdof)
+        for (int jdof = 0; jdof < nsource_dof; ++jdof)
         {
           const int lid = solb->get_map().lid(discret2()->dof(dofsetb, cnode, jdof));
           nvector[jdof] = solb->local_values_as_span()[lid] - cnode->x()[jdof];
@@ -1535,8 +1507,6 @@ void Coupling::VolMortar::VolMortarCoupl::mesh_init()
 
     std::cout << "final ra= " << finalra << "   final rb= " << finalrb << std::endl;
   }
-
-  return;
 }
 /*----------------------------------------------------------------------*
  |  print_status (public)                                     farah 02/14|
@@ -1565,15 +1535,13 @@ void Coupling::VolMortar::VolMortarCoupl::print_status(int& i, bool dis_switch)
 
     percent_counter++;
   }
-
-  return;
 }
 
 /*----------------------------------------------------------------------*
  |  Start Cut routine                                        farah 01/14|
  *----------------------------------------------------------------------*/
 void Coupling::VolMortar::VolMortarCoupl::perform_cut(
-    Core::Elements::Element* sele, Core::Elements::Element* mele, bool switched_conf)
+    Core::Elements::Element* source_ele, Core::Elements::Element* target_ele, bool switched_conf)
 {
   // create empty vector of integration cells
   std::vector<std::shared_ptr<Cell>> IntCells;
@@ -1586,44 +1554,44 @@ void Coupling::VolMortar::VolMortarCoupl::perform_cut(
   // nodes, as we only need the geometry to perform the cut, but want to make sure that the gids
   // and dofs of the original elements are kept untouched.
 
-  std::shared_ptr<Core::FE::Discretization> sauxdis =
-      std::make_shared<Core::FE::Discretization>((std::string) "slaveauxdis", comm_, dim_);
-  std::shared_ptr<Core::FE::Discretization> mauxdis =
-      std::make_shared<Core::FE::Discretization>((std::string) "masterauxdis", comm_, dim_);
+  std::shared_ptr<Core::FE::Discretization> sourceauxdis =
+      std::make_shared<Core::FE::Discretization>((std::string) "sourceauxdis", comm_, dim_);
+  std::shared_ptr<Core::FE::Discretization> targetauxdis =
+      std::make_shared<Core::FE::Discretization>((std::string) "targetauxdis", comm_, dim_);
 
   // build surface elements for all surfaces of source element
-  std::vector<std::shared_ptr<Core::Elements::Element>> sele_surfs = sele->surfaces();
+  std::vector<std::shared_ptr<Core::Elements::Element>> sele_surfs = source_ele->surfaces();
   const int numsurf = sele_surfs.size();
   for (int isurf = 0; isurf < numsurf; ++isurf)
   {
     // add all surface elements to auxiliary source discretization (no need for cloning, as surface
     // elements are
     // rebuild every time when calling Surfaces(), anyway)
-    sauxdis->add_element(sele_surfs[isurf]);
+    sourceauxdis->add_element(sele_surfs[isurf]);
   }
 
   // add clone of element to auxiliary discretization
-  mauxdis->add_element(std::shared_ptr<Core::Elements::Element>(mele->clone()));
+  targetauxdis->add_element(std::shared_ptr<Core::Elements::Element>(target_ele->clone()));
 
   // add clones of nodes to auxiliary discretizations
-  for (int node = 0; node < sele->num_node(); ++node)
+  for (int node = 0; node < source_ele->num_node(); ++node)
   {
-    auto cloned_node = std::shared_ptr<Core::Nodes::Node>(sele->nodes()[node]->clone());
-    sauxdis->add_node(cloned_node->x(), cloned_node->id(), cloned_node);
+    auto cloned_node = std::shared_ptr<Core::Nodes::Node>(source_ele->nodes()[node]->clone());
+    sourceauxdis->add_node(cloned_node->x(), cloned_node->id(), cloned_node);
   }
-  for (int node = 0; node < mele->num_node(); ++node)
+  for (int node = 0; node < target_ele->num_node(); ++node)
   {
-    auto cloned_node = std::shared_ptr<Core::Nodes::Node>(mele->nodes()[node]->clone());
-    mauxdis->add_node(cloned_node->x(), cloned_node->id(), cloned_node);
+    auto cloned_node = std::shared_ptr<Core::Nodes::Node>(target_ele->nodes()[node]->clone());
+    targetauxdis->add_node(cloned_node->x(), cloned_node->id(), cloned_node);
   }
 
   // complete dis
-  sauxdis->fill_complete({
+  sourceauxdis->fill_complete({
       .assign_degrees_of_freedom = true,
       .init_elements = false,
       .do_boundary_conditions = false,
   });
-  mauxdis->fill_complete({
+  targetauxdis->fill_complete({
       .assign_degrees_of_freedom = true,
       .init_elements = false,
       .do_boundary_conditions = false,
@@ -1633,7 +1601,7 @@ void Coupling::VolMortar::VolMortarCoupl::perform_cut(
   // Initialize the cut wizard
 
   // create new cut wizard
-  Cut::CutWizard wizard(mauxdis);
+  Cut::CutWizard wizard(targetauxdis);
 
   // *************************************
   // TESSELATION *************************
@@ -1652,23 +1620,24 @@ void Coupling::VolMortar::VolMortarCoupl::perform_cut(
 
     // cut in reference configuration
     wizard.set_background_state(nullptr, nullptr, -1);
-    wizard.add_cutter_state(0, sauxdis, nullptr);
+    wizard.add_cutter_state(0, sourceauxdis, nullptr);
 
     wizard.prepare();
     wizard.cut(true);  // include_inner
 
-    Cut::plain_volumecell_set mcells_out;
-    Cut::plain_volumecell_set mcells_in;
-    Cut::ElementHandle* em = wizard.get_element(mele);
+    Cut::plain_volumecell_set target_cells_out;
+    Cut::plain_volumecell_set target_cells_in;
+    Cut::ElementHandle* em = wizard.get_element(target_ele);
 
-    // is mele in cut involved?
+    // is target_ele in cut involved?
     if (em != nullptr)
     {
-      em->collect_volume_cells(mcells_in, mcells_out);
+      em->collect_volume_cells(target_cells_in, target_cells_out);
 
       int count = 0;
 
-      for (Cut::plain_volumecell_set::iterator u = mcells_in.begin(); u != mcells_in.end(); u++)
+      for (Cut::plain_volumecell_set::iterator u = target_cells_in.begin();
+          u != target_cells_in.end(); u++)
       {
         Cut::VolumeCell* vc = *u;
         const Cut::plain_integrationcell_set& intcells = vc->integration_cells();
@@ -1687,12 +1656,12 @@ void Coupling::VolMortar::VolMortarCoupl::perform_cut(
       }
       // integrate found cells - tesselation
       if (!switched_conf)
-        integrate_3d_cell(*sele, *mele, IntCells);
+        integrate_3d_cell(*source_ele, *target_ele, IntCells);
       else
-        integrate_3d_cell(*mele, *sele, IntCells);
+        integrate_3d_cell(*target_ele, *source_ele, IntCells);
 
       // count the cells and the polygons/polyhedra
-      polygoncounter_ += mcells_in.size();
+      polygoncounter_ += target_cells_in.size();
       cellcounter_ += count;
     }
   }
@@ -1714,25 +1683,25 @@ void Coupling::VolMortar::VolMortarCoupl::perform_cut(
 
     // cut in reference configuration
     wizard.set_background_state(nullptr, nullptr, -1);
-    wizard.add_cutter_state(0, sauxdis, nullptr);
+    wizard.add_cutter_state(0, sourceauxdis, nullptr);
 
     wizard.cut(true);  // include_inner
 
-    Cut::plain_volumecell_set mcells_out;
-    Cut::plain_volumecell_set mcells_in;
-    Cut::ElementHandle* em = wizard.get_element(mele);
+    Cut::plain_volumecell_set target_cells_out;
+    Cut::plain_volumecell_set target_cells_in;
+    Cut::ElementHandle* em = wizard.get_element(target_ele);
 
     // for safety
     volcell_.clear();
     if (em != nullptr)
     {
-      em->collect_volume_cells(volcell_, mcells_out);
+      em->collect_volume_cells(volcell_, target_cells_out);
 
       // start integration
       if (switched_conf)
-        integrate_3d_cell_direct_divergence(*mele, *sele, switched_conf);
+        integrate_3d_cell_direct_divergence(*target_ele, *source_ele, switched_conf);
       else
-        integrate_3d_cell_direct_divergence(*sele, *mele, switched_conf);
+        integrate_3d_cell_direct_divergence(*source_ele, *target_ele, switched_conf);
 
       polygoncounter_ += volcell_.size();
     }
@@ -1742,15 +1711,13 @@ void Coupling::VolMortar::VolMortarCoupl::perform_cut(
   // DEFAULT           *************************
   else
     FOUR_C_THROW("ERROR: Chosen Cuttype for volmortar not supported!");
-
-  return;
 }
 
 /*----------------------------------------------------------------------*
  |  Check need for element-based integration                 farah 01/14|
  *----------------------------------------------------------------------*/
 bool Coupling::VolMortar::VolMortarCoupl::check_ele_integration(
-    Core::Elements::Element& sele, Core::Elements::Element& mele)
+    Core::Elements::Element& source_ele, Core::Elements::Element& target_ele)
 {
   bool integrateele = true;
   bool converged = false;
@@ -1760,32 +1727,33 @@ bool Coupling::VolMortar::VolMortarCoupl::check_ele_integration(
 
   //--------------------------------------------------------
   // 1. all source nodes within with target ele ?
-  for (int u = 0; u < sele.num_node(); ++u)
+  for (int u = 0; u < source_ele.num_node(); ++u)
   {
-    xgl[0] = sele.nodes()[u]->x()[0];
-    xgl[1] = sele.nodes()[u]->x()[1];
-    xgl[2] = sele.nodes()[u]->x()[2];
+    xgl[0] = source_ele.nodes()[u]->x()[0];
+    xgl[1] = source_ele.nodes()[u]->x()[1];
+    xgl[2] = source_ele.nodes()[u]->x()[2];
 
     // global to local:
-    if (mele.shape() == Core::FE::CellType::hex8)
-      Mortar::Utils::global_to_local<Core::FE::CellType::hex8>(mele, xgl, xi, converged);
-    else if (mele.shape() == Core::FE::CellType::hex20)
-      Mortar::Utils::global_to_local<Core::FE::CellType::hex20>(mele, xgl, xi, converged);
-    else if (mele.shape() == Core::FE::CellType::hex27)
-      Mortar::Utils::global_to_local<Core::FE::CellType::hex27>(mele, xgl, xi, converged);
-    else if (mele.shape() == Core::FE::CellType::tet4)
-      Mortar::Utils::global_to_local<Core::FE::CellType::tet4>(mele, xgl, xi, converged);
-    else if (mele.shape() == Core::FE::CellType::tet10)
-      Mortar::Utils::global_to_local<Core::FE::CellType::tet10>(mele, xgl, xi, converged);
-    else if (mele.shape() == Core::FE::CellType::pyramid5)
-      Mortar::Utils::global_to_local<Core::FE::CellType::pyramid5>(mele, xgl, xi, converged);
+    if (target_ele.shape() == Core::FE::CellType::hex8)
+      Mortar::Utils::global_to_local<Core::FE::CellType::hex8>(target_ele, xgl, xi, converged);
+    else if (target_ele.shape() == Core::FE::CellType::hex20)
+      Mortar::Utils::global_to_local<Core::FE::CellType::hex20>(target_ele, xgl, xi, converged);
+    else if (target_ele.shape() == Core::FE::CellType::hex27)
+      Mortar::Utils::global_to_local<Core::FE::CellType::hex27>(target_ele, xgl, xi, converged);
+    else if (target_ele.shape() == Core::FE::CellType::tet4)
+      Mortar::Utils::global_to_local<Core::FE::CellType::tet4>(target_ele, xgl, xi, converged);
+    else if (target_ele.shape() == Core::FE::CellType::tet10)
+      Mortar::Utils::global_to_local<Core::FE::CellType::tet10>(target_ele, xgl, xi, converged);
+    else if (target_ele.shape() == Core::FE::CellType::pyramid5)
+      Mortar::Utils::global_to_local<Core::FE::CellType::pyramid5>(target_ele, xgl, xi, converged);
     else
       FOUR_C_THROW("ERROR: Shape function not supported!");
 
     if (converged == true)
     {
-      if (mele.shape() == Core::FE::CellType::hex8 or mele.shape() == Core::FE::CellType::hex20 or
-          mele.shape() == Core::FE::CellType::hex27)
+      if (target_ele.shape() == Core::FE::CellType::hex8 or
+          target_ele.shape() == Core::FE::CellType::hex20 or
+          target_ele.shape() == Core::FE::CellType::hex27)
       {
         if (xi[0] > -1.0 - VOLMORTARELETOL and xi[0] < 1.0 + VOLMORTARELETOL and
             xi[1] > -1.0 - VOLMORTARELETOL and xi[1] < 1.0 + VOLMORTARELETOL and
@@ -1794,8 +1762,8 @@ bool Coupling::VolMortar::VolMortarCoupl::check_ele_integration(
         else
           return false;
       }
-      else if (mele.shape() == Core::FE::CellType::tet4 or
-               mele.shape() == Core::FE::CellType::tet10)
+      else if (target_ele.shape() == Core::FE::CellType::tet4 or
+               target_ele.shape() == Core::FE::CellType::tet10)
       {
         if (xi[0] > 0.0 - VOLMORTARELETOL and xi[0] < 1.0 + VOLMORTARELETOL and
             xi[1] > 0.0 - VOLMORTARELETOL and xi[1] < 1.0 + VOLMORTARELETOL and
@@ -1822,7 +1790,7 @@ bool Coupling::VolMortar::VolMortarCoupl::check_ele_integration(
  |  Check need for cut and element-based integration         farah 01/14|
  *----------------------------------------------------------------------*/
 bool Coupling::VolMortar::VolMortarCoupl::check_cut(
-    Core::Elements::Element& sele, Core::Elements::Element& mele)
+    Core::Elements::Element& source_ele, Core::Elements::Element& target_ele)
 {
   double xi[3] = {0.0, 0.0, 0.0};
   double xgl[3] = {0.0, 0.0, 0.0};
@@ -1842,32 +1810,34 @@ bool Coupling::VolMortar::VolMortarCoupl::check_cut(
     bool xi1n = false;
     bool xi2n = false;
 
-    for (int u = 0; u < mele.num_node(); ++u)
+    for (int u = 0; u < target_ele.num_node(); ++u)
     {
-      xgl[0] = mele.nodes()[u]->x()[0];
-      xgl[1] = mele.nodes()[u]->x()[1];
-      xgl[2] = mele.nodes()[u]->x()[2];
+      xgl[0] = target_ele.nodes()[u]->x()[0];
+      xgl[1] = target_ele.nodes()[u]->x()[1];
+      xgl[2] = target_ele.nodes()[u]->x()[2];
 
       // global to local:
-      if (sele.shape() == Core::FE::CellType::hex8)
-        Mortar::Utils::global_to_local<Core::FE::CellType::hex8>(sele, xgl, xi, converged);
-      else if (sele.shape() == Core::FE::CellType::hex20)
-        Mortar::Utils::global_to_local<Core::FE::CellType::hex20>(sele, xgl, xi, converged);
-      else if (sele.shape() == Core::FE::CellType::hex27)
-        Mortar::Utils::global_to_local<Core::FE::CellType::hex27>(sele, xgl, xi, converged);
-      else if (sele.shape() == Core::FE::CellType::tet4)
-        Mortar::Utils::global_to_local<Core::FE::CellType::tet4>(sele, xgl, xi, converged);
-      else if (sele.shape() == Core::FE::CellType::tet10)
-        Mortar::Utils::global_to_local<Core::FE::CellType::tet10>(sele, xgl, xi, converged);
-      else if (sele.shape() == Core::FE::CellType::pyramid5)
-        Mortar::Utils::global_to_local<Core::FE::CellType::pyramid5>(sele, xgl, xi, converged);
+      if (source_ele.shape() == Core::FE::CellType::hex8)
+        Mortar::Utils::global_to_local<Core::FE::CellType::hex8>(source_ele, xgl, xi, converged);
+      else if (source_ele.shape() == Core::FE::CellType::hex20)
+        Mortar::Utils::global_to_local<Core::FE::CellType::hex20>(source_ele, xgl, xi, converged);
+      else if (source_ele.shape() == Core::FE::CellType::hex27)
+        Mortar::Utils::global_to_local<Core::FE::CellType::hex27>(source_ele, xgl, xi, converged);
+      else if (source_ele.shape() == Core::FE::CellType::tet4)
+        Mortar::Utils::global_to_local<Core::FE::CellType::tet4>(source_ele, xgl, xi, converged);
+      else if (source_ele.shape() == Core::FE::CellType::tet10)
+        Mortar::Utils::global_to_local<Core::FE::CellType::tet10>(source_ele, xgl, xi, converged);
+      else if (source_ele.shape() == Core::FE::CellType::pyramid5)
+        Mortar::Utils::global_to_local<Core::FE::CellType::pyramid5>(
+            source_ele, xgl, xi, converged);
       else
         FOUR_C_THROW("ERROR: Shape function not supported!");
 
       if (converged == true)
       {
-        if (sele.shape() == Core::FE::CellType::hex8 or sele.shape() == Core::FE::CellType::hex20 or
-            sele.shape() == Core::FE::CellType::hex27)
+        if (source_ele.shape() == Core::FE::CellType::hex8 or
+            source_ele.shape() == Core::FE::CellType::hex20 or
+            source_ele.shape() == Core::FE::CellType::hex27)
         {
           if (xi[0] > -1.0 + VOLMORTARCUTTOL) xi0 = true;
           if (xi[1] > -1.0 + VOLMORTARCUTTOL) xi1 = true;
@@ -1877,8 +1847,8 @@ bool Coupling::VolMortar::VolMortarCoupl::check_cut(
           if (xi[1] < 1.0 - VOLMORTARCUTTOL) xi1n = true;
           if (xi[2] < 1.0 - VOLMORTARCUTTOL) xi2n = true;
         }
-        else if (sele.shape() == Core::FE::CellType::tet4 or
-                 sele.shape() == Core::FE::CellType::tet10)
+        else if (source_ele.shape() == Core::FE::CellType::tet4 or
+                 source_ele.shape() == Core::FE::CellType::tet10)
         {
           if (xi[0] > 0.0 + VOLMORTARCUTTOL) xi0 = true;
           if (xi[1] > 0.0 + VOLMORTARCUTTOL) xi1 = true;
@@ -1890,12 +1860,14 @@ bool Coupling::VolMortar::VolMortarCoupl::check_cut(
       }
     }  // end node loop
 
-    if (sele.shape() == Core::FE::CellType::tet4 or sele.shape() == Core::FE::CellType::tet10)
+    if (source_ele.shape() == Core::FE::CellType::tet4 or
+        source_ele.shape() == Core::FE::CellType::tet10)
     {
       if (!xi0 or !xi1 or !xi2 or !all) return false;
     }
-    else if (sele.shape() == Core::FE::CellType::hex8 or
-             sele.shape() == Core::FE::CellType::hex20 or sele.shape() == Core::FE::CellType::hex27)
+    else if (source_ele.shape() == Core::FE::CellType::hex8 or
+             source_ele.shape() == Core::FE::CellType::hex20 or
+             source_ele.shape() == Core::FE::CellType::hex27)
     {
       if (!xi0 or !xi1 or !xi2 or !xi0n or !xi1n or !xi2n) return false;
     }
@@ -1916,32 +1888,34 @@ bool Coupling::VolMortar::VolMortarCoupl::check_cut(
     bool xi1n = false;
     bool xi2n = false;
 
-    for (int u = 0; u < sele.num_node(); ++u)
+    for (int u = 0; u < source_ele.num_node(); ++u)
     {
-      xgl[0] = sele.nodes()[u]->x()[0];
-      xgl[1] = sele.nodes()[u]->x()[1];
-      xgl[2] = sele.nodes()[u]->x()[2];
+      xgl[0] = source_ele.nodes()[u]->x()[0];
+      xgl[1] = source_ele.nodes()[u]->x()[1];
+      xgl[2] = source_ele.nodes()[u]->x()[2];
 
       // global to local:
-      if (mele.shape() == Core::FE::CellType::hex8)
-        Mortar::Utils::global_to_local<Core::FE::CellType::hex8>(mele, xgl, xi, converged);
-      else if (mele.shape() == Core::FE::CellType::hex20)
-        Mortar::Utils::global_to_local<Core::FE::CellType::hex20>(mele, xgl, xi, converged);
-      else if (mele.shape() == Core::FE::CellType::hex27)
-        Mortar::Utils::global_to_local<Core::FE::CellType::hex27>(mele, xgl, xi, converged);
-      else if (mele.shape() == Core::FE::CellType::tet4)
-        Mortar::Utils::global_to_local<Core::FE::CellType::tet4>(mele, xgl, xi, converged);
-      else if (mele.shape() == Core::FE::CellType::tet10)
-        Mortar::Utils::global_to_local<Core::FE::CellType::tet10>(mele, xgl, xi, converged);
-      else if (mele.shape() == Core::FE::CellType::pyramid5)
-        Mortar::Utils::global_to_local<Core::FE::CellType::pyramid5>(mele, xgl, xi, converged);
+      if (target_ele.shape() == Core::FE::CellType::hex8)
+        Mortar::Utils::global_to_local<Core::FE::CellType::hex8>(target_ele, xgl, xi, converged);
+      else if (target_ele.shape() == Core::FE::CellType::hex20)
+        Mortar::Utils::global_to_local<Core::FE::CellType::hex20>(target_ele, xgl, xi, converged);
+      else if (target_ele.shape() == Core::FE::CellType::hex27)
+        Mortar::Utils::global_to_local<Core::FE::CellType::hex27>(target_ele, xgl, xi, converged);
+      else if (target_ele.shape() == Core::FE::CellType::tet4)
+        Mortar::Utils::global_to_local<Core::FE::CellType::tet4>(target_ele, xgl, xi, converged);
+      else if (target_ele.shape() == Core::FE::CellType::tet10)
+        Mortar::Utils::global_to_local<Core::FE::CellType::tet10>(target_ele, xgl, xi, converged);
+      else if (target_ele.shape() == Core::FE::CellType::pyramid5)
+        Mortar::Utils::global_to_local<Core::FE::CellType::pyramid5>(
+            target_ele, xgl, xi, converged);
       else
         FOUR_C_THROW("ERROR: Shape function not supported!");
 
       if (converged == true)
       {
-        if (mele.shape() == Core::FE::CellType::hex8 or mele.shape() == Core::FE::CellType::hex20 or
-            mele.shape() == Core::FE::CellType::hex27)
+        if (target_ele.shape() == Core::FE::CellType::hex8 or
+            target_ele.shape() == Core::FE::CellType::hex20 or
+            target_ele.shape() == Core::FE::CellType::hex27)
         {
           if (xi[0] > -1.0 + VOLMORTARCUTTOL) xi0 = true;
           if (xi[1] > -1.0 + VOLMORTARCUTTOL) xi1 = true;
@@ -1952,8 +1926,8 @@ bool Coupling::VolMortar::VolMortarCoupl::check_cut(
           if (xi[2] < 1.0 - VOLMORTARCUTTOL) xi2n = true;
         }
 
-        else if (mele.shape() == Core::FE::CellType::tet4 or
-                 mele.shape() == Core::FE::CellType::tet10)
+        else if (target_ele.shape() == Core::FE::CellType::tet4 or
+                 target_ele.shape() == Core::FE::CellType::tet10)
         {
           if (xi[0] > 0.0 + VOLMORTARCUTTOL) xi0 = true;
           if (xi[1] > 0.0 + VOLMORTARCUTTOL) xi1 = true;
@@ -1965,12 +1939,14 @@ bool Coupling::VolMortar::VolMortarCoupl::check_cut(
       }
     }
 
-    if (mele.shape() == Core::FE::CellType::tet4 or mele.shape() == Core::FE::CellType::tet10)
+    if (target_ele.shape() == Core::FE::CellType::tet4 or
+        target_ele.shape() == Core::FE::CellType::tet10)
     {
       if (!xi0 or !xi1 or !xi2 or !all) return false;
     }
-    else if (mele.shape() == Core::FE::CellType::hex8 or
-             mele.shape() == Core::FE::CellType::hex20 or mele.shape() == Core::FE::CellType::hex27)
+    else if (target_ele.shape() == Core::FE::CellType::hex8 or
+             target_ele.shape() == Core::FE::CellType::hex20 or
+             target_ele.shape() == Core::FE::CellType::hex27)
     {
       if (!xi0 or !xi1 or !xi2 or !xi0n or !xi1n or !xi2n) return false;
     }
@@ -1980,39 +1956,40 @@ bool Coupling::VolMortar::VolMortarCoupl::check_cut(
 
   //--------------------------------------------------------
   // 3. target nodes within source parameter space?
-  for (int u = 0; u < mele.num_node(); ++u)
+  for (int u = 0; u < target_ele.num_node(); ++u)
   {
-    xgl[0] = mele.nodes()[u]->x()[0];
-    xgl[1] = mele.nodes()[u]->x()[1];
-    xgl[2] = mele.nodes()[u]->x()[2];
+    xgl[0] = target_ele.nodes()[u]->x()[0];
+    xgl[1] = target_ele.nodes()[u]->x()[1];
+    xgl[2] = target_ele.nodes()[u]->x()[2];
 
     // global to local:
-    if (sele.shape() == Core::FE::CellType::hex8)
-      Mortar::Utils::global_to_local<Core::FE::CellType::hex8>(sele, xgl, xi, converged);
-    else if (sele.shape() == Core::FE::CellType::hex20)
-      Mortar::Utils::global_to_local<Core::FE::CellType::hex20>(sele, xgl, xi, converged);
-    else if (sele.shape() == Core::FE::CellType::hex27)
-      Mortar::Utils::global_to_local<Core::FE::CellType::hex27>(sele, xgl, xi, converged);
-    else if (sele.shape() == Core::FE::CellType::tet4)
-      Mortar::Utils::global_to_local<Core::FE::CellType::tet4>(sele, xgl, xi, converged);
-    else if (sele.shape() == Core::FE::CellType::tet10)
-      Mortar::Utils::global_to_local<Core::FE::CellType::tet10>(sele, xgl, xi, converged);
-    else if (sele.shape() == Core::FE::CellType::pyramid5)
-      Mortar::Utils::global_to_local<Core::FE::CellType::pyramid5>(sele, xgl, xi, converged);
+    if (source_ele.shape() == Core::FE::CellType::hex8)
+      Mortar::Utils::global_to_local<Core::FE::CellType::hex8>(source_ele, xgl, xi, converged);
+    else if (source_ele.shape() == Core::FE::CellType::hex20)
+      Mortar::Utils::global_to_local<Core::FE::CellType::hex20>(source_ele, xgl, xi, converged);
+    else if (source_ele.shape() == Core::FE::CellType::hex27)
+      Mortar::Utils::global_to_local<Core::FE::CellType::hex27>(source_ele, xgl, xi, converged);
+    else if (source_ele.shape() == Core::FE::CellType::tet4)
+      Mortar::Utils::global_to_local<Core::FE::CellType::tet4>(source_ele, xgl, xi, converged);
+    else if (source_ele.shape() == Core::FE::CellType::tet10)
+      Mortar::Utils::global_to_local<Core::FE::CellType::tet10>(source_ele, xgl, xi, converged);
+    else if (source_ele.shape() == Core::FE::CellType::pyramid5)
+      Mortar::Utils::global_to_local<Core::FE::CellType::pyramid5>(source_ele, xgl, xi, converged);
     else
       FOUR_C_THROW("ERROR: Shape function not supported!");
 
     if (converged == true)
     {
-      if (sele.shape() == Core::FE::CellType::hex8 or sele.shape() == Core::FE::CellType::hex20 or
-          sele.shape() == Core::FE::CellType::hex27)
+      if (source_ele.shape() == Core::FE::CellType::hex8 or
+          source_ele.shape() == Core::FE::CellType::hex20 or
+          source_ele.shape() == Core::FE::CellType::hex27)
       {
         if (abs(xi[0]) < 1.0 - VOLMORTARCUT2TOL and abs(xi[1]) < 1.0 - VOLMORTARCUT2TOL and
             abs(xi[2]) < 1.0 - VOLMORTARCUT2TOL)
           return true;
       }
-      else if (sele.shape() == Core::FE::CellType::tet4 or
-               sele.shape() == Core::FE::CellType::tet10)
+      else if (source_ele.shape() == Core::FE::CellType::tet4 or
+               source_ele.shape() == Core::FE::CellType::tet10)
       {
         if (xi[0] > 0.0 + VOLMORTARCUT2TOL and xi[0] < 1.0 - VOLMORTARCUT2TOL and
             xi[1] > 0.0 + VOLMORTARCUT2TOL and xi[1] < 1.0 - VOLMORTARCUT2TOL and
@@ -2027,39 +2004,40 @@ bool Coupling::VolMortar::VolMortarCoupl::check_cut(
 
   //--------------------------------------------------------
   // 4. source nodes within target parameter space?
-  for (int u = 0; u < sele.num_node(); ++u)
+  for (int u = 0; u < source_ele.num_node(); ++u)
   {
-    xgl[0] = sele.nodes()[u]->x()[0];
-    xgl[1] = sele.nodes()[u]->x()[1];
-    xgl[2] = sele.nodes()[u]->x()[2];
+    xgl[0] = source_ele.nodes()[u]->x()[0];
+    xgl[1] = source_ele.nodes()[u]->x()[1];
+    xgl[2] = source_ele.nodes()[u]->x()[2];
 
     // global to local:
-    if (mele.shape() == Core::FE::CellType::hex8)
-      Mortar::Utils::global_to_local<Core::FE::CellType::hex8>(mele, xgl, xi, converged);
-    else if (mele.shape() == Core::FE::CellType::hex20)
-      Mortar::Utils::global_to_local<Core::FE::CellType::hex20>(mele, xgl, xi, converged);
-    else if (mele.shape() == Core::FE::CellType::hex27)
-      Mortar::Utils::global_to_local<Core::FE::CellType::hex27>(mele, xgl, xi, converged);
-    else if (mele.shape() == Core::FE::CellType::tet4)
-      Mortar::Utils::global_to_local<Core::FE::CellType::tet4>(mele, xgl, xi, converged);
-    else if (mele.shape() == Core::FE::CellType::tet10)
-      Mortar::Utils::global_to_local<Core::FE::CellType::tet10>(mele, xgl, xi, converged);
-    else if (mele.shape() == Core::FE::CellType::pyramid5)
-      Mortar::Utils::global_to_local<Core::FE::CellType::pyramid5>(mele, xgl, xi, converged);
+    if (target_ele.shape() == Core::FE::CellType::hex8)
+      Mortar::Utils::global_to_local<Core::FE::CellType::hex8>(target_ele, xgl, xi, converged);
+    else if (target_ele.shape() == Core::FE::CellType::hex20)
+      Mortar::Utils::global_to_local<Core::FE::CellType::hex20>(target_ele, xgl, xi, converged);
+    else if (target_ele.shape() == Core::FE::CellType::hex27)
+      Mortar::Utils::global_to_local<Core::FE::CellType::hex27>(target_ele, xgl, xi, converged);
+    else if (target_ele.shape() == Core::FE::CellType::tet4)
+      Mortar::Utils::global_to_local<Core::FE::CellType::tet4>(target_ele, xgl, xi, converged);
+    else if (target_ele.shape() == Core::FE::CellType::tet10)
+      Mortar::Utils::global_to_local<Core::FE::CellType::tet10>(target_ele, xgl, xi, converged);
+    else if (target_ele.shape() == Core::FE::CellType::pyramid5)
+      Mortar::Utils::global_to_local<Core::FE::CellType::pyramid5>(target_ele, xgl, xi, converged);
     else
       FOUR_C_THROW("ERROR: Shape function not supported!");
 
     if (converged == true)
     {
-      if (mele.shape() == Core::FE::CellType::hex8 or mele.shape() == Core::FE::CellType::hex20 or
-          mele.shape() == Core::FE::CellType::hex27)
+      if (target_ele.shape() == Core::FE::CellType::hex8 or
+          target_ele.shape() == Core::FE::CellType::hex20 or
+          target_ele.shape() == Core::FE::CellType::hex27)
       {
         if (abs(xi[0]) < 1.0 - VOLMORTARCUT2TOL and abs(xi[1]) < 1.0 - VOLMORTARCUT2TOL and
             abs(xi[2]) < 1.0 - VOLMORTARCUT2TOL)
           return true;
       }
-      else if (mele.shape() == Core::FE::CellType::tet4 or
-               mele.shape() == Core::FE::CellType::tet10)
+      else if (target_ele.shape() == Core::FE::CellType::tet4 or
+               target_ele.shape() == Core::FE::CellType::tet10)
       {
         if (xi[0] > 0.0 + VOLMORTARCUT2TOL and xi[0] < 1.0 - VOLMORTARCUT2TOL and
             xi[1] > 0.0 + VOLMORTARCUT2TOL and xi[1] < 1.0 - VOLMORTARCUT2TOL and
@@ -2078,36 +2056,36 @@ bool Coupling::VolMortar::VolMortarCoupl::check_cut(
 /*----------------------------------------------------------------------*
  |  integrate_2d Cells                                        farah 01/14|
  *----------------------------------------------------------------------*/
-void Coupling::VolMortar::VolMortarCoupl::integrate_2d(Core::Elements::Element& sele,
-    Core::Elements::Element& mele, std::vector<std::shared_ptr<Mortar::IntCell>>& cells)
+void Coupling::VolMortar::VolMortarCoupl::integrate_2d(Core::Elements::Element& source_ele,
+    Core::Elements::Element& target_ele, std::vector<std::shared_ptr<Mortar::IntCell>>& cells)
 {
   //--------------------------------------------------------------------
   // loop over cells for A Field
   // loop over cells
   for (int q = 0; q < (int)cells.size(); ++q)
   {
-    switch (sele.shape())
+    switch (source_ele.shape())
     {
       // 2D surface elements
       case Core::FE::CellType::quad4:
       {
-        switch (mele.shape())
+        switch (target_ele.shape())
         {
           // 2D surface elements
           case Core::FE::CellType::quad4:
           {
             static VolMortarIntegrator<Core::FE::CellType::quad4, Core::FE::CellType::quad4>
                 integrator(params());
-            integrator.integrate_cells_2d(sele, mele, *cells[q], *d1_, *m12_, *dis1_, *dis2_,
-                dofset12_.first, dofset12_.second);
+            integrator.integrate_cells_2d(source_ele, target_ele, *cells[q], *d1_, *m12_, *dis1_,
+                *dis2_, dofset12_.first, dofset12_.second);
             break;
           }
           case Core::FE::CellType::tri3:
           {
             static VolMortarIntegrator<Core::FE::CellType::quad4, Core::FE::CellType::tri3>
                 integrator(params());
-            integrator.integrate_cells_2d(sele, mele, *cells[q], *d1_, *m12_, *dis1_, *dis2_,
-                dofset12_.first, dofset12_.second);
+            integrator.integrate_cells_2d(source_ele, target_ele, *cells[q], *d1_, *m12_, *dis1_,
+                *dis2_, dofset12_.first, dofset12_.second);
             break;
           }
           default:
@@ -2120,23 +2098,23 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_2d(Core::Elements::Element& 
       }
       case Core::FE::CellType::tri3:
       {
-        switch (mele.shape())
+        switch (target_ele.shape())
         {
           // 2D surface elements
           case Core::FE::CellType::quad4:
           {
             static VolMortarIntegrator<Core::FE::CellType::tri3, Core::FE::CellType::quad4>
                 integrator(params());
-            integrator.integrate_cells_2d(sele, mele, *cells[q], *d1_, *m12_, *dis1_, *dis2_,
-                dofset12_.first, dofset12_.second);
+            integrator.integrate_cells_2d(source_ele, target_ele, *cells[q], *d1_, *m12_, *dis1_,
+                *dis2_, dofset12_.first, dofset12_.second);
             break;
           }
           case Core::FE::CellType::tri3:
           {
             static VolMortarIntegrator<Core::FE::CellType::tri3, Core::FE::CellType::tri3>
                 integrator(params());
-            integrator.integrate_cells_2d(sele, mele, *cells[q], *d1_, *m12_, *dis1_, *dis2_,
-                dofset12_.first, dofset12_.second);
+            integrator.integrate_cells_2d(source_ele, target_ele, *cells[q], *d1_, *m12_, *dis1_,
+                *dis2_, dofset12_.first, dofset12_.second);
             break;
           }
           default:
@@ -2156,28 +2134,28 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_2d(Core::Elements::Element& 
 
     //--------------------------------------------------------------------
     // loop over cells for A Field
-    switch (mele.shape())
+    switch (target_ele.shape())
     {
       // 2D surface elements
       case Core::FE::CellType::quad4:
       {
-        switch (sele.shape())
+        switch (source_ele.shape())
         {
           // 2D surface elements
           case Core::FE::CellType::quad4:
           {
             static VolMortarIntegrator<Core::FE::CellType::quad4, Core::FE::CellType::quad4>
                 integrator(params());
-            integrator.integrate_cells_2d(mele, sele, *cells[q], *d2_, *m21_, *dis2_, *dis1_,
-                dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_2d(target_ele, source_ele, *cells[q], *d2_, *m21_, *dis2_,
+                *dis1_, dofset21_.first, dofset21_.second);
             break;
           }
           case Core::FE::CellType::tri3:
           {
             static VolMortarIntegrator<Core::FE::CellType::quad4, Core::FE::CellType::tri3>
                 integrator(params());
-            integrator.integrate_cells_2d(mele, sele, *cells[q], *d2_, *m21_, *dis2_, *dis1_,
-                dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_2d(target_ele, source_ele, *cells[q], *d2_, *m21_, *dis2_,
+                *dis1_, dofset21_.first, dofset21_.second);
             break;
           }
           default:
@@ -2190,23 +2168,23 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_2d(Core::Elements::Element& 
       }
       case Core::FE::CellType::tri3:
       {
-        switch (sele.shape())
+        switch (source_ele.shape())
         {
           // 2D surface elements
           case Core::FE::CellType::quad4:
           {
             static VolMortarIntegrator<Core::FE::CellType::tri3, Core::FE::CellType::quad4>
                 integrator(params());
-            integrator.integrate_cells_2d(mele, sele, *cells[q], *d2_, *m21_, *dis2_, *dis1_,
-                dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_2d(target_ele, source_ele, *cells[q], *d2_, *m21_, *dis2_,
+                *dis1_, dofset21_.first, dofset21_.second);
             break;
           }
           case Core::FE::CellType::tri3:
           {
             static VolMortarIntegrator<Core::FE::CellType::tri3, Core::FE::CellType::tri3>
                 integrator(params());
-            integrator.integrate_cells_2d(mele, sele, *cells[q], *d2_, *m21_, *dis2_, *dis1_,
-                dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_2d(target_ele, source_ele, *cells[q], *d2_, *m21_, *dis2_,
+                *dis1_, dofset21_.first, dofset21_.second);
             break;
           }
           default:
@@ -2224,26 +2202,24 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_2d(Core::Elements::Element& 
       }
     }
   }  // end loop
-
-  return;
 }
 
 /*----------------------------------------------------------------------*
  |  integrate_3d Cells                                        farah 01/14|
  *----------------------------------------------------------------------*/
-void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Element& sele,
-    Core::Elements::Element& mele, std::vector<std::shared_ptr<Cell>>& cells)
+void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Element& source_ele,
+    Core::Elements::Element& target_ele, std::vector<std::shared_ptr<Cell>>& cells)
 {
   //--------------------------------------------------------------------
   // loop over cells for A Field
   for (int q = 0; q < (int)cells.size(); ++q)
   {
-    switch (sele.shape())
+    switch (source_ele.shape())
     {
       // 2D surface elements
       case Core::FE::CellType::hex8:
       {
-        switch (mele.shape())
+        switch (target_ele.shape())
         {
           // 2D surface elements
           case Core::FE::CellType::hex8:
@@ -2251,8 +2227,9 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
             static VolMortarIntegrator<Core::FE::CellType::hex8, Core::FE::CellType::hex8>
                 integrator(params());
             integrator.initialize_gp(false, 0, cells[q]->shape());
-            integrator.integrate_cells_3d(sele, mele, *cells[q], *d1_, *m12_, *d2_, *m21_, *dis1_,
-                *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_3d(source_ele, target_ele, *cells[q], *d1_, *m12_, *d2_,
+                *m21_, *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first,
+                dofset21_.second);
             break;
           }
           case Core::FE::CellType::hex20:
@@ -2260,8 +2237,9 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
             static VolMortarIntegrator<Core::FE::CellType::hex8, Core::FE::CellType::hex20>
                 integrator(params());
             integrator.initialize_gp(false, 0, cells[q]->shape());
-            integrator.integrate_cells_3d(sele, mele, *cells[q], *d1_, *m12_, *d2_, *m21_, *dis1_,
-                *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_3d(source_ele, target_ele, *cells[q], *d1_, *m12_, *d2_,
+                *m21_, *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first,
+                dofset21_.second);
             break;
           }
           case Core::FE::CellType::hex27:
@@ -2269,8 +2247,9 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
             static VolMortarIntegrator<Core::FE::CellType::hex8, Core::FE::CellType::hex27>
                 integrator(params());
             integrator.initialize_gp(false, 0, cells[q]->shape());
-            integrator.integrate_cells_3d(sele, mele, *cells[q], *d1_, *m12_, *d2_, *m21_, *dis1_,
-                *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_3d(source_ele, target_ele, *cells[q], *d1_, *m12_, *d2_,
+                *m21_, *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first,
+                dofset21_.second);
             break;
           }
           case Core::FE::CellType::tet4:
@@ -2278,8 +2257,9 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
             static VolMortarIntegrator<Core::FE::CellType::hex8, Core::FE::CellType::tet4>
                 integrator(params());
             integrator.initialize_gp(false, 0, cells[q]->shape());
-            integrator.integrate_cells_3d(sele, mele, *cells[q], *d1_, *m12_, *d2_, *m21_, *dis1_,
-                *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_3d(source_ele, target_ele, *cells[q], *d1_, *m12_, *d2_,
+                *m21_, *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first,
+                dofset21_.second);
             break;
           }
           case Core::FE::CellType::tet10:
@@ -2287,8 +2267,9 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
             static VolMortarIntegrator<Core::FE::CellType::hex8, Core::FE::CellType::tet10>
                 integrator(params());
             integrator.initialize_gp(false, 0, cells[q]->shape());
-            integrator.integrate_cells_3d(sele, mele, *cells[q], *d1_, *m12_, *d2_, *m21_, *dis1_,
-                *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_3d(source_ele, target_ele, *cells[q], *d1_, *m12_, *d2_,
+                *m21_, *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first,
+                dofset21_.second);
             break;
           }
           case Core::FE::CellType::pyramid5:
@@ -2296,8 +2277,9 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
             static VolMortarIntegrator<Core::FE::CellType::hex8, Core::FE::CellType::pyramid5>
                 integrator(params());
             integrator.initialize_gp(false, 0, cells[q]->shape());
-            integrator.integrate_cells_3d(sele, mele, *cells[q], *d1_, *m12_, *d2_, *m21_, *dis1_,
-                *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_3d(source_ele, target_ele, *cells[q], *d1_, *m12_, *d2_,
+                *m21_, *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first,
+                dofset21_.second);
             break;
           }
           default:
@@ -2311,7 +2293,7 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
       // #######################################################
       case Core::FE::CellType::hex20:
       {
-        switch (mele.shape())
+        switch (target_ele.shape())
         {
           // 2D surface elements
           case Core::FE::CellType::hex8:
@@ -2319,8 +2301,9 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
             static VolMortarIntegrator<Core::FE::CellType::hex20, Core::FE::CellType::hex8>
                 integrator(params());
             integrator.initialize_gp(false, 0, cells[q]->shape());
-            integrator.integrate_cells_3d(sele, mele, *cells[q], *d1_, *m12_, *d2_, *m21_, *dis1_,
-                *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_3d(source_ele, target_ele, *cells[q], *d1_, *m12_, *d2_,
+                *m21_, *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first,
+                dofset21_.second);
             break;
           }
           case Core::FE::CellType::hex20:
@@ -2328,8 +2311,9 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
             static VolMortarIntegrator<Core::FE::CellType::hex20, Core::FE::CellType::hex20>
                 integrator(params());
             integrator.initialize_gp(false, 0, cells[q]->shape());
-            integrator.integrate_cells_3d(sele, mele, *cells[q], *d1_, *m12_, *d2_, *m21_, *dis1_,
-                *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_3d(source_ele, target_ele, *cells[q], *d1_, *m12_, *d2_,
+                *m21_, *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first,
+                dofset21_.second);
             break;
           }
           case Core::FE::CellType::hex27:
@@ -2337,8 +2321,9 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
             static VolMortarIntegrator<Core::FE::CellType::hex20, Core::FE::CellType::hex27>
                 integrator(params());
             integrator.initialize_gp(false, 0, cells[q]->shape());
-            integrator.integrate_cells_3d(sele, mele, *cells[q], *d1_, *m12_, *d2_, *m21_, *dis1_,
-                *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_3d(source_ele, target_ele, *cells[q], *d1_, *m12_, *d2_,
+                *m21_, *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first,
+                dofset21_.second);
             break;
           }
           case Core::FE::CellType::tet4:
@@ -2346,8 +2331,9 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
             static VolMortarIntegrator<Core::FE::CellType::hex20, Core::FE::CellType::tet4>
                 integrator(params());
             integrator.initialize_gp(false, 0, cells[q]->shape());
-            integrator.integrate_cells_3d(sele, mele, *cells[q], *d1_, *m12_, *d2_, *m21_, *dis1_,
-                *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_3d(source_ele, target_ele, *cells[q], *d1_, *m12_, *d2_,
+                *m21_, *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first,
+                dofset21_.second);
             break;
           }
           case Core::FE::CellType::tet10:
@@ -2355,8 +2341,9 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
             static VolMortarIntegrator<Core::FE::CellType::hex20, Core::FE::CellType::tet10>
                 integrator(params());
             integrator.initialize_gp(false, 0, cells[q]->shape());
-            integrator.integrate_cells_3d(sele, mele, *cells[q], *d1_, *m12_, *d2_, *m21_, *dis1_,
-                *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_3d(source_ele, target_ele, *cells[q], *d1_, *m12_, *d2_,
+                *m21_, *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first,
+                dofset21_.second);
             break;
           }
           case Core::FE::CellType::pyramid5:
@@ -2364,8 +2351,9 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
             static VolMortarIntegrator<Core::FE::CellType::hex20, Core::FE::CellType::pyramid5>
                 integrator(params());
             integrator.initialize_gp(false, 0, cells[q]->shape());
-            integrator.integrate_cells_3d(sele, mele, *cells[q], *d1_, *m12_, *d2_, *m21_, *dis1_,
-                *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_3d(source_ele, target_ele, *cells[q], *d1_, *m12_, *d2_,
+                *m21_, *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first,
+                dofset21_.second);
             break;
           }
           default:
@@ -2379,7 +2367,7 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
       // #######################################################
       case Core::FE::CellType::hex27:
       {
-        switch (mele.shape())
+        switch (target_ele.shape())
         {
           // 2D surface elements
           case Core::FE::CellType::hex8:
@@ -2387,8 +2375,9 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
             static VolMortarIntegrator<Core::FE::CellType::hex27, Core::FE::CellType::hex8>
                 integrator(params());
             integrator.initialize_gp(false, 0, cells[q]->shape());
-            integrator.integrate_cells_3d(sele, mele, *cells[q], *d1_, *m12_, *d2_, *m21_, *dis1_,
-                *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_3d(source_ele, target_ele, *cells[q], *d1_, *m12_, *d2_,
+                *m21_, *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first,
+                dofset21_.second);
             break;
           }
           case Core::FE::CellType::hex20:
@@ -2396,8 +2385,9 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
             static VolMortarIntegrator<Core::FE::CellType::hex27, Core::FE::CellType::hex20>
                 integrator(params());
             integrator.initialize_gp(false, 0, cells[q]->shape());
-            integrator.integrate_cells_3d(sele, mele, *cells[q], *d1_, *m12_, *d2_, *m21_, *dis1_,
-                *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_3d(source_ele, target_ele, *cells[q], *d1_, *m12_, *d2_,
+                *m21_, *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first,
+                dofset21_.second);
             break;
           }
           case Core::FE::CellType::hex27:
@@ -2405,8 +2395,9 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
             static VolMortarIntegrator<Core::FE::CellType::hex27, Core::FE::CellType::hex27>
                 integrator(params());
             integrator.initialize_gp(false, 0, cells[q]->shape());
-            integrator.integrate_cells_3d(sele, mele, *cells[q], *d1_, *m12_, *d2_, *m21_, *dis1_,
-                *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_3d(source_ele, target_ele, *cells[q], *d1_, *m12_, *d2_,
+                *m21_, *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first,
+                dofset21_.second);
             break;
           }
           case Core::FE::CellType::tet4:
@@ -2414,8 +2405,9 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
             static VolMortarIntegrator<Core::FE::CellType::hex27, Core::FE::CellType::tet4>
                 integrator(params());
             integrator.initialize_gp(false, 0, cells[q]->shape());
-            integrator.integrate_cells_3d(sele, mele, *cells[q], *d1_, *m12_, *d2_, *m21_, *dis1_,
-                *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_3d(source_ele, target_ele, *cells[q], *d1_, *m12_, *d2_,
+                *m21_, *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first,
+                dofset21_.second);
             break;
           }
           case Core::FE::CellType::tet10:
@@ -2423,8 +2415,9 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
             static VolMortarIntegrator<Core::FE::CellType::hex27, Core::FE::CellType::tet10>
                 integrator(params());
             integrator.initialize_gp(false, 0, cells[q]->shape());
-            integrator.integrate_cells_3d(sele, mele, *cells[q], *d1_, *m12_, *d2_, *m21_, *dis1_,
-                *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_3d(source_ele, target_ele, *cells[q], *d1_, *m12_, *d2_,
+                *m21_, *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first,
+                dofset21_.second);
             break;
           }
           case Core::FE::CellType::pyramid5:
@@ -2432,8 +2425,9 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
             static VolMortarIntegrator<Core::FE::CellType::hex27, Core::FE::CellType::pyramid5>
                 integrator(params());
             integrator.initialize_gp(false, 0, cells[q]->shape());
-            integrator.integrate_cells_3d(sele, mele, *cells[q], *d1_, *m12_, *d2_, *m21_, *dis1_,
-                *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_3d(source_ele, target_ele, *cells[q], *d1_, *m12_, *d2_,
+                *m21_, *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first,
+                dofset21_.second);
             break;
           }
           default:
@@ -2447,7 +2441,7 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
       // #######################################################
       case Core::FE::CellType::tet4:
       {
-        switch (mele.shape())
+        switch (target_ele.shape())
         {
           // 2D surface elements
           case Core::FE::CellType::hex8:
@@ -2455,8 +2449,9 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
             static VolMortarIntegrator<Core::FE::CellType::tet4, Core::FE::CellType::hex8>
                 integrator(params());
             integrator.initialize_gp(false, 0, cells[q]->shape());
-            integrator.integrate_cells_3d(sele, mele, *cells[q], *d1_, *m12_, *d2_, *m21_, *dis1_,
-                *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_3d(source_ele, target_ele, *cells[q], *d1_, *m12_, *d2_,
+                *m21_, *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first,
+                dofset21_.second);
             break;
           }
           case Core::FE::CellType::hex20:
@@ -2464,8 +2459,9 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
             static VolMortarIntegrator<Core::FE::CellType::tet4, Core::FE::CellType::hex20>
                 integrator(params());
             integrator.initialize_gp(false, 0, cells[q]->shape());
-            integrator.integrate_cells_3d(sele, mele, *cells[q], *d1_, *m12_, *d2_, *m21_, *dis1_,
-                *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_3d(source_ele, target_ele, *cells[q], *d1_, *m12_, *d2_,
+                *m21_, *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first,
+                dofset21_.second);
             break;
           }
           case Core::FE::CellType::hex27:
@@ -2473,8 +2469,9 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
             static VolMortarIntegrator<Core::FE::CellType::tet4, Core::FE::CellType::hex27>
                 integrator(params());
             integrator.initialize_gp(false, 0, cells[q]->shape());
-            integrator.integrate_cells_3d(sele, mele, *cells[q], *d1_, *m12_, *d2_, *m21_, *dis1_,
-                *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_3d(source_ele, target_ele, *cells[q], *d1_, *m12_, *d2_,
+                *m21_, *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first,
+                dofset21_.second);
             break;
           }
           case Core::FE::CellType::tet4:
@@ -2482,8 +2479,9 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
             static VolMortarIntegrator<Core::FE::CellType::tet4, Core::FE::CellType::tet4>
                 integrator(params());
             integrator.initialize_gp(false, 0, cells[q]->shape());
-            integrator.integrate_cells_3d(sele, mele, *cells[q], *d1_, *m12_, *d2_, *m21_, *dis1_,
-                *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_3d(source_ele, target_ele, *cells[q], *d1_, *m12_, *d2_,
+                *m21_, *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first,
+                dofset21_.second);
             break;
           }
           case Core::FE::CellType::tet10:
@@ -2491,8 +2489,9 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
             static VolMortarIntegrator<Core::FE::CellType::tet4, Core::FE::CellType::tet10>
                 integrator(params());
             integrator.initialize_gp(false, 0, cells[q]->shape());
-            integrator.integrate_cells_3d(sele, mele, *cells[q], *d1_, *m12_, *d2_, *m21_, *dis1_,
-                *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_3d(source_ele, target_ele, *cells[q], *d1_, *m12_, *d2_,
+                *m21_, *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first,
+                dofset21_.second);
             break;
           }
           case Core::FE::CellType::pyramid5:
@@ -2500,8 +2499,9 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
             static VolMortarIntegrator<Core::FE::CellType::tet4, Core::FE::CellType::pyramid5>
                 integrator(params());
             integrator.initialize_gp(false, 0, cells[q]->shape());
-            integrator.integrate_cells_3d(sele, mele, *cells[q], *d1_, *m12_, *d2_, *m21_, *dis1_,
-                *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_3d(source_ele, target_ele, *cells[q], *d1_, *m12_, *d2_,
+                *m21_, *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first,
+                dofset21_.second);
             break;
           }
           default:
@@ -2515,7 +2515,7 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
       // #######################################################
       case Core::FE::CellType::tet10:
       {
-        switch (mele.shape())
+        switch (target_ele.shape())
         {
           // 2D surface elements
           case Core::FE::CellType::hex8:
@@ -2523,8 +2523,9 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
             static VolMortarIntegrator<Core::FE::CellType::tet10, Core::FE::CellType::hex8>
                 integrator(params());
             integrator.initialize_gp(false, 0, cells[q]->shape());
-            integrator.integrate_cells_3d(sele, mele, *cells[q], *d1_, *m12_, *d2_, *m21_, *dis1_,
-                *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_3d(source_ele, target_ele, *cells[q], *d1_, *m12_, *d2_,
+                *m21_, *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first,
+                dofset21_.second);
             break;
           }
           case Core::FE::CellType::hex20:
@@ -2532,8 +2533,9 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
             static VolMortarIntegrator<Core::FE::CellType::tet10, Core::FE::CellType::hex20>
                 integrator(params());
             integrator.initialize_gp(false, 0, cells[q]->shape());
-            integrator.integrate_cells_3d(sele, mele, *cells[q], *d1_, *m12_, *d2_, *m21_, *dis1_,
-                *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_3d(source_ele, target_ele, *cells[q], *d1_, *m12_, *d2_,
+                *m21_, *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first,
+                dofset21_.second);
             break;
           }
           case Core::FE::CellType::hex27:
@@ -2541,8 +2543,9 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
             static VolMortarIntegrator<Core::FE::CellType::tet10, Core::FE::CellType::hex27>
                 integrator(params());
             integrator.initialize_gp(false, 0, cells[q]->shape());
-            integrator.integrate_cells_3d(sele, mele, *cells[q], *d1_, *m12_, *d2_, *m21_, *dis1_,
-                *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_3d(source_ele, target_ele, *cells[q], *d1_, *m12_, *d2_,
+                *m21_, *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first,
+                dofset21_.second);
             break;
           }
           case Core::FE::CellType::tet4:
@@ -2550,8 +2553,9 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
             static VolMortarIntegrator<Core::FE::CellType::tet10, Core::FE::CellType::tet4>
                 integrator(params());
             integrator.initialize_gp(false, 0, cells[q]->shape());
-            integrator.integrate_cells_3d(sele, mele, *cells[q], *d1_, *m12_, *d2_, *m21_, *dis1_,
-                *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_3d(source_ele, target_ele, *cells[q], *d1_, *m12_, *d2_,
+                *m21_, *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first,
+                dofset21_.second);
             break;
           }
           case Core::FE::CellType::tet10:
@@ -2559,8 +2563,9 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
             static VolMortarIntegrator<Core::FE::CellType::tet10, Core::FE::CellType::tet10>
                 integrator(params());
             integrator.initialize_gp(false, 0, cells[q]->shape());
-            integrator.integrate_cells_3d(sele, mele, *cells[q], *d1_, *m12_, *d2_, *m21_, *dis1_,
-                *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_3d(source_ele, target_ele, *cells[q], *d1_, *m12_, *d2_,
+                *m21_, *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first,
+                dofset21_.second);
             break;
           }
           case Core::FE::CellType::pyramid5:
@@ -2568,8 +2573,9 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
             static VolMortarIntegrator<Core::FE::CellType::tet10, Core::FE::CellType::pyramid5>
                 integrator(params());
             integrator.initialize_gp(false, 0, cells[q]->shape());
-            integrator.integrate_cells_3d(sele, mele, *cells[q], *d1_, *m12_, *d2_, *m21_, *dis1_,
-                *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_3d(source_ele, target_ele, *cells[q], *d1_, *m12_, *d2_,
+                *m21_, *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first,
+                dofset21_.second);
             break;
           }
           default:
@@ -2583,7 +2589,7 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
       // #######################################################
       case Core::FE::CellType::pyramid5:
       {
-        switch (mele.shape())
+        switch (target_ele.shape())
         {
           // 2D surface elements
           case Core::FE::CellType::hex8:
@@ -2591,8 +2597,9 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
             static VolMortarIntegrator<Core::FE::CellType::pyramid5, Core::FE::CellType::hex8>
                 integrator(params());
             integrator.initialize_gp(false, 0, cells[q]->shape());
-            integrator.integrate_cells_3d(sele, mele, *cells[q], *d1_, *m12_, *d2_, *m21_, *dis1_,
-                *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_3d(source_ele, target_ele, *cells[q], *d1_, *m12_, *d2_,
+                *m21_, *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first,
+                dofset21_.second);
             break;
           }
           case Core::FE::CellType::hex20:
@@ -2600,8 +2607,9 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
             static VolMortarIntegrator<Core::FE::CellType::pyramid5, Core::FE::CellType::hex20>
                 integrator(params());
             integrator.initialize_gp(false, 0, cells[q]->shape());
-            integrator.integrate_cells_3d(sele, mele, *cells[q], *d1_, *m12_, *d2_, *m21_, *dis1_,
-                *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_3d(source_ele, target_ele, *cells[q], *d1_, *m12_, *d2_,
+                *m21_, *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first,
+                dofset21_.second);
             break;
           }
           case Core::FE::CellType::hex27:
@@ -2609,8 +2617,9 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
             static VolMortarIntegrator<Core::FE::CellType::pyramid5, Core::FE::CellType::hex27>
                 integrator(params());
             integrator.initialize_gp(false, 0, cells[q]->shape());
-            integrator.integrate_cells_3d(sele, mele, *cells[q], *d1_, *m12_, *d2_, *m21_, *dis1_,
-                *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_3d(source_ele, target_ele, *cells[q], *d1_, *m12_, *d2_,
+                *m21_, *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first,
+                dofset21_.second);
             break;
           }
           case Core::FE::CellType::tet4:
@@ -2618,8 +2627,9 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
             static VolMortarIntegrator<Core::FE::CellType::pyramid5, Core::FE::CellType::tet4>
                 integrator(params());
             integrator.initialize_gp(false, 0, cells[q]->shape());
-            integrator.integrate_cells_3d(sele, mele, *cells[q], *d1_, *m12_, *d2_, *m21_, *dis1_,
-                *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_3d(source_ele, target_ele, *cells[q], *d1_, *m12_, *d2_,
+                *m21_, *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first,
+                dofset21_.second);
             break;
           }
           case Core::FE::CellType::tet10:
@@ -2627,8 +2637,9 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
             static VolMortarIntegrator<Core::FE::CellType::pyramid5, Core::FE::CellType::tet10>
                 integrator(params());
             integrator.initialize_gp(false, 0, cells[q]->shape());
-            integrator.integrate_cells_3d(sele, mele, *cells[q], *d1_, *m12_, *d2_, *m21_, *dis1_,
-                *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_3d(source_ele, target_ele, *cells[q], *d1_, *m12_, *d2_,
+                *m21_, *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first,
+                dofset21_.second);
             break;
           }
           case Core::FE::CellType::pyramid5:
@@ -2636,8 +2647,9 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
             static VolMortarIntegrator<Core::FE::CellType::pyramid5, Core::FE::CellType::pyramid5>
                 integrator(params());
             integrator.initialize_gp(false, 0, cells[q]->shape());
-            integrator.integrate_cells_3d(sele, mele, *cells[q], *d1_, *m12_, *d2_, *m21_, *dis1_,
-                *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+            integrator.integrate_cells_3d(source_ele, target_ele, *cells[q], *d1_, *m12_, *d2_,
+                *m21_, *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first,
+                dofset21_.second);
             break;
           }
           default:
@@ -2655,7 +2667,6 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell(Core::Elements::Elem
       }
     }
   }  // end cell loop
-  return;
 }
 
 /*----------------------------------------------------------------------*
@@ -2762,8 +2773,6 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_ele_based_p12(
       break;
     }
   }
-
-  return;
 }
 
 /*----------------------------------------------------------------------*
@@ -2870,7 +2879,6 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_ele_based_p21(
       break;
     }
   }
-  return;
 }
 
 /*----------------------------------------------------------------------*
@@ -2936,8 +2944,6 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_ele_based_a_dis_mesh_init
       break;
     }
   }
-
-  return;
 }
 
 /*----------------------------------------------------------------------*
@@ -3003,7 +3009,6 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_ele_based_b_dis_mesh_init
       break;
     }
   }
-  return;
 }
 
 /*----------------------------------------------------------------------*
@@ -3015,8 +3020,6 @@ void Coupling::VolMortar::VolMortarCoupl::assemble_consistent_interpolation_p12(
   static ConsInterpolator interpolator;
   interpolator.interpolate(
       node, *p12_, *dis1_, *dis2_, foundeles, dofset12_, *p12_dofrowmap_, *p12_dofcolmap_);
-
-  return;
 }
 
 /*----------------------------------------------------------------------*
@@ -3028,15 +3031,13 @@ void Coupling::VolMortar::VolMortarCoupl::assemble_consistent_interpolation_p21(
   static ConsInterpolator interpolator;
   interpolator.interpolate(
       node, *p21_, *dis2_, *dis1_, foundeles, dofset21_, *p21_dofrowmap_, *p21_dofcolmap_);
-
-  return;
 }
 
 /*----------------------------------------------------------------------*
  |  integrate_3d Cells for direct divergence approach         farah 04/14|
  *----------------------------------------------------------------------*/
 void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell_direct_divergence(
-    Core::Elements::Element& sele, Core::Elements::Element& mele, bool switched_conf)
+    Core::Elements::Element& source_ele, Core::Elements::Element& target_ele, bool switched_conf)
 {
   if ((int)(volcell_.size()) > 1)
     std::cout << "****************************   CELL SIZE > 1 ***************************"
@@ -3056,19 +3057,19 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell_direct_divergence(
     //--------------------------------------------------------------------
     // loop over cells for A Field
 
-    switch (sele.shape())
+    switch (source_ele.shape())
     {
       // 2D surface elements
       case Core::FE::CellType::hex8:
       {
-        switch (mele.shape())
+        switch (target_ele.shape())
         {
           // 2D surface elements
           case Core::FE::CellType::hex8:
           {
             static VolMortarIntegrator<Core::FE::CellType::hex8, Core::FE::CellType::hex8>
                 integrator(params());
-            integrator.integrate_cells_3d_direct_diveregence(sele, mele, *vc, intpoints,
+            integrator.integrate_cells_3d_direct_diveregence(source_ele, target_ele, *vc, intpoints,
                 switched_conf, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_, dofset12_.first,
                 dofset12_.second, dofset21_.first, dofset21_.second);
             break;
@@ -3077,7 +3078,7 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell_direct_divergence(
           {
             static VolMortarIntegrator<Core::FE::CellType::hex8, Core::FE::CellType::tet4>
                 integrator(params());
-            integrator.integrate_cells_3d_direct_diveregence(sele, mele, *vc, intpoints,
+            integrator.integrate_cells_3d_direct_diveregence(source_ele, target_ele, *vc, intpoints,
                 switched_conf, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_, dofset12_.first,
                 dofset12_.second, dofset21_.first, dofset21_.second);
             break;
@@ -3086,7 +3087,7 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell_direct_divergence(
           {
             static VolMortarIntegrator<Core::FE::CellType::hex8, Core::FE::CellType::pyramid5>
                 integrator(params());
-            integrator.integrate_cells_3d_direct_diveregence(sele, mele, *vc, intpoints,
+            integrator.integrate_cells_3d_direct_diveregence(source_ele, target_ele, *vc, intpoints,
                 switched_conf, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_, dofset12_.first,
                 dofset12_.second, dofset21_.first, dofset21_.second);
             break;
@@ -3101,14 +3102,14 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell_direct_divergence(
       }
       case Core::FE::CellType::tet4:
       {
-        switch (mele.shape())
+        switch (target_ele.shape())
         {
           // 2D surface elements
           case Core::FE::CellType::hex8:
           {
             static VolMortarIntegrator<Core::FE::CellType::tet4, Core::FE::CellType::hex8>
                 integrator(params());
-            integrator.integrate_cells_3d_direct_diveregence(sele, mele, *vc, intpoints,
+            integrator.integrate_cells_3d_direct_diveregence(source_ele, target_ele, *vc, intpoints,
                 switched_conf, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_, dofset12_.first,
                 dofset12_.second, dofset21_.first, dofset21_.second);
             break;
@@ -3117,7 +3118,7 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell_direct_divergence(
           {
             static VolMortarIntegrator<Core::FE::CellType::tet4, Core::FE::CellType::tet4>
                 integrator(params());
-            integrator.integrate_cells_3d_direct_diveregence(sele, mele, *vc, intpoints,
+            integrator.integrate_cells_3d_direct_diveregence(source_ele, target_ele, *vc, intpoints,
                 switched_conf, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_, dofset12_.first,
                 dofset12_.second, dofset21_.first, dofset21_.second);
             break;
@@ -3126,7 +3127,7 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell_direct_divergence(
           {
             static VolMortarIntegrator<Core::FE::CellType::tet4, Core::FE::CellType::pyramid5>
                 integrator(params());
-            integrator.integrate_cells_3d_direct_diveregence(sele, mele, *vc, intpoints,
+            integrator.integrate_cells_3d_direct_diveregence(source_ele, target_ele, *vc, intpoints,
                 switched_conf, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_, dofset12_.first,
                 dofset12_.second, dofset21_.first, dofset21_.second);
             break;
@@ -3141,14 +3142,14 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell_direct_divergence(
       }
       case Core::FE::CellType::pyramid5:
       {
-        switch (mele.shape())
+        switch (target_ele.shape())
         {
           // 2D surface elements
           case Core::FE::CellType::hex8:
           {
             static VolMortarIntegrator<Core::FE::CellType::pyramid5, Core::FE::CellType::hex8>
                 integrator(params());
-            integrator.integrate_cells_3d_direct_diveregence(sele, mele, *vc, intpoints,
+            integrator.integrate_cells_3d_direct_diveregence(source_ele, target_ele, *vc, intpoints,
                 switched_conf, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_, dofset12_.first,
                 dofset12_.second, dofset21_.first, dofset21_.second);
             break;
@@ -3157,7 +3158,7 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell_direct_divergence(
           {
             static VolMortarIntegrator<Core::FE::CellType::pyramid5, Core::FE::CellType::tet4>
                 integrator(params());
-            integrator.integrate_cells_3d_direct_diveregence(sele, mele, *vc, intpoints,
+            integrator.integrate_cells_3d_direct_diveregence(source_ele, target_ele, *vc, intpoints,
                 switched_conf, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_, dofset12_.first,
                 dofset12_.second, dofset21_.first, dofset21_.second);
             break;
@@ -3166,7 +3167,7 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell_direct_divergence(
           {
             static VolMortarIntegrator<Core::FE::CellType::pyramid5, Core::FE::CellType::pyramid5>
                 integrator(params());
-            integrator.integrate_cells_3d_direct_diveregence(sele, mele, *vc, intpoints,
+            integrator.integrate_cells_3d_direct_diveregence(source_ele, target_ele, *vc, intpoints,
                 switched_conf, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_, dofset12_.first,
                 dofset12_.second, dofset21_.first, dofset21_.second);
             break;
@@ -3186,24 +3187,22 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d_cell_direct_divergence(
       }
     }
   }
-
-  return;
 }
 
 /*----------------------------------------------------------------------*
  |  Integrate over A-element domain                          farah 01/14|
  *----------------------------------------------------------------------*/
 void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
-    Core::Elements::Element& sele, Core::Elements::Element& mele, int domain)
+    Core::Elements::Element& source_ele, Core::Elements::Element& target_ele, int domain)
 {
   //--------------------------------------------------------------------
   // loop over cells for A Field
-  switch (sele.shape())
+  switch (source_ele.shape())
   {
     // 2D surface elements
     case Core::FE::CellType::hex8:
     {
-      switch (mele.shape())
+      switch (target_ele.shape())
       {
         // 2D surface elements
         case Core::FE::CellType::hex8:
@@ -3211,8 +3210,8 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
           static VolMortarIntegrator<Core::FE::CellType::hex8, Core::FE::CellType::hex8> integrator(
               params());
           integrator.initialize_gp(true, domain);
-          integrator.integrate_ele_3d(domain, sele, mele, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_,
-              dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+          integrator.integrate_ele_3d(domain, source_ele, target_ele, *d1_, *m12_, *d2_, *m21_,
+              *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
           break;
         }
         case Core::FE::CellType::hex20:
@@ -3220,8 +3219,8 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
           static VolMortarIntegrator<Core::FE::CellType::hex8, Core::FE::CellType::hex20>
               integrator(params());
           integrator.initialize_gp(true, domain);
-          integrator.integrate_ele_3d(domain, sele, mele, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_,
-              dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+          integrator.integrate_ele_3d(domain, source_ele, target_ele, *d1_, *m12_, *d2_, *m21_,
+              *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
           break;
         }
         case Core::FE::CellType::hex27:
@@ -3229,8 +3228,8 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
           static VolMortarIntegrator<Core::FE::CellType::hex8, Core::FE::CellType::hex27>
               integrator(params());
           integrator.initialize_gp(true, domain);
-          integrator.integrate_ele_3d(domain, sele, mele, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_,
-              dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+          integrator.integrate_ele_3d(domain, source_ele, target_ele, *d1_, *m12_, *d2_, *m21_,
+              *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
           break;
         }
         case Core::FE::CellType::tet4:
@@ -3238,8 +3237,8 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
           static VolMortarIntegrator<Core::FE::CellType::hex8, Core::FE::CellType::tet4> integrator(
               params());
           integrator.initialize_gp(true, domain);
-          integrator.integrate_ele_3d(domain, sele, mele, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_,
-              dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+          integrator.integrate_ele_3d(domain, source_ele, target_ele, *d1_, *m12_, *d2_, *m21_,
+              *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
           break;
         }
         case Core::FE::CellType::tet10:
@@ -3247,8 +3246,8 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
           static VolMortarIntegrator<Core::FE::CellType::hex8, Core::FE::CellType::tet10>
               integrator(params());
           integrator.initialize_gp(true, domain);
-          integrator.integrate_ele_3d(domain, sele, mele, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_,
-              dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+          integrator.integrate_ele_3d(domain, source_ele, target_ele, *d1_, *m12_, *d2_, *m21_,
+              *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
           break;
         }
         case Core::FE::CellType::pyramid5:
@@ -3256,8 +3255,8 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
           static VolMortarIntegrator<Core::FE::CellType::hex8, Core::FE::CellType::pyramid5>
               integrator(params());
           integrator.initialize_gp(true, domain);
-          integrator.integrate_ele_3d(domain, sele, mele, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_,
-              dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+          integrator.integrate_ele_3d(domain, source_ele, target_ele, *d1_, *m12_, *d2_, *m21_,
+              *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
           break;
         }
         default:
@@ -3271,7 +3270,7 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
     // ########################################################
     case Core::FE::CellType::hex20:
     {
-      switch (mele.shape())
+      switch (target_ele.shape())
       {
         // 2D surface elements
         case Core::FE::CellType::hex8:
@@ -3279,8 +3278,8 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
           static VolMortarIntegrator<Core::FE::CellType::hex20, Core::FE::CellType::hex8>
               integrator(params());
           integrator.initialize_gp(true, domain);
-          integrator.integrate_ele_3d(domain, sele, mele, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_,
-              dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+          integrator.integrate_ele_3d(domain, source_ele, target_ele, *d1_, *m12_, *d2_, *m21_,
+              *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
           break;
         }
         case Core::FE::CellType::hex20:
@@ -3288,8 +3287,8 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
           static VolMortarIntegrator<Core::FE::CellType::hex20, Core::FE::CellType::hex20>
               integrator(params());
           integrator.initialize_gp(true, domain);
-          integrator.integrate_ele_3d(domain, sele, mele, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_,
-              dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+          integrator.integrate_ele_3d(domain, source_ele, target_ele, *d1_, *m12_, *d2_, *m21_,
+              *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
           break;
         }
         case Core::FE::CellType::hex27:
@@ -3297,8 +3296,8 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
           static VolMortarIntegrator<Core::FE::CellType::hex20, Core::FE::CellType::hex27>
               integrator(params());
           integrator.initialize_gp(true, domain);
-          integrator.integrate_ele_3d(domain, sele, mele, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_,
-              dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+          integrator.integrate_ele_3d(domain, source_ele, target_ele, *d1_, *m12_, *d2_, *m21_,
+              *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
           break;
         }
         case Core::FE::CellType::tet4:
@@ -3306,8 +3305,8 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
           static VolMortarIntegrator<Core::FE::CellType::hex20, Core::FE::CellType::tet4>
               integrator(params());
           integrator.initialize_gp(true, domain);
-          integrator.integrate_ele_3d(domain, sele, mele, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_,
-              dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+          integrator.integrate_ele_3d(domain, source_ele, target_ele, *d1_, *m12_, *d2_, *m21_,
+              *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
           break;
         }
         case Core::FE::CellType::tet10:
@@ -3315,8 +3314,8 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
           static VolMortarIntegrator<Core::FE::CellType::hex20, Core::FE::CellType::tet10>
               integrator(params());
           integrator.initialize_gp(true, domain);
-          integrator.integrate_ele_3d(domain, sele, mele, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_,
-              dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+          integrator.integrate_ele_3d(domain, source_ele, target_ele, *d1_, *m12_, *d2_, *m21_,
+              *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
           break;
         }
         case Core::FE::CellType::pyramid5:
@@ -3324,8 +3323,8 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
           static VolMortarIntegrator<Core::FE::CellType::hex20, Core::FE::CellType::pyramid5>
               integrator(params());
           integrator.initialize_gp(true, domain);
-          integrator.integrate_ele_3d(domain, sele, mele, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_,
-              dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+          integrator.integrate_ele_3d(domain, source_ele, target_ele, *d1_, *m12_, *d2_, *m21_,
+              *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
           break;
         }
         default:
@@ -3339,7 +3338,7 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
     // ########################################################
     case Core::FE::CellType::hex27:
     {
-      switch (mele.shape())
+      switch (target_ele.shape())
       {
         // 2D surface elements
         case Core::FE::CellType::hex8:
@@ -3347,8 +3346,8 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
           static VolMortarIntegrator<Core::FE::CellType::hex27, Core::FE::CellType::hex8>
               integrator(params());
           integrator.initialize_gp(true, domain);
-          integrator.integrate_ele_3d(domain, sele, mele, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_,
-              dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+          integrator.integrate_ele_3d(domain, source_ele, target_ele, *d1_, *m12_, *d2_, *m21_,
+              *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
           break;
         }
         case Core::FE::CellType::hex20:
@@ -3356,8 +3355,8 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
           static VolMortarIntegrator<Core::FE::CellType::hex27, Core::FE::CellType::hex20>
               integrator(params());
           integrator.initialize_gp(true, domain);
-          integrator.integrate_ele_3d(domain, sele, mele, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_,
-              dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+          integrator.integrate_ele_3d(domain, source_ele, target_ele, *d1_, *m12_, *d2_, *m21_,
+              *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
           break;
         }
         case Core::FE::CellType::hex27:
@@ -3365,8 +3364,8 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
           static VolMortarIntegrator<Core::FE::CellType::hex27, Core::FE::CellType::hex27>
               integrator(params());
           integrator.initialize_gp(true, domain);
-          integrator.integrate_ele_3d(domain, sele, mele, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_,
-              dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+          integrator.integrate_ele_3d(domain, source_ele, target_ele, *d1_, *m12_, *d2_, *m21_,
+              *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
           break;
         }
         case Core::FE::CellType::tet4:
@@ -3374,8 +3373,8 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
           static VolMortarIntegrator<Core::FE::CellType::hex27, Core::FE::CellType::tet4>
               integrator(params());
           integrator.initialize_gp(true, domain);
-          integrator.integrate_ele_3d(domain, sele, mele, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_,
-              dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+          integrator.integrate_ele_3d(domain, source_ele, target_ele, *d1_, *m12_, *d2_, *m21_,
+              *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
           break;
         }
         case Core::FE::CellType::tet10:
@@ -3383,8 +3382,8 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
           static VolMortarIntegrator<Core::FE::CellType::hex27, Core::FE::CellType::tet10>
               integrator(params());
           integrator.initialize_gp(true, domain);
-          integrator.integrate_ele_3d(domain, sele, mele, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_,
-              dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+          integrator.integrate_ele_3d(domain, source_ele, target_ele, *d1_, *m12_, *d2_, *m21_,
+              *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
           break;
         }
         case Core::FE::CellType::pyramid5:
@@ -3392,8 +3391,8 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
           static VolMortarIntegrator<Core::FE::CellType::hex27, Core::FE::CellType::pyramid5>
               integrator(params());
           integrator.initialize_gp(true, domain);
-          integrator.integrate_ele_3d(domain, sele, mele, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_,
-              dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+          integrator.integrate_ele_3d(domain, source_ele, target_ele, *d1_, *m12_, *d2_, *m21_,
+              *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
           break;
         }
         default:
@@ -3407,7 +3406,7 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
     // ########################################################
     case Core::FE::CellType::tet4:
     {
-      switch (mele.shape())
+      switch (target_ele.shape())
       {
         // 2D surface elements
         case Core::FE::CellType::hex8:
@@ -3415,8 +3414,8 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
           static VolMortarIntegrator<Core::FE::CellType::tet4, Core::FE::CellType::hex8> integrator(
               params());
           integrator.initialize_gp(true, domain);
-          integrator.integrate_ele_3d(domain, sele, mele, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_,
-              dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+          integrator.integrate_ele_3d(domain, source_ele, target_ele, *d1_, *m12_, *d2_, *m21_,
+              *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
           break;
         }
         case Core::FE::CellType::hex20:
@@ -3424,8 +3423,8 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
           static VolMortarIntegrator<Core::FE::CellType::tet4, Core::FE::CellType::hex20>
               integrator(params());
           integrator.initialize_gp(true, domain);
-          integrator.integrate_ele_3d(domain, sele, mele, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_,
-              dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+          integrator.integrate_ele_3d(domain, source_ele, target_ele, *d1_, *m12_, *d2_, *m21_,
+              *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
           break;
         }
         case Core::FE::CellType::hex27:
@@ -3433,8 +3432,8 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
           static VolMortarIntegrator<Core::FE::CellType::tet4, Core::FE::CellType::hex27>
               integrator(params());
           integrator.initialize_gp(true, domain);
-          integrator.integrate_ele_3d(domain, sele, mele, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_,
-              dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+          integrator.integrate_ele_3d(domain, source_ele, target_ele, *d1_, *m12_, *d2_, *m21_,
+              *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
           break;
         }
         case Core::FE::CellType::tet4:
@@ -3442,8 +3441,8 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
           static VolMortarIntegrator<Core::FE::CellType::tet4, Core::FE::CellType::tet4> integrator(
               params());
           integrator.initialize_gp(true, domain);
-          integrator.integrate_ele_3d(domain, sele, mele, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_,
-              dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+          integrator.integrate_ele_3d(domain, source_ele, target_ele, *d1_, *m12_, *d2_, *m21_,
+              *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
           break;
         }
         case Core::FE::CellType::tet10:
@@ -3451,8 +3450,8 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
           static VolMortarIntegrator<Core::FE::CellType::tet4, Core::FE::CellType::tet10>
               integrator(params());
           integrator.initialize_gp(true, domain);
-          integrator.integrate_ele_3d(domain, sele, mele, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_,
-              dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+          integrator.integrate_ele_3d(domain, source_ele, target_ele, *d1_, *m12_, *d2_, *m21_,
+              *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
           break;
         }
         case Core::FE::CellType::pyramid5:
@@ -3460,8 +3459,8 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
           static VolMortarIntegrator<Core::FE::CellType::tet4, Core::FE::CellType::pyramid5>
               integrator(params());
           integrator.initialize_gp(true, domain);
-          integrator.integrate_ele_3d(domain, sele, mele, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_,
-              dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+          integrator.integrate_ele_3d(domain, source_ele, target_ele, *d1_, *m12_, *d2_, *m21_,
+              *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
           break;
         }
         default:
@@ -3475,7 +3474,7 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
     // ########################################################
     case Core::FE::CellType::tet10:
     {
-      switch (mele.shape())
+      switch (target_ele.shape())
       {
         // 2D surface elements
         case Core::FE::CellType::hex8:
@@ -3483,8 +3482,8 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
           static VolMortarIntegrator<Core::FE::CellType::tet10, Core::FE::CellType::hex8>
               integrator(params());
           integrator.initialize_gp(true, domain);
-          integrator.integrate_ele_3d(domain, sele, mele, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_,
-              dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+          integrator.integrate_ele_3d(domain, source_ele, target_ele, *d1_, *m12_, *d2_, *m21_,
+              *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
           break;
         }
         case Core::FE::CellType::hex20:
@@ -3492,8 +3491,8 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
           static VolMortarIntegrator<Core::FE::CellType::tet10, Core::FE::CellType::hex20>
               integrator(params());
           integrator.initialize_gp(true, domain);
-          integrator.integrate_ele_3d(domain, sele, mele, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_,
-              dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+          integrator.integrate_ele_3d(domain, source_ele, target_ele, *d1_, *m12_, *d2_, *m21_,
+              *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
           break;
         }
         case Core::FE::CellType::hex27:
@@ -3501,8 +3500,8 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
           static VolMortarIntegrator<Core::FE::CellType::tet10, Core::FE::CellType::hex27>
               integrator(params());
           integrator.initialize_gp(true, domain);
-          integrator.integrate_ele_3d(domain, sele, mele, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_,
-              dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+          integrator.integrate_ele_3d(domain, source_ele, target_ele, *d1_, *m12_, *d2_, *m21_,
+              *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
           break;
         }
         case Core::FE::CellType::tet4:
@@ -3510,8 +3509,8 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
           static VolMortarIntegrator<Core::FE::CellType::tet10, Core::FE::CellType::tet4>
               integrator(params());
           integrator.initialize_gp(true, domain);
-          integrator.integrate_ele_3d(domain, sele, mele, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_,
-              dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+          integrator.integrate_ele_3d(domain, source_ele, target_ele, *d1_, *m12_, *d2_, *m21_,
+              *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
           break;
         }
         case Core::FE::CellType::tet10:
@@ -3519,8 +3518,8 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
           static VolMortarIntegrator<Core::FE::CellType::tet10, Core::FE::CellType::tet10>
               integrator(params());
           integrator.initialize_gp(true, domain);
-          integrator.integrate_ele_3d(domain, sele, mele, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_,
-              dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+          integrator.integrate_ele_3d(domain, source_ele, target_ele, *d1_, *m12_, *d2_, *m21_,
+              *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
           break;
         }
         case Core::FE::CellType::pyramid5:
@@ -3528,8 +3527,8 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
           static VolMortarIntegrator<Core::FE::CellType::tet10, Core::FE::CellType::pyramid5>
               integrator(params());
           integrator.initialize_gp(true, domain);
-          integrator.integrate_ele_3d(domain, sele, mele, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_,
-              dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+          integrator.integrate_ele_3d(domain, source_ele, target_ele, *d1_, *m12_, *d2_, *m21_,
+              *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
           break;
         }
         default:
@@ -3543,7 +3542,7 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
     // ########################################################
     case Core::FE::CellType::pyramid5:
     {
-      switch (mele.shape())
+      switch (target_ele.shape())
       {
         // 2D surface elements
         case Core::FE::CellType::hex8:
@@ -3551,8 +3550,8 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
           static VolMortarIntegrator<Core::FE::CellType::pyramid5, Core::FE::CellType::hex8>
               integrator(params());
           integrator.initialize_gp(true, domain);
-          integrator.integrate_ele_3d(domain, sele, mele, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_,
-              dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+          integrator.integrate_ele_3d(domain, source_ele, target_ele, *d1_, *m12_, *d2_, *m21_,
+              *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
           break;
         }
         case Core::FE::CellType::hex20:
@@ -3560,8 +3559,8 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
           static VolMortarIntegrator<Core::FE::CellType::pyramid5, Core::FE::CellType::hex20>
               integrator(params());
           integrator.initialize_gp(true, domain);
-          integrator.integrate_ele_3d(domain, sele, mele, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_,
-              dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+          integrator.integrate_ele_3d(domain, source_ele, target_ele, *d1_, *m12_, *d2_, *m21_,
+              *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
           break;
         }
         case Core::FE::CellType::hex27:
@@ -3569,8 +3568,8 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
           static VolMortarIntegrator<Core::FE::CellType::pyramid5, Core::FE::CellType::hex27>
               integrator(params());
           integrator.initialize_gp(true, domain);
-          integrator.integrate_ele_3d(domain, sele, mele, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_,
-              dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+          integrator.integrate_ele_3d(domain, source_ele, target_ele, *d1_, *m12_, *d2_, *m21_,
+              *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
           break;
         }
         case Core::FE::CellType::tet4:
@@ -3578,8 +3577,8 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
           static VolMortarIntegrator<Core::FE::CellType::pyramid5, Core::FE::CellType::tet4>
               integrator(params());
           integrator.initialize_gp(true, domain);
-          integrator.integrate_ele_3d(domain, sele, mele, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_,
-              dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+          integrator.integrate_ele_3d(domain, source_ele, target_ele, *d1_, *m12_, *d2_, *m21_,
+              *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
           break;
         }
         case Core::FE::CellType::tet10:
@@ -3587,8 +3586,8 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
           static VolMortarIntegrator<Core::FE::CellType::pyramid5, Core::FE::CellType::tet10>
               integrator(params());
           integrator.initialize_gp(true, domain);
-          integrator.integrate_ele_3d(domain, sele, mele, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_,
-              dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+          integrator.integrate_ele_3d(domain, source_ele, target_ele, *d1_, *m12_, *d2_, *m21_,
+              *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
           break;
         }
         case Core::FE::CellType::pyramid5:
@@ -3596,8 +3595,8 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
           static VolMortarIntegrator<Core::FE::CellType::pyramid5, Core::FE::CellType::pyramid5>
               integrator(params());
           integrator.initialize_gp(true, domain);
-          integrator.integrate_ele_3d(domain, sele, mele, *d1_, *m12_, *d2_, *m21_, *dis1_, *dis2_,
-              dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
+          integrator.integrate_ele_3d(domain, source_ele, target_ele, *d1_, *m12_, *d2_, *m21_,
+              *dis1_, *dis2_, dofset12_.first, dofset12_.second, dofset21_.first, dofset21_.second);
           break;
         }
         default:
@@ -3617,8 +3616,6 @@ void Coupling::VolMortar::VolMortarCoupl::integrate_3d(
 
   // integration element counter
   inteles_++;
-
-  return;
 }
 
 /*----------------------------------------------------------------------*
@@ -3645,8 +3642,6 @@ void Coupling::VolMortar::VolMortarCoupl::initialize()
     t1_ = std::make_shared<Core::LinAlg::SparseMatrix>(*p12_dofrowmap_, 10);
     t2_ = std::make_shared<Core::LinAlg::SparseMatrix>(*p21_dofrowmap_, 10);
   }
-
-  return;
 }
 
 /*----------------------------------------------------------------------*
@@ -3667,8 +3662,6 @@ void Coupling::VolMortar::VolMortarCoupl::complete()
     t1_->complete(*p12_dofrowmap_, *p12_dofrowmap_);
     t2_->complete(*p21_dofrowmap_, *p21_dofrowmap_);
   }
-
-  return;
 }
 
 /*----------------------------------------------------------------------*
@@ -3735,8 +3728,6 @@ void Coupling::VolMortar::VolMortarCoupl::create_projection_operator()
     p12_ = aux12;
     p21_ = aux21;
   }
-
-  return;
 }
 
 /*----------------------------------------------------------------------*
@@ -3804,8 +3795,8 @@ void Coupling::VolMortar::VolMortarCoupl::define_vertices_target(
  *----------------------------------------------------------------------*/
 bool Coupling::VolMortar::VolMortarCoupl::polygon_clipping_convex_hull(
     std::vector<Mortar::Vertex>& poly1, std::vector<Mortar::Vertex>& poly2,
-    std::vector<Mortar::Vertex>& respoly, Core::Elements::Element& sele,
-    Core::Elements::Element& mele, double& tol)
+    std::vector<Mortar::Vertex>& respoly, Core::Elements::Element& source_ele,
+    Core::Elements::Element& target_ele, double& tol)
 {
   //**********************************************************************
   // STEP1: Input check
@@ -3942,14 +3933,8 @@ bool Coupling::VolMortar::VolMortarCoupl::polygon_clipping_convex_hull(
       // but instead check if the two elements to be clipped are
       // close to each other at all. If so, then really throw the
       // dserror, if not, simply continue with the next pair!
-      int sid = sele.id();
-      int mid = mele.id();
-      bool nearcheck = true;  // rough_check_nodes();
-      if (nearcheck)
-      {
-        std::cout << "***WARNING*** Input polygon 2 not convex! (S/M-pair: " << sid << "/" << mid
-                  << ")" << std::endl;
-      }
+      std::cout << "***WARNING*** Input polygon 2 not convex! (source-target-pair: "
+                << source_ele.id() << "/" << target_ele.id() << ")" << std::endl;
 
       return false;
     }
@@ -4565,43 +4550,6 @@ bool Coupling::VolMortar::VolMortarCoupl::center_triangulation(
     // get out of here
     return true;
   }
-
-  /*
-   // clip polygon = quadrilateral
-   // no triangulation necessary -> 2 IntCells
-   else if (clipsize==4)
-   {
-   // IntCell 1 vertices = clip polygon vertices 0,1,2
-   Core::LinAlg::SerialDenseMatrix coords(3,3);
-   for (int k=0;k<3;++k)
-   {
-   coords(k,0) = Clip()[0].Coord()[k];
-   coords(k,1) = Clip()[1].Coord()[k];
-   coords(k,2) = Clip()[2].Coord()[k];
-   }
-
-   // create 1st IntCell object and push back
-   Cells().push_back(Teuchos::rcp(new
-   IntCell(0,3,coords,Auxn(),Core::FE::CellType::tri3,
-   linvertex[0],linvertex[1],linvertex[2],get_deriv_auxn())));
-
-   // IntCell vertices = clip polygon vertices 2,3,0
-   for (int k=0;k<3;++k)
-   {
-   coords(k,0) = Clip()[2].Coord()[k];
-   coords(k,1) = Clip()[3].Coord()[k];
-   coords(k,2) = Clip()[0].Coord()[k];
-   }
-
-   // create 2nd IntCell object and push back
-   Cells().push_back(Teuchos::rcp(new
-   IntCell(1,3,coords,Auxn(),Core::FE::CellType::tri3,
-   linvertex[2],linvertex[3],linvertex[0],get_deriv_auxn())));
-
-   // get out of here
-   return true;
-   }
-   */
 
   //**********************************************************************
   // (2) Find center of clipping polygon (centroid formula)

--- a/src/coupling/src/volmortar/4C_coupling_volmortar.hpp
+++ b/src/coupling/src/volmortar/4C_coupling_volmortar.hpp
@@ -213,14 +213,15 @@ namespace Coupling::VolMortar
      \brief check if we need cut (3D)
 
      */
-    virtual bool check_cut(Core::Elements::Element& sele, Core::Elements::Element& mele);
+    virtual bool check_cut(
+        Core::Elements::Element& source_ele, Core::Elements::Element& target_ele);
 
     /*!
      \brief check if we can integrate element-wise (3D)
 
      */
     virtual bool check_ele_integration(
-        Core::Elements::Element& sele, Core::Elements::Element& mele);
+        Core::Elements::Element& source_ele, Core::Elements::Element& target_ele);
 
     /*!
      \brief check initial coupling constraint
@@ -333,15 +334,15 @@ namespace Coupling::VolMortar
      \brief perform 2D integration
 
      */
-    virtual void integrate_2d(Core::Elements::Element& sele, Core::Elements::Element& mele,
-        std::vector<std::shared_ptr<Mortar::IntCell>>& cells);
+    virtual void integrate_2d(Core::Elements::Element& source_ele,
+        Core::Elements::Element& target_ele, std::vector<std::shared_ptr<Mortar::IntCell>>& cells);
 
     /*!
      \brief perform 3D element-wise integration
 
      */
     virtual void integrate_3d(
-        Core::Elements::Element& sele, Core::Elements::Element& mele, int domain);
+        Core::Elements::Element& source_ele, Core::Elements::Element& target_ele, int domain);
 
     /*!
      \brief perform 3D element-wise integration for P12
@@ -374,15 +375,15 @@ namespace Coupling::VolMortar
      \brief perform 3D integration of created cells
 
      */
-    virtual void integrate_3d_cell(Core::Elements::Element& sele, Core::Elements::Element& mele,
-        std::vector<std::shared_ptr<Cell>>& cells);
+    virtual void integrate_3d_cell(Core::Elements::Element& source_ele,
+        Core::Elements::Element& target_ele, std::vector<std::shared_ptr<Cell>>& cells);
 
     /*!
      \brief perform 3D integration of created cells
 
      */
-    virtual void integrate_3d_cell_direct_divergence(
-        Core::Elements::Element& sele, Core::Elements::Element& mele, bool switched_conf = false);
+    virtual void integrate_3d_cell_direct_divergence(Core::Elements::Element& source_ele,
+        Core::Elements::Element& target_ele, bool switched_conf = false);
     /*!
      \brief perform mesh init procedure
 
@@ -399,8 +400,8 @@ namespace Coupling::VolMortar
      \brief perform cut and create integration cells (3D)
 
      */
-    virtual void perform_cut(
-        Core::Elements::Element* sele, Core::Elements::Element* mele, bool switched_conf = false);
+    virtual void perform_cut(Core::Elements::Element* source_ele,
+        Core::Elements::Element* target_ele, bool switched_conf = false);
 
     /*!
      \brief perform 2D polygon clipping
@@ -408,7 +409,7 @@ namespace Coupling::VolMortar
      */
     virtual bool polygon_clipping_convex_hull(std::vector<Mortar::Vertex>& poly1,
         std::vector<Mortar::Vertex>& poly2, std::vector<Mortar::Vertex>& respoly,
-        Core::Elements::Element& sele, Core::Elements::Element& mele, double& tol);
+        Core::Elements::Element& source_ele, Core::Elements::Element& target_ele, double& tol);
 
     /*!
      \brief Output for evaluation status -- progress

--- a/src/coupling/src/volmortar/4C_coupling_volmortar_integrator.cpp
+++ b/src/coupling/src/volmortar/4C_coupling_volmortar_integrator.cpp
@@ -1192,7 +1192,7 @@ void Coupling::VolMortar::VolMortarIntegrator<distype_source,
 
           for (int kdof = 0; kdof < ntarget_dof; ++kdof)
           {
-            int col = Adis.dof(source_dofset_B, target_node, kdof);
+            int col = Adis.dof(target_dofset_B, target_node, kdof);
 
             // multiply the two shape functions
             double prod = lmval_B(j) * source_val_A(k) * jac * weight_out;
@@ -1658,7 +1658,7 @@ bool Coupling::VolMortar::VolMortarIntegrator<distype_source, distype_target>::c
       return false;
     }
   }
-  else if (distype_source == Core::FE::CellType::tri3 || distype_source == Core::FE::CellType::tri6)
+  else if (distype_target == Core::FE::CellType::tri3 || distype_target == Core::FE::CellType::tri6)
   {
     if (target_xi[0] < -tol || target_xi[1] < -tol || target_xi[0] > 1.0 + tol ||
         target_xi[1] > 1.0 + tol || target_xi[0] + target_xi[1] > 1.0 + 2 * tol)

--- a/src/coupling/src/volmortar/4C_coupling_volmortar_integrator.cpp
+++ b/src/coupling/src/volmortar/4C_coupling_volmortar_integrator.cpp
@@ -27,8 +27,8 @@ FOUR_C_NAMESPACE_OPEN
 /*----------------------------------------------------------------------*
  |  ctor (public)                                            farah 02/15|
  *----------------------------------------------------------------------*/
-template <Core::FE::CellType distype_s>
-Coupling::VolMortar::VolMortarIntegratorEleBased<distype_s>::VolMortarIntegratorEleBased(
+template <Core::FE::CellType distype_source>
+Coupling::VolMortar::VolMortarIntegratorEleBased<distype_source>::VolMortarIntegratorEleBased(
     Teuchos::ParameterList& params)
 {
   // get type of quadratic modification
@@ -41,11 +41,11 @@ Coupling::VolMortar::VolMortarIntegratorEleBased<distype_s>::VolMortarIntegrator
 /*----------------------------------------------------------------------*
  |  Initialize gauss points for ele-based integration        farah 02/15|
  *----------------------------------------------------------------------*/
-template <Core::FE::CellType distype_s>
-void Coupling::VolMortar::VolMortarIntegratorEleBased<distype_s>::initialize_gp()
+template <Core::FE::CellType distype_source>
+void Coupling::VolMortar::VolMortarIntegratorEleBased<distype_source>::initialize_gp()
 {
   // init shape of integration domain
-  Core::FE::CellType intshape = distype_s;
+  Core::FE::CellType intshape = distype_source;
 
   //*******************************
   // choose Gauss rule accordingly
@@ -256,9 +256,9 @@ void Coupling::VolMortar::VolMortarIntegratorEleBased<distype_s>::initialize_gp(
 /*----------------------------------------------------------------------*
  |  Initialize gauss points for ele-based integration        farah 02/15|
  *----------------------------------------------------------------------*/
-template <Core::FE::CellType distype_s>
-void Coupling::VolMortar::VolMortarIntegratorEleBased<distype_s>::integrate_ele_based_3d(
-    Core::Elements::Element& sele, std::vector<int>& foundeles, Core::LinAlg::SparseMatrix& D,
+template <Core::FE::CellType distype_source>
+void Coupling::VolMortar::VolMortarIntegratorEleBased<distype_source>::integrate_ele_based_3d(
+    Core::Elements::Element& source_ele, std::vector<int>& foundeles, Core::LinAlg::SparseMatrix& D,
     Core::LinAlg::SparseMatrix& M, const Core::FE::Discretization& Adis,
     const Core::FE::Discretization& Bdis, int dofseta, int dofsetb,
     const Core::LinAlg::Map& PAB_dofrowmap, const Core::LinAlg::Map& PAB_dofcolmap)
@@ -283,14 +283,14 @@ void Coupling::VolMortar::VolMortarIntegratorEleBased<distype_s>::integrate_ele_
     double AuxXi[3] = {0.0, 0.0, 0.0};
 
     // evaluate the integration cell Jacobian
-    jac = Utils::jacobian<distype_s>(eta, sele);
+    jac = Utils::jacobian<distype_source>(eta, source_ele);
 
     // get global Gauss point coordinates
-    Utils::local_to_global<distype_s>(sele, eta, globgp);
+    Utils::local_to_global<distype_source>(source_ele, eta, globgp);
 
     // map gp into A and B para space
     double Axi[3] = {0.0, 0.0, 0.0};
-    Mortar::Utils::global_to_local<distype_s>(sele, globgp, Axi);
+    Mortar::Utils::global_to_local<distype_source>(source_ele, globgp, Axi);
 
     // loop over beles
     for (int found = 0; found < (int)foundeles.size(); ++found)
@@ -308,41 +308,41 @@ void Coupling::VolMortar::VolMortarIntegratorEleBased<distype_s>::integrate_ele_
         //************************************************
         case Core::FE::CellType::tri3:
         {
-          proj = vol_mortar_ele_based_gp<distype_s, Core::FE::CellType::tri3>(sele, Bele, foundeles,
-              found, gpid, jac, wgt, gpdist, Axi, AuxXi, globgp, dualquad_, shape_, D, M, Adis,
-              Bdis, dofseta, dofsetb, PAB_dofrowmap, PAB_dofcolmap);
+          proj = vol_mortar_ele_based_gp<distype_source, Core::FE::CellType::tri3>(source_ele, Bele,
+              foundeles, found, gpid, jac, wgt, gpdist, Axi, AuxXi, globgp, dualquad_, shape_, D, M,
+              Adis, Bdis, dofseta, dofsetb, PAB_dofrowmap, PAB_dofcolmap);
 
           break;
         }
         case Core::FE::CellType::tri6:
         {
-          proj = vol_mortar_ele_based_gp<distype_s, Core::FE::CellType::tri6>(sele, Bele, foundeles,
-              found, gpid, jac, wgt, gpdist, Axi, AuxXi, globgp, dualquad_, shape_, D, M, Adis,
-              Bdis, dofseta, dofsetb, PAB_dofrowmap, PAB_dofcolmap);
+          proj = vol_mortar_ele_based_gp<distype_source, Core::FE::CellType::tri6>(source_ele, Bele,
+              foundeles, found, gpid, jac, wgt, gpdist, Axi, AuxXi, globgp, dualquad_, shape_, D, M,
+              Adis, Bdis, dofseta, dofsetb, PAB_dofrowmap, PAB_dofcolmap);
 
           break;
         }
         case Core::FE::CellType::quad4:
         {
-          proj = vol_mortar_ele_based_gp<distype_s, Core::FE::CellType::quad4>(sele, Bele,
-              foundeles, found, gpid, jac, wgt, gpdist, Axi, AuxXi, globgp, dualquad_, shape_, D, M,
-              Adis, Bdis, dofseta, dofsetb, PAB_dofrowmap, PAB_dofcolmap);
+          proj = vol_mortar_ele_based_gp<distype_source, Core::FE::CellType::quad4>(source_ele,
+              Bele, foundeles, found, gpid, jac, wgt, gpdist, Axi, AuxXi, globgp, dualquad_, shape_,
+              D, M, Adis, Bdis, dofseta, dofsetb, PAB_dofrowmap, PAB_dofcolmap);
 
           break;
         }
         case Core::FE::CellType::quad8:
         {
-          proj = vol_mortar_ele_based_gp<distype_s, Core::FE::CellType::quad8>(sele, Bele,
-              foundeles, found, gpid, jac, wgt, gpdist, Axi, AuxXi, globgp, dualquad_, shape_, D, M,
-              Adis, Bdis, dofseta, dofsetb, PAB_dofrowmap, PAB_dofcolmap);
+          proj = vol_mortar_ele_based_gp<distype_source, Core::FE::CellType::quad8>(source_ele,
+              Bele, foundeles, found, gpid, jac, wgt, gpdist, Axi, AuxXi, globgp, dualquad_, shape_,
+              D, M, Adis, Bdis, dofseta, dofsetb, PAB_dofrowmap, PAB_dofcolmap);
 
           break;
         }
         case Core::FE::CellType::quad9:
         {
-          proj = vol_mortar_ele_based_gp<distype_s, Core::FE::CellType::quad9>(sele, Bele,
-              foundeles, found, gpid, jac, wgt, gpdist, Axi, AuxXi, globgp, dualquad_, shape_, D, M,
-              Adis, Bdis, dofseta, dofsetb, PAB_dofrowmap, PAB_dofcolmap);
+          proj = vol_mortar_ele_based_gp<distype_source, Core::FE::CellType::quad9>(source_ele,
+              Bele, foundeles, found, gpid, jac, wgt, gpdist, Axi, AuxXi, globgp, dualquad_, shape_,
+              D, M, Adis, Bdis, dofseta, dofsetb, PAB_dofrowmap, PAB_dofcolmap);
           break;
         }
         //************************************************
@@ -350,49 +350,49 @@ void Coupling::VolMortar::VolMortarIntegratorEleBased<distype_s>::integrate_ele_
         //************************************************
         case Core::FE::CellType::hex8:
         {
-          proj = vol_mortar_ele_based_gp<distype_s, Core::FE::CellType::hex8>(sele, Bele, foundeles,
-              found, gpid, jac, wgt, gpdist, Axi, AuxXi, globgp, dualquad_, shape_, D, M, Adis,
-              Bdis, dofseta, dofsetb, PAB_dofrowmap, PAB_dofcolmap);
+          proj = vol_mortar_ele_based_gp<distype_source, Core::FE::CellType::hex8>(source_ele, Bele,
+              foundeles, found, gpid, jac, wgt, gpdist, Axi, AuxXi, globgp, dualquad_, shape_, D, M,
+              Adis, Bdis, dofseta, dofsetb, PAB_dofrowmap, PAB_dofcolmap);
 
           break;
         }
         case Core::FE::CellType::hex20:
         {
-          proj = vol_mortar_ele_based_gp<distype_s, Core::FE::CellType::hex20>(sele, Bele,
-              foundeles, found, gpid, jac, wgt, gpdist, Axi, AuxXi, globgp, dualquad_, shape_, D, M,
-              Adis, Bdis, dofseta, dofsetb, PAB_dofrowmap, PAB_dofcolmap);
+          proj = vol_mortar_ele_based_gp<distype_source, Core::FE::CellType::hex20>(source_ele,
+              Bele, foundeles, found, gpid, jac, wgt, gpdist, Axi, AuxXi, globgp, dualquad_, shape_,
+              D, M, Adis, Bdis, dofseta, dofsetb, PAB_dofrowmap, PAB_dofcolmap);
 
           break;
         }
         case Core::FE::CellType::hex27:
         {
-          proj = vol_mortar_ele_based_gp<distype_s, Core::FE::CellType::hex27>(sele, Bele,
-              foundeles, found, gpid, jac, wgt, gpdist, Axi, AuxXi, globgp, dualquad_, shape_, D, M,
-              Adis, Bdis, dofseta, dofsetb, PAB_dofrowmap, PAB_dofcolmap);
+          proj = vol_mortar_ele_based_gp<distype_source, Core::FE::CellType::hex27>(source_ele,
+              Bele, foundeles, found, gpid, jac, wgt, gpdist, Axi, AuxXi, globgp, dualquad_, shape_,
+              D, M, Adis, Bdis, dofseta, dofsetb, PAB_dofrowmap, PAB_dofcolmap);
 
           break;
         }
         case Core::FE::CellType::tet4:
         {
-          proj = vol_mortar_ele_based_gp<distype_s, Core::FE::CellType::tet4>(sele, Bele, foundeles,
-              found, gpid, jac, wgt, gpdist, Axi, AuxXi, globgp, dualquad_, shape_, D, M, Adis,
-              Bdis, dofseta, dofsetb, PAB_dofrowmap, PAB_dofcolmap);
+          proj = vol_mortar_ele_based_gp<distype_source, Core::FE::CellType::tet4>(source_ele, Bele,
+              foundeles, found, gpid, jac, wgt, gpdist, Axi, AuxXi, globgp, dualquad_, shape_, D, M,
+              Adis, Bdis, dofseta, dofsetb, PAB_dofrowmap, PAB_dofcolmap);
 
           break;
         }
         case Core::FE::CellType::tet10:
         {
-          proj = vol_mortar_ele_based_gp<distype_s, Core::FE::CellType::tet10>(sele, Bele,
-              foundeles, found, gpid, jac, wgt, gpdist, Axi, AuxXi, globgp, dualquad_, shape_, D, M,
-              Adis, Bdis, dofseta, dofsetb, PAB_dofrowmap, PAB_dofcolmap);
+          proj = vol_mortar_ele_based_gp<distype_source, Core::FE::CellType::tet10>(source_ele,
+              Bele, foundeles, found, gpid, jac, wgt, gpdist, Axi, AuxXi, globgp, dualquad_, shape_,
+              D, M, Adis, Bdis, dofseta, dofsetb, PAB_dofrowmap, PAB_dofcolmap);
 
           break;
         }
         case Core::FE::CellType::pyramid5:
         {
-          proj = vol_mortar_ele_based_gp<distype_s, Core::FE::CellType::pyramid5>(sele, Bele,
-              foundeles, found, gpid, jac, wgt, gpdist, Axi, AuxXi, globgp, dualquad_, shape_, D, M,
-              Adis, Bdis, dofseta, dofsetb, PAB_dofrowmap, PAB_dofcolmap);
+          proj = vol_mortar_ele_based_gp<distype_source, Core::FE::CellType::pyramid5>(source_ele,
+              Bele, foundeles, found, gpid, jac, wgt, gpdist, Axi, AuxXi, globgp, dualquad_, shape_,
+              D, M, Adis, Bdis, dofseta, dofsetb, PAB_dofrowmap, PAB_dofcolmap);
 
           break;
         }
@@ -410,7 +410,6 @@ void Coupling::VolMortar::VolMortarIntegratorEleBased<distype_s>::integrate_ele_
         continue;
     }  // beles
   }  // end gp loop
-  return;
 }
 
 
@@ -437,29 +436,29 @@ template class Coupling::VolMortar::VolMortarIntegratorEleBased<Core::FE::CellTy
 /*----------------------------------------------------------------------*
  |  gp evaluation                                            farah 02/15|
  *----------------------------------------------------------------------*/
-template <Core::FE::CellType distype_s, Core::FE::CellType distype_m>
-bool Coupling::VolMortar::vol_mortar_ele_based_gp(Core::Elements::Element& sele,
-    Core::Elements::Element* mele, std::vector<int>& foundeles, int& found, int& gpid, double& jac,
-    double& wgt, double& gpdist, double* Axi, double* AuxXi, double* globgp, DualQuad& dq,
-    Shapefcn& shape, Core::LinAlg::SparseMatrix& D, Core::LinAlg::SparseMatrix& M,
+template <Core::FE::CellType distype_source, Core::FE::CellType distype_target>
+bool Coupling::VolMortar::vol_mortar_ele_based_gp(Core::Elements::Element& source_ele,
+    Core::Elements::Element* target_ele, std::vector<int>& foundeles, int& found, int& gpid,
+    double& jac, double& wgt, double& gpdist, double* Axi, double* AuxXi, double* globgp,
+    DualQuad& dq, Shapefcn& shape, Core::LinAlg::SparseMatrix& D, Core::LinAlg::SparseMatrix& M,
     const Core::FE::Discretization& Adis, const Core::FE::Discretization& Bdis, int dofseta,
     int dofsetb, const Core::LinAlg::Map& PAB_dofrowmap, const Core::LinAlg::Map& PAB_dofcolmap)
 {
-  //! ns_: number of source element nodes
-  static const int ns_ = Core::FE::num_nodes(distype_s);
+  //! nsource_: number of source element nodes
+  static const int nsource_ = Core::FE::num_nodes(distype_source);
 
-  //! nm_: number of target element nodes
-  static const int nm_ = Core::FE::num_nodes(distype_m);
+  //! ntarget_: number of target element nodes
+  static const int ntarget_ = Core::FE::num_nodes(distype_target);
 
   // create empty vectors for shape fct. evaluation
-  Core::LinAlg::Matrix<ns_, 1> sval_A;
-  Core::LinAlg::Matrix<nm_, 1> mval_A;
-  Core::LinAlg::Matrix<ns_, 1> lmval_A;
+  Core::LinAlg::Matrix<nsource_, 1> source_val_A;
+  Core::LinAlg::Matrix<ntarget_, 1> target_val_A;
+  Core::LinAlg::Matrix<nsource_, 1> lmval_A;
 
   double Bxi[3] = {0.0, 0.0, 0.0};
 
   bool converged = true;
-  Mortar::Utils::global_to_local<distype_m>(*mele, globgp, Bxi, converged);
+  Mortar::Utils::global_to_local<distype_target>(*target_ele, globgp, Bxi, converged);
   if (!converged and found != ((int)foundeles.size() - 1)) return false;
 
   // save distance of gp
@@ -474,7 +473,7 @@ bool Coupling::VolMortar::vol_mortar_ele_based_gp(Core::Elements::Element& sele,
   }
 
   // Check parameter space mapping
-  bool proj = check_mapping<distype_s, distype_m>(sele, *mele, Axi, Bxi);
+  bool proj = check_mapping<distype_source, distype_target>(source_ele, *target_ele, Axi, Bxi);
 
   // if gp outside continue or eval nearest gp
   if (!proj and (found != ((int)foundeles.size() - 1)))
@@ -484,49 +483,49 @@ bool Coupling::VolMortar::vol_mortar_ele_based_gp(Core::Elements::Element& sele,
     Bxi[0] = AuxXi[0];
     Bxi[1] = AuxXi[1];
     Bxi[2] = AuxXi[2];
-    mele = Bdis.g_element(gpid);
+    target_ele = Bdis.g_element(gpid);
   }
 
   // for "target" side
-  Utils::shape_function<distype_s>(sval_A, Axi, dq);
-  Utils::shape_function<distype_m>(mval_A, Bxi);
+  Utils::shape_function<distype_source>(source_val_A, Axi, dq);
+  Utils::shape_function<distype_target>(target_val_A, Bxi);
 
   // evaluate Lagrange multiplier shape functions (on source element)
-  Utils::dual_shape_function<distype_s>(lmval_A, Axi, sele, dq);
+  Utils::dual_shape_function<distype_source>(lmval_A, Axi, source_ele, dq);
 
   // compute cell D/M matrix ****************************************
   // dual shape functions
-  for (int j = 0; j < ns_; ++j)
+  for (int j = 0; j < nsource_; ++j)
   {
-    Core::Nodes::Node* cnode = sele.nodes()[j];
+    Core::Nodes::Node* cnode = source_ele.nodes()[j];
     if (cnode->owner() != Core::Communication::my_mpi_rank(Adis.get_comm())) continue;
 
-    const int nsdof = Adis.num_dof(dofseta, cnode);
+    const int nsource_dof = Adis.num_dof(dofseta, cnode);
 
     if (shape == shape_std)
     {
-      for (int j = 0; j < ns_; ++j)
+      for (int j = 0; j < nsource_; ++j)
       {
-        Core::Nodes::Node* cnode = sele.nodes()[j];
-        int nsdof = Adis.num_dof(dofseta, cnode);
+        Core::Nodes::Node* cnode = source_ele.nodes()[j];
+        int nsource_dof = Adis.num_dof(dofseta, cnode);
 
         // loop over source dofs
-        for (int jdof = 0; jdof < nsdof; ++jdof)
+        for (int jdof = 0; jdof < nsource_dof; ++jdof)
         {
           int row = Adis.dof(dofseta, cnode, jdof);
 
           // integrate M
-          for (int k = 0; k < nm_; ++k)
+          for (int k = 0; k < ntarget_; ++k)
           {
-            Core::Nodes::Node* mnode = mele->nodes()[k];
-            int nmdof = Bdis.num_dof(dofsetb, mnode);
+            Core::Nodes::Node* target_node = target_ele->nodes()[k];
+            int ntarget_dof = Bdis.num_dof(dofsetb, target_node);
 
-            for (int kdof = 0; kdof < nmdof; ++kdof)
+            for (int kdof = 0; kdof < ntarget_dof; ++kdof)
             {
-              int col = Bdis.dof(dofsetb, mnode, kdof);
+              int col = Bdis.dof(dofsetb, target_node, kdof);
 
               // multiply the two shape functions
-              double prod = sval_A(j) * mval_A(k) * jac * wgt;
+              double prod = source_val_A(j) * target_val_A(k) * jac * wgt;
 
               // dof to dof
               if (jdof == kdof)
@@ -537,15 +536,15 @@ bool Coupling::VolMortar::vol_mortar_ele_based_gp(Core::Elements::Element& sele,
           }
 
           // integrate D
-          for (int k = 0; k < ns_; ++k)
+          for (int k = 0; k < nsource_; ++k)
           {
-            Core::Nodes::Node* snode = sele.nodes()[k];
-            int nddof = Adis.num_dof(dofseta, snode);
+            Core::Nodes::Node* source_node = source_ele.nodes()[k];
+            int nddof = Adis.num_dof(dofseta, source_node);
 
             for (int kdof = 0; kdof < nddof; ++kdof)
             {
               // multiply the two shape functions
-              double prod = sval_A(j) * sval_A(k) * jac * wgt;
+              double prod = source_val_A(j) * source_val_A(k) * jac * wgt;
 
               // dof to dof
               if (jdof == kdof)
@@ -560,26 +559,26 @@ bool Coupling::VolMortar::vol_mortar_ele_based_gp(Core::Elements::Element& sele,
     else if (shape == shape_dual)
     {
       // loop over source dofs
-      for (int jdof = 0; jdof < nsdof; ++jdof)
+      for (int jdof = 0; jdof < nsource_dof; ++jdof)
       {
         const int row = Adis.dof(dofseta, cnode, jdof);
 
         if (not PAB_dofrowmap.my_gid(row)) continue;
 
         // integrate D
-        const double prod2 = lmval_A(j) * sval_A(j) * jac * wgt;
+        const double prod2 = lmval_A(j) * source_val_A(j) * jac * wgt;
         if (abs(prod2) > VOLMORTARINTTOL) D.assemble(prod2, row, row);
 
         // integrate M
-        for (int k = 0; k < nm_; ++k)
+        for (int k = 0; k < ntarget_; ++k)
         {
-          Core::Nodes::Node* mnode = mele->nodes()[k];
-          const int col = Bdis.dof(dofsetb, mnode, jdof);
+          Core::Nodes::Node* target_node = target_ele->nodes()[k];
+          const int col = Bdis.dof(dofsetb, target_node, jdof);
 
           if (not PAB_dofcolmap.my_gid(col)) continue;
 
           // multiply the two shape functions
-          const double prod = lmval_A(j) * mval_A(k) * jac * wgt;
+          const double prod = lmval_A(j) * target_val_A(k) * jac * wgt;
 
           if (abs(prod) > VOLMORTARINTTOL) M.assemble(prod, row, col);
         }
@@ -598,8 +597,8 @@ bool Coupling::VolMortar::vol_mortar_ele_based_gp(Core::Elements::Element& sele,
 /*----------------------------------------------------------------------*
  |  ctor (public)                                            farah 01/14|
  *----------------------------------------------------------------------*/
-template <Core::FE::CellType distype_s, Core::FE::CellType distype_m>
-Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::VolMortarIntegrator(
+template <Core::FE::CellType distype_source, Core::FE::CellType distype_target>
+Coupling::VolMortar::VolMortarIntegrator<distype_source, distype_target>::VolMortarIntegrator(
     Teuchos::ParameterList& params)
 {
   // get type of quadratic modification
@@ -616,8 +615,8 @@ Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::VolMortarIntegra
 /*----------------------------------------------------------------------*
  |  Initialize gauss points                                  farah 01/14|
  *----------------------------------------------------------------------*/
-template <Core::FE::CellType distype_s, Core::FE::CellType distype_m>
-void Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::initialize_gp(
+template <Core::FE::CellType distype_source, Core::FE::CellType distype_target>
+void Coupling::VolMortar::VolMortarIntegrator<distype_source, distype_target>::initialize_gp(
     bool integrateele, int domain, Core::FE::CellType shape)
 {
   // init shape of integration domain
@@ -626,9 +625,9 @@ void Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::initialize_
   if (integrateele)
   {
     if (domain == 0)
-      intshape = distype_s;
+      intshape = distype_source;
     else if (domain == 1)
-      intshape = distype_m;
+      intshape = distype_target;
     else
       FOUR_C_THROW("integration domain not specified!");
   }
@@ -779,17 +778,17 @@ void Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::initialize_
 /*----------------------------------------------------------------------*
  |  Compute D/M entries for Volumetric Mortar                farah 01/14|
  *----------------------------------------------------------------------*/
-template <Core::FE::CellType distype_s, Core::FE::CellType distype_m>
-void Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::integrate_cells_2d(
-    Core::Elements::Element& sele, Core::Elements::Element& mele, Mortar::IntCell& cell,
+template <Core::FE::CellType distype_source, Core::FE::CellType distype_target>
+void Coupling::VolMortar::VolMortarIntegrator<distype_source, distype_target>::integrate_cells_2d(
+    Core::Elements::Element& source_ele, Core::Elements::Element& target_ele, Mortar::IntCell& cell,
     Core::LinAlg::SparseMatrix& dmatrix, Core::LinAlg::SparseMatrix& mmatrix,
     const Core::FE::Discretization& source_dis, const Core::FE::Discretization& target_dis,
-    int sdofset, int mdofset)
+    int source_dofset, int target_dofset)
 {
   // create empty vectors for shape fct. evaluation
-  Core::LinAlg::Matrix<ns_, 1> sval;
-  Core::LinAlg::Matrix<nm_, 1> mval;
-  Core::LinAlg::Matrix<ns_, 1> lmval;
+  Core::LinAlg::Matrix<nsource_, 1> source_val;
+  Core::LinAlg::Matrix<ntarget_, 1> target_val;
+  Core::LinAlg::Matrix<nsource_, 1> lmval;
 
   //**********************************************************************
   // loop over all Gauss points for integration
@@ -805,21 +804,21 @@ void Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::integrate_c
     cell.local_to_global(eta, globgp, 0);
 
     // map gp into source and target para space
-    double sxi[3] = {0.0, 0.0, 0.0};
-    double mxi[3] = {0.0, 0.0, 0.0};
-    Mortar::Utils::global_to_local<distype_s>(sele, globgp, sxi);
-    Mortar::Utils::global_to_local<distype_m>(mele, globgp, mxi);
+    double source_xi[3] = {0.0, 0.0, 0.0};
+    double target_xi[3] = {0.0, 0.0, 0.0};
+    Mortar::Utils::global_to_local<distype_source>(source_ele, globgp, source_xi);
+    Mortar::Utils::global_to_local<distype_target>(target_ele, globgp, target_xi);
 
     // Check parameter space mapping
-    bool proj = check_mapping_2d(sele, mele, sxi, mxi);
+    bool proj = check_mapping_2d(source_ele, target_ele, source_xi, target_xi);
     if (proj == false) FOUR_C_THROW("ERROR: Mapping failed!");
 
     // evaluate trace space shape functions (on both elements)
-    Utils::shape_function<distype_s>(sval, sxi);
-    Utils::shape_function<distype_m>(mval, mxi);
+    Utils::shape_function<distype_source>(source_val, source_xi);
+    Utils::shape_function<distype_target>(target_val, target_xi);
 
     // evaluate Lagrange multiplier shape functions (on source element)
-    Utils::dual_shape_function<distype_s>(lmval, sxi, sele);
+    Utils::dual_shape_function<distype_source>(lmval, source_xi, source_ele);
 
     // evaluate the integration cell Jacobian
     double jac = cell.jacobian();
@@ -828,31 +827,31 @@ void Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::integrate_c
     // standard shape functions
     if (shape_ == shape_std)
     {
-      for (int j = 0; j < ns_; ++j)
+      for (int j = 0; j < nsource_; ++j)
       {
-        Core::Nodes::Node* cnode = sele.nodes()[j];
-        int nsdof = source_dis.num_dof(sdofset, cnode);
+        Core::Nodes::Node* cnode = source_ele.nodes()[j];
+        int nsource_dof = source_dis.num_dof(source_dofset, cnode);
 
         if (cnode->owner() != Core::Communication::my_mpi_rank(source_dis.get_comm())) continue;
 
         // loop over source dofs
-        for (int jdof = 0; jdof < nsdof; ++jdof)
+        for (int jdof = 0; jdof < nsource_dof; ++jdof)
         {
-          int row = source_dis.dof(sdofset, cnode, jdof);
+          int row = source_dis.dof(source_dofset, cnode, jdof);
 
           ////////////////////////////////////////
           // integrate M
-          for (int k = 0; k < nm_; ++k)
+          for (int k = 0; k < ntarget_; ++k)
           {
-            Core::Nodes::Node* mnode = mele.nodes()[k];
-            int nmdof = target_dis.num_dof(mdofset, mnode);
+            Core::Nodes::Node* target_node = target_ele.nodes()[k];
+            int ntarget_dof = target_dis.num_dof(target_dofset, target_node);
 
-            for (int kdof = 0; kdof < nmdof; ++kdof)
+            for (int kdof = 0; kdof < ntarget_dof; ++kdof)
             {
-              int col = target_dis.dof(mdofset, mnode, kdof);
+              int col = target_dis.dof(target_dofset, target_node, kdof);
 
               // multiply the two shape functions
-              double prod = sval(j) * mval(k) * jac * wgt;
+              double prod = source_val(j) * target_val(k) * jac * wgt;
 
               // dof to dof
               if (jdof == kdof)
@@ -864,17 +863,17 @@ void Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::integrate_c
 
           ////////////////////////////////////////
           // integrate D
-          for (int k = 0; k < ns_; ++k)
+          for (int k = 0; k < nsource_; ++k)
           {
-            Core::Nodes::Node* snode = sele.nodes()[k];
-            int nddof = source_dis.num_dof(sdofset, snode);
+            Core::Nodes::Node* source_node = source_ele.nodes()[k];
+            int nddof = source_dis.num_dof(source_dofset, source_node);
 
             for (int kdof = 0; kdof < nddof; ++kdof)
             {
-              // int col = source_dis->Dof(sdofset,snode,kdof);
+              // int col = source_dis->Dof(source_dofset,source_node,kdof);
 
               // multiply the two shape functions
-              double prod = sval(j) * sval(k) * jac * wgt;
+              double prod = source_val(j) * source_val(k) * jac * wgt;
 
               // dof to dof
               if (jdof == kdof)
@@ -888,32 +887,32 @@ void Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::integrate_c
     }
     else if (shape_ == shape_dual)
     {
-      for (int j = 0; j < ns_; ++j)
+      for (int j = 0; j < nsource_; ++j)
       {
-        Core::Nodes::Node* cnode = sele.nodes()[j];
+        Core::Nodes::Node* cnode = source_ele.nodes()[j];
 
         if (cnode->owner() != Core::Communication::my_mpi_rank(source_dis.get_comm())) continue;
 
-        int nsdof = source_dis.num_dof(sdofset, cnode);
+        int nsource_dof = source_dis.num_dof(source_dofset, cnode);
 
         // loop over source dofs
-        for (int jdof = 0; jdof < nsdof; ++jdof)
+        for (int jdof = 0; jdof < nsource_dof; ++jdof)
         {
-          int row = source_dis.dof(sdofset, cnode, jdof);
+          int row = source_dis.dof(source_dofset, cnode, jdof);
 
           ////////////////////////////////////////////////////////////////
           // integrate M and D
-          for (int k = 0; k < nm_; ++k)
+          for (int k = 0; k < ntarget_; ++k)
           {
-            Core::Nodes::Node* mnode = mele.nodes()[k];
-            int nmdof = target_dis.num_dof(mdofset, mnode);
+            Core::Nodes::Node* target_node = target_ele.nodes()[k];
+            int ntarget_dof = target_dis.num_dof(target_dofset, target_node);
 
-            for (int kdof = 0; kdof < nmdof; ++kdof)
+            for (int kdof = 0; kdof < ntarget_dof; ++kdof)
             {
-              int col = target_dis.dof(mdofset, mnode, kdof);
+              int col = target_dis.dof(target_dofset, target_node, kdof);
 
               // multiply the two shape functions
-              double prod = lmval(j) * mval(k) * jac * wgt;
+              double prod = lmval(j) * target_val(k) * jac * wgt;
 
               // dof to dof
               if (jdof == kdof)
@@ -932,29 +931,27 @@ void Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::integrate_c
       FOUR_C_THROW("ERROR: Unknown shape function!");
     }
   }  // end gp loop
-
-  return;
 }
 
 
 /*----------------------------------------------------------------------*
  |  Compute D/M entries for Volumetric Mortar                farah 01/14|
  *----------------------------------------------------------------------*/
-template <Core::FE::CellType distype_s, Core::FE::CellType distype_m>
-void Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::integrate_cells_3d(
+template <Core::FE::CellType distype_source, Core::FE::CellType distype_target>
+void Coupling::VolMortar::VolMortarIntegrator<distype_source, distype_target>::integrate_cells_3d(
     Core::Elements::Element& Aele, Core::Elements::Element& Bele, Coupling::VolMortar::Cell& cell,
     Core::LinAlg::SparseMatrix& dmatrix_A, Core::LinAlg::SparseMatrix& mmatrix_A,
     Core::LinAlg::SparseMatrix& dmatrix_B, Core::LinAlg::SparseMatrix& mmatrix_B,
-    const Core::FE::Discretization& Adis, const Core::FE::Discretization& Bdis, int sdofset_A,
-    int mdofset_A, int sdofset_B, int mdofset_B)
+    const Core::FE::Discretization& Adis, const Core::FE::Discretization& Bdis, int source_dofset_A,
+    int target_dofset_A, int source_dofset_B, int target_dofset_B)
 {
   if (shape_ == shape_std) FOUR_C_THROW("ERROR: std. shape functions not supported");
 
   // create empty vectors for shape fct. evaluation
-  Core::LinAlg::Matrix<ns_, 1> sval_A;
-  Core::LinAlg::Matrix<nm_, 1> mval_A;
-  Core::LinAlg::Matrix<ns_, 1> lmval_A;
-  Core::LinAlg::Matrix<nm_, 1> lmval_B;
+  Core::LinAlg::Matrix<nsource_, 1> source_val_A;
+  Core::LinAlg::Matrix<ntarget_, 1> target_val_A;
+  Core::LinAlg::Matrix<nsource_, 1> lmval_A;
+  Core::LinAlg::Matrix<ntarget_, 1> lmval_B;
 
   //**********************************************************************
   // loop over all Gauss points for integration
@@ -972,8 +969,8 @@ void Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::integrate_c
     // map gp into A and B para space
     double Axi[3] = {0.0, 0.0, 0.0};
     double Bxi[3] = {0.0, 0.0, 0.0};
-    Mortar::Utils::global_to_local<distype_s>(Aele, globgp, Axi);
-    Mortar::Utils::global_to_local<distype_m>(Bele, globgp, Bxi);
+    Mortar::Utils::global_to_local<distype_source>(Aele, globgp, Axi);
+    Mortar::Utils::global_to_local<distype_target>(Bele, globgp, Bxi);
 
     // evaluate the integration cell Jacobian
     double jac = 0.0;
@@ -991,37 +988,37 @@ void Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::integrate_c
     if (!check) continue;
 
     // evaluate trace space shape functions (on both elements)
-    Utils::shape_function<distype_s>(sval_A, Axi);
-    Utils::shape_function<distype_m>(mval_A, Bxi);
+    Utils::shape_function<distype_source>(source_val_A, Axi);
+    Utils::shape_function<distype_target>(target_val_A, Bxi);
 
     // evaluate Lagrange multiplier shape functions (on source element)
-    Utils::dual_shape_function<distype_s>(lmval_A, Axi, Aele, dualquad_);
-    Utils::dual_shape_function<distype_m>(lmval_B, Bxi, Bele, dualquad_);
+    Utils::dual_shape_function<distype_source>(lmval_A, Axi, Aele, dualquad_);
+    Utils::dual_shape_function<distype_target>(lmval_B, Bxi, Bele, dualquad_);
 
     // compute cell D/M matrix ****************************************
     // dual shape functions
-    for (int j = 0; j < ns_; ++j)
+    for (int j = 0; j < nsource_; ++j)
     {
       Core::Nodes::Node* cnode = Aele.nodes()[j];
-      int nsdof = Adis.num_dof(sdofset_A, cnode);
+      int nsource_dof = Adis.num_dof(source_dofset_A, cnode);
 
       // loop over source dofs
-      for (int jdof = 0; jdof < nsdof; ++jdof)
+      for (int jdof = 0; jdof < nsource_dof; ++jdof)
       {
-        int row = Adis.dof(sdofset_A, cnode, jdof);
+        int row = Adis.dof(source_dofset_A, cnode, jdof);
 
         // integrate M and D
-        for (int k = 0; k < nm_; ++k)
+        for (int k = 0; k < ntarget_; ++k)
         {
-          Core::Nodes::Node* mnode = Bele.nodes()[k];
-          int nmdof = Bdis.num_dof(mdofset_A, mnode);
+          Core::Nodes::Node* target_node = Bele.nodes()[k];
+          int ntarget_dof = Bdis.num_dof(target_dofset_A, target_node);
 
-          for (int kdof = 0; kdof < nmdof; ++kdof)
+          for (int kdof = 0; kdof < ntarget_dof; ++kdof)
           {
-            int col = Bdis.dof(mdofset_A, mnode, kdof);
+            int col = Bdis.dof(target_dofset_A, target_node, kdof);
 
             // multiply the two shape functions
-            double prod = lmval_A(j) * mval_A(k) * jac * wgt;
+            double prod = lmval_A(j) * target_val_A(k) * jac * wgt;
 
             // dof to dof
             if (jdof == kdof)
@@ -1036,28 +1033,28 @@ void Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::integrate_c
 
     // compute cell D/M matrix ****************************************
     // dual shape functions
-    for (int j = 0; j < nm_; ++j)
+    for (int j = 0; j < ntarget_; ++j)
     {
       Core::Nodes::Node* cnode = Bele.nodes()[j];
-      int nsdof = Bdis.num_dof(sdofset_B, cnode);
+      int nsource_dof = Bdis.num_dof(source_dofset_B, cnode);
 
       // loop over source dofs
-      for (int jdof = 0; jdof < nsdof; ++jdof)
+      for (int jdof = 0; jdof < nsource_dof; ++jdof)
       {
-        int row = Bdis.dof(sdofset_B, cnode, jdof);
+        int row = Bdis.dof(source_dofset_B, cnode, jdof);
 
         // integrate M and D
-        for (int k = 0; k < ns_; ++k)
+        for (int k = 0; k < nsource_; ++k)
         {
-          Core::Nodes::Node* mnode = Aele.nodes()[k];
-          int nmdof = Adis.num_dof(mdofset_B, mnode);
+          Core::Nodes::Node* target_node = Aele.nodes()[k];
+          int ntarget_dof = Adis.num_dof(target_dofset_B, target_node);
 
-          for (int kdof = 0; kdof < nmdof; ++kdof)
+          for (int kdof = 0; kdof < ntarget_dof; ++kdof)
           {
-            int col = Adis.dof(mdofset_B, mnode, kdof);
+            int col = Adis.dof(target_dofset_B, target_node, kdof);
 
             // multiply the two shape functions
-            double prod = lmval_B(j) * sval_A(k) * jac * wgt;
+            double prod = lmval_B(j) * source_val_A(k) * jac * wgt;
 
             // dof to dof
             if (jdof == kdof)
@@ -1078,23 +1075,23 @@ void Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::integrate_c
 /*----------------------------------------------------------------------*
  |  Compute D/M entries for Volumetric Mortar                farah 04/14|
  *----------------------------------------------------------------------*/
-template <Core::FE::CellType distype_s, Core::FE::CellType distype_m>
-void Coupling::VolMortar::VolMortarIntegrator<distype_s,
-    distype_m>::integrate_cells_3d_direct_diveregence(Core::Elements::Element& Aele,
+template <Core::FE::CellType distype_source, Core::FE::CellType distype_target>
+void Coupling::VolMortar::VolMortarIntegrator<distype_source,
+    distype_target>::integrate_cells_3d_direct_diveregence(Core::Elements::Element& Aele,
     Core::Elements::Element& Bele, Cut::VolumeCell& vc,
     std::shared_ptr<Core::FE::GaussPoints> intpoints, bool switched_conf,
     Core::LinAlg::SparseMatrix& dmatrix_A, Core::LinAlg::SparseMatrix& mmatrix_A,
     Core::LinAlg::SparseMatrix& dmatrix_B, Core::LinAlg::SparseMatrix& mmatrix_B,
-    const Core::FE::Discretization& Adis, const Core::FE::Discretization& Bdis, int sdofset_A,
-    int mdofset_A, int sdofset_B, int mdofset_B)
+    const Core::FE::Discretization& Adis, const Core::FE::Discretization& Bdis, int source_dofset_A,
+    int target_dofset_A, int source_dofset_B, int target_dofset_B)
 {
   if (shape_ == shape_std) FOUR_C_THROW("ERROR: std. shape functions not supported");
 
   // create empty vectors for shape fct. evaluation
-  Core::LinAlg::Matrix<ns_, 1> sval_A;
-  Core::LinAlg::Matrix<nm_, 1> mval_A;
-  Core::LinAlg::Matrix<ns_, 1> lmval_A;
-  Core::LinAlg::Matrix<nm_, 1> lmval_B;
+  Core::LinAlg::Matrix<nsource_, 1> source_val_A;
+  Core::LinAlg::Matrix<ntarget_, 1> target_val_A;
+  Core::LinAlg::Matrix<nsource_, 1> lmval_A;
+  Core::LinAlg::Matrix<ntarget_, 1> lmval_B;
 
   //**********************************************************************
   // loop over all Gauss points for integration
@@ -1108,68 +1105,62 @@ void Coupling::VolMortar::VolMortarIntegrator<distype_s,
     double globgp[3] = {0.0, 0.0, 0.0};
 
     if (switched_conf)
-      Utils::local_to_global<distype_s>(Aele, eta, globgp);
+      Utils::local_to_global<distype_source>(Aele, eta, globgp);
     else
-      Utils::local_to_global<distype_m>(Bele, eta, globgp);
+      Utils::local_to_global<distype_target>(Bele, eta, globgp);
 
     // map gp into A and B para space
     double Axi[3] = {0.0, 0.0, 0.0};
     double Bxi[3] = {0.0, 0.0, 0.0};
-    Mortar::Utils::global_to_local<distype_s>(Aele, globgp, Axi);
-    Mortar::Utils::global_to_local<distype_m>(Bele, globgp, Bxi);
-
-    //      std::cout << "-------------------------------------" << std::endl;
-    //      std::cout << "globgp= " << globgp[0] << "  " << globgp[1] << "  " << globgp[2] <<
-    //      std::endl; std::cout << "eta= " << eta[0] << "  " << eta[1] << "  " << eta[2] <<
-    //      std::endl; std::cout << "Axi= " << Axi[0] << "  " << Axi[1] << "  " << Axi[2] <<
-    //      std::endl; std::cout << "Bxi= " << Bxi[0] << "  " << Bxi[1] << "  " << Bxi[2] <<
-    //      std::endl;
+    Mortar::Utils::global_to_local<distype_source>(Aele, globgp, Axi);
+    Mortar::Utils::global_to_local<distype_target>(Bele, globgp, Bxi);
 
     // evaluate the integration cell Jacobian
     double jac = 0.0;
 
     if (switched_conf)
-      jac = Utils::jacobian<distype_s>(Axi, Aele);
+      jac = Utils::jacobian<distype_source>(Axi, Aele);
     else
-      jac = Utils::jacobian<distype_m>(Bxi, Bele);
+      jac = Utils::jacobian<distype_target>(Bxi, Bele);
 
     // Check parameter space mapping
     // check_mapping_3d(Aele,Bele,Axi,Bxi);
 
     // evaluate trace space shape functions (on both elements)
-    Utils::shape_function<distype_s>(sval_A, Axi);
-    Utils::shape_function<distype_m>(mval_A, Bxi);
+    Utils::shape_function<distype_source>(source_val_A, Axi);
+    Utils::shape_function<distype_target>(target_val_A, Bxi);
 
     // evaluate Lagrange multiplier shape functions (on source element)
-    Utils::dual_shape_function<distype_s>(lmval_A, Axi, Aele, dualquad_);
-    Utils::dual_shape_function<distype_m>(lmval_B, Bxi, Bele, dualquad_);
+    Utils::dual_shape_function<distype_source>(lmval_A, Axi, Aele, dualquad_);
+    Utils::dual_shape_function<distype_target>(lmval_B, Bxi, Bele, dualquad_);
 
     // compute cell D/M matrix ****************************************
     // dual shape functions
-    for (int j = 0; j < ns_; ++j)
+    for (int j = 0; j < nsource_; ++j)
     {
       Core::Nodes::Node* cnode = Aele.nodes()[j];
-      int nsdof = Adis.num_dof(sdofset_A, cnode);
+      int nsource_dof = Adis.num_dof(source_dofset_A, cnode);
 
       // loop over source dofs
-      for (int jdof = 0; jdof < nsdof; ++jdof)
+      for (int jdof = 0; jdof < nsource_dof; ++jdof)
       {
-        int row = Adis.dof(sdofset_A, cnode, jdof);
+        int row = Adis.dof(source_dofset_A, cnode, jdof);
 
         // integrate M and D
-        for (int k = 0; k < nm_; ++k)
+        for (int k = 0; k < ntarget_; ++k)
         {
-          Core::Nodes::Node* mnode = Bele.nodes()[k];
-          int nmdof = Bdis.num_dof(mdofset_A, mnode);
+          Core::Nodes::Node* target_node = Bele.nodes()[k];
+          int ntarget_dof = Bdis.num_dof(target_dofset_A, target_node);
 
-          for (int kdof = 0; kdof < nmdof; ++kdof)
+          for (int kdof = 0; kdof < ntarget_dof; ++kdof)
           {
-            int col = Bdis.dof(mdofset_A, mnode, kdof);
+            int col = Bdis.dof(target_dofset_A, target_node, kdof);
 
             // multiply the two shape functions
-            double prod = lmval_A(j) * mval_A(k) * jac * weight_out;
+            double prod = lmval_A(j) * target_val_A(k) * jac * weight_out;
             //              std::cout << "PROD1 = " << prod  << " row= " << row << "  col= " << col
-            //              << "  j= " << j<<  "  nsdof= " << nsdof<< std::endl; cnode->print(cout);
+            //              << "  j= " << j<<  "  nsource_dof= " << nsource_dof<< std::endl;
+            //              cnode->print(cout);
             // dof to dof
             if (jdof == kdof)
             {
@@ -1183,28 +1174,28 @@ void Coupling::VolMortar::VolMortarIntegrator<distype_s,
 
     // compute cell D/M matrix ****************************************
     // dual shape functions
-    for (int j = 0; j < nm_; ++j)
+    for (int j = 0; j < ntarget_; ++j)
     {
       Core::Nodes::Node* cnode = Bele.nodes()[j];
-      int nsdof = Bdis.num_dof(sdofset_B, cnode);
+      int nsource_dof = Bdis.num_dof(source_dofset_B, cnode);
 
       // loop over source dofs
-      for (int jdof = 0; jdof < nsdof; ++jdof)
+      for (int jdof = 0; jdof < nsource_dof; ++jdof)
       {
-        int row = Bdis.dof(sdofset_B, cnode, jdof);
+        int row = Bdis.dof(source_dofset_B, cnode, jdof);
 
         // integrate M and D
-        for (int k = 0; k < ns_; ++k)
+        for (int k = 0; k < nsource_; ++k)
         {
-          Core::Nodes::Node* mnode = Aele.nodes()[k];
-          int nmdof = Adis.num_dof(mdofset_B, mnode);
+          Core::Nodes::Node* target_node = Aele.nodes()[k];
+          int ntarget_dof = Adis.num_dof(target_dofset_B, target_node);
 
-          for (int kdof = 0; kdof < nmdof; ++kdof)
+          for (int kdof = 0; kdof < ntarget_dof; ++kdof)
           {
-            int col = Adis.dof(sdofset_B, mnode, kdof);
+            int col = Adis.dof(source_dofset_B, target_node, kdof);
 
             // multiply the two shape functions
-            double prod = lmval_B(j) * sval_A(k) * jac * weight_out;
+            double prod = lmval_B(j) * source_val_A(k) * jac * weight_out;
             //              std::cout << "PROD2 = " << prod  << " row= " << row << "  col= " <<
             //              col<< std::endl; cnode->print(cout);
 
@@ -1219,27 +1210,25 @@ void Coupling::VolMortar::VolMortarIntegrator<distype_s,
       }
     }
   }  // end gp loop
-
-  return;
 }
 
 
 /*----------------------------------------------------------------------*
  |  Compute D/M entries for Volumetric Mortar                farah 04/14|
  *----------------------------------------------------------------------*/
-template <Core::FE::CellType distype_s, Core::FE::CellType distype_m>
-void Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::integrate_ele_based_3d_a_dis(
-    Core::Elements::Element& Aele, std::vector<int>& foundeles,
-    Core::LinAlg::SparseMatrix& dmatrix_A, Core::LinAlg::SparseMatrix& mmatrix_A,
-    const Core::FE::Discretization& Adis, const Core::FE::Discretization& Bdis, int dofsetA,
-    int dofsetB)
+template <Core::FE::CellType distype_source, Core::FE::CellType distype_target>
+void Coupling::VolMortar::VolMortarIntegrator<distype_source,
+    distype_target>::integrate_ele_based_3d_a_dis(Core::Elements::Element& Aele,
+    std::vector<int>& foundeles, Core::LinAlg::SparseMatrix& dmatrix_A,
+    Core::LinAlg::SparseMatrix& mmatrix_A, const Core::FE::Discretization& Adis,
+    const Core::FE::Discretization& Bdis, int dofsetA, int dofsetB)
 {
   if (shape_ == shape_std) FOUR_C_THROW("ERROR: std. shape functions not supported");
 
   // create empty vectors for shape fct. evaluation
-  Core::LinAlg::Matrix<ns_, 1> sval_A;
-  Core::LinAlg::Matrix<nm_, 1> mval_A;
-  Core::LinAlg::Matrix<ns_, 1> lmval_A;
+  Core::LinAlg::Matrix<nsource_, 1> source_val_A;
+  Core::LinAlg::Matrix<ntarget_, 1> target_val_A;
+  Core::LinAlg::Matrix<nsource_, 1> lmval_A;
 
   //**********************************************************************
   // loop over all Gauss points for integration
@@ -1258,14 +1247,14 @@ void Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::integrate_e
     std::array<double, 3> AuxXi = {0.0, 0.0, 0.0};
 
     // evaluate the integration cell Jacobian
-    jac = Utils::jacobian<distype_s>(eta, Aele);
+    jac = Utils::jacobian<distype_source>(eta, Aele);
 
     // get global Gauss point coordinates
-    Utils::local_to_global<distype_s>(Aele, eta, globgp);
+    Utils::local_to_global<distype_source>(Aele, eta, globgp);
 
     // map gp into A and B para space
     double Axi[3] = {0.0, 0.0, 0.0};
-    Mortar::Utils::global_to_local<distype_s>(Aele, globgp, Axi);
+    Mortar::Utils::global_to_local<distype_source>(Aele, globgp, Axi);
 
     // loop over beles
     for (int found = 0; found < (int)foundeles.size(); ++found)
@@ -1275,7 +1264,7 @@ void Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::integrate_e
       double Bxi[3] = {0.0, 0.0, 0.0};
 
       bool converged = true;
-      Mortar::Utils::global_to_local<distype_m>(*Bele, globgp, Bxi, converged);
+      Mortar::Utils::global_to_local<distype_target>(*Bele, globgp, Bxi, converged);
       if (!converged and found != ((int)foundeles.size() - 1)) continue;
 
       // save distance of gp
@@ -1304,38 +1293,38 @@ void Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::integrate_e
       }
 
       // for "target" side
-      Utils::shape_function<distype_s>(sval_A, Axi, dualquad_);
-      Utils::shape_function<distype_m>(mval_A, Bxi);
+      Utils::shape_function<distype_source>(source_val_A, Axi, dualquad_);
+      Utils::shape_function<distype_target>(target_val_A, Bxi);
 
       // evaluate Lagrange multiplier shape functions (on source element)
-      Utils::dual_shape_function<distype_s>(lmval_A, Axi, Aele, dualquad_);
+      Utils::dual_shape_function<distype_source>(lmval_A, Axi, Aele, dualquad_);
 
       // compute cell D/M matrix ****************************************
       // dual shape functions
-      for (int j = 0; j < ns_; ++j)
+      for (int j = 0; j < nsource_; ++j)
       {
         Core::Nodes::Node* cnode = Aele.nodes()[j];
         if (cnode->owner() != Core::Communication::my_mpi_rank(Adis.get_comm())) continue;
 
-        int nsdof = Adis.num_dof(dofsetA, cnode);
+        int nsource_dof = Adis.num_dof(dofsetA, cnode);
 
         // loop over source dofs
-        for (int jdof = 0; jdof < nsdof; ++jdof)
+        for (int jdof = 0; jdof < nsource_dof; ++jdof)
         {
           int row = Adis.dof(dofsetA, cnode, jdof);
 
           // integrate D
-          double prod2 = lmval_A(j) * sval_A(j) * jac * wgt;
+          double prod2 = lmval_A(j) * source_val_A(j) * jac * wgt;
           if (abs(prod2) > VOLMORTARINTTOL) dmatrix_A.assemble(prod2, row, row);
 
           // integrate M
-          for (int k = 0; k < nm_; ++k)
+          for (int k = 0; k < ntarget_; ++k)
           {
-            Core::Nodes::Node* mnode = Bele->nodes()[k];
-            int col = Bdis.dof(dofsetB, mnode, jdof);
+            Core::Nodes::Node* target_node = Bele->nodes()[k];
+            int col = Bdis.dof(dofsetB, target_node, jdof);
 
             // multiply the two shape functions
-            double prod = lmval_A(j) * mval_A(k) * jac * wgt;
+            double prod = lmval_A(j) * target_val_A(k) * jac * wgt;
 
             if (abs(prod) > VOLMORTARINTTOL) mmatrix_A.assemble(prod, row, col);
           }
@@ -1345,27 +1334,25 @@ void Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::integrate_e
       break;
     }  // beles
   }  // end gp loop
-
-  return;
 }
 
 
 /*----------------------------------------------------------------------*
  |  Compute D/M entries for Volumetric Mortar                farah 04/14|
  *----------------------------------------------------------------------*/
-template <Core::FE::CellType distype_s, Core::FE::CellType distype_m>
-void Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::integrate_ele_based_3d_b_dis(
-    Core::Elements::Element& Bele, std::vector<int>& foundeles,
-    Core::LinAlg::SparseMatrix& dmatrix_B, Core::LinAlg::SparseMatrix& mmatrix_B,
-    const Core::FE::Discretization& Adis, const Core::FE::Discretization& Bdis, int dofsetA,
-    int dofsetB)
+template <Core::FE::CellType distype_source, Core::FE::CellType distype_target>
+void Coupling::VolMortar::VolMortarIntegrator<distype_source,
+    distype_target>::integrate_ele_based_3d_b_dis(Core::Elements::Element& Bele,
+    std::vector<int>& foundeles, Core::LinAlg::SparseMatrix& dmatrix_B,
+    Core::LinAlg::SparseMatrix& mmatrix_B, const Core::FE::Discretization& Adis,
+    const Core::FE::Discretization& Bdis, int dofsetA, int dofsetB)
 {
   if (shape_ == shape_std) FOUR_C_THROW("ERROR: std. shape functions not supported");
 
   // create empty vectors for shape fct. evaluation
-  Core::LinAlg::Matrix<ns_, 1> mval_A;
-  Core::LinAlg::Matrix<nm_, 1> sval_B;
-  Core::LinAlg::Matrix<nm_, 1> lmval_B;
+  Core::LinAlg::Matrix<nsource_, 1> target_val_A;
+  Core::LinAlg::Matrix<ntarget_, 1> source_val_B;
+  Core::LinAlg::Matrix<ntarget_, 1> lmval_B;
 
   //**********************************************************************
   // loop over all Gauss points for integration
@@ -1384,14 +1371,14 @@ void Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::integrate_e
     double AuxXi[3] = {0.0, 0.0, 0.0};
 
     // evaluate the integration cell Jacobian
-    jac = Utils::jacobian<distype_m>(eta, Bele);
+    jac = Utils::jacobian<distype_target>(eta, Bele);
 
     // get global Gauss point coordinates
-    Utils::local_to_global<distype_m>(Bele, eta, globgp);
+    Utils::local_to_global<distype_target>(Bele, eta, globgp);
 
     // map gp into A and B para space
     double Bxi[3] = {0.0, 0.0, 0.0};
-    Mortar::Utils::global_to_local<distype_m>(Bele, globgp, Bxi);
+    Mortar::Utils::global_to_local<distype_target>(Bele, globgp, Bxi);
 
     // loop over beles
     for (int found = 0; found < (int)foundeles.size(); ++found)
@@ -1401,7 +1388,7 @@ void Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::integrate_e
       double Axi[3] = {0.0, 0.0, 0.0};
 
       bool converged = true;
-      Mortar::Utils::global_to_local<distype_s>(*Aele, globgp, Axi, converged);
+      Mortar::Utils::global_to_local<distype_source>(*Aele, globgp, Axi, converged);
       if (!converged and found != ((int)foundeles.size() - 1)) continue;
 
       // save distance of gp
@@ -1430,37 +1417,37 @@ void Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::integrate_e
       }
 
       // evaluate trace space shape functions (on both elements)
-      Utils::shape_function<distype_m>(sval_B, Bxi, dualquad_);
-      Utils::shape_function<distype_s>(mval_A, Axi);
+      Utils::shape_function<distype_target>(source_val_B, Bxi, dualquad_);
+      Utils::shape_function<distype_source>(target_val_A, Axi);
 
       // evaluate Lagrange multiplier shape functions (on source element)
-      Utils::dual_shape_function<distype_m>(lmval_B, Bxi, Bele, dualquad_);
+      Utils::dual_shape_function<distype_target>(lmval_B, Bxi, Bele, dualquad_);
       // compute cell D/M matrix ****************************************
       // dual shape functions
-      for (int j = 0; j < nm_; ++j)
+      for (int j = 0; j < ntarget_; ++j)
       {
         Core::Nodes::Node* cnode = Bele.nodes()[j];
         if (cnode->owner() != Core::Communication::my_mpi_rank(Bdis.get_comm())) continue;
 
-        int nsdof = Bdis.num_dof(dofsetB, cnode);
+        int nsource_dof = Bdis.num_dof(dofsetB, cnode);
 
         // loop over source dofs
-        for (int jdof = 0; jdof < nsdof; ++jdof)
+        for (int jdof = 0; jdof < nsource_dof; ++jdof)
         {
           int row = Bdis.dof(dofsetB, cnode, jdof);
 
           // integrate D
-          double prod2 = lmval_B(j) * sval_B(j) * jac * wgt;
+          double prod2 = lmval_B(j) * source_val_B(j) * jac * wgt;
           if (abs(prod2) > VOLMORTARINTTOL) dmatrix_B.assemble(prod2, row, row);
 
           // integrate M
-          for (int k = 0; k < ns_; ++k)
+          for (int k = 0; k < nsource_; ++k)
           {
-            Core::Nodes::Node* mnode = Aele->nodes()[k];
-            int col = Adis.dof(dofsetA, mnode, jdof);
+            Core::Nodes::Node* target_node = Aele->nodes()[k];
+            int col = Adis.dof(dofsetA, target_node, jdof);
 
             // multiply the two shape functions
-            double prod = lmval_B(j) * mval_A(k) * jac * wgt;
+            double prod = lmval_B(j) * target_val_A(k) * jac * wgt;
 
             if (abs(prod) > VOLMORTARINTTOL) mmatrix_B.assemble(prod, row, col);
           }
@@ -1470,8 +1457,6 @@ void Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::integrate_e
       break;
     }  // beles
   }  // end gp loop
-
-  return;
 }
 
 
@@ -1480,21 +1465,21 @@ void Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::integrate_e
  |  This function is for element-wise integration when an               |
  |  element is completely located within an other element               |
  *----------------------------------------------------------------------*/
-template <Core::FE::CellType distype_s, Core::FE::CellType distype_m>
-void Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::integrate_ele_3d(int domain,
-    Core::Elements::Element& Aele, Core::Elements::Element& Bele,
+template <Core::FE::CellType distype_source, Core::FE::CellType distype_target>
+void Coupling::VolMortar::VolMortarIntegrator<distype_source, distype_target>::integrate_ele_3d(
+    int domain, Core::Elements::Element& Aele, Core::Elements::Element& Bele,
     Core::LinAlg::SparseMatrix& dmatrix_A, Core::LinAlg::SparseMatrix& mmatrix_A,
     Core::LinAlg::SparseMatrix& dmatrix_B, Core::LinAlg::SparseMatrix& mmatrix_B,
-    const Core::FE::Discretization& Adis, const Core::FE::Discretization& Bdis, int sdofset_A,
-    int mdofset_A, int sdofset_B, int mdofset_B)
+    const Core::FE::Discretization& Adis, const Core::FE::Discretization& Bdis, int source_dofset_A,
+    int target_dofset_A, int source_dofset_B, int target_dofset_B)
 {
   if (shape_ == shape_std) FOUR_C_THROW("ERROR: std. shape functions not supported");
 
   // create empty vectors for shape fct. evaluation
-  Core::LinAlg::Matrix<ns_, 1> sval_A;
-  Core::LinAlg::Matrix<nm_, 1> mval_A;
-  Core::LinAlg::Matrix<ns_, 1> lmval_A;
-  Core::LinAlg::Matrix<nm_, 1> lmval_B;
+  Core::LinAlg::Matrix<nsource_, 1> source_val_A;
+  Core::LinAlg::Matrix<ntarget_, 1> target_val_A;
+  Core::LinAlg::Matrix<nsource_, 1> lmval_A;
+  Core::LinAlg::Matrix<ntarget_, 1> lmval_B;
 
   //**********************************************************************
   // loop over all Gauss points for integration
@@ -1511,18 +1496,18 @@ void Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::integrate_e
     if (domain == 0)
     {
       // evaluate the integration cell Jacobian
-      jac = Utils::jacobian<distype_s>(eta, Aele);
+      jac = Utils::jacobian<distype_source>(eta, Aele);
 
       // get global Gauss point coordinates
-      Utils::local_to_global<distype_s>(Aele, eta, globgp);
+      Utils::local_to_global<distype_source>(Aele, eta, globgp);
     }
     else if (domain == 1)
     {
       // evaluate the integration cell Jacobian
-      jac = Utils::jacobian<distype_m>(eta, Bele);
+      jac = Utils::jacobian<distype_target>(eta, Bele);
 
       // get global Gauss point coordinates
-      Utils::local_to_global<distype_m>(Bele, eta, globgp);
+      Utils::local_to_global<distype_target>(Bele, eta, globgp);
     }
     else
       FOUR_C_THROW("wrong domain for integration!");
@@ -1531,44 +1516,44 @@ void Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::integrate_e
     // map gp into A and B para space
     double Axi[3] = {0.0, 0.0, 0.0};
     double Bxi[3] = {0.0, 0.0, 0.0};
-    Mortar::Utils::global_to_local<distype_s>(Aele, globgp, Axi);
-    Mortar::Utils::global_to_local<distype_m>(Bele, globgp, Bxi);
+    Mortar::Utils::global_to_local<distype_source>(Aele, globgp, Axi);
+    Mortar::Utils::global_to_local<distype_target>(Bele, globgp, Bxi);
 
     // Check parameter space mapping
     check_mapping_3d(Aele, Bele, Axi, Bxi);
 
     // evaluate trace space shape functions (on both elements)
-    Utils::shape_function<distype_s>(sval_A, Axi);
-    Utils::shape_function<distype_m>(mval_A, Bxi);
+    Utils::shape_function<distype_source>(source_val_A, Axi);
+    Utils::shape_function<distype_target>(target_val_A, Bxi);
 
     // evaluate Lagrange multiplier shape functions (on source element)
-    Utils::dual_shape_function<distype_s>(lmval_A, Axi, Aele, dualquad_);
-    Utils::dual_shape_function<distype_m>(lmval_B, Bxi, Bele, dualquad_);
+    Utils::dual_shape_function<distype_source>(lmval_A, Axi, Aele, dualquad_);
+    Utils::dual_shape_function<distype_target>(lmval_B, Bxi, Bele, dualquad_);
 
     // compute cell D/M matrix ****************************************
     // dual shape functions
-    for (int j = 0; j < ns_; ++j)
+    for (int j = 0; j < nsource_; ++j)
     {
       Core::Nodes::Node* cnode = Aele.nodes()[j];
-      int nsdof = Adis.num_dof(sdofset_A, cnode);
+      int nsource_dof = Adis.num_dof(source_dofset_A, cnode);
 
       // loop over source dofs
-      for (int jdof = 0; jdof < nsdof; ++jdof)
+      for (int jdof = 0; jdof < nsource_dof; ++jdof)
       {
-        int row = Adis.dof(sdofset_A, cnode, jdof);
+        int row = Adis.dof(source_dofset_A, cnode, jdof);
 
         // integrate M and D
-        for (int k = 0; k < nm_; ++k)
+        for (int k = 0; k < ntarget_; ++k)
         {
-          Core::Nodes::Node* mnode = Bele.nodes()[k];
-          int nmdof = Bdis.num_dof(mdofset_A, mnode);
+          Core::Nodes::Node* target_node = Bele.nodes()[k];
+          int ntarget_dof = Bdis.num_dof(target_dofset_A, target_node);
 
-          for (int kdof = 0; kdof < nmdof; ++kdof)
+          for (int kdof = 0; kdof < ntarget_dof; ++kdof)
           {
-            int col = Bdis.dof(mdofset_A, mnode, kdof);
+            int col = Bdis.dof(target_dofset_A, target_node, kdof);
 
             // multiply the two shape functions
-            double prod = lmval_A(j) * mval_A(k) * jac * wgt;
+            double prod = lmval_A(j) * target_val_A(k) * jac * wgt;
 
             // dof to dof
             if (jdof == kdof)
@@ -1583,28 +1568,28 @@ void Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::integrate_e
 
     // compute cell D/M matrix ****************************************
     // dual shape functions
-    for (int j = 0; j < nm_; ++j)
+    for (int j = 0; j < ntarget_; ++j)
     {
       Core::Nodes::Node* cnode = Bele.nodes()[j];
-      int nsdof = Bdis.num_dof(sdofset_B, cnode);
+      int nsource_dof = Bdis.num_dof(source_dofset_B, cnode);
 
       // loop over source dofs
-      for (int jdof = 0; jdof < nsdof; ++jdof)
+      for (int jdof = 0; jdof < nsource_dof; ++jdof)
       {
-        int row = Bdis.dof(sdofset_B, cnode, jdof);
+        int row = Bdis.dof(source_dofset_B, cnode, jdof);
 
         // integrate M and D
-        for (int k = 0; k < ns_; ++k)
+        for (int k = 0; k < nsource_; ++k)
         {
-          Core::Nodes::Node* mnode = Aele.nodes()[k];
-          int nmdof = Adis.num_dof(mdofset_B, mnode);
+          Core::Nodes::Node* target_node = Aele.nodes()[k];
+          int ntarget_dof = Adis.num_dof(target_dofset_B, target_node);
 
-          for (int kdof = 0; kdof < nmdof; ++kdof)
+          for (int kdof = 0; kdof < ntarget_dof; ++kdof)
           {
-            int col = Adis.dof(mdofset_B, mnode, kdof);
+            int col = Adis.dof(target_dofset_B, target_node, kdof);
 
             // multiply the two shape functions
-            double prod = lmval_B(j) * sval_A(k) * jac * wgt;
+            double prod = lmval_B(j) * source_val_A(k) * jac * wgt;
 
             // dof to dof
             if (jdof == kdof)
@@ -1618,39 +1603,41 @@ void Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::integrate_e
     }
 
   }  // end gp loop
-
-  return;
 }
 
 
 /*----------------------------------------------------------------------*
  |  Compute D/M entries for Volumetric Mortar                farah 01/14|
  *----------------------------------------------------------------------*/
-template <Core::FE::CellType distype_s, Core::FE::CellType distype_m>
-bool Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::check_mapping_2d(
-    Core::Elements::Element& sele, Core::Elements::Element& mele, double* sxi, double* mxi)
+template <Core::FE::CellType distype_source, Core::FE::CellType distype_target>
+bool Coupling::VolMortar::VolMortarIntegrator<distype_source, distype_target>::check_mapping_2d(
+    Core::Elements::Element& source_ele, Core::Elements::Element& target_ele, double* source_xi,
+    double* target_xi)
 {
   // check GP projection (SOURCE)
   const double tol = 1e-10;
-  if (distype_s == Core::FE::CellType::quad4 || distype_s == Core::FE::CellType::quad8 ||
-      distype_s == Core::FE::CellType::quad9)
+  if (distype_source == Core::FE::CellType::quad4 || distype_source == Core::FE::CellType::quad8 ||
+      distype_source == Core::FE::CellType::quad9)
   {
-    if (sxi[0] < -1.0 - tol || sxi[1] < -1.0 - tol || sxi[0] > 1.0 + tol || sxi[1] > 1.0 + tol)
+    if (source_xi[0] < -1.0 - tol || source_xi[1] < -1.0 - tol || source_xi[0] > 1.0 + tol ||
+        source_xi[1] > 1.0 + tol)
     {
       std::cout << "\n***Warning: Gauss point projection outside!";
-      std::cout << "Source ID: " << sele.id() << " Target ID: " << mele.id() << std::endl;
-      std::cout << "Source GP projection: " << sxi[0] << " " << sxi[1] << std::endl;
+      std::cout << "Source ID: " << source_ele.id() << " Target ID: " << target_ele.id()
+                << std::endl;
+      std::cout << "Source GP projection: " << source_xi[0] << " " << source_xi[1] << std::endl;
       return false;
     }
   }
-  else if (distype_s == Core::FE::CellType::tri3 || distype_s == Core::FE::CellType::tri6)
+  else if (distype_source == Core::FE::CellType::tri3 || distype_source == Core::FE::CellType::tri6)
   {
-    if (sxi[0] < -tol || sxi[1] < -tol || sxi[0] > 1.0 + tol || sxi[1] > 1.0 + tol ||
-        sxi[0] + sxi[1] > 1.0 + 2 * tol)
+    if (source_xi[0] < -tol || source_xi[1] < -tol || source_xi[0] > 1.0 + tol ||
+        source_xi[1] > 1.0 + tol || source_xi[0] + source_xi[1] > 1.0 + 2 * tol)
     {
       std::cout << "\n***Warning: Gauss point projection outside!";
-      std::cout << "Source ID: " << sele.id() << " Target ID: " << mele.id() << std::endl;
-      std::cout << "Source GP projection: " << sxi[0] << " " << sxi[1] << std::endl;
+      std::cout << "Source ID: " << source_ele.id() << " Target ID: " << target_ele.id()
+                << std::endl;
+      std::cout << "Source GP projection: " << source_xi[0] << " " << source_xi[1] << std::endl;
       return false;
     }
   }
@@ -1658,25 +1645,28 @@ bool Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::check_mappi
     FOUR_C_THROW("Wrong element type!");
 
   // check GP projection (TARGET)
-  if (distype_m == Core::FE::CellType::quad4 || distype_m == Core::FE::CellType::quad8 ||
-      distype_m == Core::FE::CellType::quad9)
+  if (distype_target == Core::FE::CellType::quad4 || distype_target == Core::FE::CellType::quad8 ||
+      distype_target == Core::FE::CellType::quad9)
   {
-    if (mxi[0] < -1.0 - tol || mxi[1] < -1.0 - tol || mxi[0] > 1.0 + tol || mxi[1] > 1.0 + tol)
+    if (target_xi[0] < -1.0 - tol || target_xi[1] < -1.0 - tol || target_xi[0] > 1.0 + tol ||
+        target_xi[1] > 1.0 + tol)
     {
       std::cout << "\n***Warning: Gauss point projection outside!";
-      std::cout << "Source ID: " << sele.id() << " Target ID: " << mele.id() << std::endl;
-      std::cout << "Target GP projection: " << mxi[0] << " " << mxi[1] << std::endl;
+      std::cout << "Source ID: " << source_ele.id() << " Target ID: " << target_ele.id()
+                << std::endl;
+      std::cout << "Target GP projection: " << target_xi[0] << " " << target_xi[1] << std::endl;
       return false;
     }
   }
-  else if (distype_s == Core::FE::CellType::tri3 || distype_s == Core::FE::CellType::tri6)
+  else if (distype_source == Core::FE::CellType::tri3 || distype_source == Core::FE::CellType::tri6)
   {
-    if (mxi[0] < -tol || mxi[1] < -tol || mxi[0] > 1.0 + tol || mxi[1] > 1.0 + tol ||
-        mxi[0] + mxi[1] > 1.0 + 2 * tol)
+    if (target_xi[0] < -tol || target_xi[1] < -tol || target_xi[0] > 1.0 + tol ||
+        target_xi[1] > 1.0 + tol || target_xi[0] + target_xi[1] > 1.0 + 2 * tol)
     {
       std::cout << "\n***Warning: Gauss point projection outside!";
-      std::cout << "Source ID: " << sele.id() << " Target ID: " << mele.id() << std::endl;
-      std::cout << "Target GP projection: " << mxi[0] << " " << mxi[1] << std::endl;
+      std::cout << "Source ID: " << source_ele.id() << " Target ID: " << target_ele.id()
+                << std::endl;
+      std::cout << "Target GP projection: " << target_xi[0] << " " << target_xi[1] << std::endl;
       return false;
     }
   }
@@ -1690,79 +1680,37 @@ bool Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::check_mappi
 /*----------------------------------------------------------------------*
  |  Compute D/M entries for Volumetric Mortar                farah 01/14|
  *----------------------------------------------------------------------*/
-template <Core::FE::CellType distype_s, Core::FE::CellType distype_m>
-bool Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::check_mapping_3d(
-    Core::Elements::Element& sele, Core::Elements::Element& mele, double* sxi, double* mxi)
+template <Core::FE::CellType distype_source, Core::FE::CellType distype_target>
+bool Coupling::VolMortar::VolMortarIntegrator<distype_source, distype_target>::check_mapping_3d(
+    Core::Elements::Element& source_ele, Core::Elements::Element& target_ele, double* source_xi,
+    double* target_xi)
 {
   // check GP projection (SOURCE)
   double tol = 1e-5;
-  if (distype_s == Core::FE::CellType::hex8 || distype_s == Core::FE::CellType::hex20 ||
-      distype_s == Core::FE::CellType::hex27)
+  if (distype_source == Core::FE::CellType::hex8 || distype_source == Core::FE::CellType::hex20 ||
+      distype_source == Core::FE::CellType::hex27)
   {
-    if (sxi[0] < -1.0 - tol || sxi[1] < -1.0 - tol || sxi[2] < -1.0 - tol || sxi[0] > 1.0 + tol ||
-        sxi[1] > 1.0 + tol || sxi[2] > 1.0 + tol)
+    if (source_xi[0] < -1.0 - tol || source_xi[1] < -1.0 - tol || source_xi[2] < -1.0 - tol ||
+        source_xi[0] > 1.0 + tol || source_xi[1] > 1.0 + tol || source_xi[2] > 1.0 + tol)
     {
-      //      std::cout << "\n***Warning: Gauss point projection outside!";
-      //      std::cout << "Source ID: " << sele.Id() << " Target ID: " << mele.Id() << std::endl;
-      //      std::cout << "Source GP projection: " << sxi[0] << " " << sxi[1] << " " << sxi[2] <<
-      //      std::endl;
-      //
-      //      for(int i=0;i<sele.num_node();++i)
-      //      {
-      //        std::cout << "create vertex " << sele.Nodes()[i]->X()[0] <<"  "<<
-      //        sele.Nodes()[i]->X()[1] <<"  "<< sele.Nodes()[i]->X()[2] <<std::endl;
-      //      }
-      //      std::cout << "------------" << std::endl;
-      //      for(int i=0;i<mele.num_node();++i)
-      //      {
-      //        std::cout << "create vertex " << mele.Nodes()[i]->X()[0] <<"  "<<
-      //        mele.Nodes()[i]->X()[1] <<"  "<< mele.Nodes()[i]->X()[2] <<std::endl;
-      //      }
-
       return false;
     }
   }
-  else if (distype_s == Core::FE::CellType::tet4 || distype_s == Core::FE::CellType::tet10)
+  else if (distype_source == Core::FE::CellType::tet4 ||
+           distype_source == Core::FE::CellType::tet10)
   {
-    if (sxi[0] < 0.0 - tol || sxi[1] < 0.0 - tol || sxi[2] < 0.0 - tol ||
-        (sxi[0] + sxi[1] + sxi[2]) > 1.0 + tol)
+    if (source_xi[0] < 0.0 - tol || source_xi[1] < 0.0 - tol || source_xi[2] < 0.0 - tol ||
+        (source_xi[0] + source_xi[1] + source_xi[2]) > 1.0 + tol)
     {
-      //      std::cout << "\n***Warning: Gauss point projection outside!";
-      //      std::cout << "Source ID: " << sele.Id() << " Target ID: " << mele.Id() << std::endl;
-      //      std::cout << "Source GP projection: " << sxi[0] << " " << sxi[1] << " " << sxi[2] <<
-      //      std::endl; for(int i=0;i<sele.num_node();++i)
-      //      {
-      //        std::cout << "create vertex " << sele.Nodes()[i]->X()[0] <<"  "<<
-      //        sele.Nodes()[i]->X()[1] <<"  "<< sele.Nodes()[i]->X()[2] <<std::endl;
-      //      }
-      //      std::cout << "------------" << std::endl;
-      //      for(int i=0;i<mele.num_node();++i)
-      //      {
-      //        std::cout << "create vertex " << mele.Nodes()[i]->X()[0] <<"  "<<
-      //        mele.Nodes()[i]->X()[1] <<"  "<< mele.Nodes()[i]->X()[2] <<std::endl;
-      //      }
       return false;
     }
   }
-  else if (distype_s == Core::FE::CellType::pyramid5)
+  else if (distype_source == Core::FE::CellType::pyramid5)
   {
-    if (sxi[2] < 0.0 - tol || -sxi[0] + sxi[2] > 1.0 + tol || sxi[0] + sxi[2] > 1.0 + tol ||
-        -sxi[1] + sxi[2] > 1.0 + tol || sxi[1] + sxi[2] > 1.0 + tol)
+    if (source_xi[2] < 0.0 - tol || -source_xi[0] + source_xi[2] > 1.0 + tol ||
+        source_xi[0] + source_xi[2] > 1.0 + tol || -source_xi[1] + source_xi[2] > 1.0 + tol ||
+        source_xi[1] + source_xi[2] > 1.0 + tol)
     {
-      //      std::cout << "\n***Warning: Gauss point projection outside!";
-      //      std::cout << "Source ID: " << sele.Id() << " Target ID: " << mele.Id() << std::endl;
-      //      std::cout << "Source GP projection: " << sxi[0] << " " << sxi[1] << " " << sxi[2] <<
-      //      std::endl; for(int i=0;i<sele.num_node();++i)
-      //      {
-      //        std::cout << "create vertex " << sele.Nodes()[i]->X()[0] <<"  "<<
-      //        sele.Nodes()[i]->X()[1] <<"  "<< sele.Nodes()[i]->X()[2] <<std::endl;
-      //      }
-      //      std::cout << "------------" << std::endl;
-      //      for(int i=0;i<mele.num_node();++i)
-      //      {
-      //        std::cout << "create vertex " << mele.Nodes()[i]->X()[0] <<"  "<<
-      //        mele.Nodes()[i]->X()[1] <<"  "<< mele.Nodes()[i]->X()[2] <<std::endl;
-      //      }
       return false;
     }
   }
@@ -1770,70 +1718,30 @@ bool Coupling::VolMortar::VolMortarIntegrator<distype_s, distype_m>::check_mappi
     FOUR_C_THROW("Wrong element type!");
 
   // check GP projection (TARGET)
-  if (distype_m == Core::FE::CellType::hex8 || distype_m == Core::FE::CellType::hex20 ||
-      distype_m == Core::FE::CellType::hex27)
+  if (distype_target == Core::FE::CellType::hex8 || distype_target == Core::FE::CellType::hex20 ||
+      distype_target == Core::FE::CellType::hex27)
   {
-    if (mxi[0] < -1.0 - tol || mxi[1] < -1.0 - tol || mxi[2] < -1.0 - tol || mxi[0] > 1.0 + tol ||
-        mxi[1] > 1.0 + tol || mxi[2] > 1.0 + tol)
+    if (target_xi[0] < -1.0 - tol || target_xi[1] < -1.0 - tol || target_xi[2] < -1.0 - tol ||
+        target_xi[0] > 1.0 + tol || target_xi[1] > 1.0 + tol || target_xi[2] > 1.0 + tol)
     {
-      //      std::cout << "\n***Warning: Gauss point projection outside!";
-      //      std::cout << "Source ID: " << sele.Id() << " Target ID: " << mele.Id() << std::endl;
-      //      std::cout << "Target GP projection: " << mxi[0] << " " << mxi[1] << " " << mxi[2] <<
-      //      std::endl; for(int i=0;i<sele.num_node();++i)
-      //      {
-      //        std::cout << "create vertex " << sele.Nodes()[i]->X()[0] <<"  "<<
-      //        sele.Nodes()[i]->X()[1] <<"  "<< sele.Nodes()[i]->X()[2] <<std::endl;
-      //      }
-      //      std::cout << "------------" << std::endl;
-      //      for(int i=0;i<mele.num_node();++i)
-      //      {
-      //        std::cout << "create vertex " << mele.Nodes()[i]->X()[0] <<"  "<<
-      //        mele.Nodes()[i]->X()[1] <<"  "<< mele.Nodes()[i]->X()[2] <<std::endl;
-      //      }
       return false;
     }
   }
-  else if (distype_m == Core::FE::CellType::tet4 || distype_m == Core::FE::CellType::tet10)
+  else if (distype_target == Core::FE::CellType::tet4 ||
+           distype_target == Core::FE::CellType::tet10)
   {
-    if (mxi[0] < 0.0 - tol || mxi[1] < 0.0 - tol || mxi[2] < 0.0 - tol ||
-        (mxi[0] + mxi[1] + mxi[2]) > 1.0 + tol)
+    if (target_xi[0] < 0.0 - tol || target_xi[1] < 0.0 - tol || target_xi[2] < 0.0 - tol ||
+        (target_xi[0] + target_xi[1] + target_xi[2]) > 1.0 + tol)
     {
-      //      std::cout << "\n***Warning: Gauss point projection outside!";
-      //      std::cout << "Source ID: " << sele.Id() << " Target ID: " << mele.Id() << std::endl;
-      //      std::cout << "Target GP projection: " << mxi[0] << " " << mxi[1] << " " << mxi[2] <<
-      //      std::endl; for(int i=0;i<sele.num_node();++i)
-      //      {
-      //        std::cout << "create vertex " << sele.Nodes()[i]->X()[0] <<"  "<<
-      //        sele.Nodes()[i]->X()[1] <<"  "<< sele.Nodes()[i]->X()[2] <<std::endl;
-      //      }
-      //      std::cout << "------------" << std::endl;
-      //      for(int i=0;i<mele.num_node();++i)
-      //      {
-      //        std::cout << "create vertex " << mele.Nodes()[i]->X()[0] <<"  "<<
-      //        mele.Nodes()[i]->X()[1] <<"  "<< mele.Nodes()[i]->X()[2] <<std::endl;
-      //      }
       return false;
     }
   }
-  else if (distype_m == Core::FE::CellType::pyramid5)
+  else if (distype_target == Core::FE::CellType::pyramid5)
   {
-    if (mxi[2] < 0.0 - tol || -mxi[0] + mxi[2] > 1.0 + tol || mxi[0] + mxi[2] > 1.0 + tol ||
-        -mxi[1] + mxi[2] > 1.0 + tol || mxi[1] + mxi[2] > 1.0 + tol)
+    if (target_xi[2] < 0.0 - tol || -target_xi[0] + target_xi[2] > 1.0 + tol ||
+        target_xi[0] + target_xi[2] > 1.0 + tol || -target_xi[1] + target_xi[2] > 1.0 + tol ||
+        target_xi[1] + target_xi[2] > 1.0 + tol)
     {
-      //      std::cout << "\n***Warning: Gauss point projection outside!";
-      //      std::cout << "Source ID: " << sele.Id() << " Target ID: " << mele.Id() << std::endl;
-      //      std::cout << "Target GP projection: " << mxi[0] << " " << mxi[1] << " " << mxi[2] <<
-      //      std::endl; for(int i=0;i<sele.num_node();++i)
-      //      {
-      //        std::cout << "create vertex " << sele.Nodes()[i]->X()[0] <<"  "<<
-      //        sele.Nodes()[i]->X()[1] <<"  "<< sele.Nodes()[i]->X()[2] <<std::endl;
-      //      }
-      //      std::cout << "------------" << std::endl;
-      //      for(int i=0;i<mele.num_node();++i)
-      //      {
-      //        std::cout << "create vertex " << mele.Nodes()[i]->X()[0] <<"  "<<
-      //        mele.Nodes()[i]->X()[1] <<"  "<< mele.Nodes()[i]->X()[2] <<std::endl;
-      //      }
       return false;
     }
   }
@@ -2099,7 +2007,7 @@ bool Coupling::VolMortar::cons_interpolator_eval(Core::Nodes::Node* node,
     double* nodepos, std::pair<int, int>& dofset, const Core::LinAlg::Map& P_dofrowmap,
     const Core::LinAlg::Map& P_dofcolmap)
 {
-  //! ns_: number of source element nodes
+  //! nsource_: number of source element nodes
   static const int n_ = Core::FE::num_nodes(distype);
 
   double xi[3] = {0.0, 0.0, 0.0};
@@ -2141,10 +2049,10 @@ bool Coupling::VolMortar::cons_interpolator_eval(Core::Nodes::Node* node,
   Core::LinAlg::Matrix<n_, 1> val;
   Utils::shape_function<distype>(val, xi);
 
-  int nsdof = nodediscret.num_dof(dofset.first, node);
+  int nsource_dof = nodediscret.num_dof(dofset.first, node);
 
   // loop over source dofs
-  for (int jdof = 0; jdof < nsdof; ++jdof)
+  for (int jdof = 0; jdof < nsource_dof; ++jdof)
   {
     const int row = nodediscret.dof(dofset.first, node, jdof);
 
@@ -2166,22 +2074,5 @@ bool Coupling::VolMortar::cons_interpolator_eval(Core::Nodes::Node* node,
   return true;
 }
 
-
-/*----------------------------------------------------------------------*
- |  possible elements for interpolation                      farah 06/14|
- *----------------------------------------------------------------------*/
-// template class Coupling::VolMortar::ConsInterpolator<Core::FE::CellType::quad4>;
-// template class Coupling::VolMortar::ConsInterpolator<Core::FE::CellType::quad8>;
-// template class Coupling::VolMortar::ConsInterpolator<Core::FE::CellType::quad9>;
-//
-// template class Coupling::VolMortar::ConsInterpolator<Core::FE::CellType::tri3>;
-// template class Coupling::VolMortar::ConsInterpolator<Core::FE::CellType::tri6>;
-//
-// template class Coupling::VolMortar::ConsInterpolator<Core::FE::CellType::hex8>;
-// template class Coupling::VolMortar::ConsInterpolator<Core::FE::CellType::hex20>;
-// template class Coupling::VolMortar::ConsInterpolator<Core::FE::CellType::hex27>;
-//
-// template class Coupling::VolMortar::ConsInterpolator<Core::FE::CellType::tet4>;
-// template class Coupling::VolMortar::ConsInterpolator<Core::FE::CellType::tet10>;
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/coupling/src/volmortar/4C_coupling_volmortar_integrator.hpp
+++ b/src/coupling/src/volmortar/4C_coupling_volmortar_integrator.hpp
@@ -37,7 +37,7 @@ namespace Coupling::VolMortar
 {
   class Cell;
 
-  template <Core::FE::CellType distype_s, Core::FE::CellType distype_m>
+  template <Core::FE::CellType distype_source, Core::FE::CellType distype_target>
   class VolMortarIntegrator
   {
    public:
@@ -47,14 +47,14 @@ namespace Coupling::VolMortar
     // destructor
     virtual ~VolMortarIntegrator() = default;
 
-    //! ns_: number of source element nodes
-    static constexpr int ns_ = Core::FE::num_nodes(distype_s);
+    //! nsource_: number of source element nodes
+    static constexpr int nsource_ = Core::FE::num_nodes(distype_source);
 
-    //! nm_: number of target element nodes
-    static constexpr int nm_ = Core::FE::num_nodes(distype_m);
+    //! ntarget_: number of target element nodes
+    static constexpr int ntarget_ = Core::FE::num_nodes(distype_target);
 
     //! number of space dimensions ("+1" due to considering only interface elements)
-    static constexpr int ndim_ = Core::FE::dim<distype_s>;
+    static constexpr int ndim_ = Core::FE::dim<distype_source>;
 
     /*!
     \brief Initialize Gauss rule (points, weights)
@@ -67,10 +67,11 @@ namespace Coupling::VolMortar
     \brief Integrate cell for 2D problems
 
     */
-    void integrate_cells_2d(Core::Elements::Element& sele, Core::Elements::Element& mele,
-        Mortar::IntCell& cell, Core::LinAlg::SparseMatrix& dmatrix,
-        Core::LinAlg::SparseMatrix& mmatrix, const Core::FE::Discretization& source_dis,
-        const Core::FE::Discretization& target_dis, int sdofset, int mdofset);
+    void integrate_cells_2d(Core::Elements::Element& source_ele,
+        Core::Elements::Element& target_ele, Mortar::IntCell& cell,
+        Core::LinAlg::SparseMatrix& dmatrix, Core::LinAlg::SparseMatrix& mmatrix,
+        const Core::FE::Discretization& source_dis, const Core::FE::Discretization& target_dis,
+        int source_dofset, int target_dofset);
 
     /*!
     \brief Integrate cell for 3D problems
@@ -80,8 +81,8 @@ namespace Coupling::VolMortar
         Coupling::VolMortar::Cell& cell, Core::LinAlg::SparseMatrix& dmatrix_A,
         Core::LinAlg::SparseMatrix& mmatrix_A, Core::LinAlg::SparseMatrix& dmatrix_B,
         Core::LinAlg::SparseMatrix& mmatrix_B, const Core::FE::Discretization& Adis,
-        const Core::FE::Discretization& Bdis, int sdofset_A, int mdofset_A, int sdofset_B,
-        int mdofset_B);
+        const Core::FE::Discretization& Bdis, int source_dofset_A, int target_dofset_A,
+        int source_dofset_B, int target_dofset_B);
 
     /*!
     \brief Integrate cell for 3D problems
@@ -92,8 +93,8 @@ namespace Coupling::VolMortar
         std::shared_ptr<Core::FE::GaussPoints> intpoints, bool switched_conf,
         Core::LinAlg::SparseMatrix& dmatrix_A, Core::LinAlg::SparseMatrix& mmatrix_A,
         Core::LinAlg::SparseMatrix& dmatrix_B, Core::LinAlg::SparseMatrix& mmatrix_B,
-        const Core::FE::Discretization& Adis, const Core::FE::Discretization& Bdis, int sdofset_A,
-        int mdofset_A, int sdofset_B, int mdofset_B);
+        const Core::FE::Discretization& Adis, const Core::FE::Discretization& Bdis,
+        int source_dofset_A, int target_dofset_A, int source_dofset_B, int target_dofset_B);
 
     /*!
     \brief Integrate ele for 3D problems
@@ -102,8 +103,8 @@ namespace Coupling::VolMortar
     void integrate_ele_3d(int domain, Core::Elements::Element& Aele, Core::Elements::Element& Bele,
         Core::LinAlg::SparseMatrix& dmatrix_A, Core::LinAlg::SparseMatrix& mmatrix_A,
         Core::LinAlg::SparseMatrix& dmatrix_B, Core::LinAlg::SparseMatrix& mmatrix_B,
-        const Core::FE::Discretization& Adis, const Core::FE::Discretization& Bdis, int sdofset_A,
-        int mdofset_A, int sdofset_B, int mdofset_B);
+        const Core::FE::Discretization& Adis, const Core::FE::Discretization& Bdis,
+        int source_dofset_A, int target_dofset_A, int source_dofset_B, int target_dofset_B);
 
     /*!
     \brief Integrate ele for 3D problems
@@ -128,15 +129,15 @@ namespace Coupling::VolMortar
     \brief Check integration point mapping (2D)
 
     */
-    bool check_mapping_2d(
-        Core::Elements::Element& sele, Core::Elements::Element& mele, double* sxi, double* mxi);
+    bool check_mapping_2d(Core::Elements::Element& source_ele, Core::Elements::Element& target_ele,
+        double* source_xi, double* target_xi);
 
     /*!
     \brief Check integration point mapping (3D)
 
     */
-    bool check_mapping_3d(
-        Core::Elements::Element& sele, Core::Elements::Element& mele, double* sxi, double* mxi);
+    bool check_mapping_3d(Core::Elements::Element& source_ele, Core::Elements::Element& target_ele,
+        double* source_xi, double* target_xi);
 
     //@}
     int ngp_;                                 // number of Gauss points
@@ -148,7 +149,7 @@ namespace Coupling::VolMortar
     Shapefcn shape_;     // type of test function
   };
 
-  template <Core::FE::CellType distype_s>
+  template <Core::FE::CellType distype_source>
   class VolMortarIntegratorEleBased
   {
    public:
@@ -158,11 +159,11 @@ namespace Coupling::VolMortar
     // destructor
     virtual ~VolMortarIntegratorEleBased() = default;
 
-    //! ns_: number of source element nodes
-    static constexpr int ns_ = Core::FE::num_nodes(distype_s);
+    //! nsource_: number of source element nodes
+    static constexpr int nsource_ = Core::FE::num_nodes(distype_source);
 
     //! number of space dimensions ("+1" due to considering only interface elements)
-    static constexpr int ndim_ = Core::FE::dim<distype_s>;
+    static constexpr int ndim_ = Core::FE::dim<distype_source>;
 
     /*!
     \brief Initialize Gauss rule (points, weights)
@@ -174,7 +175,7 @@ namespace Coupling::VolMortar
     \brief Integrate ele for 3D problems
 
     */
-    void integrate_ele_based_3d(Core::Elements::Element& sele, std::vector<int>& foundeles,
+    void integrate_ele_based_3d(Core::Elements::Element& source_ele, std::vector<int>& foundeles,
         Core::LinAlg::SparseMatrix& dmatrixA, Core::LinAlg::SparseMatrix& mmatrixA,
         const Core::FE::Discretization& Adiscret, const Core::FE::Discretization& Bdiscret,
         int dofseta, int dofsetb, const Core::LinAlg::Map& PAB_dofrowmap,
@@ -185,8 +186,8 @@ namespace Coupling::VolMortar
     \brief Check integration point mapping (3D)
 
     */
-    bool check_mapping_3d(
-        Core::Elements::Element& sele, Core::Elements::Element& mele, double* sxi, double* mxi);
+    bool check_mapping_3d(Core::Elements::Element& source_ele, Core::Elements::Element& target_ele,
+        double* source_xi, double* target_xi);
 
     //@}
     int ngp_;                                 // number of Gauss points
@@ -201,48 +202,54 @@ namespace Coupling::VolMortar
   /*----------------------------------------------------------------------*
    |  Check paraspace mapping                                  farah 02/15|
    *----------------------------------------------------------------------*/
-  template <Core::FE::CellType distype_s, Core::FE::CellType distype_m>
-  bool check_mapping(
-      Core::Elements::Element& sele, Core::Elements::Element& mele, double* sxi, double* mxi)
+  template <Core::FE::CellType distype_source, Core::FE::CellType distype_target>
+  bool check_mapping(Core::Elements::Element& source_ele, Core::Elements::Element& target_ele,
+      double* source_xi, double* target_xi)
   {
     // check GP projection (SOURCE)
     double tol = 1e-5;
-    if (distype_s == Core::FE::CellType::hex8 || distype_s == Core::FE::CellType::hex20 ||
-        distype_s == Core::FE::CellType::hex27)
+    if (distype_source == Core::FE::CellType::hex8 || distype_source == Core::FE::CellType::hex20 ||
+        distype_source == Core::FE::CellType::hex27)
     {
-      if (sxi[0] < -1.0 - tol || sxi[1] < -1.0 - tol || sxi[2] < -1.0 - tol || sxi[0] > 1.0 + tol ||
-          sxi[1] > 1.0 + tol || sxi[2] > 1.0 + tol)
+      if (source_xi[0] < -1.0 - tol || source_xi[1] < -1.0 - tol || source_xi[2] < -1.0 - tol ||
+          source_xi[0] > 1.0 + tol || source_xi[1] > 1.0 + tol || source_xi[2] > 1.0 + tol)
       {
         return false;
       }
     }
-    else if (distype_s == Core::FE::CellType::pyramid5)
+    else if (distype_source == Core::FE::CellType::pyramid5)
     {
-      if (sxi[2] < 0.0 - tol || -sxi[0] + sxi[2] > 1.0 + tol || sxi[0] + sxi[2] > 1.0 + tol ||
-          -sxi[1] + sxi[2] > 1.0 + tol || sxi[1] + sxi[2] > 1.0 + tol)
+      if (source_xi[2] < 0.0 - tol || -source_xi[0] + source_xi[2] > 1.0 + tol ||
+          source_xi[0] + source_xi[2] > 1.0 + tol || -source_xi[1] + source_xi[2] > 1.0 + tol ||
+          source_xi[1] + source_xi[2] > 1.0 + tol)
       {
         return false;
       }
     }
-    else if (distype_s == Core::FE::CellType::tet4 || distype_s == Core::FE::CellType::tet10)
+    else if (distype_source == Core::FE::CellType::tet4 ||
+             distype_source == Core::FE::CellType::tet10)
     {
-      if (sxi[0] < 0.0 - tol || sxi[1] < 0.0 - tol || sxi[2] < 0.0 - tol ||
-          (sxi[0] + sxi[1] + sxi[2]) > 1.0 + tol)
+      if (source_xi[0] < 0.0 - tol || source_xi[1] < 0.0 - tol || source_xi[2] < 0.0 - tol ||
+          (source_xi[0] + source_xi[1] + source_xi[2]) > 1.0 + tol)
       {
         return false;
       }
     }
-    else if (distype_s == Core::FE::CellType::tri3 || distype_s == Core::FE::CellType::tri6)
+    else if (distype_source == Core::FE::CellType::tri3 ||
+             distype_source == Core::FE::CellType::tri6)
     {
-      if (sxi[0] < 0.0 - tol || sxi[1] < 0.0 - tol || (sxi[0] + sxi[1]) > 1.0 + tol)
+      if (source_xi[0] < 0.0 - tol || source_xi[1] < 0.0 - tol ||
+          (source_xi[0] + source_xi[1]) > 1.0 + tol)
       {
         return false;
       }
     }
-    else if (distype_s == Core::FE::CellType::quad4 || distype_s == Core::FE::CellType::quad8 ||
-             distype_s == Core::FE::CellType::quad9)
+    else if (distype_source == Core::FE::CellType::quad4 ||
+             distype_source == Core::FE::CellType::quad8 ||
+             distype_source == Core::FE::CellType::quad9)
     {
-      if (sxi[0] < -1.0 - tol || sxi[1] < -1.0 - tol || sxi[0] > 1.0 + tol || sxi[1] > 1.0 + tol)
+      if (source_xi[0] < -1.0 - tol || source_xi[1] < -1.0 - tol || source_xi[0] > 1.0 + tol ||
+          source_xi[1] > 1.0 + tol)
       {
         return false;
       }
@@ -251,42 +258,48 @@ namespace Coupling::VolMortar
       FOUR_C_THROW("Wrong element type!");
 
     // check GP projection (TARGET)
-    if (distype_m == Core::FE::CellType::hex8 || distype_m == Core::FE::CellType::hex20 ||
-        distype_m == Core::FE::CellType::hex27)
+    if (distype_target == Core::FE::CellType::hex8 || distype_target == Core::FE::CellType::hex20 ||
+        distype_target == Core::FE::CellType::hex27)
     {
-      if (mxi[0] < -1.0 - tol || mxi[1] < -1.0 - tol || mxi[2] < -1.0 - tol || mxi[0] > 1.0 + tol ||
-          mxi[1] > 1.0 + tol || mxi[2] > 1.0 + tol)
+      if (target_xi[0] < -1.0 - tol || target_xi[1] < -1.0 - tol || target_xi[2] < -1.0 - tol ||
+          target_xi[0] > 1.0 + tol || target_xi[1] > 1.0 + tol || target_xi[2] > 1.0 + tol)
       {
         return false;
       }
     }
-    else if (distype_m == Core::FE::CellType::pyramid5)
+    else if (distype_target == Core::FE::CellType::pyramid5)
     {
-      if (mxi[2] < 0.0 - tol || -mxi[0] + mxi[2] > 1.0 + tol || mxi[0] + mxi[2] > 1.0 + tol ||
-          -mxi[1] + mxi[2] > 1.0 + tol || mxi[1] + mxi[2] > 1.0 + tol)
+      if (target_xi[2] < 0.0 - tol || -target_xi[0] + target_xi[2] > 1.0 + tol ||
+          target_xi[0] + target_xi[2] > 1.0 + tol || -target_xi[1] + target_xi[2] > 1.0 + tol ||
+          target_xi[1] + target_xi[2] > 1.0 + tol)
       {
         return false;
       }
     }
-    else if (distype_m == Core::FE::CellType::tet4 || distype_m == Core::FE::CellType::tet10)
+    else if (distype_target == Core::FE::CellType::tet4 ||
+             distype_target == Core::FE::CellType::tet10)
     {
-      if (mxi[0] < 0.0 - tol || mxi[1] < 0.0 - tol || mxi[2] < 0.0 - tol ||
-          (mxi[0] + mxi[1] + mxi[2]) > 1.0 + tol)
+      if (target_xi[0] < 0.0 - tol || target_xi[1] < 0.0 - tol || target_xi[2] < 0.0 - tol ||
+          (target_xi[0] + target_xi[1] + target_xi[2]) > 1.0 + tol)
       {
         return false;
       }
     }
-    else if (distype_m == Core::FE::CellType::tri3 || distype_m == Core::FE::CellType::tri6)
+    else if (distype_target == Core::FE::CellType::tri3 ||
+             distype_target == Core::FE::CellType::tri6)
     {
-      if (mxi[0] < 0.0 - tol || mxi[1] < 0.0 - tol || (mxi[0] + mxi[1]) > 1.0 + tol)
+      if (target_xi[0] < 0.0 - tol || target_xi[1] < 0.0 - tol ||
+          (target_xi[0] + target_xi[1]) > 1.0 + tol)
       {
         return false;
       }
     }
-    else if (distype_m == Core::FE::CellType::quad4 || distype_m == Core::FE::CellType::quad8 ||
-             distype_m == Core::FE::CellType::quad9)
+    else if (distype_target == Core::FE::CellType::quad4 ||
+             distype_target == Core::FE::CellType::quad8 ||
+             distype_target == Core::FE::CellType::quad9)
     {
-      if (mxi[0] < -1.0 - tol || mxi[1] < -1.0 - tol || mxi[0] > 1.0 + tol || mxi[1] > 1.0 + tol)
+      if (target_xi[0] < -1.0 - tol || target_xi[1] < -1.0 - tol || target_xi[0] > 1.0 + tol ||
+          target_xi[1] > 1.0 + tol)
       {
         return false;
       }
@@ -355,13 +368,14 @@ namespace Coupling::VolMortar
   }
 
   //===================================
-  template <Core::FE::CellType distype_s, Core::FE::CellType distype_m>
-  bool vol_mortar_ele_based_gp(Core::Elements::Element& sele, Core::Elements::Element* mele,
-      std::vector<int>& foundeles, int& found, int& gpid, double& jac, double& wgt, double& gpdist,
-      double* Axi, double* AuxXi, double* globgp, DualQuad& dq, Shapefcn& shape,
-      Core::LinAlg::SparseMatrix& dmatrix_A, Core::LinAlg::SparseMatrix& mmatrix_A,
-      const Core::FE::Discretization& Adis, const Core::FE::Discretization& Bdis, int dofseta,
-      int dofsetb, const Core::LinAlg::Map& PAB_dofrowmap, const Core::LinAlg::Map& PAB_dofcolmap);
+  template <Core::FE::CellType distype_source, Core::FE::CellType distype_target>
+  bool vol_mortar_ele_based_gp(Core::Elements::Element& source_ele,
+      Core::Elements::Element* target_ele, std::vector<int>& foundeles, int& found, int& gpid,
+      double& jac, double& wgt, double& gpdist, double* Axi, double* AuxXi, double* globgp,
+      DualQuad& dq, Shapefcn& shape, Core::LinAlg::SparseMatrix& dmatrix_A,
+      Core::LinAlg::SparseMatrix& mmatrix_A, const Core::FE::Discretization& Adis,
+      const Core::FE::Discretization& Bdis, int dofseta, int dofsetb,
+      const Core::LinAlg::Map& PAB_dofrowmap, const Core::LinAlg::Map& PAB_dofcolmap);
 
   // evaluation of nts approach
   template <Core::FE::CellType distype>

--- a/src/ehl/4C_ehl_base.cpp
+++ b/src/ehl/4C_ehl_base.cpp
@@ -211,7 +211,7 @@ void EHL::Base::set_struct_solution(std::shared_ptr<const Core::LinAlg::Vector<d
   // Reevaluate the mortar martices D and M
   mortaradapter_->integrate(disp, dt());
 
-  // Displace the mesh of the lubrication field in accordance with the slave-side interface
+  // Displace the mesh of the lubrication field in accordance with the source-side interface
   set_mesh_disp(*disp);
 
   // Calculate the average tangential fractions of the structure velocities at the interface and
@@ -230,8 +230,6 @@ void EHL::Base::set_struct_solution(std::shared_ptr<const Core::LinAlg::Vector<d
 
   // Create DBC map for unprojectable nodes
   setup_unprojectable_dbc();
-
-  return;
 }
 
 /*----------------------------------------------------------------------*
@@ -252,8 +250,8 @@ std::shared_ptr<Core::LinAlg::Vector<double>> EHL::Base::evaluate_fluid_force(
     }
 
   // Forces on the interfaces due to the fluid traction
-  Core::LinAlg::Vector<double> slaveiforce(mortaradapter_->get_mortar_matrix_d()->domain_map());
-  Core::LinAlg::Vector<double> masteriforce(mortaradapter_->get_mortar_matrix_m()->domain_map());
+  Core::LinAlg::Vector<double> sourceiforce(mortaradapter_->get_mortar_matrix_d()->domain_map());
+  Core::LinAlg::Vector<double> targetiforce(mortaradapter_->get_mortar_matrix_m()->domain_map());
 
   stritraction_D_ =
       std::make_shared<Core::LinAlg::Vector<double>>(*ada_strDisp_to_lubDisp_->target_dof_map());
@@ -261,19 +259,19 @@ std::shared_ptr<Core::LinAlg::Vector<double>> EHL::Base::evaluate_fluid_force(
       std::make_shared<Core::LinAlg::Vector<double>>(*ada_strDisp_to_lubDisp_->target_dof_map());
 
   // add pressure force
-  add_pressure_force(slaveiforce, masteriforce);
+  add_pressure_force(sourceiforce, targetiforce);
   // add poiseuille flow force
-  add_poiseuille_force(slaveiforce, masteriforce);
+  add_poiseuille_force(sourceiforce, targetiforce);
   // add couette flow force
-  add_couette_force(slaveiforce, masteriforce);
+  add_couette_force(sourceiforce, targetiforce);
 
   // External force vector (global)
   std::shared_ptr<Core::LinAlg::Vector<double>> strforce =
       std::make_shared<Core::LinAlg::Vector<double>>(*(structure_->dof_row_map()));
 
   // Insert both interface forces into the global force vector
-  slaverowmapextr_->insert_vector(slaveiforce, 0, *strforce);
-  masterrowmapextr_->insert_vector(masteriforce, 0, *strforce);
+  sourcerowmapextr_->insert_vector(sourceiforce, 0, *strforce);
+  targetrowmapextr_->insert_vector(targetiforce, 0, *strforce);
 
   return strforce;
 }
@@ -291,7 +289,7 @@ void EHL::Base::set_lubrication_solution(
 }
 
 void EHL::Base::add_pressure_force(
-    Core::LinAlg::Vector<double>& slaveiforce, Core::LinAlg::Vector<double>& masteriforce)
+    Core::LinAlg::Vector<double>& sourceiforce, Core::LinAlg::Vector<double>& targetiforce)
 {
   std::shared_ptr<Core::LinAlg::Vector<double>> stritraction;
 
@@ -309,18 +307,18 @@ void EHL::Base::add_pressure_force(
   const std::shared_ptr<Core::LinAlg::SparseMatrix> mortard = mortaradapter_->get_mortar_matrix_d();
   const std::shared_ptr<Core::LinAlg::SparseMatrix> mortarm = mortaradapter_->get_mortar_matrix_m();
 
-  // f_slave = D^T*t
-  mortard->multiply(true, *stritraction, slaveiforce);
+  // f_source = D^T*t
+  mortard->multiply(true, *stritraction, sourceiforce);
   stritraction_D_->update(1., *stritraction, 1.);
 
-  // f_master = -M^T*t
-  mortarm->multiply(true, *stritraction, masteriforce);
-  masteriforce.scale(-1.0);
+  // f_target = -M^T*t
+  mortarm->multiply(true, *stritraction, targetiforce);
+  targetiforce.scale(-1.0);
   stritraction_M_->update(-1., *stritraction, 1.);
 }
 
 void EHL::Base::add_poiseuille_force(
-    Core::LinAlg::Vector<double>& slaveiforce, Core::LinAlg::Vector<double>& masteriforce)
+    Core::LinAlg::Vector<double>& sourceiforce, Core::LinAlg::Vector<double>& targetiforce)
 {
   // poiseuille flow forces
   std::shared_ptr<Core::LinAlg::Vector<double>> p_int =
@@ -329,7 +327,7 @@ void EHL::Base::add_poiseuille_force(
   Core::LinAlg::export_to(*p_int, p_int_full);
 
   Core::LinAlg::Vector<double> nodal_gap(*mortaradapter_->source_dof_map());
-  slavemaptransform_->multiply(false, *mortaradapter_->nodal_gap(), nodal_gap);
+  sourcemaptransform_->multiply(false, *mortaradapter_->nodal_gap(), nodal_gap);
 
   Core::LinAlg::SparseMatrix m(*mortaradapter_->surf_grad_matrix());
 
@@ -339,31 +337,31 @@ void EHL::Base::add_poiseuille_force(
   Core::LinAlg::Vector<double> poiseuille_force(*mortaradapter_->source_dof_map());
   m.multiply(false, p_int_full, poiseuille_force);
 
-  Core::LinAlg::Vector<double> slave_psl(mortaradapter_->get_mortar_matrix_d()->domain_map());
-  Core::LinAlg::Vector<double> master_psl(mortaradapter_->get_mortar_matrix_m()->domain_map());
+  Core::LinAlg::Vector<double> source_psl(mortaradapter_->get_mortar_matrix_d()->domain_map());
+  Core::LinAlg::Vector<double> target_psl(mortaradapter_->get_mortar_matrix_m()->domain_map());
 
-  // f_slave = D^T*t
-  mortaradapter_->get_mortar_matrix_d()->multiply(true, poiseuille_force, slave_psl);
+  // f_source = D^T*t
+  mortaradapter_->get_mortar_matrix_d()->multiply(true, poiseuille_force, source_psl);
   stritraction_D_->update(1., poiseuille_force, 1.);
 
-  // f_master = +M^T*t // attention: no minus sign here: poiseuille points in same direction on
-  // slave and master side
-  mortaradapter_->get_mortar_matrix_m()->multiply(true, poiseuille_force, master_psl);
+  // f_target = +M^T*t // attention: no minus sign here: poiseuille points in same direction on
+  // source and target side
+  mortaradapter_->get_mortar_matrix_m()->multiply(true, poiseuille_force, target_psl);
   stritraction_M_->update(1., poiseuille_force, 1.);
 
   // add the contribution
-  slaveiforce.update(1., slave_psl, 1.);
-  masteriforce.update(1., master_psl, 1.);
+  sourceiforce.update(1., source_psl, 1.);
+  targetiforce.update(1., target_psl, 1.);
 }
 
 
 void EHL::Base::add_couette_force(
-    Core::LinAlg::Vector<double>& slaveiforce, Core::LinAlg::Vector<double>& masteriforce)
+    Core::LinAlg::Vector<double>& sourceiforce, Core::LinAlg::Vector<double>& targetiforce)
 {
   const int ndim = Global::Problem::instance()->n_dim();
   const std::shared_ptr<const Core::LinAlg::Vector<double>> relVel = mortaradapter_->rel_tang_vel();
   Core::LinAlg::Vector<double> height(*mortaradapter_->source_dof_map());
-  slavemaptransform_->multiply(false, *mortaradapter_->nodal_gap(), height);
+  sourcemaptransform_->multiply(false, *mortaradapter_->nodal_gap(), height);
   Core::LinAlg::Vector<double> h_inv(*mortaradapter_->source_dof_map());
   h_inv.reciprocal(height);
   Core::LinAlg::Vector<double> hinv_relV(*mortaradapter_->source_dof_map());
@@ -391,19 +389,19 @@ void EHL::Base::add_couette_force(
   Core::LinAlg::Vector<double> couette_force(*mortaradapter_->source_dof_map());
   couette_force.multiply(-1., *visc_vec_str, hinv_relV, 0.);
 
-  Core::LinAlg::Vector<double> slave_cou(mortaradapter_->get_mortar_matrix_d()->domain_map());
-  Core::LinAlg::Vector<double> master_cou(mortaradapter_->get_mortar_matrix_m()->domain_map());
-  // f_slave = D^T*t
-  mortaradapter_->get_mortar_matrix_d()->multiply(true, couette_force, slave_cou);
+  Core::LinAlg::Vector<double> source_cou(mortaradapter_->get_mortar_matrix_d()->domain_map());
+  Core::LinAlg::Vector<double> target_cou(mortaradapter_->get_mortar_matrix_m()->domain_map());
+  // f_source = D^T*t
+  mortaradapter_->get_mortar_matrix_d()->multiply(true, couette_force, source_cou);
   stritraction_D_->update(1., couette_force, 1.);
 
-  // f_master = -M^T*t
-  mortaradapter_->get_mortar_matrix_m()->multiply(true, couette_force, master_cou);
+  // f_target = -M^T*t
+  mortaradapter_->get_mortar_matrix_m()->multiply(true, couette_force, target_cou);
   stritraction_M_->update(-1., couette_force, 1.);
 
   // add the contribution
-  slaveiforce.update(1., slave_cou, 1.);
-  masteriforce.update(-1., master_cou, 1.);
+  sourceiforce.update(1., source_cou, 1.);
+  targetiforce.update(-1., target_cou, 1.);
 }
 
 /*----------------------------------------------------------------------*
@@ -434,11 +432,11 @@ void EHL::Base::set_height_field()
   //  const std::shared_ptr<Core::LinAlg::SparseMatrix> mortardinv =
   //  mortaradapter_->GetDinvMatrix();
   std::shared_ptr<Core::LinAlg::Vector<double>> discretegap =
-      std::make_shared<Core::LinAlg::Vector<double>>(*(slaverowmapextr_->map(0)), true);
+      std::make_shared<Core::LinAlg::Vector<double>>(*(sourcerowmapextr_->map(0)), true);
 
-  // get the weighted gap and store it in slave dof map (for each node, the scalar value is stored
+  // get the weighted gap and store it in source dof map (for each node, the scalar value is stored
   // in the 0th dof)
-  slavemaptransform_->multiply(false, *mortaradapter_->nodal_gap(), *discretegap);
+  sourcemaptransform_->multiply(false, *mortaradapter_->nodal_gap(), *discretegap);
 
   // store discrete gap in lubrication disp dof map (its the film height)
   std::shared_ptr<Core::LinAlg::Vector<double>> height =
@@ -459,10 +457,10 @@ void EHL::Base::set_height_dot()
   heightdot.update(-1.0 / dt(), *heightold_, 1.0 / dt());
 
   std::shared_ptr<Core::LinAlg::Vector<double>> discretegap =
-      std::make_shared<Core::LinAlg::Vector<double>>(*(slaverowmapextr_->map(0)), true);
-  // get the weighted heightdot and store it in slave dof map (for each node, the scalar value is
+      std::make_shared<Core::LinAlg::Vector<double>>(*(sourcerowmapextr_->map(0)), true);
+  // get the weighted heightdot and store it in source dof map (for each node, the scalar value is
   // stored in the 0th dof)
-  slavemaptransform_->multiply(false, heightdot, *discretegap);
+  sourcemaptransform_->multiply(false, heightdot, *discretegap);
   // store discrete heightDot in lubrication disp dof map (its the film height time derivative)
   std::shared_ptr<Core::LinAlg::Vector<double>> heightdotSet =
       ada_strDisp_to_lubDisp_->target_to_source(*discretegap);
@@ -476,15 +474,15 @@ void EHL::Base::set_height_dot()
  *----------------------------------------------------------------------*/
 void EHL::Base::set_mesh_disp(const Core::LinAlg::Vector<double>& disp)
 {
-  // Extract the structure displacement at the slave-side interface
-  std::shared_ptr<Core::LinAlg::Vector<double>> slaveidisp =
-      std::make_shared<Core::LinAlg::Vector<double>>(
-          *(slaverowmapextr_->map(0)), true);  // Structure displacement at the lubricated interface
-  slaverowmapextr_->extract_vector(disp, 0, *slaveidisp);
+  // Extract the structure displacement at the source-side interface
+  std::shared_ptr<Core::LinAlg::Vector<double>> sourceidisp =
+      std::make_shared<Core::LinAlg::Vector<double>>(*(sourcerowmapextr_->map(0)),
+          true);  // Structure displacement at the lubricated interface
+  sourcerowmapextr_->extract_vector(disp, 0, *sourceidisp);
 
   // Transfer the displacement vector onto the lubrication field
   std::shared_ptr<Core::LinAlg::Vector<double>> lubridisp =
-      ada_strDisp_to_lubDisp_->target_to_source(*slaveidisp);
+      ada_strDisp_to_lubDisp_->target_to_source(*sourceidisp);
 
   // Provide the lubrication discretization with the displacement
   lubrication_->lubrication_field()->apply_mesh_movement(lubridisp, 1);
@@ -584,9 +582,9 @@ void EHL::Base::setup_field_coupling(
   //------------------------------------------------------------------
 
   // A mortar coupling adapter, using the "EHL Coupling Condition" is set up. The Coupling is
-  // between the slave- and the master-side interface of the structure. Dofs, which, need to be
-  // transferred from the master-side to the lubrication field, need to be mortar-projected to the
-  // slave-side interface and then transferred by a matching-node coupling,  and vice versa. The
+  // between the source- and the target-side interface of the structure. Dofs, which, need to be
+  // transferred from the target-side to the lubrication field, need to be mortar-projected to the
+  // source-side interface and then transferred by a matching-node coupling,  and vice versa. The
   // matching node coupling is defined below.
 
   std::vector<int> coupleddof(ndim, 1);
@@ -614,18 +612,18 @@ void EHL::Base::setup_field_coupling(
   mortaradapter_->integrate(idisp, dt());
 
   // Maps of the interface dofs
-  std::shared_ptr<const Core::LinAlg::Map> masterdofrowmap =
+  std::shared_ptr<const Core::LinAlg::Map> targetdofrowmap =
       mortaradapter_->interface()->target_row_dofs();
-  std::shared_ptr<const Core::LinAlg::Map> slavedofrowmap =
+  std::shared_ptr<const Core::LinAlg::Map> sourcedofrowmap =
       mortaradapter_->interface()->source_row_dofs();
   std::shared_ptr<Core::LinAlg::Map> mergeddofrowmap =
-      Core::LinAlg::merge_map(masterdofrowmap, slavedofrowmap, false);
+      Core::LinAlg::merge_map(targetdofrowmap, sourcedofrowmap, false);
 
   // Map extractors with the structure dofs as full maps and local interface maps
-  slaverowmapextr_ = std::make_shared<Core::LinAlg::MapExtractor>(
-      *(structdis->dof_row_map()), slavedofrowmap, false);
-  masterrowmapextr_ = std::make_shared<Core::LinAlg::MapExtractor>(
-      *(structdis->dof_row_map()), masterdofrowmap, false);
+  sourcerowmapextr_ = std::make_shared<Core::LinAlg::MapExtractor>(
+      *(structdis->dof_row_map()), sourcedofrowmap, false);
+  targetrowmapextr_ = std::make_shared<Core::LinAlg::MapExtractor>(
+      *(structdis->dof_row_map()), targetdofrowmap, false);
   mergedrowmapextr_ = std::make_shared<Core::LinAlg::MapExtractor>(
       *(structdis->dof_row_map()), mergeddofrowmap, false);
 
@@ -649,22 +647,23 @@ void EHL::Base::setup_field_coupling(
       *mortaradapter_->interface()->source_row_nodes(), *lubricationdis->node_row_map(), 1, true,
       1.e-3);
 
-  // Setup of transformation matrix: slave node map <-> slave disp dof map
-  slavemaptransform_ =
-      std::make_shared<Core::LinAlg::SparseMatrix>(*slavedofrowmap, 81, false, false);
+  // Setup of transformation matrix: source node map <-> source disp dof map
+  sourcemaptransform_ =
+      std::make_shared<Core::LinAlg::SparseMatrix>(*sourcedofrowmap, 81, false, false);
   for (int i = 0; i < mortaradapter_->interface()->source_row_nodes()->num_my_elements(); ++i)
   {
     int gid = mortaradapter_->interface()->source_row_nodes()->gid(i);
     Core::Nodes::Node* node = structdis->g_node(gid);
     std::vector<int> dofs = structdis->dof(0, node);
-    // slavemaptransform_->Assemble(1.0,dofs[0],gid);
+    // sourcemaptransform_->Assemble(1.0,dofs[0],gid);
     for (unsigned int idim = 0; idim < dofs.size(); idim++)
     {
       int row = dofs[idim];
-      slavemaptransform_->assemble(1.0, row, gid);
+      sourcemaptransform_->assemble(1.0, row, gid);
     }
   }
-  slavemaptransform_->complete(*(mortaradapter_->interface()->source_row_nodes()), *slavedofrowmap);
+  sourcemaptransform_->complete(
+      *(mortaradapter_->interface()->source_row_nodes()), *sourcedofrowmap);
 
   // Setup of transformation matrix: lubrication pre dof map <-> lubrication disp dof map
   lubrimaptransform_ = std::make_shared<Core::LinAlg::SparseMatrix>(
@@ -695,8 +694,6 @@ void EHL::Base::update()
   mortaradapter_->interface()->store_to_old(Mortar::StrategyBase::activeold);
   structure_field()->update();
   lubrication_->lubrication_field()->update();
-
-  return;
 }
 
 /*----------------------------------------------------------------------*
@@ -767,11 +764,11 @@ void EHL::Base::output(bool forced_writerestart)
   // Additional output on the lubrication field
   {
     std::shared_ptr<Core::LinAlg::Vector<double>> discretegap =
-        std::make_shared<Core::LinAlg::Vector<double>>(*(slaverowmapextr_->map(0)), true);
+        std::make_shared<Core::LinAlg::Vector<double>>(*(sourcerowmapextr_->map(0)), true);
 
-    // get the weighted gap and store it in slave dof map (for each node, the scalar value is stored
-    // in the 0th dof)
-    slavemaptransform_->multiply(false, *mortaradapter_->nodal_gap(), *discretegap);
+    // get the weighted gap and store it in source dof map (for each node, the scalar value is
+    // stored in the 0th dof)
+    sourcemaptransform_->multiply(false, *mortaradapter_->nodal_gap(), *discretegap);
 
     // store discrete gap in lubrication disp dof map (its the film height)
     std::shared_ptr<Core::LinAlg::Vector<double>> height =

--- a/src/ehl/4C_ehl_base.hpp
+++ b/src/ehl/4C_ehl_base.hpp
@@ -77,13 +77,13 @@ namespace EHL
 
    protected:
     void add_pressure_force(
-        Core::LinAlg::Vector<double>& slaveiforce, Core::LinAlg::Vector<double>& masteriforce);
+        Core::LinAlg::Vector<double>& sourceiforce, Core::LinAlg::Vector<double>& targetiforce);
 
     void add_poiseuille_force(
-        Core::LinAlg::Vector<double>& slaveiforce, Core::LinAlg::Vector<double>& masteriforce);
+        Core::LinAlg::Vector<double>& sourceiforce, Core::LinAlg::Vector<double>& targetiforce);
 
     void add_couette_force(
-        Core::LinAlg::Vector<double>& slaveiforce, Core::LinAlg::Vector<double>& masteriforce);
+        Core::LinAlg::Vector<double>& sourceiforce, Core::LinAlg::Vector<double>& targetiforce);
 
     /// underlying structure of the EHL problem
     std::shared_ptr<Adapter::Structure> structure_;
@@ -94,11 +94,11 @@ namespace EHL
     //! Type of coupling strategy between the two fields of the EHL problems
     const EHL::FieldCoupling fieldcoupling_;
 
-    //! adapter for coupling the nodes of the lubrication field with the nodes from the master side
+    //! adapter for coupling the nodes of the lubrication field with the nodes from the target side
     //! of the structure
     std::shared_ptr<Adapter::CouplingEhlMortar> mortaradapter_;
 
-    //! Interface traction vector in the slave str dof map
+    //! Interface traction vector in the source str dof map
     std::shared_ptr<Core::LinAlg::Vector<double>> stritraction_D_;
     std::shared_ptr<Core::LinAlg::Vector<double>> stritraction_M_;
 
@@ -106,12 +106,12 @@ namespace EHL
     std::shared_ptr<Core::LinAlg::SparseMatrix> lubrimaptransform_;
 
     //! Mapextractors for dealing with interface vectors of the structure field
-    std::shared_ptr<Core::LinAlg::MapExtractor> slaverowmapextr_;
-    std::shared_ptr<Core::LinAlg::MapExtractor> masterrowmapextr_;
+    std::shared_ptr<Core::LinAlg::MapExtractor> sourcerowmapextr_;
+    std::shared_ptr<Core::LinAlg::MapExtractor> targetrowmapextr_;
     std::shared_ptr<Core::LinAlg::MapExtractor> mergedrowmapextr_;
 
-    //! Transformation matrix for slave side node map <-> slave side disp dof map
-    std::shared_ptr<Core::LinAlg::SparseMatrix> slavemaptransform_;
+    //! Transformation matrix for source side node map <-> source side disp dof map
+    std::shared_ptr<Core::LinAlg::SparseMatrix> sourcemaptransform_;
 
     //! several adapters to transform maps
     std::shared_ptr<Coupling::Adapter::Coupling> ada_strDisp_to_lubDisp_;

--- a/src/ehl/4C_ehl_monolithic.cpp
+++ b/src/ehl/4C_ehl_monolithic.cpp
@@ -482,7 +482,7 @@ void EHL::Monolithic::setup_system_matrix()
       std::make_shared<Core::LinAlg::Vector<double>>(
           *(mortaradapter_->interface()->source_col_dofs()), true);
   Core::LinAlg::export_to(*stritraction_D_, *stritraction_D_col);
-  std::shared_ptr<Core::LinAlg::SparseMatrix> slaveiforce_derivd1 =
+  std::shared_ptr<Core::LinAlg::SparseMatrix> sourceiforce_derivd1 =
       mortaradapter_->assemble_ehl_lin_d(stritraction_D_col);
 
   // d(-M^T)/dd * t
@@ -490,13 +490,13 @@ void EHL::Monolithic::setup_system_matrix()
       std::make_shared<Core::LinAlg::Vector<double>>(
           *(mortaradapter_->interface()->source_col_dofs()), true);
   Core::LinAlg::export_to(*stritraction_M_, *stritraction_M_col);
-  std::shared_ptr<Core::LinAlg::SparseMatrix> masteriforce_derivd1 =
+  std::shared_ptr<Core::LinAlg::SparseMatrix> targetiforce_derivd1 =
       mortaradapter_->assemble_ehl_lin_m(stritraction_M_col);
-  masteriforce_derivd1->scale(-1.0);
+  targetiforce_derivd1->scale(-1.0);
 
   // Add the negative midpoint values (remember, we are linearizing an extforce-like term)
-  Core::LinAlg::matrix_add(*slaveiforce_derivd1, false, -(1.0 - alphaf), *k_ss, 1.0);
-  Core::LinAlg::matrix_add(*masteriforce_derivd1, false, -(1.0 - alphaf), *k_ss, 1.0);
+  Core::LinAlg::matrix_add(*sourceiforce_derivd1, false, -(1.0 - alphaf), *k_ss, 1.0);
+  Core::LinAlg::matrix_add(*targetiforce_derivd1, false, -(1.0 - alphaf), *k_ss, 1.0);
 
   // linearization of D.t and M.t (the part with D.(dt/dd))
   std::shared_ptr<Core::LinAlg::SparseMatrix> ds_dd =
@@ -536,30 +536,30 @@ void EHL::Monolithic::setup_system_matrix()
   k_sl_->un_complete();
 
   // linearization of traction w.r.t. fluid pressure
-  std::shared_ptr<Core::LinAlg::SparseMatrix> slaveiforce_derivp =
+  std::shared_ptr<Core::LinAlg::SparseMatrix> sourceiforce_derivp =
       std::make_shared<Core::LinAlg::SparseMatrix>(
           *mortaradapter_->source_dof_map(), 81, true, true);
-  std::shared_ptr<Core::LinAlg::SparseMatrix> masteriforce_derivp =
+  std::shared_ptr<Core::LinAlg::SparseMatrix> targetiforce_derivp =
       std::make_shared<Core::LinAlg::SparseMatrix>(
           *mortaradapter_->target_dof_map(), 81, true, true);
 
   // pressure force
-  lin_pressure_force_pres(*slaveiforce_derivp, *masteriforce_derivp);
+  lin_pressure_force_pres(*sourceiforce_derivp, *targetiforce_derivp);
 
   // poiseuille force
-  lin_poiseuille_force_pres(*slaveiforce_derivp, *masteriforce_derivp);
+  lin_poiseuille_force_pres(*sourceiforce_derivp, *targetiforce_derivp);
 
   // couette force
-  lin_couette_force_pres(*slaveiforce_derivp, *masteriforce_derivp);
+  lin_couette_force_pres(*sourceiforce_derivp, *targetiforce_derivp);
 
-  slaveiforce_derivp->complete(
+  sourceiforce_derivp->complete(
       *lubrication_->lubrication_field()->dof_row_map(), *mortaradapter_->source_dof_map());
-  masteriforce_derivp->complete(
+  targetiforce_derivp->complete(
       *lubrication_->lubrication_field()->dof_row_map(), *mortaradapter_->target_dof_map());
 
   // Add the negative midpoint values (remember, we are linearizing an extforce-like term)
-  Core::LinAlg::matrix_add(*slaveiforce_derivp, false, -(1.0 - alphaf), *k_sl_, 1.0);
-  Core::LinAlg::matrix_add(*masteriforce_derivp, false, -(1.0 - alphaf), *k_sl_, 1.0);
+  Core::LinAlg::matrix_add(*sourceiforce_derivp, false, -(1.0 - alphaf), *k_sl_, 1.0);
+  Core::LinAlg::matrix_add(*targetiforce_derivp, false, -(1.0 - alphaf), *k_sl_, 1.0);
 
   k_sl_->complete(*(extractor()->map(1)),  // pressure dof map
       *(extractor()->map(0))               // displacement dof map
@@ -1043,10 +1043,6 @@ void EHL::Monolithic::print_newton_iter_header(FILE* ofile)
 
   // print it, now
   fflush(ofile);
-
-  // nice to have met you
-  return;
-
 }  // print_newton_iter_header()
 
 
@@ -1199,10 +1195,6 @@ void EHL::Monolithic::print_newton_iter_text(FILE* ofile)
 
   // print it, now
   fflush(ofile);
-
-  // nice to have met you
-  return;
-
 }  // print_newton_iter_text
 
 
@@ -1210,11 +1202,7 @@ void EHL::Monolithic::print_newton_iter_text(FILE* ofile)
  | print statistics of converged NRI                        wirtz 01/16 |
  | originally by bborn 08/09                                            |
  *----------------------------------------------------------------------*/
-void EHL::Monolithic::print_newton_conv()
-{
-  // somebody did the door
-  return;
-}  // print_newton_conv()
+void EHL::Monolithic::print_newton_conv() {}  // print_newton_conv()
 
 
 
@@ -1262,8 +1250,6 @@ void EHL::Monolithic::apply_lubrication_coupl_matrix(
       *(lubrication_->lubrication_field()->discretization()->dof_row_map(0)));
 
   lubrication_->lubrication_field()->discretization()->clear_state(true);
-
-  return;
 }  // apply_lubrication_coupl_matrix()
 
 /*----------------------------------------------------------------------*
@@ -1578,9 +1564,6 @@ void EHL::Monolithic::set_default_parameters()
   normprei_ = 0.0;
   normlubricationrhs_ = 0.0;
   normlubricationrhsiter0_ = 0.0;
-
-  return;
-
 }  // SetDefaultParameter()
 
 /*----------------------------------------------------------------------*
@@ -1622,8 +1605,6 @@ void EHL::Monolithic::lin_pressure_force_disp(
       *mortaradapter_->get_mortar_matrix_m(), true, *p_deriv_normal, false, false, false, true);
   if (!tmp) FOUR_C_THROW("matrix_multiply failed");
   Core::LinAlg::matrix_add(*tmp, false, -1., dm_dd, 1.);
-
-  return;
 }
 
 void EHL::Monolithic::lin_poiseuille_force_disp(
@@ -1635,7 +1616,7 @@ void EHL::Monolithic::lin_poiseuille_force_disp(
   Core::LinAlg::export_to(*p_int, p_int_full);
 
   Core::LinAlg::Vector<double> nodal_gap(*mortaradapter_->source_dof_map());
-  slavemaptransform_->multiply(false, *mortaradapter_->nodal_gap(), nodal_gap);
+  sourcemaptransform_->multiply(false, *mortaradapter_->nodal_gap(), nodal_gap);
 
   Core::LinAlg::Vector<double> grad_p(*mortaradapter_->source_dof_map());
   mortaradapter_->surf_grad_matrix()->multiply(false, p_int_full, grad_p);
@@ -1695,7 +1676,7 @@ void EHL::Monolithic::lin_couette_force_disp(
       ada_strDisp_to_lubDisp_->source_to_target(visc_vec);
 
   Core::LinAlg::Vector<double> height(*mortaradapter_->source_dof_map());
-  slavemaptransform_->multiply(false, *mortaradapter_->nodal_gap(), height);
+  sourcemaptransform_->multiply(false, *mortaradapter_->nodal_gap(), height);
   Core::LinAlg::Vector<double> h_inv(*mortaradapter_->source_dof_map());
   h_inv.reciprocal(height);
 
@@ -1767,7 +1748,7 @@ void EHL::Monolithic::lin_poiseuille_force_pres(
     Core::LinAlg::SparseMatrix& ds_dp, Core::LinAlg::SparseMatrix& dm_dp)
 {
   Core::LinAlg::Vector<double> nodal_gap(*mortaradapter_->source_dof_map());
-  slavemaptransform_->multiply(false, *mortaradapter_->nodal_gap(), nodal_gap);
+  sourcemaptransform_->multiply(false, *mortaradapter_->nodal_gap(), nodal_gap);
 
   Core::LinAlg::SparseMatrix m(*mortaradapter_->surf_grad_matrix());
   m.left_scale(nodal_gap);
@@ -1806,7 +1787,6 @@ void EHL::Monolithic::lin_poiseuille_force_pres(
     Core::LinAlg::matrix_add(b, false, 1., dm_dp, 1.);
     dm_dp.complete(*d, *r);
   }
-  return;
 }
 
 void EHL::Monolithic::lin_couette_force_pres(
@@ -1815,7 +1795,7 @@ void EHL::Monolithic::lin_couette_force_pres(
   const int ndim = Global::Problem::instance()->n_dim();
   const std::shared_ptr<const Core::LinAlg::Vector<double>> relVel = mortaradapter_->rel_tang_vel();
   Core::LinAlg::Vector<double> height(*mortaradapter_->source_dof_map());
-  slavemaptransform_->multiply(false, *mortaradapter_->nodal_gap(), height);
+  sourcemaptransform_->multiply(false, *mortaradapter_->nodal_gap(), height);
   Core::LinAlg::Vector<double> h_inv(*mortaradapter_->source_dof_map());
   h_inv.reciprocal(height);
   Core::LinAlg::Vector<double> hinv_relV(*mortaradapter_->source_dof_map());

--- a/src/scatra/4C_scatra_s2i_input.cpp
+++ b/src/scatra/4C_scatra_s2i_input.cpp
@@ -40,7 +40,7 @@ std::vector<Core::IO::InputSpec> S2I::valid_parameters()
           deprecated_selection<InterfaceSides>("LMSIDE",
               {
                   {"slave", side_source},
-                  {"master", side_master},
+                  {"master", side_target},
               },
               {.description = "flag for interface side underlying Lagrange multiplier definition",
                   .default_value = side_source}),
@@ -137,7 +137,7 @@ void S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDefinition
       cond.add_component(parameter<int>("ConditionID"));
       cond.add_component(deprecated_selection<S2I::InterfaceSides>("INTERFACE_SIDE",
           {{"Undefined", S2I::side_undefined}, {"Slave", S2I::side_source},
-              {"Master", S2I::side_master}},
+              {"Master", S2I::side_target}},
           {.description = "interface side"}));
       cond.add_component(parameter<int>("S2I_KINETICS_ID"));
 
@@ -349,7 +349,7 @@ void S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDefinition
 
     auto interface_side_options = one_of({
         deprecated_selection<InterfaceSides>(
-            "INTERFACE_SIDE", {{"Master", side_master}, {"Undefined", side_undefined}}),
+            "INTERFACE_SIDE", {{"Master", side_target}, {"Undefined", side_undefined}}),
         all_of({
             deprecated_selection<InterfaceSides>("INTERFACE_SIDE", {{"Slave", side_source}}),
             one_of(kinetic_model_choices),
@@ -437,7 +437,7 @@ void S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDefinition
 
     s2isclcond.add_component(deprecated_selection<InterfaceSides>("INTERFACE_SIDE",
         {{"Undefined", S2I::side_undefined}, {"Slave", S2I::side_source},
-            {"Master", S2I::side_master}},
+            {"Master", S2I::side_target}},
         {.description = "interface side"}));
 
     condlist.emplace_back(s2isclcond);

--- a/src/scatra/4C_scatra_s2i_input.hpp
+++ b/src/scatra/4C_scatra_s2i_input.hpp
@@ -27,7 +27,7 @@ namespace S2I
   {
     side_undefined,
     side_source,
-    side_master
+    side_target
   };
 
   //! type of mesh coupling

--- a/src/scatra/4C_scatra_timint_elch_scl.cpp
+++ b/src/scatra/4C_scatra_timint_elch_scl.cpp
@@ -606,7 +606,7 @@ void ScaTra::ScaTraTimIntElchSCL::setup_coupling()
         case S2I::side_source:
           my_macro_slave_node_gids.emplace_back(coupling_node_gid);
           break;
-        case S2I::side_master:
+        case S2I::side_target:
           my_macro_master_node_gids.emplace_back(coupling_node_gid);
           break;
         default:

--- a/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
+++ b/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
@@ -566,7 +566,7 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
       }
 
       // initialize auxiliary system matrix and vector for master side
-      if (couplingtype_ == S2I::coupling_mortar_standard or lmside_ == S2I::side_master or
+      if (couplingtype_ == S2I::coupling_mortar_standard or lmside_ == S2I::side_target or
           couplingtype_ == S2I::coupling_nts_standard)
       {
         imastermatrix_->zero();
@@ -599,12 +599,12 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
           params.set<S2I::EvaluationActions>("action", S2I::evaluate_condition);
 
           evaluate_mortar_cells(idiscret, params, islavematrix_, S2I::side_source, S2I::side_source,
-              islavematrix_, S2I::side_source, S2I::side_master, imastermatrix_, S2I::side_master,
-              S2I::side_source, imastermatrix_, S2I::side_master, S2I::side_master,
+              islavematrix_, S2I::side_source, S2I::side_target, imastermatrix_, S2I::side_target,
+              S2I::side_source, imastermatrix_, S2I::side_target, S2I::side_target,
               islaveresidual_ != nullptr
                   ? Core::Utils::shared_ptr_from_ref(islaveresidual_->as_multi_vector())
                   : nullptr,
-              S2I::side_source, imasterresidual_, S2I::side_master);
+              S2I::side_source, imasterresidual_, S2I::side_target);
         }
 
         else
@@ -616,12 +616,12 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
           evaluate_nts(*islavenodestomasterelements_[condition_id],
               *islavenodeslumpedareas_[condition_id], *islavenodesimpltypes_[condition_id],
               idiscret, params, islavematrix_, S2I::side_source, S2I::side_source, islavematrix_,
-              S2I::side_source, S2I::side_master, imastermatrix_, S2I::side_master,
-              S2I::side_source, imastermatrix_, S2I::side_master, S2I::side_master,
+              S2I::side_source, S2I::side_target, imastermatrix_, S2I::side_target,
+              S2I::side_source, imastermatrix_, S2I::side_target, S2I::side_target,
               islaveresidual_ != nullptr
                   ? Core::Utils::shared_ptr_from_ref(islaveresidual_->as_multi_vector())
                   : nullptr,
-              S2I::side_source, imasterresidual_, S2I::side_master);
+              S2I::side_source, imasterresidual_, S2I::side_target);
         }
       }
 
@@ -631,7 +631,7 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
         islavematrix_->complete(*interfacemaps_->full_map(), *interfacemaps_->map(1));
 
       // finalize auxiliary system matrix and residual vector for master side
-      if (couplingtype_ == S2I::coupling_mortar_standard or lmside_ == S2I::side_master or
+      if (couplingtype_ == S2I::coupling_mortar_standard or lmside_ == S2I::side_target or
           couplingtype_ == S2I::coupling_nts_standard)
       {
         imastermatrix_->complete(*interfacemaps_->full_map(), *interfacemaps_->map(2));
@@ -1946,7 +1946,7 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
           break;
         }
 
-        case S2I::side_master:
+        case S2I::side_target:
         {
           if (!master_conditions_.contains(s2ikinetics_cond_id))
           {
@@ -2479,7 +2479,7 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
         islaveresidual_ = std::make_shared<Core::LinAlg::Vector<double>>(*interfacemaps_->map(1));
       }
 
-      if (couplingtype_ == S2I::coupling_mortar_standard or lmside_ == S2I::side_master or
+      if (couplingtype_ == S2I::coupling_mortar_standard or lmside_ == S2I::side_target or
           couplingtype_ == S2I::coupling_nts_standard)
       {
         // initialize auxiliary system matrix for master side
@@ -2532,12 +2532,12 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
 
             // evaluate mortar integration cells at current interface
             evaluate_mortar_cells(icoupmortar_[kinetics_slave_cond.first]->interface()->discret(),
-                params, D_, lmside_ == S2I::side_source ? S2I::side_source : S2I::side_master,
-                lmside_ == S2I::side_source ? S2I::side_source : S2I::side_master, M_,
-                lmside_ == S2I::side_source ? S2I::side_source : S2I::side_master,
-                lmside_ == S2I::side_source ? S2I::side_master : S2I::side_source, E_,
-                lmside_ == S2I::side_source ? S2I::side_source : S2I::side_master,
-                lmside_ == S2I::side_source ? S2I::side_source : S2I::side_master, nullptr,
+                params, D_, lmside_ == S2I::side_source ? S2I::side_source : S2I::side_target,
+                lmside_ == S2I::side_source ? S2I::side_source : S2I::side_target, M_,
+                lmside_ == S2I::side_source ? S2I::side_source : S2I::side_target,
+                lmside_ == S2I::side_source ? S2I::side_target : S2I::side_source, E_,
+                lmside_ == S2I::side_source ? S2I::side_source : S2I::side_target,
+                lmside_ == S2I::side_source ? S2I::side_source : S2I::side_target, nullptr,
                 S2I::side_undefined, S2I::side_undefined, nullptr, S2I::side_undefined, nullptr,
                 S2I::side_undefined);
           }
@@ -4811,7 +4811,7 @@ void ScaTra::MortarCellAssemblyStrategy::assemble_cell_matrix(
       break;
     }
 
-    case S2I::side_master:
+    case S2I::side_target:
     {
       std::dynamic_pointer_cast<Core::LinAlg::SparseMatrix>(systemmatrix)
           ->fe_assemble(cellmatrix, la_master[nds_rows_].lm_,
@@ -4849,7 +4849,7 @@ void ScaTra::MortarCellAssemblyStrategy::assemble_cell_vector(
       break;
     }
 
-    case S2I::side_master:
+    case S2I::side_target:
     {
       if (assembler_pid_master == Core::Communication::my_mpi_rank(systemvector.get_comm()))
       {
@@ -4885,7 +4885,7 @@ void ScaTra::MortarCellAssemblyStrategy::assemble_cell_vector(
       break;
     }
 
-    case S2I::side_master:
+    case S2I::side_target:
     {
       if (assembler_pid_master == Core::Communication::my_mpi_rank(systemvector->get_comm()))
       {

--- a/src/scatra/4C_scatra_timint_meshtying_strategy_s2i_elch.cpp
+++ b/src/scatra/4C_scatra_timint_meshtying_strategy_s2i_elch.cpp
@@ -1236,7 +1236,7 @@ void ScaTra::MeshtyingStrategyS2IElchSCL::setup_meshtying()
             *s2imeshtying_condition->get_nodes(), islavenodegidset);
         break;
       }
-      case S2I::side_master:
+      case S2I::side_target:
       {
         Core::Communication::add_owned_node_gid_from_list(*scatratimint_->discretization(),
             *s2imeshtying_condition->get_nodes(), imasternodegidset);

--- a/src/scatra/4C_scatra_utils.cpp
+++ b/src/scatra/4C_scatra_utils.cpp
@@ -138,7 +138,7 @@ void ScaTra::ScaTraUtils::check_consistency_with_s2_i_kinetics_condition(
         isslave = true;
         break;
       }
-      case S2I::side_master:
+      case S2I::side_target:
       {
         isslave = false;
         break;
@@ -167,7 +167,7 @@ void ScaTra::ScaTraUtils::check_consistency_with_s2_i_kinetics_condition(
 
           break;
         }
-        case S2I::side_master:
+        case S2I::side_target:
         {
           if (!isslave) assert_same_nodes(conditionToBeTested, s2ikinetics_cond);
 

--- a/src/ssi/4C_ssi_input.cpp
+++ b/src/ssi/4C_ssi_input.cpp
@@ -340,7 +340,7 @@ void SSI::set_valid_conditions(std::vector<Core::Conditions::ConditionDefinition
     cond.add_component(parameter<int>("ConditionID"));
     cond.add_component(deprecated_selection<S2I::InterfaceSides>("INTERFACE_SIDE",
         {{"Undefined", S2I::side_undefined}, {"Slave", S2I::side_source},
-            {"Master", S2I::side_master}},
+            {"Master", S2I::side_target}},
         {.description = "interface_side"}));
     cond.add_component(parameter<int>("S2I_KINETICS_ID"));
 
@@ -475,7 +475,7 @@ void SSI::set_valid_conditions(std::vector<Core::Conditions::ConditionDefinition
     cond.add_component(parameter<int>("ConditionID"));
     cond.add_component(deprecated_selection<S2I::InterfaceSides>("INTERFACE_SIDE",
         {{"Undefined", S2I::side_undefined}, {"Slave", S2I::side_source},
-            {"Master", S2I::side_master}},
+            {"Master", S2I::side_target}},
         {.description = "interface_side"}));
     cond.add_component(parameter<int>("S2I_KINETICS_ID"));
     cond.add_component(parameter<int>("CONTACT_CONDITION_ID"));

--- a/src/ssti/4C_ssti_input.cpp
+++ b/src/ssti/4C_ssti_input.cpp
@@ -151,7 +151,7 @@ void SSTI::set_valid_conditions(std::vector<Core::Conditions::ConditionDefinitio
     cond.add_component(parameter<int>("ConditionID"));
     cond.add_component(deprecated_selection<S2I::InterfaceSides>("INTERFACE_SIDE",
         {{"Undefined", S2I::side_undefined}, {"Slave", S2I::side_source},
-            {"Master", S2I::side_master}},
+            {"Master", S2I::side_target}},
         {.description = "interface side"}));
     cond.add_component(parameter<int>("S2I_KINETICS_ID"));
     condlist.push_back(cond);

--- a/src/sti/4C_sti_monolithic_evaluate_OffDiag.cpp
+++ b/src/sti/4C_sti_monolithic_evaluate_OffDiag.cpp
@@ -653,7 +653,7 @@ void STI::ScatraThermoOffDiagCouplingMortarStandard::
   // create strategy for assembly of auxiliary system matrices
   ScaTra::MortarCellAssemblyStrategy strategyscatrathermos2i(slavematrix, S2I::side_source,
       S2I::side_source, nullptr, S2I::side_undefined, S2I::side_undefined, mastermatrix_sparse,
-      S2I::side_master, S2I::side_source, nullptr, S2I::side_undefined, S2I::side_undefined,
+      S2I::side_target, S2I::side_source, nullptr, S2I::side_undefined, S2I::side_undefined,
       nullptr, S2I::side_undefined, nullptr, S2I::side_undefined, 0, 1);
 
   // extract scatra-scatra interface kinetics conditions
@@ -796,7 +796,7 @@ void STI::ScatraThermoOffDiagCouplingMortarStandard::
 
   // create strategy for assembly of auxiliary system matrix
   ScaTra::MortarCellAssemblyStrategy strategythermoscatras2i(slavematrix, S2I::side_source,
-      S2I::side_source, slavematrix, S2I::side_source, S2I::side_master, nullptr,
+      S2I::side_source, slavematrix, S2I::side_source, S2I::side_target, nullptr,
       S2I::side_undefined, S2I::side_undefined, nullptr, S2I::side_undefined, S2I::side_undefined,
       nullptr, S2I::side_undefined, nullptr, S2I::side_undefined, 0, 1);
 


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
This PR renames further occurences of master/slave to source/target, specifically:
- in volmortar (this commit was assisted by opencode)
- in ehl (this commit was assisted by opencode)
- in contact constitutive law
- rename `S2I::side_master`, which I forgot one of the previous PRs
- rename further occurences in core, which I overlooked in #2066 

I also remove unused code/unnecessary return statements on the go.

## Related Issues and Pull Requests
PRs
https://github.com/4C-multiphysics/4C/pull/1927
https://github.com/4C-multiphysics/4C/pull/2055
#2066

Issue
https://github.com/4C-multiphysics/4C/issues/1094