### PR TITLE
Remove NUMMAT from MIX_Constituent_ElastHyper

### DIFF
--- a/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
+++ b/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
@@ -4173,10 +4173,8 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
   {
     known_materials[Core::Materials::mix_elasthyper] = group("MIX_Constituent_ElastHyper",
         {
-            parameter<int>("NUMMAT", {.description = "number of summands"}),
             parameter<std::vector<int>>(
-                "MATIDS", {.description = "list material IDs of the summands",
-                              .size = from_parameter<int>("NUMMAT")}),
+                "MATIDS", {.description = "list material IDs of the summands"}),
             parameter<int>(
                 "PRESTRESS_STRATEGY", {.description = "Material id of the prestress strategy "
                                                       "(optional, by default no prestretch)",

--- a/src/mixture/src/4C_mixture_constituent_elasthyperbase.cpp
+++ b/src/mixture/src/4C_mixture_constituent_elasthyperbase.cpp
@@ -24,17 +24,8 @@ Mixture::PAR::MixtureConstituentElastHyperBase::MixtureConstituentElastHyperBase
     const Core::Mat::PAR::Parameter::Data& matdata)
     : MixtureConstituent(matdata),
       matid_prestress_strategy_(matdata.parameters.get<int>("PRESTRESS_STRATEGY")),
-      nummat_(matdata.parameters.get<int>("NUMMAT")),
       matids_(matdata.parameters.get<std::vector<int>>("MATIDS"))
 {
-  // check, if size of summands fits to the number of summands
-  if (nummat_ != (int)matids_.size())
-  {
-    FOUR_C_THROW(
-        "number of summands {} does not fit to the size of the summands vector"
-        " {}",
-        nummat_, matids_.size());
-  }
 }
 
 // Constructor of the constituent holding the material parameters

--- a/src/mixture/src/4C_mixture_constituent_elasthyperbase.hpp
+++ b/src/mixture/src/4C_mixture_constituent_elasthyperbase.hpp
@@ -42,9 +42,6 @@ namespace Mixture
       /// Material id of the prestress strategy
       const int matid_prestress_strategy_;
 
-      /// number of summands
-      const int nummat_;
-
       /// List of material ids of the summands
       const std::vector<int> matids_;
       /// @}

--- a/tests/input_files/homogenized-constrained-mixture-cube-aniso-expl.4C.yaml
+++ b/tests/input_files/homogenized-constrained-mixture-cube-aniso-expl.4C.yaml
@@ -62,7 +62,6 @@ MATERIALS:
       COMPRESSION: false
   - MAT: 12
     MIX_Constituent_ElastHyper:
-      NUMMAT: 2
       MATIDS: [121, 122]
       PRESTRESS_STRATEGY: 129
   - MAT: 121

--- a/tests/input_files/homogenized-constrained-mixture-cube-aniso-impl.4C.yaml
+++ b/tests/input_files/homogenized-constrained-mixture-cube-aniso-impl.4C.yaml
@@ -62,7 +62,6 @@ MATERIALS:
       COMPRESSION: false
   - MAT: 12
     MIX_Constituent_ElastHyper:
-      NUMMAT: 2
       MATIDS: [121, 122]
       PRESTRESS_STRATEGY: 129
   - MAT: 121

--- a/tests/input_files/homogenized-constrained-mixture-cube-iso-expl.4C.yaml
+++ b/tests/input_files/homogenized-constrained-mixture-cube-iso-expl.4C.yaml
@@ -60,7 +60,6 @@ MATERIALS:
       COMPRESSION: false
   - MAT: 12
     MIX_Constituent_ElastHyper:
-      NUMMAT: 2
       MATIDS: [121, 122]
       PRESTRESS_STRATEGY: 129
   - MAT: 121

--- a/tests/input_files/homogenized-constrained-mixture-cube-stiffness-expl.4C.yaml
+++ b/tests/input_files/homogenized-constrained-mixture-cube-stiffness-expl.4C.yaml
@@ -61,7 +61,6 @@ MATERIALS:
       COMPRESSION: true
   - MAT: 12
     MIX_Constituent_ElastHyper:
-      NUMMAT: 1
       MATIDS: [121]
       PRESTRESS_STRATEGY: 129
   - MAT: 121

--- a/tests/input_files/homogenized-constrained-mixture-cube-stiffness-impl.4C.yaml
+++ b/tests/input_files/homogenized-constrained-mixture-cube-stiffness-impl.4C.yaml
@@ -65,7 +65,6 @@ MATERIALS:
       DENS: 1
   - MAT: 12
     MIX_Constituent_ElastHyper:
-      NUMMAT: 1
       MATIDS: [121]
       PRESTRESS_STRATEGY: 129
   - MAT: 121

--- a/tests/input_files/mat_elasthyper_coupanisoexpoactive.4C.yaml
+++ b/tests/input_files/mat_elasthyper_coupanisoexpoactive.4C.yaml
@@ -49,7 +49,6 @@ MATERIALS:
       DENS: 1050
   - MAT: 12
     MIX_Constituent_ElastHyper:
-      NUMMAT: 2
       MATIDS: [121, 122]
       PRESTRESS_STRATEGY: 129
   - MAT: 121

--- a/tests/input_files/mat_elasthyper_coupanisoexpoactive_restart.4C.yaml
+++ b/tests/input_files/mat_elasthyper_coupanisoexpoactive_restart.4C.yaml
@@ -48,7 +48,6 @@ MATERIALS:
       DENS: 1050
   - MAT: 12
     MIX_Constituent_ElastHyper:
-      NUMMAT: 2
       MATIDS: [121, 122]
       PRESTRESS_STRATEGY: 129
   - MAT: 121

--- a/tests/input_files/mixture_elast_hyper.4C.yaml
+++ b/tests/input_files/mixture_elast_hyper.4C.yaml
@@ -60,11 +60,9 @@ MATERIALS:
         constant: [0.4, 0.6]
   - MAT: 11
     MIX_Constituent_ElastHyper:
-      NUMMAT: 1
       MATIDS: [101]
   - MAT: 12
     MIX_Constituent_ElastHyper:
-      NUMMAT: 1
       MATIDS: [102]
   - MAT: 101
     ELAST_CoupLogNeoHooke:

--- a/tests/input_files/mixture_elast_hyper_dynamic.4C.yaml
+++ b/tests/input_files/mixture_elast_hyper_dynamic.4C.yaml
@@ -64,11 +64,9 @@ MATERIALS:
         constant: [0.4, 0.6]
   - MAT: 11
     MIX_Constituent_ElastHyper:
-      NUMMAT: 1
       MATIDS: [101]
   - MAT: 12
     MIX_Constituent_ElastHyper:
-      NUMMAT: 1
       MATIDS: [102]
   - MAT: 101
     ELAST_CoupLogNeoHooke:

--- a/tests/input_files/mixture_elast_hyper_function.4C.yaml
+++ b/tests/input_files/mixture_elast_hyper_function.4C.yaml
@@ -62,11 +62,9 @@ MATERIALS:
       MASSFRACFUNCT: [4, 5]
   - MAT: 11
     MIX_Constituent_ElastHyper:
-      NUMMAT: 1
       MATIDS: [101]
   - MAT: 12
     MIX_Constituent_ElastHyper:
-      NUMMAT: 1
       MATIDS: [102]
   - MAT: 101
     ELAST_CoupLogNeoHooke:

--- a/tests/input_files/mixture_elast_hyper_input_field.4C.yaml
+++ b/tests/input_files/mixture_elast_hyper_input_field.4C.yaml
@@ -61,11 +61,9 @@ MATERIALS:
         from_file: "mixture_elast_hyper_input_field.json"
   - MAT: 11
     MIX_Constituent_ElastHyper:
-      NUMMAT: 1
       MATIDS: [101]
   - MAT: 12
     MIX_Constituent_ElastHyper:
-      NUMMAT: 1
       MATIDS: [102]
   - MAT: 101
     ELAST_CoupLogNeoHooke:

--- a/tests/input_files/mixture_growth_expl_remodel_fiber_no_basal_mass_production.4C.yaml
+++ b/tests/input_files/mixture_growth_expl_remodel_fiber_no_basal_mass_production.4C.yaml
@@ -77,7 +77,6 @@ MATERIALS:
       COMPRESSION: false
   - MAT: 13
     MIX_Constituent_ElastHyper:
-      NUMMAT: 2
       MATIDS: [131, 132]
       PRESTRESS_STRATEGY: 139
   - MAT: 131

--- a/tests/input_files/mixture_growth_full_constrained_mixture_fiber_adaptive_higher_order.4C.yaml
+++ b/tests/input_files/mixture_growth_full_constrained_mixture_fiber_adaptive_higher_order.4C.yaml
@@ -65,7 +65,6 @@ MATERIALS:
       COMPRESSION: false
   - MAT: 12
     MIX_Constituent_ElastHyper:
-      NUMMAT: 2
       MATIDS: [121, 122]
       PRESTRESS_STRATEGY: 129
   - MAT: 121

--- a/tests/input_files/mixture_growth_full_constrained_mixture_fiber_adaptive_model_equation.4C.yaml
+++ b/tests/input_files/mixture_growth_full_constrained_mixture_fiber_adaptive_model_equation.4C.yaml
@@ -65,7 +65,6 @@ MATERIALS:
       COMPRESSION: false
   - MAT: 12
     MIX_Constituent_ElastHyper:
-      NUMMAT: 2
       MATIDS: [121, 122]
       PRESTRESS_STRATEGY: 129
   - MAT: 121

--- a/tests/input_files/mixture_growth_full_constrained_mixture_fiber_no_basal_mass_production.4C.yaml
+++ b/tests/input_files/mixture_growth_full_constrained_mixture_fiber_no_basal_mass_production.4C.yaml
@@ -77,7 +77,6 @@ MATERIALS:
       COMPRESSION: false
   - MAT: 13
     MIX_Constituent_ElastHyper:
-      NUMMAT: 2
       MATIDS: [131, 132]
       PRESTRESS_STRATEGY: 139
   - MAT: 131

--- a/tests/input_files/mixture_growth_full_constrained_mixture_fiber_non_adaptive.4C.yaml
+++ b/tests/input_files/mixture_growth_full_constrained_mixture_fiber_non_adaptive.4C.yaml
@@ -63,7 +63,6 @@ MATERIALS:
       COMPRESSION: false
   - MAT: 12
     MIX_Constituent_ElastHyper:
-      NUMMAT: 2
       MATIDS: [121, 122]
       PRESTRESS_STRATEGY: 129
   - MAT: 121

--- a/tests/input_files/mixture_growth_impl_remodel_fiber_no_basal_mass_production.4C.yaml
+++ b/tests/input_files/mixture_growth_impl_remodel_fiber_no_basal_mass_production.4C.yaml
@@ -77,7 +77,6 @@ MATERIALS:
       COMPRESSION: false
   - MAT: 13
     MIX_Constituent_ElastHyper:
-      NUMMAT: 2
       MATIDS: [131, 132]
       PRESTRESS_STRATEGY: 139
   - MAT: 131

--- a/tests/input_files/mixture_prestress_arc_hex8.4C.yaml
+++ b/tests/input_files/mixture_prestress_arc_hex8.4C.yaml
@@ -83,7 +83,6 @@ MATERIALS:
       COMPRESSION: false
   - MAT: 14
     MIX_Constituent_ElastHyper:
-      NUMMAT: 2
       MATIDS: [141, 143]
       PRESTRESS_STRATEGY: 149
   - MAT: 141

--- a/tests/input_files/mixture_prestress_arc_tet10.4C.yaml
+++ b/tests/input_files/mixture_prestress_arc_tet10.4C.yaml
@@ -83,7 +83,6 @@ MATERIALS:
       COMPRESSION: false
   - MAT: 14
     MIX_Constituent_ElastHyper:
-      NUMMAT: 2
       MATIDS: [141, 143]
       PRESTRESS_STRATEGY: 149
   - MAT: 141

--- a/tests/input_files/mixture_prestress_arc_tet4.4C.yaml
+++ b/tests/input_files/mixture_prestress_arc_tet4.4C.yaml
@@ -83,7 +83,6 @@ MATERIALS:
       COMPRESSION: false
   - MAT: 14
     MIX_Constituent_ElastHyper:
-      NUMMAT: 2
       MATIDS: [141, 143]
       PRESTRESS_STRATEGY: 149
   - MAT: 141

--- a/tests/input_files/mixture_prestress_cube.4C.yaml
+++ b/tests/input_files/mixture_prestress_cube.4C.yaml
@@ -64,7 +64,6 @@ MATERIALS:
       COMPRESSION: false
   - MAT: 14
     MIX_Constituent_ElastHyper:
-      NUMMAT: 2
       MATIDS: [141, 143]
       PRESTRESS_STRATEGY: 149
   - MAT: 141

--- a/tests/input_files/mixture_prestress_cube_restart_from_prestress.4C.yaml
+++ b/tests/input_files/mixture_prestress_cube_restart_from_prestress.4C.yaml
@@ -61,7 +61,6 @@ MATERIALS:
       COMPRESSION: false
   - MAT: 14
     MIX_Constituent_ElastHyper:
-      NUMMAT: 2
       MATIDS: [141, 143]
       PRESTRESS_STRATEGY: 149
   - MAT: 141

--- a/tests/input_files/mixture_prestress_isochoric_spring_dashpot.4C.yaml
+++ b/tests/input_files/mixture_prestress_isochoric_spring_dashpot.4C.yaml
@@ -95,7 +95,6 @@ MATERIALS:
       COMPRESSION: false
   - MAT: 14
     MIX_Constituent_ElastHyper:
-      NUMMAT: 1
       MATIDS: [141]
       PRESTRESS_STRATEGY: 149
   - MAT: 141

--- a/tests/input_files/mixture_prestress_isochoric_spring_dashpot_restart_from_prestress.4C.yaml
+++ b/tests/input_files/mixture_prestress_isochoric_spring_dashpot_restart_from_prestress.4C.yaml
@@ -89,7 +89,6 @@ MATERIALS:
       COMPRESSION: false
   - MAT: 14
     MIX_Constituent_ElastHyper:
-      NUMMAT: 1
       MATIDS: [141]
       PRESTRESS_STRATEGY: 149
   - MAT: 141

--- a/tests/input_files/mixture_prestress_iterative_prescribed.4C.yaml
+++ b/tests/input_files/mixture_prestress_iterative_prescribed.4C.yaml
@@ -62,7 +62,6 @@ MATERIALS:
         constant: [1.0, 0.0, 0.0]
   - MAT: 11
     MIX_Constituent_ElastHyper:
-      NUMMAT: 2
       MATIDS: [111, 112]
       PRESTRESS_STRATEGY: 119
   - MAT: 111

--- a/tests/input_files/mixture_prestress_minimum_number_of_prestress_steps.4C.yaml
+++ b/tests/input_files/mixture_prestress_minimum_number_of_prestress_steps.4C.yaml
@@ -66,7 +66,6 @@ MATERIALS:
       COMPRESSION: false
   - MAT: 14
     MIX_Constituent_ElastHyper:
-      NUMMAT: 2
       MATIDS: [141, 143]
       PRESTRESS_STRATEGY: 149
   - MAT: 141

--- a/tests/input_files/mixture_prestress_spring_dashpot.4C.yaml
+++ b/tests/input_files/mixture_prestress_spring_dashpot.4C.yaml
@@ -65,7 +65,6 @@ MATERIALS:
       COMPRESSION: false
   - MAT: 14
     MIX_Constituent_ElastHyper:
-      NUMMAT: 2
       MATIDS: [141, 143]
       PRESTRESS_STRATEGY: 149
   - MAT: 141

--- a/tests/input_files/mixture_prestress_spring_dashpot_restart_from_prestress.4C.yaml
+++ b/tests/input_files/mixture_prestress_spring_dashpot_restart_from_prestress.4C.yaml
@@ -61,7 +61,6 @@ MATERIALS:
       COMPRESSION: false
   - MAT: 14
     MIX_Constituent_ElastHyper:
-      NUMMAT: 2
       MATIDS: [141, 143]
       PRESTRESS_STRATEGY: 149
   - MAT: 141

--- a/tests/input_files/shell7p_mixture_vtu_input_field.4C.yaml
+++ b/tests/input_files/shell7p_mixture_vtu_input_field.4C.yaml
@@ -63,7 +63,6 @@ MATERIALS:
       COMPRESSION: false
   - MAT: 4
     MIX_Constituent_ElastHyper:
-      NUMMAT: 2
       MATIDS: [44, 45]
       PRESTRESS_STRATEGY: 129
   - MAT: 44

--- a/tests/input_files/solid_runtime_gauss_point_quantity_output_element_center.4C.yaml
+++ b/tests/input_files/solid_runtime_gauss_point_quantity_output_element_center.4C.yaml
@@ -60,7 +60,6 @@ MATERIALS:
       COMPRESSION: false
   - MAT: 12
     MIX_Constituent_ElastHyper:
-      NUMMAT: 2
       MATIDS: [121, 122]
       PRESTRESS_STRATEGY: 129
   - MAT: 121

--- a/tests/input_files/solid_runtime_gauss_point_quantity_output_gauss_point.4C.yaml
+++ b/tests/input_files/solid_runtime_gauss_point_quantity_output_gauss_point.4C.yaml
@@ -60,7 +60,6 @@ MATERIALS:
       COMPRESSION: false
   - MAT: 12
     MIX_Constituent_ElastHyper:
-      NUMMAT: 2
       MATIDS: [121, 122]
       PRESTRESS_STRATEGY: 129
   - MAT: 121

--- a/tests/input_files/solid_runtime_gauss_point_quantity_output_nodal.4C.yaml
+++ b/tests/input_files/solid_runtime_gauss_point_quantity_output_nodal.4C.yaml
@@ -59,7 +59,6 @@ MATERIALS:
       COMPRESSION: false
   - MAT: 12
     MIX_Constituent_ElastHyper:
-      NUMMAT: 2
       MATIDS: [121, 122]
       PRESTRESS_STRATEGY: 129
   - MAT: 121

--- a/tests/input_files/solid_runtime_gauss_point_quantity_output_result_test.4C.yaml
+++ b/tests/input_files/solid_runtime_gauss_point_quantity_output_result_test.4C.yaml
@@ -61,7 +61,6 @@ MATERIALS:
       COMPRESSION: false
   - MAT: 12
     MIX_Constituent_ElastHyper:
-      NUMMAT: 2
       MATIDS: [121, 122]
       PRESTRESS_STRATEGY: 129
   - MAT: 121

--- a/tests/input_files/ssi_homogenized_constraint_mixture_prestress_qcyl.4C.yaml
+++ b/tests/input_files/ssi_homogenized_constraint_mixture_prestress_qcyl.4C.yaml
@@ -122,7 +122,6 @@ MATERIALS:
         from_mesh: "fiber5"
   - MAT: 11
     MIX_Constituent_ElastHyper:
-      NUMMAT: 2
       MATIDS: [111, 112]
       PRESTRESS_STRATEGY: 119
   - MAT: 111

--- a/tests/input_files/ssi_homogenized_constraint_mixture_qcyl.4C.yaml
+++ b/tests/input_files/ssi_homogenized_constraint_mixture_qcyl.4C.yaml
@@ -128,7 +128,6 @@ MATERIALS:
         from_mesh: "fiber5"
   - MAT: 11
     MIX_Constituent_ElastHyper:
-      NUMMAT: 2
       MATIDS: [111, 112]
       PRESTRESS_STRATEGY: 119
   - MAT: 111

--- a/tests/input_files/ssi_homogenized_constraint_mixture_qcyl_nonlocal.4C.yaml
+++ b/tests/input_files/ssi_homogenized_constraint_mixture_qcyl_nonlocal.4C.yaml
@@ -125,7 +125,6 @@ MATERIALS:
         from_mesh: "fiber5"
   - MAT: 11
     MIX_Constituent_ElastHyper:
-      NUMMAT: 2
       MATIDS: [111, 112]
       PRESTRESS_STRATEGY: 119
   - MAT: 111

--- a/tests/input_files/ssi_homogenized_constraint_mixture_qcyl_nonlocal_mono.4C.yaml
+++ b/tests/input_files/ssi_homogenized_constraint_mixture_qcyl_nonlocal_mono.4C.yaml
@@ -123,7 +123,6 @@ MATERIALS:
         from_mesh: "fiber5"
   - MAT: 11
     MIX_Constituent_ElastHyper:
-      NUMMAT: 2
       MATIDS: [111, 112]
       PRESTRESS_STRATEGY: 119
   - MAT: 111

--- a/tests/tutorials/solid/tutorial_solid_vtu.4C.yaml
+++ b/tests/tutorials/solid/tutorial_solid_vtu.4C.yaml
@@ -62,7 +62,6 @@ MATERIALS:
       COMPRESSION: false
   - MAT: 12
     MIX_Constituent_ElastHyper:
-      NUMMAT: 2
       MATIDS: [121, 122]
       PRESTRESS_STRATEGY: 129
   - MAT: 121


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context```
The `NUMMAT` parameter is not needed anymore since the vector size is directly derived from the length of the `MATIDS` list in the input.

@tuchpaul Feel free to adapt this for the other materials in the mixture framework if you like. I didn't want to change the input format of materials I don't use much, as that will require updating your input files.
