### PR TITLE
Tensor migration 

### DIFF
--- a/src/core/linalg/src/dense/4C_linalg_fixedsizematrix_tensor_products.cpp
+++ b/src/core/linalg/src/dense/4C_linalg_fixedsizematrix_tensor_products.cpp
@@ -150,120 +150,6 @@ void Core::LinAlg::FourTensorOperations::add_kronecker_tensor_product(Core::LinA
       scalar_this * C(5, 5) + scalar_AB_half * (A(0, 0) * B(2, 2) + A(0, 2) * B(2, 0));  // C1313
 }
 
-
-void Core::LinAlg::FourTensorOperations::add_kronecker_tensor_product(Core::LinAlg::Matrix<6, 9>& C,
-    const double scalar_AB, const Core::LinAlg::Matrix<3, 3>& A,
-    const Core::LinAlg::Matrix<3, 3>& B, const double scalar_this)
-{
-  const double scalar_AB_half = scalar_AB * 0.5;
-  C(0, 0) = scalar_this * C(0, 0) + scalar_AB * (A(0, 0) * B(0, 0));  // C1111
-  C(0, 1) = scalar_this * C(0, 1) + scalar_AB * (A(0, 1) * B(0, 1));  // C1122
-  C(0, 2) = scalar_this * C(0, 2) + scalar_AB * (A(0, 2) * B(0, 2));  // C1133
-  C(0, 3) =
-      scalar_this * C(0, 3) + scalar_AB_half * (A(0, 0) * B(0, 1) + A(0, 1) * B(0, 0));  // C1112
-  C(0, 4) =
-      scalar_this * C(0, 4) + scalar_AB_half * (A(0, 1) * B(0, 2) + A(0, 2) * B(0, 1));  // C1123
-  C(0, 5) =
-      scalar_this * C(0, 5) + scalar_AB_half * (A(0, 0) * B(0, 2) + A(0, 2) * B(0, 0));  // C1113
-  C(0, 6) =
-      scalar_this * C(0, 6) + scalar_AB_half * (A(0, 1) * B(0, 0) + A(0, 0) * B(0, 1));  // C1121
-  C(0, 7) =
-      scalar_this * C(0, 7) + scalar_AB_half * (A(0, 2) * B(0, 1) + A(0, 1) * B(0, 2));  // C1132
-  C(0, 8) =
-      scalar_this * C(0, 8) + scalar_AB_half * (A(0, 2) * B(0, 0) + A(0, 0) * B(0, 2));  // C1131
-
-
-  C(1, 0) = scalar_this * C(1, 0) + scalar_AB * (A(1, 0) * B(1, 0));  // C2211
-  C(1, 1) = scalar_this * C(1, 1) + scalar_AB * (A(1, 1) * B(1, 1));  // C2222
-  C(1, 2) = scalar_this * C(1, 2) + scalar_AB * (A(1, 2) * B(1, 2));  // C2233
-  C(1, 3) =
-      scalar_this * C(1, 3) + scalar_AB_half * (A(1, 0) * B(1, 1) + A(1, 1) * B(1, 0));  // C2212
-  C(1, 4) =
-      scalar_this * C(1, 4) + scalar_AB_half * (A(1, 1) * B(1, 2) + A(1, 2) * B(1, 1));  // C2223
-  C(1, 5) =
-      scalar_this * C(1, 5) + scalar_AB_half * (A(1, 0) * B(1, 2) + A(1, 2) * B(1, 0));  // C2213
-  C(1, 6) =
-      scalar_this * C(1, 6) + scalar_AB_half * (A(1, 1) * B(1, 0) + A(1, 0) * B(1, 1));  // C2221
-  C(1, 7) =
-      scalar_this * C(1, 7) + scalar_AB_half * (A(1, 2) * B(1, 1) + A(1, 1) * B(1, 2));  // C2232
-  C(1, 8) =
-      scalar_this * C(1, 8) + scalar_AB_half * (A(1, 2) * B(1, 0) + A(1, 0) * B(1, 2));  // C2231
-
-
-
-  C(2, 0) = scalar_this * C(2, 0) + scalar_AB * (A(2, 0) * B(2, 0));  // C3311
-  C(2, 1) = scalar_this * C(2, 1) + scalar_AB * (A(2, 1) * B(2, 1));  // C3322
-  C(2, 2) = scalar_this * C(2, 2) + scalar_AB * (A(2, 2) * B(2, 2));  // C3333
-  C(2, 3) =
-      scalar_this * C(2, 3) + scalar_AB_half * (A(2, 0) * B(2, 1) + A(2, 1) * B(2, 0));  // C3312
-  C(2, 4) =
-      scalar_this * C(2, 4) + scalar_AB_half * (A(2, 1) * B(2, 2) + A(2, 2) * B(2, 1));  // C3323
-  C(2, 5) =
-      scalar_this * C(2, 5) + scalar_AB_half * (A(2, 0) * B(2, 2) + A(2, 2) * B(2, 0));  // C3313
-  C(2, 6) =
-      scalar_this * C(2, 6) + scalar_AB_half * (A(2, 0) * B(2, 1) + A(2, 1) * B(2, 0));  // C3321
-  C(2, 7) =
-      scalar_this * C(2, 7) + scalar_AB_half * (A(2, 2) * B(2, 1) + A(2, 1) * B(2, 2));  // C3332
-  C(2, 8) =
-      scalar_this * C(2, 8) + scalar_AB_half * (A(2, 2) * B(2, 0) + A(2, 0) * B(2, 2));  // C3331
-
-
-
-  C(3, 0) = scalar_this * C(3, 0) + scalar_AB * (A(0, 0) * B(1, 0));  // C1211
-  C(3, 1) = scalar_this * C(3, 1) + scalar_AB * (A(0, 1) * B(1, 1));  // C1222
-  C(3, 2) = scalar_this * C(3, 2) + scalar_AB * (A(0, 2) * B(1, 2));  // C1233
-  C(3, 3) =
-      scalar_this * C(3, 3) + scalar_AB_half * (A(0, 0) * B(1, 1) + A(0, 1) * B(1, 0));  // C1212
-  C(3, 4) =
-      scalar_this * C(3, 4) + scalar_AB_half * (A(0, 1) * B(1, 2) + A(0, 2) * B(1, 1));  // C1223
-  C(3, 5) =
-      scalar_this * C(3, 5) + scalar_AB_half * (A(0, 0) * B(1, 2) + A(0, 2) * B(1, 0));  // C1213
-  C(3, 6) =
-      scalar_this * C(3, 6) + scalar_AB_half * (A(0, 1) * B(1, 0) + A(0, 0) * B(1, 1));  // C1221
-  C(3, 7) =
-      scalar_this * C(3, 7) + scalar_AB_half * (A(0, 2) * B(1, 1) + A(0, 1) * B(1, 2));  // C1232
-  C(3, 8) =
-      scalar_this * C(3, 8) + scalar_AB_half * (A(0, 2) * B(1, 0) + A(0, 0) * B(1, 2));  // C1231
-
-
-
-  C(4, 0) = scalar_this * C(4, 0) + scalar_AB * (A(1, 0) * B(2, 0));  // C2311
-  C(4, 1) = scalar_this * C(4, 1) + scalar_AB * (A(1, 1) * B(2, 1));  // C2322
-  C(4, 2) = scalar_this * C(4, 2) + scalar_AB * (A(1, 2) * B(2, 2));  // C2333
-  C(4, 3) =
-      scalar_this * C(4, 3) + scalar_AB_half * (A(1, 0) * B(2, 1) + A(1, 1) * B(2, 0));  // C2312
-  C(4, 4) =
-      scalar_this * C(4, 4) + scalar_AB_half * (A(1, 1) * B(2, 2) + A(1, 2) * B(2, 1));  // C2323
-  C(4, 5) =
-      scalar_this * C(4, 5) + scalar_AB_half * (A(1, 0) * B(2, 2) + A(1, 2) * B(2, 0));  // C2313
-  C(4, 6) =
-      scalar_this * C(4, 6) + scalar_AB_half * (A(1, 1) * B(2, 0) + A(1, 0) * B(2, 1));  // C2321
-  C(4, 7) =
-      scalar_this * C(4, 7) + scalar_AB_half * (A(1, 2) * B(2, 1) + A(1, 1) * B(2, 2));  // C2332
-  C(4, 8) =
-      scalar_this * C(4, 8) + scalar_AB_half * (A(1, 2) * B(2, 0) + A(1, 0) * B(2, 2));  // C2331
-
-
-
-  C(5, 0) = scalar_this * C(5, 0) + scalar_AB * (A(0, 0) * B(2, 0));  // C1311
-  C(5, 1) = scalar_this * C(5, 1) + scalar_AB * (A(0, 1) * B(2, 1));  // C1322
-  C(5, 2) = scalar_this * C(5, 2) + scalar_AB * (A(0, 2) * B(2, 2));  // C1333
-  C(5, 3) =
-      scalar_this * C(5, 3) + scalar_AB_half * (A(0, 0) * B(2, 1) + A(0, 1) * B(2, 0));  // C1312
-  C(5, 4) =
-      scalar_this * C(5, 4) + scalar_AB_half * (A(0, 1) * B(2, 2) + A(0, 2) * B(2, 1));  // C1323
-  C(5, 5) =
-      scalar_this * C(5, 5) + scalar_AB_half * (A(0, 0) * B(2, 2) + A(0, 2) * B(2, 0));  // C1313
-  C(5, 5) =
-      scalar_this * C(5, 5) + scalar_AB_half * (A(0, 0) * B(2, 2) + A(0, 2) * B(2, 0));  // C1313
-  C(5, 6) =
-      scalar_this * C(5, 6) + scalar_AB_half * (A(0, 1) * B(2, 0) + A(0, 0) * B(2, 1));  // C1321
-  C(5, 7) =
-      scalar_this * C(5, 7) + scalar_AB_half * (A(0, 2) * B(2, 1) + A(0, 1) * B(2, 2));  // C1332
-  C(5, 8) =
-      scalar_this * C(5, 7) + scalar_AB_half * (A(0, 2) * B(2, 0) + A(0, 0) * B(2, 2));  // C1331
-}
-
 template <typename T>
 void Core::LinAlg::FourTensorOperations::add_holzapfel_product(
     Core::LinAlg::Matrix<6, 6, T>& cmat, const Core::LinAlg::Matrix<6, 1, T>& invc, const T scalar)
