### PR TITLE
Flush error output before MPI abort in main

### DIFF
--- a/apps/global_full/4C_global_full_main.cpp
+++ b/apps/global_full/4C_global_full_main.cpp
@@ -181,8 +181,10 @@ int main(int argc, char* argv[])
     }
     catch (Core::Exception& err)
     {
-      char line[] = "=========================================================================\n";
-      std::cout << "\n\n" << line << err.what_with_stacktrace() << "\n" << line << "\n" << '\n';
+      constexpr std::string_view line =
+          "\n=========================================================================\n";
+
+      std::cerr << "\n" << line << err.what_with_stacktrace() << line << "\n\n" << std::flush;
 
       if (communicators.num_groups() > 1)
       {


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

Currently, we write the error message to `std::cout` and call `MPI_Abort` directly afterward. Sometimes, this leads to mpi abort before the error message makes it to the standard output. I had problems with that when running 4C with a python subprocess. The error message got lost in these cases. This now reliably flushes the messages to `std::cerr` before aborting.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
