### PR TITLE
Fix sign in 4 ele Maxwell residual

### DIFF
--- a/src/reduced_lung/src/terminal_units/4C_reduced_lung_terminal_unit_rheology.cpp
+++ b/src/reduced_lung/src/terminal_units/4C_reduced_lung_terminal_unit_rheology.cpp
@@ -60,7 +60,7 @@ namespace ReducedLung::TerminalUnits::Rheology
                         (four_element_maxwell_model.elasticity_E_m[i] * dt +
                             four_element_maxwell_model.viscosity_eta_m[i])) /
                     data.reference_volume_v0[i] *
-                    locally_relevant_dofs.local_values_as_span()[data.lid_q[i]] +
+                    locally_relevant_dofs.local_values_as_span()[data.lid_q[i]] -
                 four_element_maxwell_model.viscosity_eta_m[i] /
                     (four_element_maxwell_model.elasticity_E_m[i] * dt +
                         four_element_maxwell_model.viscosity_eta_m[i]) *


### PR DESCRIPTION
The sign was wrong. Once we introduce result tests for our input files, we'd catch a mistake like this.