@@ -920,16 +806,6 @@ void Core::LinAlg::FourTensorOperations::add_contraction_matrix_four_tensor(
       for (unsigned k = 0; k < 3; ++k)
         for (unsigned l = 0; l < 3; ++l)
           matrix_result(i, j) += scale * four_tensor(i, j, k, l) * matrix(k, l);
-}
-
-double Core::LinAlg::FourTensorOperations::contract_matrix_matrix(
-    const Core::LinAlg::Matrix<3, 3>& matrix_A, const Core::LinAlg::Matrix<3, 3>& matrix_B)
-{
-  double scalarContraction = 0.0;
-  for (unsigned i = 0; i < 3; ++i)
-    for (unsigned j = 0; j < 3; ++j) scalarContraction += matrix_A(i, j) * matrix_B(i, j);
-
-  return scalarContraction;
 }
 
 // explicit instantiation of template functions

--- a/src/core/linalg/src/dense/4C_linalg_fixedsizematrix_tensor_products.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_fixedsizematrix_tensor_products.hpp
@@ -21,7 +21,6 @@
 #include "4C_linalg_four_tensor.hpp"
 #include "4C_linalg_symmetric_tensor.hpp"
 #include "4C_linalg_tensor.hpp"
-
 FOUR_C_NAMESPACE_OPEN
 
 namespace Core::LinAlg::FourTensorOperations
@@ -99,25 +98,6 @@ namespace Core::LinAlg::FourTensorOperations
       const Core::LinAlg::Matrix<3, 3>& A, const Core::LinAlg::Matrix<3, 3>& B,
       const double scalar_this);
 
-  /*!
-   * @brief Multiply two 2nd order tensors A o B and add the result to a 4th order material tensor
-   * in matrix notation, possessing left minor symmetry.
-   *
-   * In tensor index notation this method does
-   * \f[
-   * C_{IJKL} := \text{scalar_this} \cdot C_{IJKL} + \frac{1}{2} \cdot \text{scalar_AB} \cdot \left(
-   *             A_{IK} \cdot B_{JL} + A_{IL} \cdot B_{JK} \right) \f]
-   *
-   *
-   * @param[in,out] C       Material tangent matrix to be modified
-   * @param[in] scalar_AB    Scalar to multiply with A o B
-   * @param[in] A           Dense matrix (3 x 3) as 2nd order tensor A
-   * @param[in] B           Dense matrix (3 x 3) as 2nd order tensor B
-   * @param[in] scalar_this  Scalar to multiply with C before adding A o B
-   */
-  void add_kronecker_tensor_product(Core::LinAlg::Matrix<6, 9>& C, const double scalar_AB,
-      const Core::LinAlg::Matrix<3, 3>& A, const Core::LinAlg::Matrix<3, 3>& B,
-      const double scalar_this);
 
 
   /*!
@@ -444,16 +424,6 @@ namespace Core::LinAlg::FourTensorOperations
   void add_contraction_matrix_four_tensor(Core::LinAlg::Matrix<3, 3>& matrix_result,
       const double scale, const Core::LinAlg::FourTensor<3>& four_tensor,
       const Core::LinAlg::Matrix<3, 3>& matrix);
-
-  /*!
-   * @brief Returns the double contraction of two 2nd order tensors
-   *
-   * @param[out]    scalarContraction   0th order tensor \f$s = A_{ij} B^{ij}\f$
-   * @param[in]     matrix_A             2nd order tensor \f$A_{ij}\f$
-   * @param[in]     matrix_B             2nd order tensor \f$B^{ij}\f$
-   */
-  double contract_matrix_matrix(
-      const Core::LinAlg::Matrix<3, 3>& matrix_A, const Core::LinAlg::Matrix<3, 3>& matrix_B);
 
 }  // namespace Core::LinAlg::FourTensorOperations
 

--- a/src/core/linalg/src/dense/4C_linalg_tensor_conversion.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_tensor_conversion.hpp
@@ -15,6 +15,7 @@
 #include "4C_linalg_tensor.hpp"
 #include "4C_linalg_tensor_internals.hpp"
 
+#include <array>
 #include <ranges>
 #include <tuple>
 #include <type_traits>
@@ -224,6 +225,89 @@ namespace Core::LinAlg
       return Core::LinAlg::Matrix<size_left*(size_left + 1) / 2, size_right*(size_right + 1) / 2,
           ValueType>(tensor.data(), true);
     }
+  }
+
+  /*!
+   * @brief Creates a 6x9 Voigt matrix from a 4th order tensor that has the minor symmetry in its
+   * first index pair (C_ijkl = C_jikl).
+   *
+   * The first (symmetric) index pair is stored in stress-like 6-Voigt notation, the second
+   * (non-symmetric) index pair as a 9-vector.
+   */
+  template <typename T>
+  Core::LinAlg::Matrix<6, 9, T> make_6x9_voigt_matrix_from_tensor(
+      const Core::LinAlg::Tensor<T, 3, 3, 3, 3>& tensor)
+  {
+    constexpr std::array<std::array<std::size_t, 2>, 6> row_index = {
+        {{0, 0}, {1, 1}, {2, 2}, {0, 1}, {1, 2}, {0, 2}}};
+    constexpr std::array<std::array<std::size_t, 2>, 9> col_index = {
+        {{0, 0}, {1, 1}, {2, 2}, {0, 1}, {1, 2}, {0, 2}, {1, 0}, {2, 1}, {2, 0}}};
+
+    Core::LinAlg::Matrix<6, 9, T> matrix_voigt;
+    for (std::size_t r = 0; r < 6; ++r)
+    {
+      for (std::size_t c = 0; c < 9; ++c)
+      {
+        matrix_voigt(r, c) =
+            0.5 * (tensor(row_index[r][0], row_index[r][1], col_index[c][0], col_index[c][1]) +
+                      tensor(row_index[r][1], row_index[r][0], col_index[c][0], col_index[c][1]));
+      }
+    }
+    return matrix_voigt;
+  }
+
+  /*!
+   * @brief Creates a 9x6 Voigt matrix from a 4th order tensor that has the minor symmetry in its
+   * second index pair (C_ijkl = C_ijlk).
+   *
+   * The first (non-symmetric) index pair is stored as a 9-vector, the second (symmetric) index
+   * pair in stress-like 6-Voigt notation.
+   */
+  template <typename T>
+  Core::LinAlg::Matrix<9, 6, T> make_9x6_voigt_matrix_from_tensor(
+      const Core::LinAlg::Tensor<T, 3, 3, 3, 3>& tensor)
+  {
+    constexpr std::array<std::array<std::size_t, 2>, 9> row_index = {
+        {{0, 0}, {1, 1}, {2, 2}, {0, 1}, {1, 2}, {0, 2}, {1, 0}, {2, 1}, {2, 0}}};
+    constexpr std::array<std::array<std::size_t, 2>, 6> col_index = {
+        {{0, 0}, {1, 1}, {2, 2}, {0, 1}, {1, 2}, {0, 2}}};
+
+    Core::LinAlg::Matrix<9, 6, T> matrix_voigt;
+    for (std::size_t r = 0; r < 9; ++r)
+    {
+      for (std::size_t c = 0; c < 6; ++c)
+      {
+        matrix_voigt(r, c) =
+            0.5 * (tensor(row_index[r][0], row_index[r][1], col_index[c][0], col_index[c][1]) +
+                      tensor(row_index[r][0], row_index[r][1], col_index[c][1], col_index[c][0]));
+      }
+    }
+    return matrix_voigt;
+  }
+
+  /*!
+   * @brief Creates a 6x6 stress-like Voigt matrix from a (minor-)symmetric 4th order tensor.
+   *
+   * The minor symmetries (IJ) and (KL) are encoded in the symmetric tensor, so its components map
+   * directly to stress-like 6-Voigt notation. The result may still be a non-symmetric 6x6 matrix
+   * if the tensor lacks major symmetry (C_IJKL != C_KLIJ).
+   */
+  template <typename T>
+  Core::LinAlg::Matrix<6, 6, T> make_6x6_voigt_matrix_from_tensor(
+      const Core::LinAlg::SymmetricTensor<T, 3, 3, 3, 3>& tensor)
+  {
+    constexpr std::array<std::array<std::size_t, 2>, 6> vi = {
+        {{0, 0}, {1, 1}, {2, 2}, {0, 1}, {1, 2}, {0, 2}}};
+
+    Core::LinAlg::Matrix<6, 6, T> result;
+    for (std::size_t r = 0; r < 6; ++r)
+    {
+      for (std::size_t c = 0; c < 6; ++c)
+      {
+        result(r, c) = tensor(vi[r][0], vi[r][1], vi[c][0], vi[c][1]);
+      }
+    }
+    return result;
   }
 
   /*!

--- a/src/core/linalg/tests/4C_linalg_tensor_conversion_test.cpp
+++ b/src/core/linalg/tests/4C_linalg_tensor_conversion_test.cpp
@@ -12,6 +12,7 @@
 #include "4C_linalg_tensor_conversion.hpp"
 
 #include "4C_linalg_fixedsizematrix.hpp"
+#include "4C_linalg_fixedsizematrix_tensor_products.hpp"
 #include "4C_linalg_symmetric_tensor.hpp"
 #include "4C_linalg_symmetric_tensor_eigen.hpp"
 #include "4C_linalg_tensor_generators.hpp"
@@ -313,6 +314,82 @@ namespace
     EXPECT_DOUBLE_EQ(nested_array[0][1], 2.0);
     EXPECT_DOUBLE_EQ(nested_array[1][1], 4.0);
     EXPECT_DOUBLE_EQ(nested_array[2][1], 6.0);
+  }
+  TEST(TensorConversionTest, Make6x9VoigtMatrixFromTensorTest)
+  {
+    // arbitrary (non-symmetric) 4th order tensor; both paths apply the same 1st-pair symmetrization
+    Core::LinAlg::Tensor<double, 3, 3, 3, 3> T{};
+    Core::LinAlg::FourTensor<3> ft(true);
+    int v = 1;
+    for (int i = 0; i < 3; ++i)
+      for (int j = 0; j < 3; ++j)
+        for (int k = 0; k < 3; ++k)
+          for (int l = 0; l < 3; ++l)
+          {
+            const double val = 0.1 * (v++);
+            T(i, j, k, l) = val;
+            ft(i, j, k, l) = val;
+          }
+
+    const Core::LinAlg::Matrix<6, 9> new_voigt = Core::LinAlg::make_6x9_voigt_matrix_from_tensor(T);
+    Core::LinAlg::Matrix<6, 9> old_voigt(Core::LinAlg::Initialization::zero);
+    Core::LinAlg::Voigt::setup_6x9_voigt_matrix_from_four_tensor(old_voigt, ft);
+
+    FOUR_C_EXPECT_NEAR(new_voigt, old_voigt, 1e-12);
+  }
+
+  TEST(TensorConversionTest, Make9x6VoigtMatrixFromTensorTest)
+  {
+    // arbitrary (non-symmetric) 4th order tensor; both paths apply the same 2nd-pair symmetrization
+    Core::LinAlg::Tensor<double, 3, 3, 3, 3> T{};
+    Core::LinAlg::FourTensor<3> ft(true);
+    int v = 1;
+    for (int i = 0; i < 3; ++i)
+      for (int j = 0; j < 3; ++j)
+        for (int k = 0; k < 3; ++k)
+          for (int l = 0; l < 3; ++l)
+          {
+            const double val = 0.1 * (v++);
+            T(i, j, k, l) = val;
+            ft(i, j, k, l) = val;
+          }
+
+    const Core::LinAlg::Matrix<9, 6> new_voigt = Core::LinAlg::make_9x6_voigt_matrix_from_tensor(T);
+    Core::LinAlg::Matrix<9, 6> old_voigt(Core::LinAlg::Initialization::zero);
+    Core::LinAlg::Voigt::setup_9x6_voigt_matrix_from_four_tensor(old_voigt, ft);
+
+    FOUR_C_EXPECT_NEAR(new_voigt, old_voigt, 1e-12);
+  }
+
+  TEST(TensorConversionTest, Make6x6StressLikeVoigtMatrixFromTensorTest)
+  {
+    Core::LinAlg::Matrix<3, 3> A;
+    A(0, 0) = 1.0;
+    A(0, 1) = 2.0;
+    A(0, 2) = 3.0;
+    A(1, 0) = 0.5;
+    A(1, 1) = 4.0;
+    A(1, 2) = 1.2;
+    A(2, 0) = 7.0;
+    A(2, 1) = 0.3;
+    A(2, 2) = 6.0;
+
+    Core::LinAlg::Tensor<double, 3, 3, 3, 3> C_full{};
+    for (int i = 0; i < 3; ++i)
+      for (int j = 0; j < 3; ++j)
+        for (int k = 0; k < 3; ++k)
+          for (int l = 0; l < 3; ++l)
+            C_full(i, j, k, l) = 0.5 * (A(i, k) * A(j, l) + A(i, l) * A(j, k));
+    const Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3> C =
+        Core::LinAlg::assume_symmetry(C_full);
+
+    const Core::LinAlg::Matrix<6, 6> result = Core::LinAlg::make_6x6_voigt_matrix_from_tensor(C);
+
+    // reference: add_kronecker_tensor_product called on non-symmetric matrix
+    Core::LinAlg::Matrix<6, 6> ref(Core::LinAlg::Initialization::zero);
+    Core::LinAlg::FourTensorOperations::add_kronecker_tensor_product(ref, 1.0, A, A, 0.0);
+
+    FOUR_C_EXPECT_NEAR(result, ref, 1e-12);
   }
 }  // namespace
 

--- a/src/mat/4C_mat_elasthyper_service.cpp
+++ b/src/mat/4C_mat_elasthyper_service.cpp
@@ -12,6 +12,7 @@
 #include "4C_linalg_fixedsizematrix_voigt_notation.hpp"
 #include "4C_linalg_symmetric_tensor_eigen.hpp"
 #include "4C_linalg_tensor_conversion.hpp"
+#include "4C_linalg_tensor_einstein.hpp"
 #include "4C_linalg_tensor_generators.hpp"
 #include "4C_linalg_utils_densematrix_eigen.hpp"
 #include "4C_linalg_vector.hpp"
@@ -577,32 +578,24 @@ void Mat::elast_hyper_check_polyconvexity(const Core::LinAlg::Tensor<double, 3, 
 
 void Mat::elast_hyper_get_derivs_of_elastic_right_cg_tensor(
     const Core::LinAlg::Tensor<double, 3, 3>& iFinM,
-    const Core::LinAlg::SymmetricTensor<double, 3, 3>& CM, Core::LinAlg::Matrix<6, 6>& dCedC,
-    Core::LinAlg::Matrix<6, 9>& dCediFin)
+    const Core::LinAlg::SymmetricTensor<double, 3, 3>& CM,
+    Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& dCedC,
+    Core::LinAlg::Tensor<double, 3, 3, 3, 3>& dCediFin)
 {
-  Core::LinAlg::Matrix<3, 3> iFinM_mat = Core::LinAlg::make_matrix_view(iFinM);
-  const Core::LinAlg::Matrix<3, 3> C_mat = Core::LinAlg::make_matrix(Core::LinAlg::get_full(CM));
-  // auxiliaries
-  Core::LinAlg::Matrix<3, 3> id3x3(Core::LinAlg::Initialization::zero);
-  for (int i = 0; i < 3; ++i) id3x3(i, i) = 1.0;
-  Core::LinAlg::Matrix<9, 9> temp9x9(Core::LinAlg::Initialization::zero);
-  Core::LinAlg::FourTensor<3> tempFourTensor(true);
+  // F_in^{-T} and the 2nd order identity tensor
+  const Core::LinAlg::Tensor<double, 3, 3> iFinT = Core::LinAlg::transpose(iFinM);
+  const Core::LinAlg::SymmetricTensor<double, 3, 3> id =
+      Core::LinAlg::TensorGenerators::identity<double, 3, 3>;
 
   // \frac{\partial C^e}{\partial C}
-  dCedC.clear();
-  Core::LinAlg::Matrix<3, 3> iFinTM(Core::LinAlg::Initialization::zero);
-  iFinTM.multiply_nt(1.0, id3x3, iFinM_mat, 0.0);
-  Core::LinAlg::FourTensorOperations::add_kronecker_tensor_product(dCedC, 1.0, iFinTM, iFinTM, 0.0);
+  dCedC = Core::LinAlg::assume_symmetry(0.5 * (Core::LinAlg::einsum<"ik", "jl">(iFinT, iFinT) +
+                                                  Core::LinAlg::einsum<"il", "jk">(iFinT, iFinT)));
+
+  const Core::LinAlg::Tensor<double, 3, 3> iFinTC = Core::LinAlg::dot(iFinT, CM);
 
   // \frac{\partial C^e}{\partial F_{in}^{-1}}
-  dCediFin.clear();
-  Core::LinAlg::Matrix<3, 3> iFinTCM(Core::LinAlg::Initialization::zero);
-  iFinTCM.multiply_tn(1.0, iFinM_mat, C_mat, 0.0);
-  temp9x9.clear();
-  Core::LinAlg::FourTensorOperations::add_adbc_tensor_product(1.0, id3x3, iFinTCM, temp9x9);
-  Core::LinAlg::FourTensorOperations::add_non_symmetric_product(1.0, iFinTCM, id3x3, temp9x9);
-  Core::LinAlg::Voigt::setup_four_tensor_from_9x9_voigt_matrix(tempFourTensor, temp9x9);
-  Core::LinAlg::Voigt::setup_6x9_voigt_matrix_from_four_tensor(dCediFin, tempFourTensor);
+  dCediFin =
+      Core::LinAlg::einsum<"ad", "bc">(id, iFinTC) + Core::LinAlg::einsum<"ac", "bd">(iFinTC, id);
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/mat/4C_mat_elasthyper_service.hpp
+++ b/src/mat/4C_mat_elasthyper_service.hpp
@@ -379,15 +379,16 @@ namespace Mat
    * @param[in] iFinM    Inverse inelastic deformation gradient
    * @param[in] CM Right Cauchy-Green deformation tensor
    * @param[out] dCedC         Partial derivative of the elastic right CG tensor w.r.t. right CG
-   *                           tensor (Voigt stress-stress notation)
+   *                           tensor (symmetric 4th order tensor)
    * @param[out] dCediFin      Partial derivative of the elastic right CG tensor w.r.t. inelastic
-   *                           deformation gradient (Voigt stress notation)
+   *                           deformation gradient (full 4th order tensor)
    *
    */
   void elast_hyper_get_derivs_of_elastic_right_cg_tensor(
       const Core::LinAlg::Tensor<double, 3, 3>& iFinM,
-      const Core::LinAlg::SymmetricTensor<double, 3, 3>& CM, Core::LinAlg::Matrix<6, 6>& dCedC,
-      Core::LinAlg::Matrix<6, 9>& dCediFin);
+      const Core::LinAlg::SymmetricTensor<double, 3, 3>& CM,
+      Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& dCedC,
+      Core::LinAlg::Tensor<double, 3, 3, 3, 3>& dCediFin);
 
   /**
    * \brief Class for holding the summand formulation properties

--- a/src/mat/4C_mat_inelastic_defgrad_factors.cpp
+++ b/src/mat/4C_mat_inelastic_defgrad_factors.cpp
@@ -1990,8 +1990,8 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_state_quantities(
   // determine scalar quantities of invariants / pseudoinvariants needed to compute the
   // equivalent tensile stress
   double Mtheta_dev_sym_contract_Mtheta_dev_sym =
-      Core::LinAlg::FourTensorOperations::contract_matrix_matrix(
-          state_quantities.curr_Mtheta_dev_sym_M, state_quantities.curr_Mtheta_dev_sym_M);
+      Core::LinAlg::ddot(Core::LinAlg::make_tensor_view(state_quantities.curr_Mtheta_dev_sym_M),
+          Core::LinAlg::make_tensor_view(state_quantities.curr_Mtheta_dev_sym_M));
   Core::LinAlg::Matrix<3, 3> Mtheta_dev_sym_squared_M(Core::LinAlg::Initialization::zero);
   Mtheta_dev_sym_squared_M.multiply_nn(
       1.0, state_quantities.curr_Mtheta_dev_sym_M, state_quantities.curr_Mtheta_dev_sym_M, 0.0);
@@ -2198,9 +2198,14 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_state_quantity_deriv
 
 
   // compute the relevant derivatives of the elastic right Cauchy-Green deformation tensor
+  Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3> dCedC_tensor;
+  Core::LinAlg::Tensor<double, 3, 3, 3, 3> dCediFin_tensor;
   Mat::elast_hyper_get_derivs_of_elastic_right_cg_tensor(Core::LinAlg::make_tensor(iFinM),
-      Core::LinAlg::assume_symmetry(Core::LinAlg::make_tensor(CM)),
-      state_quantity_derivatives.curr_dCedC, state_quantity_derivatives.curr_dCediFin);
+      Core::LinAlg::assume_symmetry(Core::LinAlg::make_tensor(CM)), dCedC_tensor, dCediFin_tensor);
+  state_quantity_derivatives.curr_dCedC =
+      Core::LinAlg::make_6x6_voigt_matrix_from_tensor(dCedC_tensor);
+  state_quantity_derivatives.curr_dCediFin =
+      Core::LinAlg::make_6x9_voigt_matrix_from_tensor(dCediFin_tensor);
   // save these also as four tensors
   Core::LinAlg::FourTensor<3> dCediFin_FourTensor(true);
   Core::LinAlg::Voigt::setup_four_tensor_from_6x9_voigt_matrix(

--- a/src/mat/4C_mat_multiplicative_split_defgrad_elasthyper.cpp
+++ b/src/mat/4C_mat_multiplicative_split_defgrad_elasthyper.cpp
@@ -692,8 +692,12 @@ void Mat::MultiplicativeSplitDefgradElastHyper::evaluate_kin_quant_elast(
   Core::LinAlg::Voigt::matrix_3x3_to_9x1(CiFiniCeM, CiFiniCe9x1);
 
   // derivatives of the elastic right CG
+  Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3> dCedC_tensor;
+  Core::LinAlg::Tensor<double, 3, 3, 3, 3> dCediFin_tensor;
   Mat::elast_hyper_get_derivs_of_elastic_right_cg_tensor(Core::LinAlg::make_tensor(iFinM),
-      Core::LinAlg::assume_symmetry(Core::LinAlg::make_tensor(CM)), dCedC, dCediFin);
+      Core::LinAlg::assume_symmetry(Core::LinAlg::make_tensor(CM)), dCedC_tensor, dCediFin_tensor);
+  dCedC = Core::LinAlg::make_6x6_voigt_matrix_from_tensor(dCedC_tensor);
+  dCediFin = Core::LinAlg::make_6x9_voigt_matrix_from_tensor(dCediFin_tensor);
 }
 
 /*--------------------------------------------------------------------*


### PR DESCRIPTION
## Migrate elastic right CG tensor derivatives to the tensor API

Part of the ongoing `FourTensorOperations` → tensor-API migration.

### Migrated
- `elast_hyper_get_derivs_of_elastic_right_cg_tensor` now returns full
  `Tensor<double, 3, 3, 3, 3>` for `dCedC` and `dCediFin`, computed directly with
  inline `einsum` expressions instead of the legacy `FourTensor` / 9x9-Voigt round-trip:
  - `dCedC = 0.5 * (einsum<"ik","jl">(iFinT, iFinT) + einsum<"il","jk">(iFinT, iFinT))`
  - `dCediFin = einsum<"ad","bc">(id, iFinTC) + einsum<"ac","bd">(iFinTC, id)`
- Callers convert the result to Voigt via the new helpers.

### Added
- Conversion helpers in `4C_linalg_tensor_conversion.hpp`:
  `make_6x9 / make_9x6 / make_6x6_voigt_matrix_from_tensor`, with unit tests.

### Removed
- The  6x9 `add_kronecker_tensor_product` overload — it had
  no callers.
- `contract_matrix_matrix`, replaced by `Core::LinAlg::ddot` at its call site.