### PR TITLE
Cleanup of scatra ele boundary calc methods

### DIFF
--- a/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
+++ b/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
@@ -139,7 +139,7 @@ void ScaTra::MeshtyingStrategyS2I::condense_mat_and_rhs(
     {
       // extract global system matrix
       std::shared_ptr<Core::LinAlg::SparseMatrix> sparsematrix = scatratimint_->system_matrix();
-      if (sparsematrix == nullptr) FOUR_C_THROW("System matrix is not a sparse matrix!");
+      FOUR_C_ASSERT(sparsematrix != nullptr, "System matrix is not a sparse matrix!");
 
       if (lmside_ == S2I::side_source)
       {
@@ -396,12 +396,13 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
             {
               // determine global ID of current matrix row
               const int slavedofgid = icoup_->source_dof_map()->gid(slavedoflid);
-              if (slavedofgid < 0) FOUR_C_THROW("Couldn't find local ID {} in map!", slavedoflid);
+              FOUR_C_ASSERT_ALWAYS(
+                  slavedofgid >= 0, "Couldn't find local ID {} in map!", slavedoflid);
 
               // determine global ID of associated master-side matrix column
               const int masterdofgid = icoup_->permuted_target_dof_map()->gid(slavedoflid);
-              if (masterdofgid < 0)
-                FOUR_C_THROW("Couldn't find local ID {} in permuted map!", slavedoflid);
+              FOUR_C_ASSERT_ALWAYS(
+                  masterdofgid >= 0, "Couldn't find local ID {} in map!", slavedoflid);
 
               // insert value -1. into intersection of slave-side row and master-side column in
               // system matrix this effectively forces the slave-side degree of freedom to assume
@@ -528,7 +529,7 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
         {
           // determine global ID of current vector entry
           const int slavedofgid = icoup_->source_dof_map()->gid(slavedoflid);
-          if (slavedofgid < 0) FOUR_C_THROW("Couldn't find local ID {} in map!", slavedoflid);
+          FOUR_C_ASSERT_ALWAYS(slavedofgid >= 0, "Couldn't find local ID {} in map!", slavedoflid);
 
           // copy current vector entry into temporary vector
           residualslave.replace_global_value(slavedofgid,
@@ -646,7 +647,7 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
           // extract global system matrix from time integrator
           const std::shared_ptr<Core::LinAlg::SparseMatrix> systemmatrix =
               scatratimint_->system_matrix();
-          if (systemmatrix == nullptr) FOUR_C_THROW("System matrix is not a sparse matrix!");
+          FOUR_C_ASSERT(systemmatrix != nullptr, "System matrix is not a sparse matrix!");
 
           // assemble interface contributions into global system of equations
           switch (couplingtype_)
@@ -776,7 +777,7 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
           // extract global system matrix from time integrator
           std::shared_ptr<Core::LinAlg::BlockSparseMatrixBase> blocksystemmatrix =
               scatratimint_->block_system_matrix();
-          if (blocksystemmatrix == nullptr) FOUR_C_THROW("System matrix is not a block matrix!");
+          FOUR_C_ASSERT(blocksystemmatrix != nullptr, "System matrix is not a block matrix!");
 
           // assemble interface contributions into global system of equations
           switch (couplingtype_)
@@ -817,7 +818,6 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
             default:
             {
               FOUR_C_THROW("Not yet implemented!");
-              break;
             }
           }
 
@@ -883,7 +883,7 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
             // check matrix
             const std::shared_ptr<Core::LinAlg::SparseMatrix>& systemmatrix =
                 scatratimint_->system_matrix();
-            if (systemmatrix == nullptr) FOUR_C_THROW("System matrix is not a sparse matrix!");
+            FOUR_C_ASSERT(systemmatrix != nullptr, "System matrix is not a sparse matrix!");
 
             // We assume that the scatra-scatra interface layer growth is caused by master-side
             // fluxes to the interface, whereas there is no mass exchange between the interface
@@ -910,7 +910,7 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
             // check matrix
             std::shared_ptr<Core::LinAlg::BlockSparseMatrixBase> blocksystemmatrix =
                 scatratimint_->block_system_matrix();
-            if (blocksystemmatrix == nullptr) FOUR_C_THROW("System matrix is not a block matrix!");
+            FOUR_C_ASSERT(blocksystemmatrix != nullptr, "System matrix is not a block matrix!");
 
             // We assume that the scatra-scatra interface layer growth is caused by master-side
             // fluxes to the interface, whereas there is no mass exchange between the interface
@@ -941,6 +941,7 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
             blockkmm->complete();
 
             // assemble interface block matrices into global block system matrix
+            FOUR_C_ASSERT(blocksystemmatrix != nullptr, "System matrix is not a block matrix!");
             blocksystemmatrix->add(*blockkms, false, 1., 1.);
             blocksystemmatrix->add(*blockkmm, false, 1., 1.);
 
@@ -952,7 +953,6 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
             FOUR_C_THROW(
                 "Type of global system matrix for scatra-scatra interface coupling involving "
                 "interface layer growth not recognized!");
-            break;
           }
         }
 
@@ -996,7 +996,7 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
                 // check matrix
                 const std::shared_ptr<Core::LinAlg::SparseMatrix> scatragrowthblock =
                     std::dynamic_pointer_cast<Core::LinAlg::SparseMatrix>(scatragrowthblock_);
-                if (scatragrowthblock == nullptr) FOUR_C_THROW("Matrix is not a sparse matrix!");
+                FOUR_C_ASSERT(scatragrowthblock != nullptr, "Matrix is not a sparse matrix!");
 
                 // initialize matrix block
                 scatragrowthblock->zero();
@@ -1087,7 +1087,7 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
                 // check matrix
                 const std::shared_ptr<Core::LinAlg::SparseMatrix> growthscatrablock =
                     std::dynamic_pointer_cast<Core::LinAlg::SparseMatrix>(growthscatrablock_);
-                if (growthscatrablock == nullptr) FOUR_C_THROW("Matrix is not a sparse matrix!");
+                FOUR_C_ASSERT(growthscatrablock != nullptr, "Matrix is not a sparse matrix!");
 
                 // initialize matrix block
                 growthscatrablock->zero();
@@ -1560,8 +1560,8 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_mortar_cells(const Core::FE::Discret
   // extract scatra-scatra interface coupling condition from parameter list
   const Core::Conditions::Condition* const condition =
       params.get<const Core::Conditions::Condition*>("condition");
-  if (condition == nullptr)
-    FOUR_C_THROW("Cannot access scatra-scatra interface coupling condition!");
+  FOUR_C_ASSERT_ALWAYS(
+      condition != nullptr, "Cannot access scatra-scatra interface coupling condition!");
 
   // extract mortar integration cells associated with current condition
   const std::vector<std::pair<std::shared_ptr<Mortar::IntCell>, ScaTra::ImplType>>& cells =
@@ -1572,17 +1572,17 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_mortar_cells(const Core::FE::Discret
   {
     // extract current mortar integration cell
     const std::shared_ptr<Mortar::IntCell>& cell = integration_cell;
-    if (cell == nullptr) FOUR_C_THROW("Invalid mortar integration cell!");
+    FOUR_C_ASSERT_ALWAYS(cell != nullptr, "Cannot access mortar integration cell!");
 
     // extract slave-side element associated with current cell
     auto* slaveelement = dynamic_cast<Mortar::Element*>(idiscret.g_element(cell->get_slave_id()));
-    if (!slaveelement)
-      FOUR_C_THROW("Couldn't extract slave element from mortar interface discretization!");
+    FOUR_C_ASSERT_ALWAYS(slaveelement != nullptr,
+        "Couldn't extract slave element from mortar interface discretization!");
 
     // extract master-side element associated with current cell
     auto* masterelement = dynamic_cast<Mortar::Element*>(idiscret.g_element(cell->get_master_id()));
-    if (!masterelement)
-      FOUR_C_THROW("Couldn't extract master element from mortar interface discretization!");
+    FOUR_C_ASSERT_ALWAYS(masterelement != nullptr,
+        "Couldn't extract master element from mortar interface discretization!");
 
     // safety check
     if (!slaveelement->is_source() or masterelement->is_source())
@@ -1644,17 +1644,18 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_nts(
     // extract slave-side node
     auto* const slavenode =
         dynamic_cast<Mortar::Node* const>(idiscret.g_node(noderowmap_slave.gid(inode)));
-    if (slavenode == nullptr) FOUR_C_THROW("Couldn't extract slave-side node from discretization!");
+    FOUR_C_ASSERT_ALWAYS(
+        slavenode != nullptr, "Couldn't extract slave node from mortar interface discretization!");
 
     // extract first slave-side element associated with current slave-side node
     auto* const slaveelement =
         dynamic_cast<Mortar::Element* const>(slavenode->adjacent_elements()[0].user_element());
-    if (!slaveelement) FOUR_C_THROW("Invalid slave-side mortar element!");
+    FOUR_C_ASSERT_ALWAYS(slaveelement != nullptr, "Invalid slave-side mortar element!");
 
     // extract master-side element associated with current slave-side node
     auto* const masterelement = dynamic_cast<Mortar::Element* const>(
         idiscret.g_element(islavenodestomasterelements.get_local_values()[inode]));
-    if (!masterelement) FOUR_C_THROW("Invalid master-side mortar element!");
+    FOUR_C_ASSERT_ALWAYS(masterelement != nullptr, "Invalid master-side mortar element!");
 
     // safety check
     if (!slaveelement->is_source() or masterelement->is_source())
@@ -1712,7 +1713,8 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_mortar_elements(const Core::LinAlg::
     // extract current mortar element
     auto* const element =
         dynamic_cast<Mortar::Element* const>(idiscret.g_element(ielecolmap.gid(ielement)));
-    if (!element) FOUR_C_THROW("Couldn't extract mortar element from mortar discretization!");
+    FOUR_C_ASSERT_ALWAYS(element != nullptr,
+        "Couldn't extract mortar element from mortar interface discretization!");
 
     // construct location array for current mortar element
     Core::Elements::LocationArray la(idiscret.num_dof_sets());
@@ -1894,8 +1896,8 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
       const int s2ikinetics_cond_interface_side =
           s2ikinetics_cond->parameters().get<S2I::InterfaceSides>("INTERFACE_SIDE");
 
-      if (s2ikinetics_cond_id < 0)
-        FOUR_C_THROW("Invalid condition ID {} for S2IKinetics Condition!", s2ikinetics_cond_id);
+      FOUR_C_ASSERT_ALWAYS(s2ikinetics_cond_id >= 0,
+          "Invalid condition ID {} for S2IKinetics Condition!", s2ikinetics_cond_id);
 
       // only continue if ID's match
       if (s2imeshtying_cond->parameters().get<int>("S2I_KINETICS_ID") != s2ikinetics_cond_id)
@@ -1965,7 +1967,6 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
         default:
         {
           FOUR_C_THROW("Invalid scatra-scatra interface kinetics condition!");
-          break;
         }
       }
     }
@@ -1989,8 +1990,8 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
             .add("ConditionID", -1);
       }
 
-      if (scatratimint_->num_scal() < 1)
-        FOUR_C_THROW("Number of transported scalars not correctly set!");
+      FOUR_C_ASSERT_ALWAYS(
+          scatratimint_->num_scal() >= 1, "Number of transported scalars not correctly set!");
 
       // construct new (empty coupling adapter)
       icoup_ = std::make_shared<Coupling::Adapter::Coupling>();
@@ -2025,8 +2026,8 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
                 *kinetics_condition->get_nodes(), islavenodegidvec);
 
             auto mastercondition = master_conditions_.find(kineticsID);
-            if (mastercondition == master_conditions_.end())
-              FOUR_C_THROW("Could not find master condition");
+            FOUR_C_ASSERT_ALWAYS(
+                mastercondition != master_conditions_.end(), "Could not find master condition");
 
             Core::Communication::add_owned_node_gid_from_list(*scatratimint_->discretization(),
                 *mastercondition->second->get_nodes(), imasternodegidvec);
@@ -2066,11 +2067,11 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
                 *kinetics_condition->get_nodes(), islavenodegidset);
 
             auto mastercondition = master_conditions_.find(kineticsID);
-            if (mastercondition == master_conditions_.end())
-              FOUR_C_THROW("Could not find master condition");
-            else
-              Core::Communication::add_owned_node_gid_from_list(*scatratimint_->discretization(),
-                  *mastercondition->second->get_nodes(), imasternodegidset);
+            FOUR_C_ASSERT_ALWAYS(
+                mastercondition != master_conditions_.end(), "Could not find master condition");
+
+            Core::Communication::add_owned_node_gid_from_list(*scatratimint_->discretization(),
+                *mastercondition->second->get_nodes(), imasternodegidset);
           }
         }
 
@@ -2330,8 +2331,8 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
             // extract slave-side node
             auto* const slavenode =
                 dynamic_cast<Mortar::Node*>(idiscret.g_node(noderowmap_slave.gid(inode)));
-            if (!slavenode)
-              FOUR_C_THROW("Couldn't extract slave-side mortar node from mortar discretization!");
+            FOUR_C_ASSERT_ALWAYS(slavenode != nullptr,
+                "Couldn't extract slave-side mortar node from mortar discretization!");
 
             // find associated master-side elements
             std::vector<Mortar::Element*> master_mortar_elements;
@@ -2857,12 +2858,9 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
               // with current node
               const int doflid_growth = scatratimint_->discretization()->dof_row_map(2)->lid(
                   scatratimint_->discretization()->dof(2, node, 0));
-              if (doflid_growth < 0)
-              {
-                FOUR_C_THROW(
-                    "Couldn't extract local ID of scatra-scatra interface layer thickness "
-                    "variable!");
-              }
+
+              FOUR_C_ASSERT_ALWAYS(doflid_growth >= 0,
+                  "Couldn't extract local ID of scatra-scatra interface layer thickness variable!");
 
               // set initial value
               growthn_->get_values()[doflid_growth] = initthickness;
@@ -2882,7 +2880,6 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
         FOUR_C_THROW(
             "Unknown evaluation method for scatra-scatra interface coupling involving interface "
             "layer growth!");
-        break;
       }
     }
   }
@@ -3249,15 +3246,14 @@ void ScaTra::MeshtyingStrategyS2I::collect_output_data() const
         {
           // extract local ID of current node
           const int nodelid = scatratimint_->discretization()->node_row_map()->lid(nodegid);
-          if (nodelid < 0) FOUR_C_THROW("Couldn't extract local node ID!");
+          FOUR_C_ASSERT_ALWAYS(nodelid >= 0, "Couldn't extract local node ID!");
 
           // extract local ID of scatra-scatra interface layer thickness variable associated with
           // current node
           const int doflid_growth = scatratimint_->discretization()->dof_row_map(2)->lid(
               scatratimint_->discretization()->dof(2, node, 0));
-          if (doflid_growth < 0)
-            FOUR_C_THROW(
-                "Couldn't extract local ID of scatra-scatra interface layer thickness variable!");
+          FOUR_C_ASSERT_ALWAYS(doflid_growth >= 0,
+              "Couldn't extract local ID of scatra-scatra interface layer thickness variable!");
 
           // copy thickness variable into target state vector of discrete scatra-scatra interface
           // layer thicknesses
@@ -3350,22 +3346,19 @@ void ScaTra::MeshtyingStrategyS2I::explicit_predictor() const
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void ScaTra::MeshtyingStrategyS2I::extract_matrix_rows(
-    const Core::LinAlg::SparseMatrix& matrix,  //!< source matrix
-    Core::LinAlg::SparseMatrix& rows,          //!< destination matrix
-    const Core::LinAlg::Map& rowmap            //!< map of matrix rows to be extracted
-)
+void ScaTra::MeshtyingStrategyS2I::extract_matrix_rows(const Core::LinAlg::SparseMatrix& matrix,
+    Core::LinAlg::SparseMatrix& rows, const Core::LinAlg::Map& rowmap)
 {
   // safety check
-  if (rows.filled())
-    FOUR_C_THROW("Source matrix rows cannot be extracted into filled destination matrix!");
+  FOUR_C_ASSERT_ALWAYS(
+      !rows.filled(), "Source matrix rows cannot be extracted into filled destination matrix!");
 
   // loop over all source matrix rows to be extracted
   for (int doflid = 0; doflid < rowmap.num_my_elements(); ++doflid)
   {
     // determine global ID of current matrix row
     const int dofgid = rowmap.gid(doflid);
-    if (dofgid < 0) FOUR_C_THROW("Couldn't find local ID {} in map!", doflid);
+    FOUR_C_ASSERT_ALWAYS(dofgid >= 0, "Couldn't find local ID {} in map!", doflid);
 
     // extract current matrix row from source matrix
     const int length = matrix.num_global_entries(dofgid);
@@ -3423,12 +3416,9 @@ void ScaTra::MeshtyingStrategyS2I::add_time_integration_specific_vectors() const
 void ScaTra::MeshtyingStrategyS2I::compute_time_step_size(double& dt)
 {
   // not implemented for standard scalar transport
-  if (intlayergrowth_timestep_ > 0.)
-  {
-    FOUR_C_THROW(
-        "Adaptive time stepping for scatra-scatra interface layer growth not implemented for "
-        "standard scalar transport!");
-  }
+  FOUR_C_ASSERT_ALWAYS(intlayergrowth_timestep_ <= 0.,
+      "Adaptive time stepping for scatra-scatra interface layer growth not implemented for "
+      "standard scalar transport!");
 }
 
 /*----------------------------------------------------------------------*
@@ -3511,12 +3501,9 @@ void ScaTra::MeshtyingStrategyS2I::init_meshtying()
                                      ->scalar_transport_dynamic_params()
                                      .sublist("S2I COUPLING")
                                      .get<int>("INTLAYERGROWTH_LINEAR_SOLVER");
-      if (extendedsolver < 1)
-      {
-        FOUR_C_THROW(
-            "Invalid ID of linear solver for monolithic scatra-scatra interface coupling involving "
-            "interface layer growth!");
-      }
+      FOUR_C_ASSERT_ALWAYS(extendedsolver >= 1,
+          "Invalid ID of linear solver for monolithic scatra-scatra interface coupling involving "
+          "interface layer growth!");
       extendedsolver_ = std::make_shared<Core::LinAlg::Solver>(
           Global::Problem::instance()->solver_params(extendedsolver),
           scatratimint_->discretization()->get_comm(),
@@ -3678,7 +3665,7 @@ void ScaTra::MeshtyingStrategyS2I::solve(const std::shared_ptr<Core::LinAlg::Sol
           // check scalar transport system matrix
           std::shared_ptr<Core::LinAlg::SparseMatrix> sparsematrix =
               std::dynamic_pointer_cast<Core::LinAlg::SparseMatrix>(systemmatrix);
-          if (sparsematrix == nullptr) FOUR_C_THROW("System matrix is not a sparse matrix!");
+          FOUR_C_ASSERT_ALWAYS(sparsematrix != nullptr, "System matrix is not a sparse matrix!");
 
           // assemble extended system matrix including rows and columns associated with Lagrange
           // multipliers
@@ -3755,7 +3742,8 @@ void ScaTra::MeshtyingStrategyS2I::solve(const std::shared_ptr<Core::LinAlg::Sol
               // check scalar transport system matrix
               const std::shared_ptr<const Core::LinAlg::SparseMatrix> sparsematrix =
                   std::dynamic_pointer_cast<Core::LinAlg::SparseMatrix>(systemmatrix);
-              if (sparsematrix == nullptr) FOUR_C_THROW("System matrix is not a sparse matrix!");
+              FOUR_C_ASSERT_ALWAYS(
+                  sparsematrix != nullptr, "System matrix is not a sparse matrix!");
 
               // assemble extended system matrix including rows and columns associated with
               // scatra-scatra interface layer thickness variables
@@ -3776,8 +3764,8 @@ void ScaTra::MeshtyingStrategyS2I::solve(const std::shared_ptr<Core::LinAlg::Sol
               // check scalar transport system matrix
               const std::shared_ptr<const Core::LinAlg::BlockSparseMatrixBase> blocksparsematrix =
                   std::dynamic_pointer_cast<Core::LinAlg::BlockSparseMatrixBase>(systemmatrix);
-              if (blocksparsematrix == nullptr)
-                FOUR_C_THROW("System matrix is not a block sparse matrix!");
+              FOUR_C_ASSERT_ALWAYS(
+                  blocksparsematrix != nullptr, "System matrix is not a block sparse matrix!");
 
               // extract number of matrix row or column blocks associated with scalar transport
               // field
@@ -3972,7 +3960,7 @@ void ScaTra::MeshtyingStrategyS2I::fd_check(
     {
       // get global index of current matrix row
       const int rowgid = sysmat_original.row_map().gid(rowlid);
-      if (rowgid < 0) FOUR_C_THROW("Invalid global ID of matrix row!");
+      FOUR_C_ASSERT_ALWAYS(rowgid >= 0, "Invalid global ID of matrix row!");
 
       // get relevant entry in current row of original system matrix
       double entry(0.);
@@ -4181,8 +4169,8 @@ void ScaTra::MortarCellCalc<distype_s, distype_m>::evaluate_nts(
     {
       // extract condition from parameter list
       const auto* const condition = params.get<const Core::Conditions::Condition*>("condition");
-      if (condition == nullptr)
-        FOUR_C_THROW("Cannot access scatra-scatra interface coupling condition!");
+      FOUR_C_ASSERT_ALWAYS(
+          condition != nullptr, "Cannot access scatra-scatra interface coupling condition!");
 
       // extract nodal state variables associated with slave and master elements
       extract_node_values(idiscret, la_slave, la_master);
@@ -4280,8 +4268,9 @@ void ScaTra::MortarCellCalc<distype_s, distype_m>::extract_node_values(
   // extract interface state vector from interface discretization
   const std::shared_ptr<const Core::LinAlg::Vector<double>> state =
       idiscret.get_state(nds, statename);
-  if (state == nullptr)
-    FOUR_C_THROW("Cannot extract state vector \"{}\" from interface discretization!", statename);
+
+  FOUR_C_ASSERT_ALWAYS(
+      state != nullptr, "Cannot extract state vector {} from interface discretization!", statename);
 
   // extract nodal state variables associated with slave element
   Core::FE::extract_my_values<Core::LinAlg::Matrix<nen_slave_, 1>>(
@@ -4301,8 +4290,8 @@ void ScaTra::MortarCellCalc<distype_s, distype_m>::extract_node_values(
   // extract interface state vector from interface discretization
   const std::shared_ptr<const Core::LinAlg::Vector<double>> state =
       idiscret.get_state(nds, statename);
-  if (state == nullptr)
-    FOUR_C_THROW("Cannot extract state vector \"{}\" from interface discretization!", statename);
+  FOUR_C_ASSERT_ALWAYS(
+      state != nullptr, "Cannot extract state vector {} from interface discretization!", statename);
 
   // extract nodal state variables associated with slave and master elements
   Core::FE::extract_my_values<Core::LinAlg::Matrix<nen_slave_, 1>>(
@@ -4452,8 +4441,8 @@ void ScaTra::MortarCellCalc<distype_s, distype_m>::eval_shape_func_at_slave_node
     const Mortar::Node& slavenode, Mortar::Element& slaveelement, Mortar::Element& masterelement)
 {
   // safety check
-  if (couplingtype_ != S2I::coupling_nts_standard)
-    FOUR_C_THROW("This function should only be called when evaluating node-to-segment coupling!");
+  FOUR_C_ASSERT_ALWAYS(couplingtype_ == S2I::coupling_nts_standard,
+      "This function should only be called when evaluating node-to-segment coupling!");
 
   // extract global ID of slave-side node
   const int& nodeid = slavenode.id();
@@ -4468,8 +4457,8 @@ void ScaTra::MortarCellCalc<distype_s, distype_m>::eval_shape_func_at_slave_node
       break;
     }
   }
-  if (index == -1)
-    FOUR_C_THROW("Couldn't find out index of slave-side node w.r.t. slave-side element!");
+  FOUR_C_ASSERT_ALWAYS(
+      index != -1, "Couldn't find out index of slave-side node w.r.t. slave-side element!");
 
   // set slave-side shape function array according to node position
   funct_slave_.clear();
@@ -4495,8 +4484,8 @@ void ScaTra::MortarCellCalc<distype_s, distype_m>::evaluate_mortar_matrices(Mort
     Core::LinAlg::SerialDenseMatrix& E)
 {
   // safety check
-  if (numdofpernode_slave_ != numdofpernode_master_)
-    FOUR_C_THROW("Must have same number of degrees of freedom per node on slave and master sides!");
+  FOUR_C_ASSERT_ALWAYS(numdofpernode_slave_ == numdofpernode_master_,
+      "Must have same number of degrees of freedom per node on slave and master sides!");
 
   // determine quadrature rule
   const Core::FE::IntPointsAndWeights<2> intpoints(Core::FE::GaussRule2D::tri_7point);
@@ -4645,7 +4634,7 @@ void ScaTra::MortarCellCalc<distype_s, distype_m>::evaluate_condition(
     if (timefacfac < 0. or timefacrhsfac < 0.) FOUR_C_THROW("Integration factor is negative!");
 
     Discret::Elements::ScaTraEleBoundaryCalc<
-        distype_s>::template evaluate_s2_i_coupling_at_integration_point<distype_m>(ephinp_slave_,
+        distype_s>::template evaluate_s2i_coupling_at_integration_point<distype_m>(ephinp_slave_,
         ephinp_master_, pseudo_contact_fac, funct_slave_, funct_master_, test_lm_slave_,
         test_lm_master_, numdofpernode_slave_, scatraparamsboundary_, timefacfac, timefacrhsfac,
         k_ss, k_sm, k_ms, k_mm, r_s, r_m);
@@ -4686,7 +4675,7 @@ void ScaTra::MortarCellCalc<distype_s, distype_m>::evaluate_condition_nts(
   if (timefacfac < 0. or timefacrhsfac < 0.) FOUR_C_THROW("Integration factor is negative!");
 
   Discret::Elements::ScaTraEleBoundaryCalc<
-      distype_s>::template evaluate_s2_i_coupling_at_integration_point<distype_m>(ephinp_slave,
+      distype_s>::template evaluate_s2i_coupling_at_integration_point<distype_m>(ephinp_slave,
       ephinp_master, pseudo_contact_fac, funct_slave_, funct_master_, funct_slave_, funct_master_,
       numdofpernode_slave_, scatraparamsboundary_, timefacfac, timefacrhsfac, k_ss, k_sm, k_ms,
       k_mm, r_s, r_m);
@@ -4841,8 +4830,8 @@ void ScaTra::MortarCellAssemblyStrategy::assemble_cell_vector(
   {
     case S2I::side_source:
     {
-      if (systemvector.num_vectors() != 1)
-        FOUR_C_THROW("Invalid number of vectors inside Core::LinAlg::MultiVector<double>!");
+      FOUR_C_ASSERT_ALWAYS(systemvector.num_vectors() == 1,
+          "Invalid number of vectors inside Core::LinAlg::MultiVector!");
       Core::LinAlg::assemble((systemvector).get_vector(nds_rows_), cellvector,
           la_slave[nds_rows_].lm_, la_slave[nds_rows_].lmowner_);
 

--- a/src/scatra/4C_scatra_timint_meshtying_strategy_s2i_elch.cpp
+++ b/src/scatra/4C_scatra_timint_meshtying_strategy_s2i_elch.cpp
@@ -634,7 +634,7 @@ void ScaTra::MortarCellCalcElch<distype_s, distype_m>::evaluate_condition(
     if (timefacfac < 0.0 or timefacrhsfac < 0.0) FOUR_C_THROW("Integration factor is negative!");
 
     Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<
-        distype_s>::template evaluate_s2_i_coupling_at_integration_point<distype_m>(matelectrode,
+        distype_s>::template evaluate_s2i_coupling_at_integration_point<distype_m>(matelectrode,
         my::ephinp_slave_, my::ephinp_master_, dummy_slave_temp, dummy_master_temp,
         pseudo_contact_fac, my::funct_slave_, my::funct_master_, my::test_lm_slave_,
         my::test_lm_master_, my::scatraparamsboundary_, timefacfac, timefacrhsfac, dummy_detF,
@@ -690,7 +690,7 @@ void ScaTra::MortarCellCalcElch<distype_s, distype_m>::evaluate_condition_nts(
   const double dummy_detF(1.0);
 
   Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<
-      distype_s>::template evaluate_s2_i_coupling_at_integration_point<distype_m>(matelectrode,
+      distype_s>::template evaluate_s2i_coupling_at_integration_point<distype_m>(matelectrode,
       ephinp_slave, ephinp_master, dummy_slave_temp, dummy_master_temp, pseudo_contact_fac,
       my::funct_slave_, my::funct_master_, my::funct_slave_, my::funct_master_,
       my::scatraparamsboundary_, timefacfac, timefacrhsfac, dummy_detF,
@@ -874,13 +874,13 @@ void ScaTra::MortarCellCalcElchSTIThermo<distype_s, distype_m>::evaluate_conditi
     // no deformation available
     const double dummy_detF(1.0);
 
-    Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeSTIThermo<distype_s>::
-        template evaluate_s2_i_coupling_od_at_integration_point<distype_m>(*matelectrode,
-            my::ephinp_slave_, etempnp_slave_, dummy_master_temp, my::ephinp_master_,
-            pseudo_contact_fac, my::funct_slave_, my::funct_master_, my::test_lm_slave_,
-            my::test_lm_master_, dummy_shapederivatives, dummy_shapederivatives,
-            my::scatraparamsboundary_, ScaTra::DifferentiationType::temp, timefacfac, timefacwgt,
-            dummy_detF, my::numdofpernode_slave_, k_ss, k_ms);
+    Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeSTIThermo<
+        distype_s>::template evaluate_s2i_coupling_od_at_integration_point<distype_m>(*matelectrode,
+        my::ephinp_slave_, etempnp_slave_, dummy_master_temp, my::ephinp_master_,
+        pseudo_contact_fac, my::funct_slave_, my::funct_master_, my::test_lm_slave_,
+        my::test_lm_master_, dummy_shapederivatives, dummy_shapederivatives,
+        my::scatraparamsboundary_, ScaTra::DifferentiationType::temp, timefacfac, timefacwgt,
+        dummy_detF, my::numdofpernode_slave_, k_ss, k_ms);
   }  // loop over integration points
 }
 
@@ -1098,7 +1098,7 @@ void ScaTra::MortarCellCalcSTIElch<distype_s, distype_m>::evaluate_condition(
     const double dummy_detF(1.0);
 
     Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<
-        distype_s>::template evaluate_s2_i_coupling_at_integration_point<distype_m>(*matelectrode,
+        distype_s>::template evaluate_s2i_coupling_at_integration_point<distype_m>(*matelectrode,
         my::ephinp_slave_[0], my::ephinp_master_[0], eelchnp_slave_, eelchnp_master_,
         pseudo_contact_fac, my::funct_slave_, my::funct_master_, my::scatraparamsboundary_,
         timefacfac, timefacrhsfac, dummy_detF, k_ss, dummy_ksm, r_s);
@@ -1175,12 +1175,12 @@ void ScaTra::MortarCellCalcSTIElch<distype_s, distype_m>::evaluate_condition_od(
     // no deformation available
     const double dummy_detF(1.0);
 
-    Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<distype_s>::
-        template evaluate_s2_i_coupling_od_at_integration_point<distype_m>(*matelectrode,
-            my::ephinp_slave_[0], my::ephinp_master_[0], eelchnp_slave_, eelchnp_master_,
-            pseudo_contact_fac, my::funct_slave_, my::funct_master_, my::scatraparamsboundary_,
-            timefacfac, fac, dummy_detF, ScaTra::DifferentiationType::elch, dummy_shape_deriv,
-            dummy_shape_deriv, k_ss, k_sm);
+    Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<
+        distype_s>::template evaluate_s2i_coupling_od_at_integration_point<distype_m>(*matelectrode,
+        my::ephinp_slave_[0], my::ephinp_master_[0], eelchnp_slave_, eelchnp_master_,
+        pseudo_contact_fac, my::funct_slave_, my::funct_master_, my::scatraparamsboundary_,
+        timefacfac, fac, dummy_detF, ScaTra::DifferentiationType::elch, dummy_shape_deriv,
+        dummy_shape_deriv, k_ss, k_sm);
   }  // loop over integration points
 }
 

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc.cpp
@@ -20,7 +20,6 @@
 #include "4C_scatra_ele_parameter_boundary.hpp"
 #include "4C_scatra_ele_parameter_std.hpp"
 #include "4C_scatra_ele_parameter_timint.hpp"
-#include "4C_utils_enum.hpp"
 #include "4C_utils_function.hpp"
 
 FOUR_C_NAMESPACE_OPEN
@@ -72,7 +71,7 @@ int Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::setup_calc(
   {
     // for isogeometric elements --- get knotvectors for parent
     // element and boundary element, get weights
-    bool zero_size = Core::FE::Nurbs::get_knot_vector_and_weights_for_nurbs_boundary(ele,
+    const bool zero_size = Core::FE::Nurbs::get_knot_vector_and_weights_for_nurbs_boundary(ele,
         ele->face_parent_number(), ele->parent_element()->id(), discretization, mypknots_, myknots_,
         weights_, normalfac_);
 
@@ -158,7 +157,6 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::extract_displac
     }
     default:
       FOUR_C_THROW("Not implemented for discretization type: {}!", ele->parent_element()->shape());
-      break;
   }
 }
 
@@ -270,9 +268,8 @@ int Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::evaluate_action(
 
     case ScaTra::BoundaryAction::calc_Neumann:
     {
-      const Core::Conditions::Condition* condition =
-          params.get<const Core::Conditions::Condition*>("condition");
-      if (condition == nullptr) FOUR_C_THROW("Cannot access Neumann boundary condition!");
+      const auto* condition = params.get<const Core::Conditions::Condition*>("condition");
+      FOUR_C_ASSERT_ALWAYS(condition != nullptr, "Cannot access Neumann boundary condition!");
 
       evaluate_neumann(ele, params, discretization, *condition, la, elevec1, 1.);
 
@@ -294,7 +291,7 @@ int Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::evaluate_action(
 
       // get values of scalar
       std::shared_ptr<const Core::LinAlg::Vector<double>> phinp = discretization.get_state("phinp");
-      if (phinp == nullptr) FOUR_C_THROW("Cannot get state vector 'phinp'");
+      FOUR_C_ASSERT(phinp != nullptr, "Cannot get state vector 'phinp'");
 
       // extract local values from global vector
       std::vector<Core::LinAlg::Matrix<nen_, 1>> ephinp(
@@ -302,9 +299,9 @@ int Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::evaluate_action(
       Core::FE::extract_my_values<Core::LinAlg::Matrix<nen_, 1>>(*phinp, ephinp, lm);
 
       // get condition
-      const Core::Conditions::Condition* cond =
-          params.get<const Core::Conditions::Condition*>("condition");
-      if (cond == nullptr) FOUR_C_THROW("Cannot access condition 'TransportThermoConvections'!");
+      const auto* cond = params.get<const Core::Conditions::Condition*>("condition");
+      FOUR_C_ASSERT_ALWAYS(
+          cond != nullptr, "Cannot access condition 'TransportThermoConvections'!");
 
       // get heat transfer coefficient and surrounding temperature
       const auto heatranscoeff = cond->parameters().get<double>("coeff");
@@ -321,7 +318,7 @@ int Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::evaluate_action(
       Core::Elements::Element* parentele = ele->parent_element();
       std::shared_ptr<Core::Mat::Material> mat = parentele->material();
 
-      if (numscal_ > 1) FOUR_C_THROW("not yet implemented for more than one scalar\n");
+      FOUR_C_ASSERT_ALWAYS(numscal_ == 1, "not yet implemented for more than one scalar");
 
       switch (distype)
       {
@@ -349,7 +346,9 @@ int Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::evaluate_action(
                 ele, params, discretization, mat, elemat1, elevec1);
           }
           else
+          {
             FOUR_C_THROW("expected combination quad4/hex8 or line2/quad4 for surface/parent pair");
+          }
 
           break;
         }
@@ -357,7 +356,6 @@ int Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::evaluate_action(
         default:
         {
           FOUR_C_THROW("not implemented yet\n");
-          break;
         }
       }
 
@@ -386,7 +384,7 @@ int Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::evaluate_action(
 
       // get actual values of transported scalars
       std::shared_ptr<const Core::LinAlg::Vector<double>> phinp = discretization.get_state("phinp");
-      if (phinp == nullptr) FOUR_C_THROW("Cannot get state vector 'phinp'");
+      FOUR_C_ASSERT(phinp != nullptr, "Cannot get state vector 'phinp'");
 
       // extract local values from the global vector
       std::vector<Core::LinAlg::Matrix<nen_, 1>> ephinp(
@@ -399,7 +397,7 @@ int Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::evaluate_action(
       // get convective (velocity - mesh displacement) velocity at nodes
       std::shared_ptr<const Core::LinAlg::Vector<double>> convel =
           discretization.get_state(ndsvel, "convective velocity field");
-      if (convel == nullptr) FOUR_C_THROW("Cannot get state vector convective velocity");
+      FOUR_C_ASSERT(convel != nullptr, "Cannot get state vector 'convective velocity field'");
 
       // determine number of velocity related dofs per node
       const int numveldofpernode = la[ndsvel].lm_.size() / nen_;
@@ -427,27 +425,27 @@ int Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::evaluate_action(
 
     case ScaTra::BoundaryAction::calc_s2icoupling:
     {
-      evaluate_s2_i_coupling(ele, params, discretization, la, elemat1, elemat2, elevec1);
+      evaluate_s2i_coupling(ele, params, discretization, la, elemat1, elemat2, elevec1);
 
       break;
     }
 
     case ScaTra::BoundaryAction::calc_s2icoupling_capacitance:
     {
-      evaluate_s2_i_coupling_capacitance(discretization, la, elemat1, elemat2, elevec1, elevec2);
+      evaluate_s2i_coupling_capacitance(discretization, la, elemat1, elemat2, elevec1, elevec2);
 
       break;
     }
 
     case ScaTra::BoundaryAction::calc_s2icoupling_od:
     {
-      evaluate_s2_i_coupling_od(ele, params, discretization, la, elemat1);
+      evaluate_s2i_coupling_od(ele, params, discretization, la, elemat1);
       break;
     }
 
     case ScaTra::BoundaryAction::calc_s2icoupling_capacitance_od:
     {
-      evaluate_s2_i_coupling_capacitance_od(params, discretization, la, elemat1, elemat2);
+      evaluate_s2i_coupling_capacitance_od(params, discretization, la, elemat1, elemat2);
       break;
     }
 
@@ -468,13 +466,12 @@ int Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::evaluate_action(
     }
     case ScaTra::BoundaryAction::calc_s2icoupling_flux:
     {
-      calc_s2_i_coupling_flux(ele, params, discretization, la, elevec1);
+      calc_s2i_coupling_flux(ele, params, discretization, la, elevec1);
       break;
     }
     default:
     {
       FOUR_C_THROW("Not acting on this boundary action. Forgot implementation?");
-      break;
     }
   }
 
@@ -504,17 +501,14 @@ int Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::evaluate_neumann
   const auto val = condition.parameters().get<std::vector<double>>("VAL");
   const auto func = condition.parameters().get<std::vector<std::optional<int>>>("FUNCT");
 
-  if (numdofpernode_ != numdof)
-  {
-    FOUR_C_THROW(
-        "The NUMDOF you have entered in your TRANSPORT NEUMANN CONDITION does not equal the number "
-        "of scalars.");
-  }
+  FOUR_C_ASSERT_ALWAYS(numdofpernode_ == numdof,
+      "The NUMDOF you have entered in your TRANSPORT NEUMANN CONDITION does not equal the number "
+      "of scalars.");
 
   // integration loop
   for (int iquad = 0; iquad < intpoints.ip().nquad; ++iquad)
   {
-    double fac = eval_shape_func_and_int_fac(intpoints, iquad);
+    const double fac = eval_shape_func_and_int_fac(intpoints, iquad);
 
     // factor given by spatial function
     double functfac = 1.0;
@@ -559,7 +553,7 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::calc_normal_vec
   // access the global vector
   const auto normals =
       params.get<std::shared_ptr<Core::LinAlg::MultiVector<double>>>("normal vectors", nullptr);
-  if (normals == nullptr) FOUR_C_THROW("Could not access vector 'normal vectors'");
+  FOUR_C_ASSERT(normals != nullptr, "Could not access vector 'normal vectors'");
 
   // determine constant outer normal to this element
   if constexpr (nsd_ == 3 and nsd_ele_ == 1)
@@ -626,7 +620,7 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::neumann_inflow(
 
   // get values of scalar
   std::shared_ptr<const Core::LinAlg::Vector<double>> phinp = discretization.get_state("phinp");
-  if (phinp == nullptr) FOUR_C_THROW("Cannot get state vector 'phinp'");
+  FOUR_C_ASSERT(phinp != nullptr, "Could not access state vector 'phinp'");
 
   // extract local values from global vector
   std::vector<Core::LinAlg::Matrix<nen_, 1>> ephinp(
@@ -639,7 +633,7 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::neumann_inflow(
   // get convective (velocity - mesh displacement) velocity at nodes
   std::shared_ptr<const Core::LinAlg::Vector<double>> convel =
       discretization.get_state(ndsvel, "convective velocity field");
-  if (convel == nullptr) FOUR_C_THROW("Cannot get state vector convective velocity");
+  FOUR_C_ASSERT(convel != nullptr, "Could not access state vector 'convective velocity field'");
 
   // determine number of velocity related dofs per node
   const int numveldofpernode = la[ndsvel].lm_.size() / nen_;
@@ -680,7 +674,7 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::neumann_inflow(
       if (normvel < -0.0001)
       {
         // set density to 1.0
-        double dens = get_density(material, ephinp, k);
+        const double dens = get_density(material, ephinp, k);
 
         // integration factor for left-hand side
         const double lhsfac = dens * normvel * scatraparamstimint_->time_fac() * fac;
@@ -767,7 +761,6 @@ double Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::get_density(
     default:
     {
       FOUR_C_THROW("Invalid material type!");
-      break;
     }
   }
 
@@ -911,8 +904,8 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::
         Core::LinAlg::Matrix<nsd_, nen_>& dsqrtdetg_dd)
 {
   // safety check
-  if (nsd_ele_ != 2)
-    FOUR_C_THROW("Computation of shape derivatives only implemented for 2D interfaces!");
+  FOUR_C_ASSERT(
+      nsd_ele_ == 2, "Computation of shape derivatives only implemented for 2D interfaces!");
 
   evaluate_shape_func_and_derivative_at_int_point(intpoints, iquad);
 
@@ -1004,7 +997,7 @@ Core::LinAlg::Matrix<3, 1>
 Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::get_const_normal(
     const Core::LinAlg::Matrix<3, nen_>& xyze)
 {
-  if (Core::FE::is_nurbs<distype>) FOUR_C_THROW("Element normal not implemented for NURBS");
+  FOUR_C_ASSERT(!Core::FE::is_nurbs<distype>, "Element normal not implemented for NURBS");
 
   Core::LinAlg::Matrix<3, 1> normal(Core::LinAlg::Initialization::zero);
   Core::LinAlg::Matrix<3, 1> dist1(Core::LinAlg::Initialization::zero);
@@ -1018,7 +1011,7 @@ Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::get_const_normal(
   normal.cross_product(dist1, dist2);
 
   const double length = normal.norm2();
-  if (length < 1.0e-16) FOUR_C_THROW("Zero length for element normal");
+  FOUR_C_ASSERT_ALWAYS(length >= 1.0e-16, "Zero length for element normal");
 
   normal.scale(1.0 / length);
 
@@ -1032,7 +1025,7 @@ Core::LinAlg::Matrix<2, 1>
 Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::get_const_normal(
     const Core::LinAlg::Matrix<2, nen_>& xyze)
 {
-  if (Core::FE::is_nurbs<distype>) FOUR_C_THROW("Element normal not implemented for NURBS");
+  FOUR_C_ASSERT(!Core::FE::is_nurbs<distype>, "Element normal not implemented for NURBS");
 
   Core::LinAlg::Matrix<2, 1> normal(Core::LinAlg::Initialization::zero);
 
@@ -1040,7 +1033,7 @@ Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::get_const_normal(
   normal(1) = (-1.0) * (xyze(0, 1) - xyze(0, 0));
 
   const double length = normal.norm2();
-  if (length < 1.0e-16) FOUR_C_THROW("Zero length for element normal");
+  FOUR_C_ASSERT_ALWAYS(length >= 1.0e-16, "Zero length for element normal");
 
   normal.scale(1.0 / length);
 
@@ -1054,7 +1047,7 @@ Core::LinAlg::Matrix<3, 1>
 Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::get_const_normal(
     const Core::LinAlg::Matrix<3, nen_>& xyze, const Core::LinAlg::Matrix<3, 3>& nodes_parent_ele)
 {
-  if (Core::FE::is_nurbs<distype>) FOUR_C_THROW("Element normal not implemented for NURBS");
+  FOUR_C_ASSERT(!Core::FE::is_nurbs<distype>, "Element normal not implemented for NURBS");
 
   Core::LinAlg::Matrix<3, 1> normal(Core::LinAlg::Initialization::zero);
   Core::LinAlg::Matrix<3, 1> normal_parent_ele(Core::LinAlg::Initialization::zero);
@@ -1102,7 +1095,7 @@ Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::get_const_normal(
   if (inward_vector.dot(normal) >= 0.0) normal.scale(-1.0);
 
   const double length = normal.norm2();
-  if (length < 1.0e-16) FOUR_C_THROW("Zero length for element normal");
+  FOUR_C_ASSERT_ALWAYS(length >= 1.0e-16, "Zero length for element normal");
 
   normal.scale(1.0 / length);
 
@@ -1112,7 +1105,7 @@ Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::get_const_normal(
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
-void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::evaluate_s2_i_coupling(
+void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::evaluate_s2i_coupling(
     const Core::Elements::FaceElement* ele, Teuchos::ParameterList& params,
     Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
     Core::LinAlg::SerialDenseMatrix& eslavematrix, Core::LinAlg::SerialDenseMatrix& emastermatrix,
@@ -1157,7 +1150,7 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::evaluate_s2_i_c
     const double pseudo_contact_fac =
         calculate_pseudo_contact_factor(is_pseudo_contact, eslavestress_vector, normal, funct_);
 
-    evaluate_s2_i_coupling_at_integration_point<distype>(ephinp_, emasterphinp, pseudo_contact_fac,
+    evaluate_s2i_coupling_at_integration_point<distype>(ephinp_, emasterphinp, pseudo_contact_fac,
         funct_, funct_, funct_, funct_, numscal_, scatraparamsboundary_, timefacfac, timefacrhsfac,
         eslavematrix, emastermatrix, dummymatrix, dummymatrix, eslaveresidual, dummyvector);
   }  // end of loop over integration points
@@ -1168,7 +1161,7 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::evaluate_s2_i_c
 template <Core::FE::CellType distype, int probdim>
 template <Core::FE::CellType distype_master>
 void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::
-    evaluate_s2_i_coupling_at_integration_point(
+    evaluate_s2i_coupling_at_integration_point(
         const std::vector<Core::LinAlg::Matrix<nen_, 1>>& eslavephinp,
         const std::vector<Core::LinAlg::Matrix<Core::FE::num_nodes(distype_master), 1>>&
             emasterphinp,
@@ -1205,11 +1198,10 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::
       // constant permeability model
       case S2I::kinetics_constperm:
       {
-        if (permeabilities == nullptr)
-          FOUR_C_THROW(
-              "Cannot access vector of permeabilities for scatra-scatra interface coupling!");
-        if (permeabilities->size() != (unsigned)numscal)
-          FOUR_C_THROW("Number of permeabilities does not match number of scalars!");
+        FOUR_C_ASSERT(permeabilities != nullptr,
+            "Cannot access vector of permeabilities for scatra-scatra interface coupling!");
+        FOUR_C_ASSERT_ALWAYS(permeabilities->size() == static_cast<std::size_t>(numscal),
+            "Number of permeabilities does not match number of scalars!");
 
         // core residual
         const double N_timefacrhsfac = pseudo_contact_fac * timefacrhsfac * (*permeabilities)[k] *
@@ -1268,7 +1260,6 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::
       default:
       {
         FOUR_C_THROW("Kinetic model for scatra-scatra interface coupling not yet implemented!");
-        break;
       }
     }
   }  // end of loop over scalars
@@ -1328,7 +1319,6 @@ Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::calculate_det_f_of_p
       {
         FOUR_C_THROW(
             "Not implemented for discretization type: {}!", faceele->parent_element()->shape());
-        break;
       }
     }
   }
@@ -1382,7 +1372,7 @@ Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::calculate_det_f_of_p
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
-void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::evaluate_s2_i_coupling_od(
+void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::evaluate_s2i_coupling_od(
     const Core::Elements::FaceElement* ele, Teuchos::ParameterList& params,
     Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
     Core::LinAlg::SerialDenseMatrix& eslavematrix)
@@ -1404,11 +1394,9 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::evaluate_s2_i_c
         scatraparams_->nds_two_tensor_quantity());
 
   // get current scatra-scatra interface coupling condition
-  const Core::Conditions::Condition* s2icondition =
-      params.get<const Core::Conditions::Condition*>("condition");
-  if (s2icondition == nullptr)
-    FOUR_C_THROW("Cannot access scatra-scatra interface coupling condition!");
-
+  const auto* s2icondition = params.get<const Core::Conditions::Condition*>("condition");
+  FOUR_C_ASSERT_ALWAYS(
+      s2icondition != nullptr, "Cannot access scatra-scatra interface coupling condition!");
   // get primary variable to derive the linearization
   const auto differentiationtype =
       Teuchos::getIntegralValue<ScaTra::DifferentiationType>(params, "differentiationtype");
@@ -1433,7 +1421,7 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::evaluate_s2_i_c
 
     // evaluate overall integration factor
     const double timefacwgt = scatraparamstimint_->time_fac() * intpoints.ip().qwgt[gpid];
-    if (timefacwgt < 0.) FOUR_C_THROW("Integration factor is negative!");
+    FOUR_C_ASSERT_ALWAYS(timefacwgt > 0.0, "Time factor and integration weight must be positive!");
 
     // loop over scalars
     for (int k = 0; k < numscal_; ++k)
@@ -1457,11 +1445,10 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::evaluate_s2_i_c
             {
               // access real vector of constant permeabilities associated with current condition
               const std::vector<double>* permeabilities = scatraparamsboundary_->permeabilities();
-              if (permeabilities == nullptr)
-                FOUR_C_THROW(
-                    "Cannot access vector of permeabilities for scatra-scatra interface coupling!");
-              if (permeabilities->size() != static_cast<unsigned>(numscal_))
-                FOUR_C_THROW("Number of permeabilities does not match number of scalars!");
+              FOUR_C_ASSERT(permeabilities != nullptr,
+                  "Cannot access vector of permeabilities for scatra-scatra interface coupling!");
+              FOUR_C_ASSERT_ALWAYS(permeabilities->size() == static_cast<std::size_t>(numscal_),
+                  "Number of permeabilities must match number of scalars!");
 
               // core linearization
               const double dN_dsqrtdetg_timefacwgt = pseudo_contact_fac * timefacwgt *
@@ -1490,7 +1477,6 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::evaluate_s2_i_c
             default:
             {
               FOUR_C_THROW("Unknown primary quantity to calculate derivative");
-              break;
             }
           }
 
@@ -1500,12 +1486,11 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::evaluate_s2_i_c
         default:
         {
           FOUR_C_THROW("Kinetic model for scatra-scatra interface coupling not yet implemented!");
-          break;
         }
       }  // selection of kinetic model
     }  // loop over scalars
   }  // loop over integration points
-}  // Discret::Elements::ScaTraEleBoundaryCalc<distype>::evaluate_s2_i_coupling_od
+}  // Discret::Elements::ScaTraEleBoundaryCalc<distype>::evaluate_s2i_coupling_od
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
@@ -1546,8 +1531,7 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::extract_node_va
   // extract global state vector from discretization
   const std::shared_ptr<const Core::LinAlg::Vector<double>> state =
       discretization.get_state(nds, statename);
-  if (state == nullptr)
-    FOUR_C_THROW("Cannot extract state vector \"{}\" from discretization!", statename);
+  FOUR_C_ASSERT(state != nullptr, "Cannot extract state vector {} from discretization!", statename);
 
   // extract nodal state variables associated with boundary element
   Core::FE::extract_my_values<Core::LinAlg::Matrix<nen_, 1>>(*state, estate, la[nds].lm_);
@@ -1630,21 +1614,17 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::calc_robin_boun
   //////////////////////////////////////////////////////////////////////
 
   // get current condition
-  const Core::Conditions::Condition* cond =
-      params.get<const Core::Conditions::Condition*>("condition");
-  if (cond == nullptr) FOUR_C_THROW("Cannot access condition 'TransportRobin'");
+  const auto* cond = params.get<const Core::Conditions::Condition*>("condition");
+  FOUR_C_ASSERT(cond != nullptr, "Cannot access condition 'TransportRobin'");
 
   // get on/off flags
   const auto onoff = cond->parameters().get<std::vector<int>>("ONOFF");
 
   // safety check
-  if ((int)(onoff.size()) != numscal_)
-  {
-    FOUR_C_THROW(
-        "Mismatch in size for Robin boundary conditions, onoff has length {}, but you have {} "
-        "scalars",
-        onoff.size(), numscal_);
-  }
+  FOUR_C_ASSERT_ALWAYS(onoff.size() == static_cast<std::size_t>(numscal_),
+      "Mismatch in size for Robin boundary conditions, onoff has length {}, but you have {} "
+      "scalars",
+      onoff.size(), numscal_);
 
   // extract prefactor and reference value from condition
   const auto prefac = cond->parameters().get<double>("PREFACTOR");
@@ -1659,7 +1639,7 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::calc_robin_boun
   // ------------get values of scalar transport------------------
   // extract global state vector from discretization
   std::shared_ptr<const Core::LinAlg::Vector<double>> phinp = discretization.get_state("phinp");
-  if (phinp == nullptr) FOUR_C_THROW("Cannot read state vector \"phinp\" from discretization!");
+  FOUR_C_ASSERT(phinp != nullptr, "Cannot extract state vector 'phinp' from discretization!");
 
   // extract local nodal state variables from global state vector
   std::vector<Core::LinAlg::Matrix<nen_, 1>> ephinp(
@@ -1753,7 +1733,7 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::evaluate_surfac
 
   // ------------get values of scalar transport------------------
   std::shared_ptr<const Core::LinAlg::Vector<double>> phinp = discretization.get_state("phinp");
-  if (phinp == nullptr) FOUR_C_THROW("Cannot get state vector 'phinp'");
+  FOUR_C_ASSERT(phinp != nullptr, "Cannot extract state vector 'phinp' from discretization!");
   // extract local values from global vector
   std::vector<Core::LinAlg::Matrix<nen_, 1>> ephinp(
       numdofpernode_, Core::LinAlg::Matrix<nen_, 1>(Core::LinAlg::Initialization::zero));
@@ -1763,7 +1743,8 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::evaluate_surfac
   // membrane)------------------
   std::shared_ptr<const Core::LinAlg::Vector<double>> phibar =
       discretization.get_state("MembraneConcentration");
-  if (phibar == nullptr) FOUR_C_THROW("Cannot get state vector 'MembraneConcentration'");
+  FOUR_C_ASSERT(phibar != nullptr,
+      "Cannot extract state vector 'MembraneConcentration' from discretization!");
   // extract local values from global vector
   std::vector<Core::LinAlg::Matrix<nen_, 1>> ephibar(
       numdofpernode_, Core::LinAlg::Matrix<nen_, 1>(Core::LinAlg::Initialization::zero));
@@ -1772,10 +1753,11 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::evaluate_surfac
   // ------------get values of wall shear stress-----------------------
   // get number of dofset associated with pressure related dofs
   const int ndswss = scatraparams_->nds_wss();
-  if (ndswss == -1) FOUR_C_THROW("Cannot get number of dofset of wss vector");
+  FOUR_C_ASSERT(ndswss != -1, "Cannot get number of dofset of wss vector");
   std::shared_ptr<const Core::LinAlg::Vector<double>> wss =
       discretization.get_state(ndswss, "WallShearStress");
-  if (wss == nullptr) FOUR_C_THROW("Cannot get state vector 'WallShearStress'");
+  FOUR_C_ASSERT(
+      wss != nullptr, "Cannot extract state vector 'WallShearStress' from discretization!");
 
   // determine number of velocity (and pressure) related dofs per node
   const int numwssdofpernode = la[ndswss].lm_.size() / nen_;
@@ -1795,9 +1777,9 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::evaluate_surfac
   //                  get current condition
   //////////////////////////////////////////////////////////////////////
 
-  const Core::Conditions::Condition* cond =
-      params.get<const Core::Conditions::Condition*>("condition");
-  if (cond == nullptr) FOUR_C_THROW("Cannot access condition 'SurfacePermeability'");
+  const auto* cond = params.get<const Core::Conditions::Condition*>("condition");
+  FOUR_C_ASSERT(
+      cond != nullptr, "Cannot extract condition 'SurfacePermeability' from parameter list!");
 
   const auto onoff = cond->parameters().get<std::vector<int>>("ONOFF");
 
@@ -1890,7 +1872,7 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::evaluate_kedem_
 
   // ------------get values of scalar transport------------------
   std::shared_ptr<const Core::LinAlg::Vector<double>> phinp = discretization.get_state("phinp");
-  if (phinp == nullptr) FOUR_C_THROW("Cannot get state vector 'phinp'");
+  FOUR_C_ASSERT(phinp != nullptr, "Cannot extract state vector 'phinp' from discretization!");
   // extract local values from global vector
   std::vector<Core::LinAlg::Matrix<nen_, 1>> ephinp(
       numdofpernode_, Core::LinAlg::Matrix<nen_, 1>(Core::LinAlg::Initialization::zero));
@@ -1901,7 +1883,8 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::evaluate_kedem_
   // membrane)------------------
   std::shared_ptr<const Core::LinAlg::Vector<double>> phibar =
       discretization.get_state("MembraneConcentration");
-  if (phibar == nullptr) FOUR_C_THROW("Cannot get state vector 'MembraneConcentration'");
+  FOUR_C_ASSERT(phibar != nullptr,
+      "Cannot extract state vector 'MembraneConcentration' from discretization!");
   // extract local values from global vector
   std::vector<Core::LinAlg::Matrix<nen_, 1>> ephibar(
       numdofpernode_, Core::LinAlg::Matrix<nen_, 1>(Core::LinAlg::Initialization::zero));
@@ -1911,10 +1894,10 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::evaluate_kedem_
   //--------get values of pressure at the interface ----------------------
   // get number of dofset associated with pressure related dofs
   const int ndspres = scatraparams_->nds_pres();
-  if (ndspres == -1) FOUR_C_THROW("Cannot get number of dofset of pressure vector");
-  std::shared_ptr<const Core::LinAlg::Vector<double>> pressure =
+  FOUR_C_ASSERT(ndspres != -1, "Cannot get number of dofset of pressure vector");
+  const std::shared_ptr<const Core::LinAlg::Vector<double>> pressure =
       discretization.get_state(ndspres, "Pressure");
-  if (pressure == nullptr) FOUR_C_THROW("Cannot get state vector 'Pressure'");
+  FOUR_C_ASSERT(pressure != nullptr, "Cannot extract state vector 'Pressure' from discretization!");
 
   // determine number of velocity (and pressure) related dofs per node
   const int numveldofpernode = la[ndspres].lm_.size() / nen_;
@@ -1933,10 +1916,11 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::evaluate_kedem_
   // ------------get values of wall shear stress-----------------------
   // get number of dofset associated with pressure related dofs
   const int ndswss = scatraparams_->nds_wss();
-  if (ndswss == -1) FOUR_C_THROW("Cannot get number of dofset of wss vector");
-  std::shared_ptr<const Core::LinAlg::Vector<double>> wss =
+  FOUR_C_ASSERT(ndswss != -1, "Cannot get number of dofset of wss vector");
+  const std::shared_ptr<const Core::LinAlg::Vector<double>> wss =
       discretization.get_state(ndswss, "WallShearStress");
-  if (wss == nullptr) FOUR_C_THROW("Cannot get state vector 'WallShearStress'");
+  FOUR_C_ASSERT(
+      wss != nullptr, "Cannot extract state vector 'WallShearStress' from discretization!");
 
   // determine number of velocity (and pressure) related dofs per node
   const int numwssdofpernode = la[ndswss].lm_.size() / nen_;
@@ -1950,10 +1934,9 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::evaluate_kedem_
   Core::FE::extract_my_values<Core::LinAlg::Matrix<nsd_, nen_>>(*wss, ewss, lmwss);
 
   // ------------get current condition----------------------------------
-  const Core::Conditions::Condition* cond =
-      params.get<const Core::Conditions::Condition*>("condition");
-  if (cond == nullptr)
-    FOUR_C_THROW("Cannot access condition 'DESIGN SCATRA COUPLING SURF CONDITIONS'");
+  const auto* cond = params.get<const Core::Conditions::Condition*>("condition");
+  FOUR_C_ASSERT(
+      cond != nullptr, "Cannot access condition 'DESIGN SCATRA COUPLING SURF CONDITIONS'");
 
   const auto onoff = cond->parameters().get<std::vector<int>>("ONOFF");
 
@@ -2118,8 +2101,7 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::weak_dirichlet(
   //------------------------------------------------------------------------
   // Dirichlet boundary condition
   //------------------------------------------------------------------------
-  const Core::Conditions::Condition* dbc =
-      params.get<const Core::Conditions::Condition*>("condition");
+  const auto* dbc = params.get<const Core::Conditions::Condition*>("condition");
 
   // check of total time
   const double time = scatraparamstimint_->time();
@@ -2162,7 +2144,8 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::weak_dirichlet(
   // get convective (velocity - mesh displacement) velocity at nodes
   std::shared_ptr<const Core::LinAlg::Vector<double>> convel =
       discretization.get_state(ndsvel, "convective velocity field");
-  if (convel == nullptr) FOUR_C_THROW("Cannot get state vector convective velocity");
+  FOUR_C_ASSERT(
+      convel != nullptr, "Cannot extract state vector 'convective velocity' from discretization!");
 
   // determine number of velocity related dofs per node
   const int numveldofpernode = pla[ndsvel].lm_.size() / pnen;
@@ -2184,7 +2167,7 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::weak_dirichlet(
 
   // get scalar values at parent element nodes
   std::shared_ptr<const Core::LinAlg::Vector<double>> phinp = discretization.get_state("phinp");
-  if (phinp == nullptr) FOUR_C_THROW("Cannot get state vector 'phinp'");
+  FOUR_C_ASSERT(phinp != nullptr, "Cannot extract state vector 'phinp' from discretization!");
 
   // extract local values from global vectors for parent element
   std::vector<Core::LinAlg::Matrix<pnen, 1>> ephinp(numscal_);
@@ -2361,9 +2344,9 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::weak_dirichlet(
       // Jacobian matrix and determinant of parent element (including check)
       pxjm.multiply_nt(pderiv, pxyze);
       const double det = pxji.invert(pxjm);
-      if (det < 1E-16)
-        FOUR_C_THROW(
-            "GLOBAL ELEMENT NO.{}\nZERO OR NEGATIVE JACOBIAN DETERMINANT: {}", pele->id(), det);
+      FOUR_C_ASSERT_ALWAYS(det >= 1.0e-16,
+          "Jacobian determinant is non-positive: {} for element with global id: {}", det,
+          pele->id());
 
       // compute integration factor
       const double fac = pintpoints.ip().qwgt[iquad] * det;
@@ -2508,9 +2491,8 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::weak_dirichlet(
     // Jacobian matrix and determinant of parent element (including check)
     pxjm.multiply_nt(pderiv, pxyze);
     const double det = pxji.invert(pxjm);
-    if (det < 1E-16)
-      FOUR_C_THROW(
-          "GLOBAL ELEMENT NO.{}\nZERO OR NEGATIVE JACOBIAN DETERMINANT: {}", pele->id(), det);
+    FOUR_C_ASSERT_ALWAYS(det >= 1.0e-16,
+        "Jacobian determinant is non-positive: {} for element with global id: {}", det, pele->id());
 
     // compute measure tensor for surface element, infinitesimal area element drs
     // and (outward-pointing) unit normal vector
@@ -2826,14 +2808,10 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::weak_dirichlet(
 template <Core::FE::CellType distype, int probdim>
 template <Core::FE::CellType bdistype, Core::FE::CellType pdistype>
 void Discret::Elements::ScaTraEleBoundaryCalc<distype,
-    probdim>::reinit_characteristic_galerkin_boundary(Core::Elements::FaceElement*
-                                                          ele,  //!< transport element
-    Teuchos::ParameterList& params,                             //!< parameter list
-    Core::FE::Discretization& discretization,                   //!< discretization
-    const Core::Mat::Material& material,                        //!< material
-    Core::LinAlg::SerialDenseMatrix& elemat,                    //!< ele sysmat
-    Core::LinAlg::SerialDenseVector& elevec                     //!< ele rhs
-)
+    probdim>::reinit_characteristic_galerkin_boundary(Core::Elements::FaceElement* ele,
+    Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
+    const Core::Mat::Material& material, Core::LinAlg::SerialDenseMatrix& elemat,
+    Core::LinAlg::SerialDenseVector& elevec)
 {
   //------------------------------------------------------------------------
   // preliminary definitions for (boundary) and parent element and
@@ -2863,9 +2841,9 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype,
 
   // get scalar values at parent element nodes
   std::shared_ptr<const Core::LinAlg::Vector<double>> phinp = discretization.get_state("phinp");
-  if (phinp == nullptr) FOUR_C_THROW("Cannot get state vector 'phinp'");
+  FOUR_C_ASSERT(phinp != nullptr, "Cannot get state vector 'phinp'");
   std::shared_ptr<const Core::LinAlg::Vector<double>> phin = discretization.get_state("phin");
-  if (phinp == nullptr) FOUR_C_THROW("Cannot get state vector 'phin'");
+  FOUR_C_ASSERT(phin != nullptr, "Cannot get state vector 'phin'");
 
   // extract local values from global vectors for parent element
   std::vector<Core::LinAlg::Matrix<pnen, 1>> ephinp(numscal_);
@@ -3020,9 +2998,8 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype,
     // Jacobian matrix and determinant of parent element (including check)
     pxjm.multiply_nt(pderiv, pxyze);
     const double det = pxji.invert(pxjm);
-    if (det < 1E-16)
-      FOUR_C_THROW(
-          "GLOBAL ELEMENT NO.{}\nZERO OR NEGATIVE JACOBIAN DETERMINANT: {}", pele->id(), det);
+    FOUR_C_ASSERT_ALWAYS(det >= 1.0e-16,
+        "Jacobian determinant is non-positive: {} for element with global id: {}", det, pele->id());
 
     // compute measure tensor for surface element, infinitesimal area element drs
     // and (outward-pointing) unit normal vector
@@ -3141,7 +3118,7 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::evaluate_nodal_
  *----------------------------------------------------------------------*/
 // explicit instantiation of template methods
 template void Discret::Elements::ScaTraEleBoundaryCalc<Core::FE::CellType::tri3>::
-    evaluate_s2_i_coupling_at_integration_point<Core::FE::CellType::tri3>(
+    evaluate_s2i_coupling_at_integration_point<Core::FE::CellType::tri3>(
         const std::vector<Core::LinAlg::Matrix<nen_, 1>>&,
         const std::vector<Core::LinAlg::Matrix<Core::FE::num_nodes(Core::FE::CellType::tri3), 1>>&,
         const double, const Core::LinAlg::Matrix<nen_, 1>&,
@@ -3153,7 +3130,7 @@ template void Discret::Elements::ScaTraEleBoundaryCalc<Core::FE::CellType::tri3>
         Core::LinAlg::SerialDenseMatrix&, Core::LinAlg::SerialDenseMatrix&,
         Core::LinAlg::SerialDenseVector&, Core::LinAlg::SerialDenseVector&);
 template void Discret::Elements::ScaTraEleBoundaryCalc<Core::FE::CellType::tri3>::
-    evaluate_s2_i_coupling_at_integration_point<Core::FE::CellType::quad4>(
+    evaluate_s2i_coupling_at_integration_point<Core::FE::CellType::quad4>(
         const std::vector<Core::LinAlg::Matrix<nen_, 1>>&,
         const std::vector<Core::LinAlg::Matrix<Core::FE::num_nodes(Core::FE::CellType::quad4), 1>>&,
         const double, const Core::LinAlg::Matrix<nen_, 1>&,
@@ -3165,7 +3142,7 @@ template void Discret::Elements::ScaTraEleBoundaryCalc<Core::FE::CellType::tri3>
         Core::LinAlg::SerialDenseMatrix&, Core::LinAlg::SerialDenseMatrix&,
         Core::LinAlg::SerialDenseVector&, Core::LinAlg::SerialDenseVector&);
 template void Discret::Elements::ScaTraEleBoundaryCalc<Core::FE::CellType::quad4>::
-    evaluate_s2_i_coupling_at_integration_point<Core::FE::CellType::tri3>(
+    evaluate_s2i_coupling_at_integration_point<Core::FE::CellType::tri3>(
         const std::vector<Core::LinAlg::Matrix<nen_, 1>>&,
         const std::vector<Core::LinAlg::Matrix<Core::FE::num_nodes(Core::FE::CellType::tri3), 1>>&,
         const double, const Core::LinAlg::Matrix<nen_, 1>&,
@@ -3177,7 +3154,7 @@ template void Discret::Elements::ScaTraEleBoundaryCalc<Core::FE::CellType::quad4
         Core::LinAlg::SerialDenseMatrix&, Core::LinAlg::SerialDenseMatrix&,
         Core::LinAlg::SerialDenseVector&, Core::LinAlg::SerialDenseVector&);
 template void Discret::Elements::ScaTraEleBoundaryCalc<Core::FE::CellType::quad4>::
-    evaluate_s2_i_coupling_at_integration_point<Core::FE::CellType::quad4>(
+    evaluate_s2i_coupling_at_integration_point<Core::FE::CellType::quad4>(
         const std::vector<Core::LinAlg::Matrix<nen_, 1>>&,
         const std::vector<Core::LinAlg::Matrix<Core::FE::num_nodes(Core::FE::CellType::quad4), 1>>&,
         const double, const Core::LinAlg::Matrix<nen_, 1>&,

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc.hpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc.hpp
@@ -10,8 +10,6 @@
 
 #include "4C_config.hpp"
 
-#include "4C_elch_input.hpp"
-#include "4C_fem_general_utils_local_connectivity_matrices.hpp"
 #include "4C_fluid_ele.hpp"
 #include "4C_scatra_ele_action.hpp"
 #include "4C_scatra_ele_boundary_interface.hpp"
@@ -195,7 +193,7 @@ namespace Discret
        * \tparam distype_master This method is templated on the master-side discretization type.
        */
       template <Core::FE::CellType distype_master>
-      static void evaluate_s2_i_coupling_at_integration_point(
+      static void evaluate_s2i_coupling_at_integration_point(
           const std::vector<Core::LinAlg::Matrix<nen_, 1>>& eslavephinp,
           const std::vector<Core::LinAlg::Matrix<Core::FE::num_nodes(distype_master), 1>>&
               emasterphinp,
@@ -227,7 +225,7 @@ namespace Discret
        * element at the current gauss point coordinates
        *
        * @param[in] faceele     pointer to current face element
-       * @param[in] faceele_xsi coordinates of current gauss point in parameter space of the face
+       * @param[in] faceele_xi  coordinates of current gauss point in parameter space of the face
        *                        element
        * @return determinant of the deformation gradient of the parent element
        */
@@ -300,7 +298,7 @@ namespace Discret
           Core::LinAlg::Matrix<nsd_, nen_>& dsqrtdetg_dd);
 
       //! evaluate scatra-scatra interface coupling condition
-      virtual void evaluate_s2_i_coupling(
+      virtual void evaluate_s2i_coupling(
           const Core::Elements::FaceElement* ele,          ///< current boundary element
           Teuchos::ParameterList& params,                  ///< parameter list
           Core::FE::Discretization& discretization,        ///< discretization
@@ -331,19 +329,18 @@ namespace Discret
        * @param[out] eslaveresidual  element residual due to capacitive flux at slave side
        * @param[out] emasterresidual element residual due to capacitive flux at master side
        */
-      virtual void evaluate_s2_i_coupling_capacitance(
-          const Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
-          Core::LinAlg::SerialDenseMatrix& eslavematrix,
+      virtual void evaluate_s2i_coupling_capacitance(const Core::FE::Discretization& discretization,
+          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& eslavematrix,
           Core::LinAlg::SerialDenseMatrix& emastermatrix,
           Core::LinAlg::SerialDenseVector& eslaveresidual,
           Core::LinAlg::SerialDenseVector& emasterresidual)
       {
         FOUR_C_THROW("not yet implemented!");
-      };
+      }
 
       //! evaluate off-diagonal system matrix contributions associated with scatra-scatra interface
       //! coupling condition
-      virtual void evaluate_s2_i_coupling_od(
+      virtual void evaluate_s2i_coupling_od(
           const Core::Elements::FaceElement* ele,        ///< current boundary element
           Teuchos::ParameterList& params,                ///< parameter list
           Core::FE::Discretization& discretization,      ///< discretization
@@ -351,13 +348,13 @@ namespace Discret
           Core::LinAlg::SerialDenseMatrix& eslavematrix  ///< element matrix for slave side
       );
 
-      virtual void evaluate_s2_i_coupling_capacitance_od(Teuchos::ParameterList& params,
+      virtual void evaluate_s2i_coupling_capacitance_od(Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
           Core::LinAlg::SerialDenseMatrix& eslavematrix,
           Core::LinAlg::SerialDenseMatrix& emastermatrix)
       {
         FOUR_C_THROW("not yet implemented");
-      };
+      }
 
       //! extract nodal state variables associated with boundary element
       virtual void extract_node_values(
@@ -449,7 +446,7 @@ namespace Discret
       )
       {
         return 1.0;
-      };
+      }
 
       //! compute integral of convective mass/heat flux over boundary surface
       virtual std::vector<double> calc_convective_flux(const Core::Elements::FaceElement* ele,
@@ -497,11 +494,12 @@ namespace Discret
       /*!
       \brief Evaluate weak Dirichlet boundary conditions
 
+      \param ele (in)           : transport face element
       \param params (in)        : ParameterList for communication between control routine
       \param discretization (in): A reference to the underlying discretization
       \param material (in)      : material of this element
-      \param elemat1 (out)      : matrix to be filled by element.
-      \param elevec1 (out)      : vector to be filled by element.
+      \param elemat (out)      : matrix to be filled by element.
+      \param elevec (out)      : vector to be filled by element.
 
       */
       template <Core::FE::CellType bdistype, Core::FE::CellType pdistype>
@@ -532,7 +530,7 @@ namespace Discret
           const double scalar);
 
       //! evaluate integral of all positive fluxes on s2i condition
-      virtual void calc_s2_i_coupling_flux(const Core::Elements::FaceElement* ele,
+      virtual void calc_s2i_coupling_flux(const Core::Elements::FaceElement* ele,
           const Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
           Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseVector& scalars)
       {

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch.cpp
@@ -17,7 +17,6 @@
 FOUR_C_NAMESPACE_OPEN
 
 /*----------------------------------------------------------------------*
- | protected constructor for singletons                      fang 01/15 |
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
 Discret::Elements::ScaTraEleBoundaryCalcElch<distype, probdim>::ScaTraEleBoundaryCalcElch(
@@ -33,23 +32,15 @@ Discret::Elements::ScaTraEleBoundaryCalcElch<distype, probdim>::ScaTraEleBoundar
 {
 }
 
-
 /*----------------------------------------------------------------------*
- | evaluate action                                           fang 02/15 |
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
 int Discret::Elements::ScaTraEleBoundaryCalcElch<distype, probdim>::evaluate_action(
-    Core::Elements::FaceElement* ele,          //!< boundary element
-    Teuchos::ParameterList& params,            //!< parameter list
-    Core::FE::Discretization& discretization,  //!< discretization
-    ScaTra::BoundaryAction action,             //!< action
-    Core::Elements::LocationArray& la,         //!< location array
-    Core::LinAlg::SerialDenseMatrix& elemat1,  //!< element matrix 1
-    Core::LinAlg::SerialDenseMatrix& elemat2,  //!< element matrix 2
-    Core::LinAlg::SerialDenseVector& elevec1,  //!< element right-hand side vector 1
-    Core::LinAlg::SerialDenseVector& elevec2,  //!< element right-hand side vector 2
-    Core::LinAlg::SerialDenseVector& elevec3   //!< element right-hand side vector 3
-)
+    Core::Elements::FaceElement* ele, Teuchos::ParameterList& params,
+    Core::FE::Discretization& discretization, ScaTra::BoundaryAction action,
+    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+    Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+    Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3)
 {
   // determine and evaluate action
   switch (action)
@@ -80,20 +71,14 @@ int Discret::Elements::ScaTraEleBoundaryCalcElch<distype, probdim>::evaluate_act
   return 0;
 }
 
-
 /*----------------------------------------------------------------------*
- | process an electrode kinetics boundary condition          fang 08/15 |
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
 void Discret::Elements::ScaTraEleBoundaryCalcElch<distype, probdim>::calc_elch_boundary_kinetics(
-    Core::Elements::FaceElement* ele,          ///< current element
-    Teuchos::ParameterList& params,            ///< parameter list
-    Core::FE::Discretization& discretization,  ///< discretization
-    Core::Elements::LocationArray& la,         ///< location array
-    Core::LinAlg::SerialDenseMatrix& elemat1,  ///< element matrix
-    Core::LinAlg::SerialDenseVector& elevec1,  ///< element right-hand side vector
-    const double scalar  ///< scaling factor for element matrix and right-hand side contributions
-)
+    const Core::Elements::FaceElement* ele, Teuchos::ParameterList& params,
+    Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
+    Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseVector& elevec1,
+    const double scalar)
 {
   // state and history variables at element nodes
   my::extract_node_values(discretization, la);
@@ -103,7 +88,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElch<distype, probdim>::calc_elch_b
 
   // get current condition
   const auto* cond = params.get<const Core::Conditions::Condition*>("condition");
-  if (cond == nullptr) FOUR_C_THROW("Cannot access condition 'ElchBoundaryKinetics'");
+  FOUR_C_ASSERT(cond != nullptr, "Cannot access condition 'ElchBoundaryKinetics'");
 
   // access parameters of the condition
   const auto kinetics = cond->parameters().get<ElCh::ElectrodeKinetics>("KINETIC_MODEL");
@@ -113,19 +98,17 @@ void Discret::Elements::ScaTraEleBoundaryCalcElch<distype, probdim>::calc_elch_b
   // if zero=1=true, the current flow across the electrode is zero (comparable to do-nothing Neuman
   // condition) but the electrode status is evaluated
   const auto zerocur = cond->parameters().get<int>("ZERO_CUR");
-  if (nume < 0)
-    FOUR_C_THROW(
-        "The convention for electrochemical reactions at the electrodes does not allow \n"
-        "a negative number of transferred electrons");
+  FOUR_C_ASSERT_ALWAYS(nume > 0,
+      "The convention for electrochemical reactions at the electrodes requires a positive number "
+      "of transferred electrons");
 
   // convention for stoichiometric coefficients s_i:
   // Sum_i (s_i  M_i^(z_i)) -> n e- (n needs to be positive)
   const auto* stoich = &cond->parameters().get<std::vector<int>>("STOICH");
-  if ((unsigned int)my::numscal_ != (*stoich).size())
-    FOUR_C_THROW(
-        "Electrode kinetics: number of stoichiometry coefficients {} does not match"
-        " the number of ionic species {}",
-        (*stoich).size(), my::numscal_);
+  FOUR_C_ASSERT_ALWAYS(stoich->size() == static_cast<std::size_t>(my::numscal_),
+      "Electrode kinetics: number of stoichiometry coefficients {} does not match the number of "
+      "ionic species {}",
+      stoich->size(), my::numscal_);
 
   // the classical implementations of kinetic electrode models does not support
   // more than one reagent or product!! There are alternative formulations
@@ -137,9 +120,11 @@ void Discret::Elements::ScaTraEleBoundaryCalcElch<distype, probdim>::calc_elch_b
     if (reactspecies > 1 and
         (kinetics == ElCh::butler_volmer or kinetics == ElCh::butler_volmer_yang1997 or
             kinetics == ElCh::tafel or kinetics == ElCh::linear))
+    {
       FOUR_C_THROW(
           "Kinetic model Butler-Volmer / Butler-Volmer-Yang / Tafel and Linear: \n"
           "Only one educt and no product is allowed in the implemented version");
+    }
   }
 
   // access input parameter
@@ -170,7 +155,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElch<distype, probdim>::calc_elch_b
       // BDF2:              timefac = 2/3 * dt
       // generalized-alpha: timefac = (gamma*alpha_F/alpha_M) * dt
       timefac = my::scatraparamstimint_->time_fac();
-      if (timefac < 0.0) FOUR_C_THROW("time factor is negative.");
+      FOUR_C_ASSERT_ALWAYS(timefac > 0.0, "Time factor for time integration is not positive");
       // for correct scaling of rhs contribution (see below)
       rhsfac = 1 / my::scatraparamstimint_->alpha_f();
     }
@@ -200,19 +185,15 @@ void Discret::Elements::ScaTraEleBoundaryCalcElch<distype, probdim>::calc_elch_b
       // BDF2:              timefacrhs = 2/3 * dt
       // generalized-alpha: timefacrhs = (gamma/alpha_M) * dt
       timefac = my::scatraparamstimint_->time_fac_rhs();
-      if (timefac < 0.) FOUR_C_THROW("time factor is negative.");
+      FOUR_C_ASSERT_ALWAYS(timefac > 0.0, "Time factor for time integration is not positive");
     }
 
     evaluate_electrode_status(ele, elevec1, params, *cond, my::ephinp_, ephidtnp, kinetics, *stoich,
         nume, pot0, frt, timefac, scalar);
   }
-
-  return;
 }  // Discret::Elements::ScaTraEleBoundaryCalcElch<distype, probdim>::calc_elch_boundary_kinetics
 
-
 /*----------------------------------------------------------------------*
- | calculate linearization of nernst equation                     ehrl  |
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
 void Discret::Elements::ScaTraEleBoundaryCalcElch<distype, probdim>::calc_nernst_linearization(
@@ -221,7 +202,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElch<distype, probdim>::calc_nernst
     Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseVector& elevec1)
 {
   const auto* cond = params.get<const Core::Conditions::Condition*>("condition");
-  if (cond == nullptr) FOUR_C_THROW("Cannot access condition 'ElchBoundaryKinetics'");
+  FOUR_C_ASSERT(cond != nullptr, "Cannot access condition 'ElchBoundaryKinetics'");
 
   const auto kinetics = cond->parameters().get<ElCh::ElectrodeKinetics>("KINETIC_MODEL");
 
@@ -238,17 +219,15 @@ void Discret::Elements::ScaTraEleBoundaryCalcElch<distype, probdim>::calc_nernst
     const auto e0 = cond->parameters().get<double>("E0");
     const auto c0 = cond->parameters().get<double>("C0");
 
-    if (nume < 0)
-      FOUR_C_THROW(
-          "The convention for electrochemical reactions at the electrodes does not allow \n"
-          "a negative number of transferred electrons");
+    FOUR_C_ASSERT_ALWAYS(nume > 0,
+        "The convention for electrochemical reactions at the electrodes requires a positive number "
+        "of transferred electrons");
 
     const auto* stoich = &cond->parameters().get<std::vector<int>>("STOICH");
-    if ((unsigned int)my::numscal_ != (*stoich).size())
-      FOUR_C_THROW(
-          "Electrode kinetics: number of stoichiometry coefficients {} does not match"
-          " the number of ionic species {}",
-          (*stoich).size(), my::numscal_);
+    FOUR_C_ASSERT_ALWAYS(stoich->size() == static_cast<std::size_t>(my::numscal_),
+        "Electrode kinetics: number of stoichiometry coefficients {} does not match the number of "
+        "ionic species {}",
+        stoich->size(), my::numscal_);
 
     // access input parameter
     const double frt = elchparams_->frt();
@@ -291,8 +270,8 @@ void Discret::Elements::ScaTraEleBoundaryCalcElch<distype, probdim>::calc_nernst
         // el. potential at integration point
         const double potint = my::funct_.dot(my::ephinp_[my::numscal_]);
 
-        if (c0 < 1e-12)
-          FOUR_C_THROW("reference concentration is too small (c0 < 1.0E-12) : {}", c0);
+        FOUR_C_ASSERT_ALWAYS(
+            c0 >= 1.0e-12, "reference concentration is too small (c0 < 1.0E-12) : {}", c0);
 
         for (int vi = 0; vi < nen_; ++vi)
         {
@@ -313,18 +292,13 @@ void Discret::Elements::ScaTraEleBoundaryCalcElch<distype, probdim>::calc_nernst
   }  // end if(kinetics == ElCh::nernst)
 }
 
-
 /*----------------------------------------------------------------------*
- | calculate cell voltage                                    fang 01/15 |
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
 void Discret::Elements::ScaTraEleBoundaryCalcElch<distype, probdim>::calc_cell_voltage(
-    const Core::Elements::Element* ele,        //!< the element we are dealing with
-    Teuchos::ParameterList& params,            //!< parameter list
-    Core::FE::Discretization& discretization,  //!< discretization
-    Core::Elements::LocationArray& la,         //!< location array
-    Core::LinAlg::SerialDenseVector& scalars  //!< result vector for scalar integrals to be computed
-)
+    const Core::Elements::Element* ele, Teuchos::ParameterList& params,
+    Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
+    Core::LinAlg::SerialDenseVector& scalars)
 {
   // extract local nodal values of electric potential from global state vector
   my::extract_node_values(discretization, la);
@@ -353,39 +327,25 @@ void Discret::Elements::ScaTraEleBoundaryCalcElch<distype, probdim>::calc_cell_v
   }  // loop over integration points
 
   // safety check
-  if (scalars.length() != 2)
-    FOUR_C_THROW("Result vector for cell voltage computation has invalid length!");
+  FOUR_C_ASSERT_ALWAYS(
+      scalars.length() == 2, "Result vector for cell voltage computation has invalid length!");
 
   // write results for electric potential and domain integrals into result vector
   scalars(0) = intpotential;
   scalars(1) = intdomain;
-
-  return;
 }
 
-
 /*----------------------------------------------------------------------*
- | evaluate an electrode kinetics boundary condition          gjb 01/09 |
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
 void Discret::Elements::ScaTraEleBoundaryCalcElch<distype,
-    probdim>::evaluate_elch_boundary_kinetics(const Core::Elements::Element*
-                                                  ele,  ///< current element
-    Core::LinAlg::SerialDenseMatrix& emat,              ///< element matrix
-    Core::LinAlg::SerialDenseVector& erhs,              ///< element right-hand side vector
-    const std::vector<Core::LinAlg::Matrix<nen_, 1>>&
-        ephinp,  ///< nodal values of concentration and electric potential
-    const std::vector<Core::LinAlg::Matrix<nen_, 1>>& ehist,  ///< nodal history vector
-    double timefac,                                           ///< time factor
-    std::shared_ptr<const Core::Mat::Material> material,      ///< material
-    const Core::Conditions::Condition& cond,  ///< electrode kinetics boundary condition
-    const int nume,                           ///< number of transferred electrons
-    const std::vector<int> stoich,            ///< stoichiometry of the reaction
-    const int kinetics,                       ///< desired electrode kinetics model
-    const double pot0,                        ///< electrode potential on metal side
-    const double frt,                         ///< factor F/RT
-    const double scalar  ///< scaling factor for element matrix and right-hand side contributions
-)
+    probdim>::evaluate_elch_boundary_kinetics(const Core::Elements::Element* ele,
+    Core::LinAlg::SerialDenseMatrix& emat, Core::LinAlg::SerialDenseVector& erhs,
+    const std::vector<Core::LinAlg::Matrix<nen_, 1>>& ephinp,
+    const std::vector<Core::LinAlg::Matrix<nen_, 1>>& ehist, double timefac,
+    const std::shared_ptr<const Core::Mat::Material> material,
+    const Core::Conditions::Condition& cond, const int nume, const std::vector<int>& stoich,
+    const int kinetics, const double pot0, const double frt, const double scalar)
 {
   // for pre-multiplication of i0 with 1/(F z_k)
   const double faraday = elchparams_->faraday();
@@ -432,31 +392,19 @@ void Discret::Elements::ScaTraEleBoundaryCalcElch<distype,
     }  // loop over integration points
   }  // loop over all scalars
 
-  return;
 }  // Discret::Elements::ScaTraEleBoundaryCalcElch<distype,
    // probdim>::evaluate_elch_boundary_kinetics
 
-
 /*----------------------------------------------------------------------*
- | evaluate electrode kinetics status information             gjb 01/09 |
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
 void Discret::Elements::ScaTraEleBoundaryCalcElch<distype, probdim>::evaluate_electrode_status(
-    const Core::Elements::Element* ele,        ///< current element
-    Core::LinAlg::SerialDenseVector& scalars,  ///< scalars to be integrated
-    Teuchos::ParameterList& params,            ///< parameter list
-    const Core::Conditions::Condition& cond,   ///< condition
-    const std::vector<Core::LinAlg::Matrix<nen_, 1>>&
-        ephinp,  ///< nodal values of concentration and electric potential
-    const std::vector<Core::LinAlg::Matrix<nen_, 1>>& ephidtnp,  ///< nodal time derivative vector
-    const int kinetics,             ///< desired electrode kinetics model
-    const std::vector<int> stoich,  ///< stoichiometry of the reaction
-    const int nume,                 ///< number of transferred electrons
-    const double pot0,              ///< electrode potential on metal side
-    const double frt,               ///< factor F/RT
-    const double timefac,           ///< time factor
-    const double scalar             ///< scaling factor for current related quantities
-)
+    const Core::Elements::Element* ele, Core::LinAlg::SerialDenseVector& scalars,
+    Teuchos::ParameterList& params, const Core::Conditions::Condition& cond,
+    const std::vector<Core::LinAlg::Matrix<nen_, 1>>& ephinp,
+    const std::vector<Core::LinAlg::Matrix<nen_, 1>>& ephidtnp, const int kinetics,
+    const std::vector<int>& stoich, const int nume, const double pot0, const double frt,
+    const double timefac, const double scalar)
 {
   // Warning:
   // Specific time integration parameter are set in the following function.
@@ -510,10 +458,9 @@ void Discret::Elements::ScaTraEleBoundaryCalcElch<distype, probdim>::evaluate_el
   }  // loop over scalars
 
   // safety check
-  if (statistics == false)
-    FOUR_C_THROW(
-        "There is no oxidized species O (stoich<0) defined in your input file!! \n"
-        " Statistics could not be evaluated");
+  FOUR_C_ASSERT_ALWAYS(statistics,
+      "There is no oxidized species O (stoich<0) defined in your input file!! \n"
+      " Statistics could not be evaluated");
 }  // Discret::Elements::ScaTraEleBoundaryCalcElch<distype, probdim>::evaluate_electrode_status
 
 

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch.hpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch.hpp
@@ -34,29 +34,15 @@ namespace Discret
       using my::nsd_;
       using my::nsd_ele_;
 
-     public:
-      //! singleton access method
-      // not needed, since class is purely virtual
-
-
-
-     protected:
       //! protected constructor for singletons
-      ScaTraEleBoundaryCalcElch(
-          const int numdofpernode, const int numscal, const std::string& disname);
+      ScaTraEleBoundaryCalcElch(int numdofpernode, int numscal, const std::string& disname);
 
-      //! evaluate action
-      int evaluate_action(Core::Elements::FaceElement* ele,  //!< boundary element
-          Teuchos::ParameterList& params,                    //!< parameter list
-          Core::FE::Discretization& discretization,          //!< discretization
-          ScaTra::BoundaryAction action,                     //!< action
-          Core::Elements::LocationArray& la,                 //!< location array
-          Core::LinAlg::SerialDenseMatrix& elemat1,          //!< element matrix 1
-          Core::LinAlg::SerialDenseMatrix& elemat2,          //!< element matrix 2
-          Core::LinAlg::SerialDenseVector& elevec1,          //!< element right-hand side vector 1
-          Core::LinAlg::SerialDenseVector& elevec2,          //!< element right-hand side vector 2
-          Core::LinAlg::SerialDenseVector& elevec3           //!< element right-hand side vector 3
-          ) override;
+      int evaluate_action(Core::Elements::FaceElement* ele, Teuchos::ParameterList& params,
+          Core::FE::Discretization& discretization, ScaTra::BoundaryAction action,
+          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3) override;
 
       //! evaluate an electrode kinetics boundary condition
       virtual void evaluate_elch_boundary_kinetics(
@@ -69,21 +55,20 @@ namespace Discret
           double timefac,                                           ///< time factor
           std::shared_ptr<const Core::Mat::Material> material,      ///< material
           const Core::Conditions::Condition& cond,  ///< electrode kinetics boundary condition
-          const int nume,                           ///< number of transferred electrons
-          const std::vector<int> stoich,            ///< stoichiometry of the reaction
-          const int kinetics,                       ///< desired electrode kinetics model
-          const double pot0,                        ///< electrode potential on metal side
-          const double frt,                         ///< factor F/RT
-          const double
-              scalar  ///< scaling factor for element matrix and right-hand side contributions
+          int nume,                                 ///< number of transferred electrons
+          const std::vector<int>& stoich,           ///< stoichiometry of the reaction
+          int kinetics,                             ///< desired electrode kinetics model
+          double pot0,                              ///< electrode potential on metal side
+          double frt,                               ///< factor F/RT
+          double scalar  ///< scaling factor for element matrix and right-hand side contributions
       );
 
       //! process an electrode kinetics boundary condition
-      void calc_elch_boundary_kinetics(Core::Elements::FaceElement* ele,  ///< current element
-          Teuchos::ParameterList& params,                                 ///< parameter list
-          Core::FE::Discretization& discretization,                       ///< discretization
-          Core::Elements::LocationArray& la,                              ///< location array
-          Core::LinAlg::SerialDenseMatrix& elemat1,                       ///< element matrix
+      void calc_elch_boundary_kinetics(const Core::Elements::FaceElement* ele,  ///< current element
+          Teuchos::ParameterList& params,                                       ///< parameter list
+          Core::FE::Discretization& discretization,                             ///< discretization
+          Core::Elements::LocationArray& la,                                    ///< location array
+          Core::LinAlg::SerialDenseMatrix& elemat1,                             ///< element matrix
           Core::LinAlg::SerialDenseVector& elevec1,  ///< element right-hand side vector
           const double
               scalar  ///< scaling factor for element matrix and right-hand side contributions
@@ -97,14 +82,14 @@ namespace Discret
           const std::vector<Core::LinAlg::Matrix<nen_, 1>>&
               ephinp,  ///< nodal values of concentration and electric potential
           const std::vector<Core::LinAlg::Matrix<nen_, 1>>&
-              ephidtnp,                   ///< nodal time derivative vector
-          const int kinetics,             ///< desired electrode kinetics model
-          const std::vector<int> stoich,  ///< stoichiometry of the reaction
-          const int nume,                 ///< number of transferred electrons
-          const double pot0,              ///< electrode potential on metal side
-          const double frt,               ///< factor F/RT
-          const double timefac,           ///< time factor
-          const double scalar             ///< scaling factor for current related quantities
+              ephidtnp,                    ///< nodal time derivative vector
+          const int kinetics,              ///< desired electrode kinetics model
+          const std::vector<int>& stoich,  ///< stoichiometry of the reaction
+          const int nume,                  ///< number of transferred electrons
+          const double pot0,               ///< electrode potential on metal side
+          const double frt,                ///< factor F/RT
+          const double timefac,            ///< time factor
+          const double scalar              ///< scaling factor for current related quantities
       );
 
       //! evaluate linearization of nernst equation
@@ -124,7 +109,7 @@ namespace Discret
       );
 
       //! extract valence of species k from element material
-      virtual double get_valence(
+      [[nodiscard]] virtual double get_valence(
           const std::shared_ptr<const Core::Mat::Material>& material,  //! element material
           const int k                                                  //! species number
       ) const = 0;

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_NP.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_NP.cpp
@@ -18,7 +18,6 @@
 FOUR_C_NAMESPACE_OPEN
 
 /*----------------------------------------------------------------------*
- | singleton access method                                   fang 02/15 |
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
 Discret::Elements::ScaTraEleBoundaryCalcElchNP<distype, probdim>*
@@ -37,7 +36,6 @@ Discret::Elements::ScaTraEleBoundaryCalcElchNP<distype, probdim>::instance(
 }
 
 /*----------------------------------------------------------------------*
- | private constructor for singletons                        fang 02/15 |
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
 Discret::Elements::ScaTraEleBoundaryCalcElchNP<distype, probdim>::ScaTraEleBoundaryCalcElchNP(
@@ -45,26 +43,17 @@ Discret::Elements::ScaTraEleBoundaryCalcElchNP<distype, probdim>::ScaTraEleBound
     :  // constructor of base class
       myelch::ScaTraEleBoundaryCalcElch(numdofpernode, numscal, disname)
 {
-  return;
 }
 
-
 /*----------------------------------------------------------------------*
- | evaluate action                                           fang 08/15 |
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
 int Discret::Elements::ScaTraEleBoundaryCalcElchNP<distype, probdim>::evaluate_action(
-    Core::Elements::FaceElement* ele,          //!< boundary element
-    Teuchos::ParameterList& params,            //!< parameter list
-    Core::FE::Discretization& discretization,  //!< discretization
-    ScaTra::BoundaryAction action,             //!< action
-    Core::Elements::LocationArray& la,         //!< location array
-    Core::LinAlg::SerialDenseMatrix& elemat1,  //!< element matrix 1
-    Core::LinAlg::SerialDenseMatrix& elemat2,  //!< element matrix 2
-    Core::LinAlg::SerialDenseVector& elevec1,  //!< element right-hand side vector 1
-    Core::LinAlg::SerialDenseVector& elevec2,  //!< element right-hand side vector 2
-    Core::LinAlg::SerialDenseVector& elevec3   //!< element right-hand side vector 3
-)
+    Core::Elements::FaceElement* ele, Teuchos::ParameterList& params,
+    Core::FE::Discretization& discretization, ScaTra::BoundaryAction action,
+    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+    Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+    Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3)
 {
   // determine and evaluate action
   switch (action)
@@ -88,9 +77,7 @@ int Discret::Elements::ScaTraEleBoundaryCalcElchNP<distype, probdim>::evaluate_a
   return 0;
 }  // Discret::Elements::ScaTraEleBoundaryCalcElchNP<distype, probdim>::evaluate_action
 
-
 /*----------------------------------------------------------------------*
- | evaluate Neumann boundary condition                       fang 02/15 |
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
 int Discret::Elements::ScaTraEleBoundaryCalcElchNP<distype, probdim>::evaluate_neumann(
@@ -130,36 +117,23 @@ int Discret::Elements::ScaTraEleBoundaryCalcElchNP<distype, probdim>::evaluate_n
     default:
     {
       FOUR_C_THROW("Closing equation for electric potential not recognized!");
-      break;
     }
   }  // switch(myelch::elchparams_->EquPot())
 
   return 0;
 }
 
-
 /*----------------------------------------------------------------------*
- | evaluate an electrode kinetics boundary condition         fang 02/15 |
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
 void Discret::Elements::ScaTraEleBoundaryCalcElchNP<distype,
-    probdim>::evaluate_elch_boundary_kinetics(const Core::Elements::Element*
-                                                  ele,  ///< current element
-    Core::LinAlg::SerialDenseMatrix& emat,              ///< element matrix
-    Core::LinAlg::SerialDenseVector& erhs,              ///< element right-hand side vector
-    const std::vector<Core::LinAlg::Matrix<nen_, 1>>&
-        ephinp,  ///< nodal values of concentration and electric potential
-    const std::vector<Core::LinAlg::Matrix<nen_, 1>>& ehist,  ///< nodal history vector
-    double timefac,                                           ///< time factor
-    std::shared_ptr<const Core::Mat::Material> material,      ///< material
-    const Core::Conditions::Condition& cond,  ///< electrode kinetics boundary condition
-    const int nume,                           ///< number of transferred electrons
-    const std::vector<int> stoich,            ///< stoichiometry of the reaction
-    const int kinetics,                       ///< desired electrode kinetics model
-    const double pot0,                        ///< electrode potential on metal side
-    const double frt,                         ///< factor F/RT
-    const double scalar  ///< scaling factor for element matrix and right-hand side contributions
-)
+    probdim>::evaluate_elch_boundary_kinetics(const Core::Elements::Element* ele,
+    Core::LinAlg::SerialDenseMatrix& emat, Core::LinAlg::SerialDenseVector& erhs,
+    const std::vector<Core::LinAlg::Matrix<nen_, 1>>& ephinp,
+    const std::vector<Core::LinAlg::Matrix<nen_, 1>>& ehist, double timefac,
+    std::shared_ptr<const Core::Mat::Material> material, const Core::Conditions::Condition& cond,
+    const int nume, const std::vector<int>& stoich, const int kinetics, const double pot0,
+    const double frt, const double scalar)
 {
   // call base class routine
   myelch::evaluate_elch_boundary_kinetics(ele, emat, erhs, ephinp, ehist, timefac, material, cond,
@@ -225,29 +199,23 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchNP<distype,
     case ElCh::equpot_poisson:
     {
       FOUR_C_THROW("Poisson equation combined with electrode boundary conditions not implemented!");
-      break;
     }
 
     default:
     {
       FOUR_C_THROW("Unknown closing equation for electric potential!");
-      break;
     }
   }  // switch(myelch::elchparams_->EquPot())
 
-  return;
 }  // Discret::Elements::ScaTraEleBoundaryCalcElchNP<distype,
    // probdim>::evaluate_elch_boundary_kinetics
 
 
-/*-------------------------------------------------------------------------------------*
- | extract valence of species k from element material                       fang 02/15 |
- *-------------------------------------------------------------------------------------*/
+/*----------------------------------------------------------------------*
+ *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
 double Discret::Elements::ScaTraEleBoundaryCalcElchNP<distype, probdim>::get_valence(
-    const std::shared_ptr<const Core::Mat::Material>& material,  // element material
-    const int k                                                  // species number
-) const
+    const std::shared_ptr<const Core::Mat::Material>& material, const int k) const
 {
   double valence(0.);
 
@@ -262,14 +230,18 @@ double Discret::Elements::ScaTraEleBoundaryCalcElchNP<distype, probdim>::get_val
     if (species->material_type() == Core::Materials::m_ion)
     {
       valence = std::static_pointer_cast<const Mat::Ion>(species)->valence();
-      if (abs(valence) < 1.e-14) FOUR_C_THROW("Received zero valence!");
+      FOUR_C_ASSERT_ALWAYS(std::abs(valence) > 1.0e-16, "Received zero valence!");
     }
     else
+    {
       FOUR_C_THROW("Material species is not an ion!");
+    }
   }
 
   else
+  {
     FOUR_C_THROW("Unknown material!");
+  }
 
   return valence;
 }

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_NP.hpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_NP.hpp
@@ -29,57 +29,35 @@ namespace Discret
      public:
       //! singleton access method
       static ScaTraEleBoundaryCalcElchNP<distype, probdim>* instance(
-          const int numdofpernode, const int numscal, const std::string& disname);
+          int numdofpernode, int numscal, const std::string& disname);
 
 
      private:
       //! private constructor for singletons
-      ScaTraEleBoundaryCalcElchNP(
-          const int numdofpernode, const int numscal, const std::string& disname);
+      ScaTraEleBoundaryCalcElchNP(int numdofpernode, int numscal, const std::string& disname);
 
-      //! evaluate action
-      int evaluate_action(Core::Elements::FaceElement* ele,  //!< boundary element
-          Teuchos::ParameterList& params,                    //!< parameter list
-          Core::FE::Discretization& discretization,          //!< discretization
-          ScaTra::BoundaryAction action,                     //!< action
-          Core::Elements::LocationArray& la,                 //!< location array
-          Core::LinAlg::SerialDenseMatrix& elemat1,          //!< element matrix 1
-          Core::LinAlg::SerialDenseMatrix& elemat2,          //!< element matrix 2
-          Core::LinAlg::SerialDenseVector& elevec1,          //!< element right-hand side vector 1
-          Core::LinAlg::SerialDenseVector& elevec2,          //!< element right-hand side vector 2
-          Core::LinAlg::SerialDenseVector& elevec3           //!< element right-hand side vector 3
-          ) override;
+      int evaluate_action(Core::Elements::FaceElement* ele, Teuchos::ParameterList& params,
+          Core::FE::Discretization& discretization, ScaTra::BoundaryAction action,
+          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3) override;
 
-      //! evaluate Neumann boundary condition
       int evaluate_neumann(Core::Elements::FaceElement* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, const Core::Conditions::Condition& condition,
           Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseVector& elevec1,
           const double scalar) override;
 
-      //! evaluate an electrode kinetics boundary condition
-      void evaluate_elch_boundary_kinetics(const Core::Elements::Element* ele,  ///< current element
-          Core::LinAlg::SerialDenseMatrix& emat,                                ///< element matrix
-          Core::LinAlg::SerialDenseVector& erhs,  ///< element right-hand side vector
-          const std::vector<Core::LinAlg::Matrix<nen_, 1>>&
-              ephinp,  ///< nodal values of concentration and electric potential
-          const std::vector<Core::LinAlg::Matrix<nen_, 1>>& ehist,  ///< nodal history vector
-          double timefac,                                           ///< time factor
-          std::shared_ptr<const Core::Mat::Material> material,      ///< material
-          const Core::Conditions::Condition& cond,  ///< electrode kinetics boundary condition
-          const int nume,                           ///< number of transferred electrons
-          const std::vector<int> stoich,            ///< stoichiometry of the reaction
-          const int kinetics,                       ///< desired electrode kinetics model
-          const double pot0,                        ///< electrode potential on metal side
-          const double frt,                         ///< factor F/RT
-          const double
-              scalar  ///< scaling factor for element matrix and right-hand side contributions
-          ) override;
+      void evaluate_elch_boundary_kinetics(const Core::Elements::Element* ele,
+          Core::LinAlg::SerialDenseMatrix& emat, Core::LinAlg::SerialDenseVector& erhs,
+          const std::vector<Core::LinAlg::Matrix<nen_, 1>>& ephinp,
+          const std::vector<Core::LinAlg::Matrix<nen_, 1>>& ehist, double timefac,
+          std::shared_ptr<const Core::Mat::Material> material,
+          const Core::Conditions::Condition& cond, int nume, const std::vector<int>& stoich,
+          int kinetics, double pot0, double frt, double scalar) override;
 
-      //! extract valence of species k from element material
-      double get_valence(
-          const std::shared_ptr<const Core::Mat::Material>& material,  //! element material
-          const int k                                                  //! species number
-      ) const override;
+      [[nodiscard]] double get_valence(
+          const std::shared_ptr<const Core::Mat::Material>& material, const int k) const override;
     };  // class ScaTraEleBoundaryCalcElchNP
   }  // namespace Elements
 }  // namespace Discret

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_diffcond.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_diffcond.cpp
@@ -18,7 +18,6 @@
 FOUR_C_NAMESPACE_OPEN
 
 /*----------------------------------------------------------------------*
- | singleton access method                                   fang 02/15 |
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
 Discret::Elements::ScaTraEleBoundaryCalcElchDiffCond<distype, probdim>*
@@ -37,9 +36,7 @@ Discret::Elements::ScaTraEleBoundaryCalcElchDiffCond<distype, probdim>::instance
       Core::Utils::SingletonAction::create, numdofpernode, numscal, disname);
 }
 
-
 /*----------------------------------------------------------------------*
- | private constructor for singletons                        fang 02/15 |
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
 Discret::Elements::ScaTraEleBoundaryCalcElchDiffCond<distype,
@@ -52,23 +49,15 @@ Discret::Elements::ScaTraEleBoundaryCalcElchDiffCond<distype,
 {
 }
 
-
 /*----------------------------------------------------------------------*
- | evaluate action                                           fang 08/15 |
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
 int Discret::Elements::ScaTraEleBoundaryCalcElchDiffCond<distype, probdim>::evaluate_action(
-    Core::Elements::FaceElement* ele,          //!< boundary element
-    Teuchos::ParameterList& params,            //!< parameter list
-    Core::FE::Discretization& discretization,  //!< discretization
-    ScaTra::BoundaryAction action,             //!< action
-    Core::Elements::LocationArray& la,         //!< location array
-    Core::LinAlg::SerialDenseMatrix& elemat1,  //!< element matrix 1
-    Core::LinAlg::SerialDenseMatrix& elemat2,  //!< element matrix 2
-    Core::LinAlg::SerialDenseVector& elevec1,  //!< element right-hand side vector 1
-    Core::LinAlg::SerialDenseVector& elevec2,  //!< element right-hand side vector 2
-    Core::LinAlg::SerialDenseVector& elevec3   //!< element right-hand side vector 3
-)
+    Core::Elements::FaceElement* ele, Teuchos::ParameterList& params,
+    Core::FE::Discretization& discretization, ScaTra::BoundaryAction action,
+    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+    Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+    Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3)
 {
   // determine and evaluate action
   switch (action)
@@ -76,7 +65,7 @@ int Discret::Elements::ScaTraEleBoundaryCalcElchDiffCond<distype, probdim>::eval
     case ScaTra::BoundaryAction::calc_elch_boundary_kinetics:
     {
       // access material of parent element
-      std::shared_ptr<Core::Mat::Material> material = ele->parent_element()->material();
+      const std::shared_ptr<Core::Mat::Material> material = ele->parent_element()->material();
 
       // extract porosity from material and store in diffusion manager
       if (material->material_type() == Core::Materials::m_elchmat)
@@ -85,7 +74,7 @@ int Discret::Elements::ScaTraEleBoundaryCalcElchDiffCond<distype, probdim>::eval
 
         for (int iphase = 0; iphase < elchmat->num_phase(); ++iphase)
         {
-          std::shared_ptr<const Core::Mat::Material> phase =
+          const std::shared_ptr<const Core::Mat::Material> phase =
               elchmat->phase_by_id(elchmat->phase_id(iphase));
 
           if (phase->material_type() == Core::Materials::m_elchphase)
@@ -94,12 +83,16 @@ int Discret::Elements::ScaTraEleBoundaryCalcElchDiffCond<distype, probdim>::eval
                 (static_cast<const Mat::ElchPhase*>(phase.get()))->epsilon(), iphase);
           }
           else
+          {
             FOUR_C_THROW("Invalid material!");
+          }
         }
       }
 
       else
+      {
         FOUR_C_THROW("Invalid material!");
+      }
 
       // process electrode kinetics boundary condition
       myelch::calc_elch_boundary_kinetics(
@@ -120,9 +113,7 @@ int Discret::Elements::ScaTraEleBoundaryCalcElchDiffCond<distype, probdim>::eval
   return 0;
 }
 
-
 /*----------------------------------------------------------------------*
- | evaluate Neumann boundary condition                       fang 02/15 |
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
 int Discret::Elements::ScaTraEleBoundaryCalcElchDiffCond<distype, probdim>::evaluate_neumann(
@@ -132,7 +123,7 @@ int Discret::Elements::ScaTraEleBoundaryCalcElchDiffCond<distype, probdim>::eval
     const double scalar)
 {
   // get material of parent element
-  std::shared_ptr<Core::Mat::Material> mat = ele->parent_element()->material();
+  const std::shared_ptr<Core::Mat::Material> mat = ele->parent_element()->material();
 
   if (mat->material_type() == Core::Materials::m_elchmat)
   {
@@ -141,7 +132,7 @@ int Discret::Elements::ScaTraEleBoundaryCalcElchDiffCond<distype, probdim>::eval
     for (int iphase = 0; iphase < actmat->num_phase(); ++iphase)
     {
       const int phaseid = actmat->phase_id(iphase);
-      std::shared_ptr<const Core::Mat::Material> singlemat = actmat->phase_by_id(phaseid);
+      const std::shared_ptr<const Core::Mat::Material> singlemat = actmat->phase_by_id(phaseid);
 
       if (singlemat->material_type() == Core::Materials::m_elchphase)
       {
@@ -150,11 +141,15 @@ int Discret::Elements::ScaTraEleBoundaryCalcElchDiffCond<distype, probdim>::eval
         dmedc_->set_phase_poro(actsinglemat->epsilon(), iphase);
       }
       else
+      {
         FOUR_C_THROW("Invalid material!");
+      }
     }
   }
   else
+  {
     FOUR_C_THROW("Invalid material!");
+  }
 
   // call base class routine
   my::evaluate_neumann(
@@ -183,7 +178,6 @@ int Discret::Elements::ScaTraEleBoundaryCalcElchDiffCond<distype, probdim>::eval
       default:
       {
         FOUR_C_THROW("Closing equation for electric potential not recognized!");
-        break;
       }
     }
   }
@@ -191,29 +185,17 @@ int Discret::Elements::ScaTraEleBoundaryCalcElchDiffCond<distype, probdim>::eval
   return 0;
 }
 
-
 /*----------------------------------------------------------------------*
- | evaluate an electrode kinetics boundary condition         fang 02/15 |
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
 void Discret::Elements::ScaTraEleBoundaryCalcElchDiffCond<distype,
-    probdim>::evaluate_elch_boundary_kinetics(const Core::Elements::Element*
-                                                  ele,  ///< current element
-    Core::LinAlg::SerialDenseMatrix& emat,              ///< element matrix
-    Core::LinAlg::SerialDenseVector& erhs,              ///< element right-hand side vector
-    const std::vector<Core::LinAlg::Matrix<nen_, 1>>&
-        ephinp,  ///< nodal values of concentration and electric potential
-    const std::vector<Core::LinAlg::Matrix<nen_, 1>>& ehist,  ///< nodal history vector
-    double timefac,                                           ///< time factor
-    std::shared_ptr<const Core::Mat::Material> material,      ///< material
-    const Core::Conditions::Condition& cond,  ///< electrode kinetics boundary condition
-    const int nume,                           ///< number of transferred electrons
-    const std::vector<int> stoich,            ///< stoichiometry of the reaction
-    const int kinetics,                       ///< desired electrode kinetics model
-    const double pot0,                        ///< electrode potential on metal side
-    const double frt,                         ///< factor F/RT
-    const double scalar  ///< scaling factor for element matrix and right-hand side contributions
-)
+    probdim>::evaluate_elch_boundary_kinetics(const Core::Elements::Element* ele,
+    Core::LinAlg::SerialDenseMatrix& emat, Core::LinAlg::SerialDenseVector& erhs,
+    const std::vector<Core::LinAlg::Matrix<nen_, 1>>& ephinp,
+    const std::vector<Core::LinAlg::Matrix<nen_, 1>>& ehist, double timefac,
+    std::shared_ptr<const Core::Mat::Material> material, const Core::Conditions::Condition& cond,
+    const int nume, const std::vector<int>& stoich, const int kinetics, const double pot0,
+    const double frt, const double scalar)
 {
   // call base class routine
   myelch::evaluate_elch_boundary_kinetics(ele, emat, erhs, ephinp, ehist, timefac, material, cond,
@@ -252,17 +234,14 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchDiffCond<distype,
     default:
     {
       FOUR_C_THROW("Unknown closing equation for electric potential!");
-      break;
     }
   }
 }
 
-
-/*-------------------------------------------------------------------------------------*
- | evaluate scatra-scatra interface coupling condition (electrochemistry)   fang 12/14 |
- *-------------------------------------------------------------------------------------*/
+/*----------------------------------------------------------------------*
+ *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
-void Discret::Elements::ScaTraEleBoundaryCalcElchDiffCond<distype, probdim>::evaluate_s2_i_coupling(
+void Discret::Elements::ScaTraEleBoundaryCalcElchDiffCond<distype, probdim>::evaluate_s2i_coupling(
     const Core::Elements::FaceElement* ele, Teuchos::ParameterList& params,
     Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
     Core::LinAlg::SerialDenseMatrix& eslavematrix, Core::LinAlg::SerialDenseMatrix& emastermatrix,
@@ -274,7 +253,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchDiffCond<distype, probdim>::eva
       break;
     case S2I::kinetics_constantinterfaceresistance:
     {
-      myelectrode::evaluate_s2_i_coupling(
+      myelectrode::evaluate_s2i_coupling(
           ele, params, discretization, la, eslavematrix, emastermatrix, eslaveresidual);
       break;
     }
@@ -284,7 +263,6 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchDiffCond<distype, probdim>::eva
           "Evaluation of scatra-scatra interface kinetics for electrochemistry problems with "
           "conforming interface discretization must have an electrode on the slave side and the "
           "electrolyte on the master side.");
-      break;
     }
   }
 }
@@ -293,7 +271,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchDiffCond<distype, probdim>::eva
  *-------------------------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
 void Discret::Elements::ScaTraEleBoundaryCalcElchDiffCond<distype,
-    probdim>::evaluate_s2_i_coupling_od(const Core::Elements::FaceElement* ele,
+    probdim>::evaluate_s2i_coupling_od(const Core::Elements::FaceElement* ele,
     Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
     Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& eslavematrix)
 {
@@ -303,7 +281,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchDiffCond<distype,
       break;
     case S2I::kinetics_constantinterfaceresistance:
     {
-      myelectrode::evaluate_s2_i_coupling_od(ele, params, discretization, la, eslavematrix);
+      myelectrode::evaluate_s2i_coupling_od(ele, params, discretization, la, eslavematrix);
       break;
     }
     default:
@@ -312,20 +290,15 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchDiffCond<distype,
           "Evaluation of scatra-scatra interface kinetics for electrochemistry problems with "
           "conforming interface discretization must have an electrode on the slave side and the "
           "electrolyte on the master side.");
-      break;
     }
   }
 }
 
-
-/*-------------------------------------------------------------------------------------*
- | extract valence of species k from element material                       fang 12/14 |
- *-------------------------------------------------------------------------------------*/
+/*----------------------------------------------------------------------*
+ *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
 double Discret::Elements::ScaTraEleBoundaryCalcElchDiffCond<distype, probdim>::get_valence(
-    const std::shared_ptr<const Core::Mat::Material>& material,  // element material
-    const int k                                                  // species number
-) const
+    const std::shared_ptr<const Core::Mat::Material>& material, const int k) const
 {
   double valence(0.);
 
@@ -335,8 +308,8 @@ double Discret::Elements::ScaTraEleBoundaryCalcElchDiffCond<distype, probdim>::g
         std::dynamic_pointer_cast<const Mat::ElchMat>(material);
 
     // safety check
-    if (elchmat->num_phase() != 1)
-      FOUR_C_THROW("Only one material phase is allowed at the moment!");
+    FOUR_C_ASSERT_ALWAYS(
+        elchmat->num_phase() == 1, "Only one material phase is allowed at the moment!");
 
     // loop over phases
     for (int iphase = 0; iphase < elchmat->num_phase(); ++iphase)
@@ -354,21 +327,25 @@ double Discret::Elements::ScaTraEleBoundaryCalcElchDiffCond<distype, probdim>::g
         if (species->material_type() == Core::Materials::m_newman)
         {
           valence = std::static_pointer_cast<const Mat::Newman>(species)->valence();
-          if (abs(valence) < 1.e-14) FOUR_C_THROW("Received zero valence!");
+          FOUR_C_ASSERT_ALWAYS(std::abs(valence) > 1.0e-16, "Received zero valence!");
         }
         else if (species->material_type() == Core::Materials::m_ion)
         {
           valence = std::static_pointer_cast<const Mat::Ion>(species)->valence();
-          if (abs(valence) < 1.e-14) FOUR_C_THROW("Received zero valence!");
+          FOUR_C_ASSERT_ALWAYS(std::abs(valence) > 1.0e-16, "Received zero valence!");
         }
         else
+        {
           FOUR_C_THROW("Unknown material species!");
+        }
       }
     }
   }
 
   else
+  {
     FOUR_C_THROW("Unknown material!");
+  }
 
   return valence;
 }

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_diffcond.hpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_diffcond.hpp
@@ -37,14 +37,13 @@ namespace Discret
      public:
       //! singleton access method
       static ScaTraEleBoundaryCalcElchDiffCond<distype, probdim>* instance(
-          const int numdofpernode, const int numscal, const std::string& disname);
+          int numdofpernode, int numscal, const std::string& disname);
 
 
 
      private:
       //! private constructor for singletons
-      ScaTraEleBoundaryCalcElchDiffCond(
-          const int numdofpernode, const int numscal, const std::string& disname);
+      ScaTraEleBoundaryCalcElchDiffCond(int numdofpernode, int numscal, const std::string& disname);
 
       int evaluate_action(Core::Elements::FaceElement* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, ScaTra::BoundaryAction action,
@@ -56,29 +55,29 @@ namespace Discret
       int evaluate_neumann(Core::Elements::FaceElement* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, const Core::Conditions::Condition& condition,
           Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseVector& elevec1,
-          const double scalar) override;
+          double scalar) override;
 
       void evaluate_elch_boundary_kinetics(const Core::Elements::Element* ele,
           Core::LinAlg::SerialDenseMatrix& emat, Core::LinAlg::SerialDenseVector& erhs,
           const std::vector<Core::LinAlg::Matrix<nen_, 1>>& ephinp,
           const std::vector<Core::LinAlg::Matrix<nen_, 1>>& ehist, double timefac,
           std::shared_ptr<const Core::Mat::Material> material,
-          const Core::Conditions::Condition& cond, const int nume, const std::vector<int> stoich,
-          const int kinetics, const double pot0, const double frt, const double scalar) override;
+          const Core::Conditions::Condition& cond, int nume, const std::vector<int>& stoich,
+          int kinetics, double pot0, double frt, double scalar) override;
 
-      void evaluate_s2_i_coupling(const Core::Elements::FaceElement* ele,
+      void evaluate_s2i_coupling(const Core::Elements::FaceElement* ele,
           Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
           Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& eslavematrix,
           Core::LinAlg::SerialDenseMatrix& emastermatrix,
           Core::LinAlg::SerialDenseVector& eslaveresidual) override;
 
-      void evaluate_s2_i_coupling_od(const Core::Elements::FaceElement* ele,
+      void evaluate_s2i_coupling_od(const Core::Elements::FaceElement* ele,
           Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
           Core::Elements::LocationArray& la,
           Core::LinAlg::SerialDenseMatrix& eslavematrix) override;
 
-      double get_valence(
-          const std::shared_ptr<const Core::Mat::Material>& material, const int k) const override;
+      [[nodiscard]] double get_valence(
+          const std::shared_ptr<const Core::Mat::Material>& material, int k) const override;
 
       //! diffusion manager
       std::shared_ptr<ScaTraEleDiffManagerElchDiffCond> dmedc_;

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode.cpp
@@ -50,15 +50,15 @@ Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
-void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
-    probdim>::evaluate_s2_i_coupling(const Core::Elements::FaceElement* ele,
-    Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
-    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& eslavematrix,
-    Core::LinAlg::SerialDenseMatrix& emastermatrix, Core::LinAlg::SerialDenseVector& eslaveresidual)
+void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype, probdim>::evaluate_s2i_coupling(
+    const Core::Elements::FaceElement* ele, Teuchos::ParameterList& params,
+    Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
+    Core::LinAlg::SerialDenseMatrix& eslavematrix, Core::LinAlg::SerialDenseMatrix& emastermatrix,
+    Core::LinAlg::SerialDenseVector& eslaveresidual)
 {
   // safety check
-  if (myelch::elchparams_->equ_pot() != ElCh::equpot_divi)
-    FOUR_C_THROW("Invalid closing equation for electric potential!");
+  FOUR_C_ASSERT_ALWAYS(myelch::elchparams_->equ_pot() == ElCh::equpot_divi,
+      "Invalid closing equation for electric potential!");
 
   // get condition specific parameter
   const int kineticmodel = my::scatraparamsboundary_->kinetic_model();
@@ -124,21 +124,21 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
     const double pseudo_contact_fac = my::calculate_pseudo_contact_factor(
         is_pseudo_contact, eslavestress_vector, normal, my::funct_);
 
-    evaluate_s2_i_coupling_at_integration_point<distype>(matelectrode, my::ephinp_, emasterphinp,
+    evaluate_s2i_coupling_at_integration_point<distype>(matelectrode, my::ephinp_, emasterphinp,
         eslavetempnp, emastertempnp, pseudo_contact_fac, my::funct_, my::funct_, my::funct_,
         my::funct_, my::scatraparamsboundary_, timefacfac, timefacrhsfac, detF, get_frt(),
         my::numdofpernode_, eslavematrix, emastermatrix, dummymatrix, dummymatrix, eslaveresidual,
         dummyvector);
   }  // loop over integration points
 }  // Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
-   // probdim>::evaluate_s2_i_coupling
+   // probdim>::evaluate_s2i_coupling
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
 template <Core::FE::CellType distype_master>
 void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype, probdim>::
-    evaluate_s2_i_coupling_at_integration_point(
+    evaluate_s2i_coupling_at_integration_point(
         const std::shared_ptr<const Mat::Electrode>& matelectrode,
         const std::vector<Core::LinAlg::Matrix<nen_, 1>>& eslavephinp,
         const std::vector<Core::LinAlg::Matrix<Core::FE::num_nodes(distype_master), 1>>&
@@ -207,8 +207,8 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype, probdim>::
     case S2I::kinetics_butlervolmerresistance:
     case S2I::kinetics_butlervolmerreducedresistance:
     {
-      if (matelectrode == nullptr)
-        FOUR_C_THROW("Invalid electrode material for scatra-scatra interface coupling!");
+      FOUR_C_ASSERT_ALWAYS(matelectrode != nullptr,
+          "Invalid electrode material for scatra-scatra interface coupling!");
 
       // extract saturation value of intercalated lithium concentration from electrode material
       const double cmax = matelectrode->c_max();
@@ -264,7 +264,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype, probdim>::
               cmax, eta, dj_dc_slave, dj_dc_master, dj_dpot_slave, dj_dpot_master);
 
           // calculate RHS and linearizations of master and slave-side residuals
-          calculate_rh_sand_global_system<distype_master>(funct_slave, funct_master, test_slave,
+          calculate_rhs_and_global_system<distype_master>(funct_slave, funct_master, test_slave,
               test_master, pseudo_contact_fac, numelectrons, nen_master, timefacfac, timefacrhsfac,
               dj_dc_slave, dj_dc_master, dj_dpot_slave, dj_dpot_master, j, num_dof_per_node, k_ss,
               k_sm, k_ms, k_mm, r_s, r_m);
@@ -299,7 +299,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype, probdim>::
               cmax, eta, dj_dc_slave, dj_dc_master, dj_dpot_slave, dj_dpot_master);
 
           // calculate RHS and linearizations of master and slave-side residuals
-          calculate_rh_sand_global_system<distype_master>(funct_slave, funct_master, test_slave,
+          calculate_rhs_and_global_system<distype_master>(funct_slave, funct_master, test_slave,
               test_master, pseudo_contact_fac, numelectrons, nen_master, timefacfac, timefacrhsfac,
               dj_dc_slave, dj_dc_master, dj_dpot_slave, dj_dpot_master, j, num_dof_per_node, k_ss,
               k_sm, k_ms, k_mm, r_s, r_m);
@@ -371,8 +371,10 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype, probdim>::
         }
       }
       else if (k_ss.numRows() or k_sm.numRows() or r_s.length())
+      {
         FOUR_C_THROW(
             "Must provide both slave-side matrices and slave-side vector or none of them!");
+      }
 
       if (k_ms.numRows() and k_mm.numRows() and r_m.length())
       {
@@ -417,8 +419,10 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype, probdim>::
         }
       }
       else if (k_ms.numRows() or k_mm.numRows() or r_m.length())
+      {
         FOUR_C_THROW(
             "Must provide both master-side matrices and master-side vector or none of them!");
+      }
 
       break;
     }  // case S2I::kinetics_constantinterfaceresistance
@@ -440,7 +444,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype, probdim>::
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
 void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
-    probdim>::evaluate_s2_i_coupling_capacitance(const Core::FE::Discretization& discretization,
+    probdim>::evaluate_s2i_coupling_capacitance(const Core::FE::Discretization& discretization,
     Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& eslavematrix,
     Core::LinAlg::SerialDenseMatrix& emastermatrix, Core::LinAlg::SerialDenseVector& eslaveresidual,
     Core::LinAlg::SerialDenseVector& emasterresidual)
@@ -491,7 +495,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
     const double pseudo_contact_fac = my::calculate_pseudo_contact_factor(
         is_pseudo_contact, eslavestress_vector, normal, my::funct_);
 
-    evaluate_s2_i_coupling_capacitance_at_integration_point<distype>(eslavephidtnp, emasterphidtnp,
+    evaluate_s2i_coupling_capacitance_at_integration_point<distype>(eslavephidtnp, emasterphidtnp,
         my::ephinp_, emasterphinp, pseudo_contact_fac, my::funct_, my::funct_, my::funct_,
         my::funct_, my::scatraparamsboundary_, my::scatraparamstimint_->time_derivative_fac(),
         timefacfac, timefacrhsfac, my::numdofpernode_, eslavematrix, emastermatrix, eslaveresidual,
@@ -504,7 +508,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
 template <Core::FE::CellType distype, int probdim>
 template <Core::FE::CellType distype_master>
 void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype, probdim>::
-    evaluate_s2_i_coupling_capacitance_at_integration_point(
+    evaluate_s2i_coupling_capacitance_at_integration_point(
         const std::vector<Core::LinAlg::Matrix<nen_, 1>>& eslavephidtnp,
         const std::vector<Core::LinAlg::Matrix<Core::FE::num_nodes(distype_master), 1>>&
             emasterphidtnp,
@@ -550,7 +554,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype, probdim>::
       // calculate non-zero linearization of capacitive mass flux density w.r.t. slave-side dofs
       const double djC_dpot_slave = capacitance * timederivfac / (numelectrons * faraday);
 
-      calculate_rh_sand_global_system_capacitive_flux<distype_master>(funct_slave, test_slave,
+      calculate_rhs_and_global_system_capacitive_flux<distype_master>(funct_slave, test_slave,
           test_master, pseudo_contact_fac, numelectrons, timefacfac, timefacrhsfac, nen_master, jC,
           djC_dpot_slave, num_dof_per_node, k_ss, k_ms, r_s, r_m);
 
@@ -570,7 +574,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype, probdim>::
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
 void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
-    probdim>::evaluate_s2_i_coupling_od(const Core::Elements::FaceElement* ele,
+    probdim>::evaluate_s2i_coupling_od(const Core::Elements::FaceElement* ele,
     Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
     Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& eslavematrix)
 {
@@ -631,7 +635,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
 
     // evaluate overall integration factors
     const double timefacwgt = my::scatraparamstimint_->time_fac() * intpoints.ip().qwgt[gpid];
-    if (timefacwgt < 0.0) FOUR_C_THROW("Integration factor is negative!");
+    FOUR_C_ASSERT_ALWAYS(timefacwgt > 0.0, "Time integration factor must be positive!");
 
     // evaluate dof values at current integration point on present and opposite side of
     // scatra-scatra interface
@@ -659,8 +663,8 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
         const double alphac = my::scatraparamsboundary_->alpha_c();
         const double kr = my::scatraparamsboundary_->charge_transfer_constant();
 
-        if (matelectrode == nullptr)
-          FOUR_C_THROW("Invalid electrode material for scatra-scatra interface coupling!");
+        FOUR_C_ASSERT_ALWAYS(matelectrode != nullptr,
+            "Invalid electrode material for scatra-scatra interface coupling!");
 
         // extract saturation value of intercalated lithium concentration from electrode material
         const double cmax = matelectrode->c_max();
@@ -800,13 +804,13 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
     }  // switch(kineticmodel)
   }  // loop over integration points
 }  // Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
-   // probdim>::evaluate_s2_i_coupling_od
+   // probdim>::evaluate_s2i_coupling_od
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
 void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
-    probdim>::evaluate_s2_i_coupling_capacitance_od(Teuchos::ParameterList& params,
+    probdim>::evaluate_s2i_coupling_capacitance_od(Teuchos::ParameterList& params,
     Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
     Core::LinAlg::SerialDenseMatrix& eslavematrix, Core::LinAlg::SerialDenseMatrix& emastermatrix)
 {
@@ -866,7 +870,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
 
     // evaluate overall integration factors
     const double timefacwgt = my::scatraparamstimint_->time_fac() * intpoints.ip().qwgt[gpid];
-    if (timefacwgt < 0.0) FOUR_C_THROW("Integration factor is negative!");
+    FOUR_C_ASSERT_ALWAYS(timefacwgt > 0.0, "Time integration factor is not positive!");
 
     // compute matrix and vector contributions according to kinetic
     // model for current scatra-scatra interface coupling condition
@@ -962,7 +966,7 @@ double Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype, probdim>::
 template <Core::FE::CellType distype, int probdim>
 template <Core::FE::CellType distype_master>
 void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
-    probdim>::calculate_rh_sand_global_system(const Core::LinAlg::Matrix<nen_, 1>& funct_slave,
+    probdim>::calculate_rhs_and_global_system(const Core::LinAlg::Matrix<nen_, 1>& funct_slave,
     const Core::LinAlg::Matrix<Core::FE::num_nodes(distype_master), 1>& funct_master,
     const Core::LinAlg::Matrix<nen_, 1>& test_slave,
     const Core::LinAlg::Matrix<Core::FE::num_nodes(distype_master), 1>& test_master,
@@ -1020,7 +1024,9 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
     }
   }
   else if (k_ss.numRows() or k_sm.numRows() or r_s.length())
+  {
     FOUR_C_THROW("Must provide both slave-side matrices and slave-side vector or none of them!");
+  }
 
   // assemble master side element rhs and linearizations
   if (k_ms.numRows() and k_mm.numRows() and r_m.length())
@@ -1061,7 +1067,9 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
     }
   }
   else if (k_ms.numRows() or k_mm.numRows() or r_m.length())
+  {
     FOUR_C_THROW("Must provide both master-side matrices and master-side vector or none of them!");
+  }
 }
 
 /*----------------------------------------------------------------------*
@@ -1069,7 +1077,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
 template <Core::FE::CellType distype, int probdim>
 template <Core::FE::CellType distype_master>
 void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
-    probdim>::calculate_rh_sand_global_system_capacitive_flux(const Core::LinAlg::Matrix<nen_, 1>&
+    probdim>::calculate_rhs_and_global_system_capacitive_flux(const Core::LinAlg::Matrix<nen_, 1>&
                                                                   funct_slave,
     const Core::LinAlg::Matrix<nen_, 1>& test_slave,
     const Core::LinAlg::Matrix<Core::FE::num_nodes(distype_master), 1>& test_master,
@@ -1123,14 +1131,16 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
     }
   }
   else if (k_ss.numRows() or k_ms.numRows() or r_s.length() or r_m.length())
+  {
     FOUR_C_THROW("You did not provide the correct set of matrices and vectors!");
+  }
 }
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
 void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
-    probdim>::calc_s2_i_coupling_flux(const Core::Elements::FaceElement* ele,
+    probdim>::calc_s2i_coupling_flux(const Core::Elements::FaceElement* ele,
     const Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
     Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseVector& scalars)
 {
@@ -1204,7 +1214,9 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
       frt = faraday / (etempint * gasconstant);
     }
     else
+    {
       frt = get_frt();
+    }
 
     const double detF = my::calculate_det_f_of_parent_element(ele, intpoints.point(gpid));
 
@@ -1221,8 +1233,8 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
       case S2I::kinetics_butlervolmerresistance:
       case S2I::kinetics_butlervolmerreducedresistance:
       {
-        if (matelectrode == nullptr)
-          FOUR_C_THROW("Invalid electrode material for scatra-scatra interface coupling!");
+        FOUR_C_ASSERT_ALWAYS(matelectrode != nullptr,
+            "Invalid electrode material for scatra-scatra interface coupling!");
 
         // extract saturation value of intercalated lithium concentration from electrode material
         const double cmax = matelectrode->c_max();
@@ -1341,7 +1353,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<distype,
 
 // explicit instantiation of template methods
 template void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<Core::FE::CellType::tri3>::
-    evaluate_s2_i_coupling_at_integration_point<Core::FE::CellType::tri3>(
+    evaluate_s2i_coupling_at_integration_point<Core::FE::CellType::tri3>(
         const std::shared_ptr<const Mat::Electrode>&,
         const std::vector<Core::LinAlg::Matrix<nen_, 1>>&,
         const std::vector<Core::LinAlg::Matrix<Core::FE::num_nodes(Core::FE::CellType::tri3), 1>>&,
@@ -1357,7 +1369,7 @@ template void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<Core::FE::Ce
         Core::LinAlg::SerialDenseMatrix&, Core::LinAlg::SerialDenseVector&,
         Core::LinAlg::SerialDenseVector&);
 template void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<Core::FE::CellType::tri3>::
-    evaluate_s2_i_coupling_at_integration_point<Core::FE::CellType::quad4>(
+    evaluate_s2i_coupling_at_integration_point<Core::FE::CellType::quad4>(
         const std::shared_ptr<const Mat::Electrode>&,
         const std::vector<Core::LinAlg::Matrix<nen_, 1>>&,
         const std::vector<Core::LinAlg::Matrix<Core::FE::num_nodes(Core::FE::CellType::quad4), 1>>&,
@@ -1373,7 +1385,7 @@ template void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<Core::FE::Ce
         Core::LinAlg::SerialDenseMatrix&, Core::LinAlg::SerialDenseVector&,
         Core::LinAlg::SerialDenseVector&);
 template void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<Core::FE::CellType::quad4>::
-    evaluate_s2_i_coupling_at_integration_point<Core::FE::CellType::tri3>(
+    evaluate_s2i_coupling_at_integration_point<Core::FE::CellType::tri3>(
         const std::shared_ptr<const Mat::Electrode>&,
         const std::vector<Core::LinAlg::Matrix<nen_, 1>>&,
         const std::vector<Core::LinAlg::Matrix<Core::FE::num_nodes(Core::FE::CellType::tri3), 1>>&,
@@ -1389,7 +1401,7 @@ template void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<Core::FE::Ce
         Core::LinAlg::SerialDenseMatrix&, Core::LinAlg::SerialDenseVector&,
         Core::LinAlg::SerialDenseVector&);
 template void Discret::Elements::ScaTraEleBoundaryCalcElchElectrode<Core::FE::CellType::quad4>::
-    evaluate_s2_i_coupling_at_integration_point<Core::FE::CellType::quad4>(
+    evaluate_s2i_coupling_at_integration_point<Core::FE::CellType::quad4>(
         const std::shared_ptr<const Mat::Electrode>&,
         const std::vector<Core::LinAlg::Matrix<nen_, 1>>&,
         const std::vector<Core::LinAlg::Matrix<Core::FE::num_nodes(Core::FE::CellType::quad4), 1>>&,

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode.hpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode.hpp
@@ -19,13 +19,11 @@ namespace Mat
 {
   class Electrode;
 }
-namespace Discret
+
+namespace Discret::Elements
 {
-  namespace Elements
-  {
-    class ScaTraEleBoundaryCalcElchElectrodeUtils;
-  }
-}  // namespace Discret
+  class ScaTraEleBoundaryCalcElchElectrodeUtils;
+}
 
 namespace Discret
 {
@@ -48,7 +46,6 @@ namespace Discret
       //! singleton access method
       static ScaTraEleBoundaryCalcElchElectrode<distype, probdim>* instance(
           int numdofpernode, int numscal, const std::string& disname);
-
 
       /*!
        * \brief evaluate scatra-scatra interface coupling condition at integration point
@@ -86,7 +83,7 @@ namespace Discret
        * \tparam distype_master  This method is templated on the master-side discretization type.
        */
       template <Core::FE::CellType distype_master>
-      static void evaluate_s2_i_coupling_at_integration_point(
+      static void evaluate_s2i_coupling_at_integration_point(
           const std::shared_ptr<const Mat::Electrode>& matelectrode,
           const std::vector<Core::LinAlg::Matrix<nen_, 1>>& eslavephinp,
           const std::vector<Core::LinAlg::Matrix<Core::FE::num_nodes(distype_master), 1>>&
@@ -134,7 +131,7 @@ namespace Discret
        * @tparam distype_master This method is templated on the master-side discretization type.
        */
       template <Core::FE::CellType distype_master>
-      static void evaluate_s2_i_coupling_capacitance_at_integration_point(
+      static void evaluate_s2i_coupling_capacitance_at_integration_point(
           const std::vector<Core::LinAlg::Matrix<nen_, 1>>& eslavephidtnp,
           const std::vector<Core::LinAlg::Matrix<Core::FE::num_nodes(distype_master), 1>>&
               emasterphidtnp,
@@ -154,7 +151,7 @@ namespace Discret
        * \brief calculate out-parameters such as residual vectors and linearizations of residuals
        *
        * \remark This is a static method as it is called from
-       * static method evaluate_s2_i_coupling_at_integration_point.
+       * static method evaluate_s2i_coupling_at_integration_point.
        *
        * @param[in] funct_slave      slave-side shape function values
        * @param[in] funct_master     master-side shape function values
@@ -188,7 +185,7 @@ namespace Discret
        * @tparam distype_master  This method is templated on the master-side discretization type.
        */
       template <Core::FE::CellType distype_master>
-      static void calculate_rh_sand_global_system(const Core::LinAlg::Matrix<nen_, 1>& funct_slave,
+      static void calculate_rhs_and_global_system(const Core::LinAlg::Matrix<nen_, 1>& funct_slave,
           const Core::LinAlg::Matrix<Core::FE::num_nodes(distype_master), 1>& funct_master,
           const Core::LinAlg::Matrix<nen_, 1>& test_slave,
           const Core::LinAlg::Matrix<Core::FE::num_nodes(distype_master), 1>& test_master,
@@ -226,7 +223,7 @@ namespace Discret
        * @tparam distype_master  This method is templated on the master-side discretization type.
        */
       template <Core::FE::CellType distype_master>
-      static void calculate_rh_sand_global_system_capacitive_flux(
+      static void calculate_rhs_and_global_system_capacitive_flux(
           const Core::LinAlg::Matrix<nen_, 1>& funct_slave,
           const Core::LinAlg::Matrix<nen_, 1>& test_slave,
           const Core::LinAlg::Matrix<Core::FE::num_nodes(distype_master), 1>& test_master,
@@ -240,37 +237,37 @@ namespace Discret
       ScaTraEleBoundaryCalcElchElectrode(
           int numdofpernode, int numscal, const std::string& disname);
 
-      void evaluate_s2_i_coupling(const Core::Elements::FaceElement* ele,
+      void evaluate_s2i_coupling(const Core::Elements::FaceElement* ele,
           Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
           Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& eslavematrix,
           Core::LinAlg::SerialDenseMatrix& emastermatrix,
           Core::LinAlg::SerialDenseVector& eslaveresidual) override;
 
-      void evaluate_s2_i_coupling_capacitance(const Core::FE::Discretization& discretization,
+      void evaluate_s2i_coupling_capacitance(const Core::FE::Discretization& discretization,
           Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& eslavematrix,
           Core::LinAlg::SerialDenseMatrix& emastermatrix,
           Core::LinAlg::SerialDenseVector& eslaveresidual,
           Core::LinAlg::SerialDenseVector& emasterresidual) override;
 
-      void evaluate_s2_i_coupling_od(const Core::Elements::FaceElement* ele,
+      void evaluate_s2i_coupling_od(const Core::Elements::FaceElement* ele,
           Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
           Core::Elements::LocationArray& la,
           Core::LinAlg::SerialDenseMatrix& eslavematrix) override;
 
-      void evaluate_s2_i_coupling_capacitance_od(Teuchos::ParameterList& params,
+      void evaluate_s2i_coupling_capacitance_od(Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
           Core::LinAlg::SerialDenseMatrix& eslavematrix,
           Core::LinAlg::SerialDenseMatrix& emastermatrix) override;
 
-      double get_valence(
+      [[nodiscard]] double get_valence(
           const std::shared_ptr<const Core::Mat::Material>& material, int k) const override;
 
-      void calc_s2_i_coupling_flux(const Core::Elements::FaceElement* ele,
+      void calc_s2i_coupling_flux(const Core::Elements::FaceElement* ele,
           const Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
           Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseVector& scalars) override;
 
       //! evaluate factor F/RT
-      virtual double get_frt() const;
+      [[nodiscard]] virtual double get_frt() const;
     };  // class ScaTraEleBoundaryCalcElchElectrode
   }  // namespace Elements
 }  // namespace Discret

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode_growth.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode_growth.cpp
@@ -60,8 +60,8 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeGrowth<distype,
   // access material of parent element
   std::shared_ptr<const Mat::Electrode> matelectrode =
       std::dynamic_pointer_cast<const Mat::Electrode>(ele->parent_element()->material());
-  if (matelectrode == nullptr)
-    FOUR_C_THROW("Invalid electrode material for scatra-scatra interface coupling!");
+  FOUR_C_ASSERT_ALWAYS(
+      matelectrode != nullptr, "Invalid electrode material for scatra-scatra interface coupling!");
 
   // extract local nodal values on present and opposite side of scatra-scatra interface
   extract_node_values(discretization, la);
@@ -69,19 +69,16 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeGrowth<distype,
       my::numdofpernode_, Core::LinAlg::Matrix<nen_, 1>(Core::LinAlg::Initialization::zero));
   my::extract_node_values(emasterphinp, discretization, la, "imasterphinp");
 
-  if (my::scatraparamsboundary_->condition_type() != Core::Conditions::S2IKineticsGrowth)
-    FOUR_C_THROW("Received illegal condition type!");
-
+  FOUR_C_ASSERT_ALWAYS(
+      my::scatraparamsboundary_->condition_type() == Core::Conditions::S2IKineticsGrowth,
+      "Received illegal condition type!");
   // access input parameters associated with condition
   const double faraday = myelch::elchparams_->faraday();
   const double resistivity = my::scatraparamsboundary_->resistivity();
   const int kineticmodel = my::scatraparamsboundary_->kinetic_model();
-  if (kineticmodel != S2I::growth_kinetics_butlervolmer)
-  {
-    FOUR_C_THROW(
-        "Received illegal kinetic model for scatra-scatra interface coupling involving interface "
-        "layer growth!");
-  }
+  FOUR_C_ASSERT_ALWAYS(kineticmodel == S2I::growth_kinetics_butlervolmer,
+      "Received illegal kinetic model for scatra-scatra interface coupling involving interface "
+      "layer growth!");
 
   // integration points and weights
   const Core::FE::IntPointsAndWeights<nsd_ele_> intpoints(
@@ -114,7 +111,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeGrowth<distype,
         const double alphaa = my::scatraparamsboundary_->alphadata();
         const double kr = my::scatraparamsboundary_->charge_transfer_constant();
         const double emasterphiint = my::funct_.dot(emasterphinp[0]);
-        const double epd = 0.0;  // equilibrium potential is 0 for the plating reaction
+        constexpr double epd = 0.0;  // equilibrium potential is 0 for the plating reaction
 
         // compute exchange mass flux density
         const double j0 = kr * std::pow(emasterphiint, alphaa);
@@ -149,22 +146,22 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeGrowth<distype,
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
 void Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeGrowth<distype,
-    probdim>::evaluate_s2_i_coupling(const Core::Elements::FaceElement* ele,
+    probdim>::evaluate_s2i_coupling(const Core::Elements::FaceElement* ele,
     Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
     Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& eslavematrix,
     Core::LinAlg::SerialDenseMatrix& emastermatrix, Core::LinAlg::SerialDenseVector& eslaveresidual)
 {
   // safety checks
-  if (my::numscal_ != 1) FOUR_C_THROW("Invalid number of transported scalars!");
-  if (my::numdofpernode_ != 2) FOUR_C_THROW("Invalid number of degrees of freedom per node!");
-  if (myelch::elchparams_->equ_pot() != ElCh::equpot_divi)
-    FOUR_C_THROW("Invalid closing equation for electric potential!");
+  FOUR_C_ASSERT_ALWAYS(my::numscal_ == 1, "Invalid number of transported scalars!");
+  FOUR_C_ASSERT_ALWAYS(my::numdofpernode_ == 2, "Invalid number of degrees of freedom per node!");
+  FOUR_C_ASSERT_ALWAYS(myelch::elchparams_->equ_pot() == ElCh::equpot_divi,
+      "Invalid closing equation for electric potential!");
 
   // access material of parent element
   std::shared_ptr<const Mat::Electrode> matelectrode =
       std::dynamic_pointer_cast<const Mat::Electrode>(ele->parent_element()->material());
-  if (matelectrode == nullptr)
-    FOUR_C_THROW("Invalid electrode material for scatra-scatra interface coupling!");
+  FOUR_C_ASSERT_ALWAYS(
+      matelectrode != nullptr, "Invalid electrode material for scatra-scatra interface coupling!");
 
   // extract local nodal values on present and opposite side of scatra-scatra interface
   extract_node_values(discretization, la);
@@ -270,7 +267,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeGrowth<distype,
       {
         // equilibrium electric potential difference and its derivative w.r.t. concentration at
         // electrode surface
-        const double epd = 0.0;
+        constexpr double epd = 0.0;
         const double epdderiv = matelectrode->compute_d_open_circuit_potential_d_concentration(
             eslavephiint, faraday, frt, detF);
 
@@ -295,7 +292,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeGrowth<distype,
               get_regularization_factor(eslavegrowthint, eta, my::scatraparamsboundary_);
 
           double dj_dc_slave(0.0), dj_dc_master(0.0), dj_dpot_slave(0.0), dj_dpot_master(0.0);
-          calculate_s2_i_growth_elch_linearizations(j0, frt, epdderiv, eta, eslaveresistanceint,
+          calculate_s2i_growth_elch_linearizations(j0, frt, epdderiv, eta, eslaveresistanceint,
               regfac, emasterphiint, eslavephiint, cmax, my::scatraparamsboundary_, dj_dc_slave,
               dj_dc_master, dj_dpot_slave, dj_dpot_master);
 
@@ -367,19 +364,19 @@ int Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeGrowth<distype, probdim
   {
     case ScaTra::BoundaryAction::calc_s2icoupling_growthgrowth:
     {
-      evaluate_s2_i_coupling_growth_growth(ele, params, discretization, la, elemat1, elevec1);
+      evaluate_s2i_coupling_growth_growth(ele, params, discretization, la, elemat1, elevec1);
       break;
     }
 
     case ScaTra::BoundaryAction::calc_s2icoupling_growthscatra:
     {
-      evaluate_s2_i_coupling_growth_scatra(ele, params, discretization, la, elemat1, elemat2);
+      evaluate_s2i_coupling_growth_scatra(ele, params, discretization, la, elemat1, elemat2);
       break;
     }
 
     case ScaTra::BoundaryAction::calc_s2icoupling_scatragrowth:
     {
-      evaluate_s2_i_coupling_scatra_growth(ele, params, discretization, la, elemat1);
+      evaluate_s2i_coupling_scatra_growth(ele, params, discretization, la, elemat1);
       break;
     }
 
@@ -404,15 +401,15 @@ int Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeGrowth<distype, probdim
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
 void Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeGrowth<distype,
-    probdim>::evaluate_s2_i_coupling_scatra_growth(const Core::Elements::FaceElement* ele,
+    probdim>::evaluate_s2i_coupling_scatra_growth(const Core::Elements::FaceElement* ele,
     Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
     Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& eslavematrix)
 {
   // access material of parent element
   std::shared_ptr<const Mat::Electrode> matelectrode =
       std::dynamic_pointer_cast<const Mat::Electrode>(ele->parent_element()->material());
-  if (matelectrode == nullptr)
-    FOUR_C_THROW("Invalid electrode material for scatra-scatra interface coupling!");
+  FOUR_C_ASSERT_ALWAYS(
+      matelectrode != nullptr, "Invalid electrode material for scatra-scatra interface coupling!");
 
   // extract local nodal values on present and opposite side of scatra-scatra interface
   extract_node_values(discretization, la);
@@ -423,9 +420,9 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeGrowth<distype,
   // extract condition type
   const Core::Conditions::ConditionType& s2iconditiontype =
       my::scatraparamsboundary_->condition_type();
-  if (s2iconditiontype != Core::Conditions::S2IKinetics and
-      s2iconditiontype != Core::Conditions::S2IKineticsGrowth)
-    FOUR_C_THROW("Received illegal condition type!");
+  FOUR_C_ASSERT_ALWAYS(s2iconditiontype == Core::Conditions::S2IKinetics or
+                           s2iconditiontype == Core::Conditions::S2IKineticsGrowth,
+      "Received illegal condition type!");
 
   // access input parameters associated with condition
   const int kineticmodel = my::scatraparamsboundary_->kinetic_model();
@@ -496,15 +493,15 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeGrowth<distype,
           // factor and derivative of regularization factor
           const double eta = eslavepotint - emasterpotint - epd - j * faraday * eslaveresistanceint;
           // no regfac required in this case
-          const double regfac_dummy = 1.0;
+          constexpr double regfac_dummy = 1.0;
 
           // exponential Butler-Volmer terms
           const double expterm1 = std::exp(alphaa * frt * eta);
           const double expterm2 = std::exp(-alphac * frt * eta);
 
-          const double dj_dgrowth = calculate_s2_i_elch_growth_linearizations(j0, j, frt,
-              eslaveresistanceint, resistivity, regfac_dummy, regfac_dummy, expterm1, expterm2,
-              my::scatraparamsboundary_);
+          const double dj_dgrowth =
+              calculate_s2i_elch_growth_linearizations(j0, j, frt, eslaveresistanceint, resistivity,
+                  regfac_dummy, regfac_dummy, expterm1, expterm2, my::scatraparamsboundary_);
 
           // compute linearizations
           for (int irow = 0; irow < nen_; ++irow)
@@ -527,7 +524,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeGrowth<distype,
       case Core::Conditions::S2IKineticsGrowth:
       {
         // equilibrium electric potential difference at electrode surface
-        const double epd = 0.0;
+        constexpr double epd = 0.0;
 
         // compute exchange mass flux density
         const double j0 = calculate_growth_exchange_mass_flux_density(
@@ -556,8 +553,8 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeGrowth<distype,
           const double expterm2 = std::exp(-alphac * frt * eta);
 
           const double dj_dgrowth =
-              calculate_s2_i_elch_growth_linearizations(j0, j, frt, eslaveresistanceint,
-                  resistivity, regfac, regfacderiv, expterm1, expterm2, my::scatraparamsboundary_);
+              calculate_s2i_elch_growth_linearizations(j0, j, frt, eslaveresistanceint, resistivity,
+                  regfac, regfacderiv, expterm1, expterm2, my::scatraparamsboundary_);
 
           // compute linearizations
           for (int irow = 0; irow < nen_; ++irow)
@@ -587,7 +584,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeGrowth<distype,
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
 void Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeGrowth<distype,
-    probdim>::evaluate_s2_i_coupling_growth_scatra(const Core::Elements::FaceElement* ele,
+    probdim>::evaluate_s2i_coupling_growth_scatra(const Core::Elements::FaceElement* ele,
     Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
     Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& eslavematrix,
     Core::LinAlg::SerialDenseMatrix& emastermatrix)
@@ -595,8 +592,8 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeGrowth<distype,
   // access material of parent element
   std::shared_ptr<const Mat::Electrode> matelectrode =
       std::dynamic_pointer_cast<const Mat::Electrode>(ele->parent_element()->material());
-  if (matelectrode == nullptr)
-    FOUR_C_THROW("Invalid electrode material for scatra-scatra interface coupling!");
+  FOUR_C_ASSERT_ALWAYS(
+      matelectrode != nullptr, "Invalid electrode material for scatra-scatra interface coupling!");
 
   // extract local nodal values on present and opposite side of scatra-scatra interface
   extract_node_values(discretization, la);
@@ -604,21 +601,17 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeGrowth<distype,
       my::numdofpernode_, Core::LinAlg::Matrix<nen_, 1>(Core::LinAlg::Initialization::zero));
   my::extract_node_values(emasterphinp, discretization, la, "imasterphinp");
 
-  if (my::scatraparamsboundary_->condition_type() != Core::Conditions::S2IKineticsGrowth)
-    FOUR_C_THROW("Received illegal condition type!");
-
+  FOUR_C_ASSERT_ALWAYS(
+      my::scatraparamsboundary_->condition_type() == Core::Conditions::S2IKineticsGrowth,
+      "Received illegal condition type!");
   // access input parameters associated with condition
   const int kineticmodel = my::scatraparamsboundary_->kinetic_model();
-  if (kineticmodel != S2I::growth_kinetics_butlervolmer)
-  {
-    FOUR_C_THROW(
-        "Received illegal kinetic model for scatra-scatra interface coupling involving interface "
-        "layer growth!");
-  }
+  FOUR_C_ASSERT_ALWAYS(kineticmodel == S2I::growth_kinetics_butlervolmer,
+      "Received illegal kinetic model for scatra-scatra interface coupling involving interface "
+      "layer growth!");
   const double faraday = myelch::elchparams_->faraday();
   const double alphaa = my::scatraparamsboundary_->alphadata();
   const double kr = my::scatraparamsboundary_->charge_transfer_constant();
-  if (kr < 0.0) FOUR_C_THROW("Charge transfer constant k_r is negative!");
   const double resistivity = my::scatraparamsboundary_->resistivity();
   const double factor =
       my::scatraparamsboundary_->molar_mass() / (my::scatraparamsboundary_->density());
@@ -670,7 +663,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeGrowth<distype,
           get_regularization_factor(eslavegrowthint, eta, my::scatraparamsboundary_);
 
       double dummy(0.0), dj_dc_master(0.0), dj_dpot_slave(0.0), dj_dpot_master(0.0);
-      calculate_s2_i_growth_elch_linearizations(j0, frt, dummy, eta, eslaveresistanceint, regfac,
+      calculate_s2i_growth_elch_linearizations(j0, frt, dummy, eta, eslaveresistanceint, regfac,
           emasterphiint, dummy, dummy, my::scatraparamsboundary_, dummy, dj_dc_master,
           dj_dpot_slave, dj_dpot_master);
 
@@ -700,7 +693,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeGrowth<distype,
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
 void Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeGrowth<distype,
-    probdim>::evaluate_s2_i_coupling_growth_growth(const Core::Elements::FaceElement* ele,
+    probdim>::evaluate_s2i_coupling_growth_growth(const Core::Elements::FaceElement* ele,
     Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
     Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& eslavematrix,
     Core::LinAlg::SerialDenseVector& eslaveresidual)
@@ -708,8 +701,8 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeGrowth<distype,
   // access material of parent element
   std::shared_ptr<const Mat::Electrode> matelectrode =
       std::dynamic_pointer_cast<const Mat::Electrode>(ele->parent_element()->material());
-  if (matelectrode == nullptr)
-    FOUR_C_THROW("Invalid electrode material for scatra-scatra interface coupling!");
+  FOUR_C_ASSERT_ALWAYS(
+      matelectrode != nullptr, "Invalid electrode material for scatra-scatra interface coupling!");
 
   // extract local nodal values on present and opposite side of scatra-scatra interface
   extract_node_values(discretization, la);
@@ -720,17 +713,15 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeGrowth<distype,
   my::extract_node_values(
       eslavegrowthhist, discretization, la, "growthhist", my::scatraparams_->nds_growth());
 
-  if (my::scatraparamsboundary_->condition_type() != Core::Conditions::S2IKineticsGrowth)
-    FOUR_C_THROW("Received illegal condition type!");
+  FOUR_C_ASSERT_ALWAYS(
+      my::scatraparamsboundary_->condition_type() == Core::Conditions::S2IKineticsGrowth,
+      "Received illegal condition type!");
 
   // access input parameters associated with condition
   const int kineticmodel = my::scatraparamsboundary_->kinetic_model();
-  if (kineticmodel != S2I::growth_kinetics_butlervolmer)
-  {
-    FOUR_C_THROW(
-        "Received illegal kinetic model for scatra-scatra interface coupling involving interface "
-        "layer growth!");
-  }
+  FOUR_C_ASSERT_ALWAYS(kineticmodel == S2I::growth_kinetics_butlervolmer,
+      "Received illegal kinetic model for scatra-scatra interface coupling involving interface "
+      "layer growth!");
   const double faraday = myelch::elchparams_->faraday();
   const double alphaa = my::scatraparamsboundary_->alphadata();
   const double alphac = my::scatraparamsboundary_->alpha_c();
@@ -801,7 +792,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeGrowth<distype,
       const double expterm2 = std::exp(-alphac * frt * eta);
 
       const double dj_dgrowth =
-          calculate_s2_i_elch_growth_linearizations(j0, j, frt, eslaveresistanceint, resistivity,
+          calculate_s2i_elch_growth_linearizations(j0, j, frt, eslaveresistanceint, resistivity,
               regfac, regfacderiv, expterm1, expterm2, my::scatraparamsboundary_);
 
       // compute linearizations and residual contributions associated with equation for

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode_growth.hpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode_growth.hpp
@@ -33,26 +33,20 @@ namespace Discret
      public:
       //! singleton access method
       static ScaTraEleBoundaryCalcElchElectrodeGrowth<distype, probdim>* instance(
-          const int numdofpernode, const int numscal, const std::string& disname);
+          int numdofpernode, int numscal, const std::string& disname);
 
 
      private:
       //! private constructor for singletons
       ScaTraEleBoundaryCalcElchElectrodeGrowth(
-          const int numdofpernode, const int numscal, const std::string& disname);
+          int numdofpernode, int numscal, const std::string& disname);
 
-      //! evaluate action
-      int evaluate_action(Core::Elements::FaceElement* ele,  //!< boundary element
-          Teuchos::ParameterList& params,                    //!< parameter list
-          Core::FE::Discretization& discretization,          //!< discretization
-          ScaTra::BoundaryAction action,                     //!< action
-          Core::Elements::LocationArray& la,                 //!< location array
-          Core::LinAlg::SerialDenseMatrix& elemat1,          //!< element matrix 1
-          Core::LinAlg::SerialDenseMatrix& elemat2,          //!< element matrix 2
-          Core::LinAlg::SerialDenseVector& elevec1,          //!< element right-hand side vector 1
-          Core::LinAlg::SerialDenseVector& elevec2,          //!< element right-hand side vector 2
-          Core::LinAlg::SerialDenseVector& elevec3           //!< element right-hand side vector 3
-          ) override;
+      int evaluate_action(Core::Elements::FaceElement* ele, Teuchos::ParameterList& params,
+          Core::FE::Discretization& discretization, ScaTra::BoundaryAction action,
+          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3) override;
 
       //! evaluate minimum and maximum interfacial overpotential associated with scatra-scatra
       //! interface layer growth
@@ -63,18 +57,7 @@ namespace Discret
           Core::Elements::LocationArray& la          //!< location array
       );
 
-      /*!
-       * \brief evaluate scatra-scatra interface coupling condition
-       *
-       * @param[in] ele              current boundary element
-       * @param[in] params           parameter list
-       * @param[in] discretization   discretization
-       * @param[in] la               location array
-       * @param[out] eslavematrix    element matrix for slave side
-       * @param[out] emastermatrix   element matrix for master side
-       * @param[out] eslaveresidual  element residual for slave side
-       */
-      void evaluate_s2_i_coupling(const Core::Elements::FaceElement* ele,
+      void evaluate_s2i_coupling(const Core::Elements::FaceElement* ele,
           Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
           Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& eslavematrix,
           Core::LinAlg::SerialDenseMatrix& emastermatrix,
@@ -82,7 +65,7 @@ namespace Discret
 
       //! evaluate global growth-growth matrix block for scatra-scatra interface coupling involving
       //! interface layer growth
-      void evaluate_s2_i_coupling_growth_growth(
+      void evaluate_s2i_coupling_growth_growth(
           const Core::Elements::FaceElement* ele,          ///< current boundary element
           Teuchos::ParameterList& params,                  ///< parameter list
           Core::FE::Discretization& discretization,        ///< discretization
@@ -93,7 +76,7 @@ namespace Discret
 
       //! evaluate global growth-scatra matrix block for scatra-scatra interface coupling involving
       //! interface layer growth
-      void evaluate_s2_i_coupling_growth_scatra(
+      void evaluate_s2i_coupling_growth_scatra(
           const Core::Elements::FaceElement* ele,         ///< current boundary element
           Teuchos::ParameterList& params,                 ///< parameter list
           Core::FE::Discretization& discretization,       ///< discretization
@@ -104,7 +87,7 @@ namespace Discret
 
       //! evaluate global scatra-growth matrix block for scatra-scatra interface coupling involving
       //! interface layer growth
-      void evaluate_s2_i_coupling_scatra_growth(
+      void evaluate_s2i_coupling_scatra_growth(
           const Core::Elements::FaceElement* ele,        ///< current boundary element
           Teuchos::ParameterList& params,                ///< parameter list
           Core::FE::Discretization& discretization,      ///< discretization
@@ -112,10 +95,8 @@ namespace Discret
           Core::LinAlg::SerialDenseMatrix& eslavematrix  ///< element matrix for slave side
       );
 
-      //! extract nodal state variables associated with boundary element
-      void extract_node_values(const Core::FE::Discretization& discretization,  //!< discretization
-          Core::Elements::LocationArray& la                                     //!< location array
-          ) override;
+      void extract_node_values(const Core::FE::Discretization& discretization,
+          Core::Elements::LocationArray& la) override;
 
       /*!
        * @brief Fill the rhs vector and the linearization matrix

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode_growth_utils.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode_growth_utils.cpp
@@ -38,7 +38,7 @@ double Discret::Elements::calculate_growth_exchange_mass_flux_density(const doub
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void Discret::Elements::calculate_s2_i_growth_elch_linearizations(const double j0, const double frt,
+void Discret::Elements::calculate_s2i_growth_elch_linearizations(const double j0, const double frt,
     const double epdderiv, const double eta, const double resistance, const double regfac,
     const double emasterphiint, const double eslavephiint, const double cmax,
     const Discret::Elements::ScaTraEleParameterBoundary* const scatraeleparamsboundary,
@@ -124,7 +124,7 @@ void Discret::Elements::calculate_s2_i_growth_elch_linearizations(const double j
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-double Discret::Elements::calculate_s2_i_elch_growth_linearizations(const double j0, const double j,
+double Discret::Elements::calculate_s2i_elch_growth_linearizations(const double j0, const double j,
     const double frt, const double resistivity, const double resistance, const double regfac,
     const double regfacderiv, const double expterm1, const double expterm2,
     const Discret::Elements::ScaTraEleParameterBoundary* const scatraeleparamsboundary)
@@ -232,11 +232,10 @@ double Discret::Elements::calculate_growth_mass_flux_density(const double j0, co
                                   : i0 * regfac * (expterm1 - expterm2) - i;
 
       // convergence check
-      if (std::abs(residual) < scatraparameterstd->int_layer_growth_conv_tol())
-        break;
-      else if (iternum == scatraparameterstd->int_layer_growth_ite_max())
-        FOUR_C_THROW(
-            "Local Newton-Raphson iteration for Butler-Volmer current density did not converge!");
+      if (std::abs(residual) < scatraparameterstd->int_layer_growth_conv_tol()) break;
+
+      FOUR_C_ASSERT_ALWAYS(iternum < scatraparameterstd->int_layer_growth_ite_max(),
+          "Local Newton-Raphson iteration for Butler-Volmer current density did not converge!");
 
       // compute linearization of current Newton-Raphson residual w.r.t. Butler-Volmer current
       // density
@@ -279,8 +278,6 @@ double Discret::Elements::get_regularization_factor(const double thickness, cons
   {
     // get the S2I coupling growth regularization parameter
     const double regularizationparameter = scatraeleparamsboundary->regularization_parameter();
-    if (regularizationparameter < 0.0)
-      FOUR_C_THROW("Regularization parameter for lithium stripping must not be negative!");
 
     // evaluate dependent on the regularization type
     switch (regularizationtype)
@@ -312,9 +309,11 @@ double Discret::Elements::get_regularization_factor(const double thickness, cons
         if (thickness <= 0.0)
           regfac = 0.0;
         else if (thickness < thickness_regend)
+        {
           regfac =
               0.5 * std::cos(thickness / thickness_regend * std::numbers::pi - std::numbers::pi) +
               0.5;
+        }
 
         break;
       }

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode_growth_utils.hpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode_growth_utils.hpp
@@ -11,7 +11,6 @@
 #include "4C_config.hpp"
 
 #include "4C_fem_condition.hpp"
-#include "4C_scatra_ele_boundary_calc_elch_electrode_utils.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -85,7 +84,7 @@ namespace Discret::Elements
    * @param[out] dj_dpot_master  linearization of Butler-Volmer mass flux density w.r.t.
    *                             electric potential on master-side
    */
-  void calculate_s2_i_growth_elch_linearizations(double j0, double frt, double epdderiv, double eta,
+  void calculate_s2i_growth_elch_linearizations(double j0, double frt, double epdderiv, double eta,
       double resistance, double regfac, double emasterphiint, double eslavephiint, double cmax,
       const Discret::Elements::ScaTraEleParameterBoundary* const scatraeleparamsboundary,
       double& dj_dc_slave, double& dj_dc_master, double& dj_dpot_slave, double& dj_dpot_master);
@@ -107,7 +106,7 @@ namespace Discret::Elements
    * @param[in] scatraeleparamsboundary   scatra ele boundary parameter class
    * @return  linearization of Butler-Volmer mass flux density w.r.t. interface film thickness
    */
-  double calculate_s2_i_elch_growth_linearizations(double j0, double j, double frt,
+  double calculate_s2i_elch_growth_linearizations(double j0, double j, double frt,
       double resistivity, double resistance, double regfac, double regfacderiv, double expterm1,
       double expterm2,
       const Discret::Elements::ScaTraEleParameterBoundary* const scatraeleparamsboundary);
@@ -120,7 +119,7 @@ namespace Discret::Elements
    * @param[in] scatraeleparamsboundary   scatra ele boundary parameter class
    * @return  return the regularization factor if regularization is applied
    */
-  double get_regularization_factor(const double thickness, const double eta,
+  double get_regularization_factor(double thickness, double eta,
       const Discret::Elements::ScaTraEleParameterBoundary* const scatraeleparamsboundary);
 
 
@@ -134,7 +133,7 @@ namespace Discret::Elements
    * @return  return the derivative of the regularization factor w.r.t. thickness of deposited
    *          material if regularization is applied
    */
-  double get_regularization_factor_derivative(const double thickness, const double eta,
+  double get_regularization_factor_derivative(double thickness, double eta,
       const Discret::Elements::ScaTraEleParameterBoundary* const scatraeleparamsboundary);
 
 }  // namespace Discret::Elements

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode_sti_thermo.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode_sti_thermo.cpp
@@ -53,21 +53,21 @@ Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeSTIThermo<distype,
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
 void Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeSTIThermo<distype,
-    probdim>::evaluate_s2_i_coupling_od(const Core::Elements::FaceElement* ele,
+    probdim>::evaluate_s2i_coupling_od(const Core::Elements::FaceElement* ele,
     Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
     Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& eslavematrix)
 {
   // safety checks
-  if (my::numscal_ != 1) FOUR_C_THROW("Invalid number of transported scalars!");
-  if (my::numdofpernode_ != 2) FOUR_C_THROW("Invalid number of degrees of freedom per node!");
-  if (myelch::elchparams_->equ_pot() != ElCh::equpot_divi)
-    FOUR_C_THROW("Invalid closing equation for electric potential!");
+  FOUR_C_ASSERT_ALWAYS(my::numscal_ == 1, "Invalid number of transported scalars!");
+  FOUR_C_ASSERT_ALWAYS(my::numdofpernode_ == 2, "Invalid number of degrees of freedom per node!");
+  FOUR_C_ASSERT_ALWAYS(myelch::elchparams_->equ_pot() == ElCh::equpot_divi,
+      "Invalid closing equation for electric potential!");
 
   // access material of parent element
   std::shared_ptr<const Mat::Electrode> matelectrode =
       std::dynamic_pointer_cast<const Mat::Electrode>(ele->parent_element()->material());
-  if (matelectrode == nullptr)
-    FOUR_C_THROW("Invalid electrode material for scatra-scatra interface coupling!");
+  FOUR_C_ASSERT_ALWAYS(
+      matelectrode != nullptr, "Invalid electrode material for scatra-scatra interface coupling!");
 
   const int kineticmodel = my::scatraparamsboundary_->kinetic_model();
   const auto differentiationtype =
@@ -124,25 +124,25 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeSTIThermo<distype,
 
     // evaluate overall integration factor
     const double timefacfac = my::scatraparamstimint_->time_fac() * fac;
-    if (timefacfac < 0.0) FOUR_C_THROW("Integration factor is negative!");
+    FOUR_C_ASSERT_ALWAYS(timefacfac > 0.0, "Integration factor is not positive negative!");
 
     const double timefacwgt = my::scatraparamstimint_->time_fac() * intpoints.ip().qwgt[gpid];
-    if (timefacwgt < 0.0) FOUR_C_THROW("Integration factor is negative!");
+    FOUR_C_ASSERT_ALWAYS(timefacwgt > 0.0, "Integration factor is not positive negative!");
 
-    evaluate_s2_i_coupling_od_at_integration_point<distype>(*matelectrode, my::ephinp_, etempnp_,
+    evaluate_s2i_coupling_od_at_integration_point<distype>(*matelectrode, my::ephinp_, etempnp_,
         emastertempnp, emasterphinp, pseudo_contact_fac, my::funct_, my::funct_, my::funct_,
         my::funct_, dsqrtdetg_dd, my::derxy_, my::scatraparamsboundary_, differentiationtype,
         timefacfac, timefacwgt, detF, my::numdofpernode_, eslavematrix, dummymatrix);
   }  // loop over integration points
 }  // Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeSTIThermo<distype,
-   // probdim>::evaluate_s2_i_coupling_od
+   // probdim>::evaluate_s2i_coupling_od
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
 template <Core::FE::CellType distype_master>
 void Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeSTIThermo<distype,
-    probdim>::evaluate_s2_i_coupling_od_at_integration_point(const Mat::Electrode& matelectrode,
+    probdim>::evaluate_s2i_coupling_od_at_integration_point(const Mat::Electrode& matelectrode,
     const std::vector<Core::LinAlg::Matrix<nen_, 1>>& eslavephinp,
     const Core::LinAlg::Matrix<nen_, 1>& eslavetempnp,
     const Core::LinAlg::Matrix<Core::FE::num_nodes(distype_master), 1>& emastertempnp,
@@ -379,7 +379,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeSTIThermo<distype,
     }
   }  // select kinetic model
 }  // Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeSTIThermo<distype,
-   // probdim>::evaluate_s2_i_coupling_od_at_integration_point
+   // probdim>::evaluate_s2i_coupling_od_at_integration_point
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
@@ -396,7 +396,7 @@ int Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeSTIThermo<distype,
   {
     case ScaTra::BoundaryAction::calc_s2icoupling_od:
     {
-      evaluate_s2_i_coupling_od(ele, params, discretization, la, elemat1);
+      evaluate_s2i_coupling_od(ele, params, discretization, la, elemat1);
       break;
     }
 
@@ -435,7 +435,7 @@ double Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeSTIThermo<distype, p
   const double temperature = my::funct_.dot(etempnp_);
 
   // safety check
-  if (temperature <= 0.) FOUR_C_THROW("Temperature is non-positive!");
+  FOUR_C_ASSERT_ALWAYS(temperature > 0.0, "Temperature must be positive!");
 
   const double faraday = myelch::elchparams_->faraday();
   const double gasconstant = myelch::elchparams_->gas_constant();
@@ -470,7 +470,7 @@ template class Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeSTIThermo<
 // explicit instantiation of template methods
 template void
 Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeSTIThermo<Core::FE::CellType::quad4>::
-    evaluate_s2_i_coupling_od_at_integration_point<Core::FE::CellType::quad4>(const Mat::Electrode&,
+    evaluate_s2i_coupling_od_at_integration_point<Core::FE::CellType::quad4>(const Mat::Electrode&,
         const std::vector<Core::LinAlg::Matrix<nen_, 1>>&, const Core::LinAlg::Matrix<nen_, 1>&,
         const Core::LinAlg::Matrix<Core::FE::num_nodes(Core::FE::CellType::quad4), 1>&,
         const std::vector<Core::LinAlg::Matrix<Core::FE::num_nodes(Core::FE::CellType::quad4), 1>>&,
@@ -484,7 +484,7 @@ Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeSTIThermo<Core::FE::CellTyp
         Core::LinAlg::SerialDenseMatrix&, Core::LinAlg::SerialDenseMatrix&);
 template void
 Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeSTIThermo<Core::FE::CellType::quad4>::
-    evaluate_s2_i_coupling_od_at_integration_point<Core::FE::CellType::tri3>(const Mat::Electrode&,
+    evaluate_s2i_coupling_od_at_integration_point<Core::FE::CellType::tri3>(const Mat::Electrode&,
         const std::vector<Core::LinAlg::Matrix<nen_, 1>>&, const Core::LinAlg::Matrix<nen_, 1>&,
         const Core::LinAlg::Matrix<Core::FE::num_nodes(Core::FE::CellType::tri3), 1>&,
         const std::vector<Core::LinAlg::Matrix<Core::FE::num_nodes(Core::FE::CellType::tri3), 1>>&,
@@ -498,7 +498,7 @@ Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeSTIThermo<Core::FE::CellTyp
         Core::LinAlg::SerialDenseMatrix&, Core::LinAlg::SerialDenseMatrix&);
 template void
 Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeSTIThermo<Core::FE::CellType::tri3>::
-    evaluate_s2_i_coupling_od_at_integration_point<Core::FE::CellType::quad4>(const Mat::Electrode&,
+    evaluate_s2i_coupling_od_at_integration_point<Core::FE::CellType::quad4>(const Mat::Electrode&,
         const std::vector<Core::LinAlg::Matrix<nen_, 1>>&, const Core::LinAlg::Matrix<nen_, 1>&,
         const Core::LinAlg::Matrix<Core::FE::num_nodes(Core::FE::CellType::quad4), 1>&,
         const std::vector<Core::LinAlg::Matrix<Core::FE::num_nodes(Core::FE::CellType::quad4), 1>>&,
@@ -512,7 +512,7 @@ Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeSTIThermo<Core::FE::CellTyp
         Core::LinAlg::SerialDenseMatrix&, Core::LinAlg::SerialDenseMatrix&);
 template void
 Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeSTIThermo<Core::FE::CellType::tri3>::
-    evaluate_s2_i_coupling_od_at_integration_point<Core::FE::CellType::tri3>(const Mat::Electrode&,
+    evaluate_s2i_coupling_od_at_integration_point<Core::FE::CellType::tri3>(const Mat::Electrode&,
         const std::vector<Core::LinAlg::Matrix<nen_, 1>>&, const Core::LinAlg::Matrix<nen_, 1>&,
         const Core::LinAlg::Matrix<Core::FE::num_nodes(Core::FE::CellType::tri3), 1>&,
         const std::vector<Core::LinAlg::Matrix<Core::FE::num_nodes(Core::FE::CellType::tri3), 1>>&,

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode_sti_thermo.hpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode_sti_thermo.hpp
@@ -39,7 +39,7 @@ namespace Discret
      public:
       //! singleton access method
       static ScaTraEleBoundaryCalcElchElectrodeSTIThermo<distype, probdim>* instance(
-          const int numdofpernode, const int numscal, const std::string& disname);
+          int numdofpernode, int numscal, const std::string& disname);
 
 
       /*!
@@ -76,7 +76,7 @@ namespace Discret
        * \tparam distype_master  This method is templated on the master-side discretization type.
        */
       template <Core::FE::CellType distype_master>
-      static void evaluate_s2_i_coupling_od_at_integration_point(const Mat::Electrode& matelectrode,
+      static void evaluate_s2i_coupling_od_at_integration_point(const Mat::Electrode& matelectrode,
           const std::vector<Core::LinAlg::Matrix<nen_, 1>>& eslavephinp,
           const Core::LinAlg::Matrix<nen_, 1>& eslavetempnp,
           const Core::LinAlg::Matrix<Core::FE::num_nodes(distype_master), 1>& emastertempnp,
@@ -96,37 +96,23 @@ namespace Discret
      private:
       //! private constructor for singletons
       ScaTraEleBoundaryCalcElchElectrodeSTIThermo(
-          const int numdofpernode, const int numscal, const std::string& disname);
+          int numdofpernode, int numscal, const std::string& disname);
 
-      //! evaluate off-diagonal system matrix contributions associated with scatra-scatra interface
-      //! coupling condition
-      void evaluate_s2_i_coupling_od(
-          const Core::Elements::FaceElement* ele,        ///< current boundary element
-          Teuchos::ParameterList& params,                ///< parameter list
-          Core::FE::Discretization& discretization,      ///< discretization
-          Core::Elements::LocationArray& la,             ///< location array
-          Core::LinAlg::SerialDenseMatrix& eslavematrix  ///< element matrix for slave side
-          ) override;
+      void evaluate_s2i_coupling_od(const Core::Elements::FaceElement* ele,
+          Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
+          Core::Elements::LocationArray& la,
+          Core::LinAlg::SerialDenseMatrix& eslavematrix) override;
 
-      //! evaluate action
-      int evaluate_action(Core::Elements::FaceElement* ele,  //!< boundary element
-          Teuchos::ParameterList& params,                    //!< parameter list
-          Core::FE::Discretization& discretization,          //!< discretization
-          ScaTra::BoundaryAction action,                     //!< action
-          Core::Elements::LocationArray& la,                 //!< location array
-          Core::LinAlg::SerialDenseMatrix& elemat1,          //!< element matrix 1
-          Core::LinAlg::SerialDenseMatrix& elemat2,          //!< element matrix 2
-          Core::LinAlg::SerialDenseVector& elevec1,          //!< element right-hand side vector 1
-          Core::LinAlg::SerialDenseVector& elevec2,          //!< element right-hand side vector 2
-          Core::LinAlg::SerialDenseVector& elevec3           //!< element right-hand side vector 3
-          ) override;
+      int evaluate_action(Core::Elements::FaceElement* ele, Teuchos::ParameterList& params,
+          Core::FE::Discretization& discretization, ScaTra::BoundaryAction action,
+          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3) override;
 
-      //! extract nodal state variables associated with boundary element
-      void extract_node_values(const Core::FE::Discretization& discretization,  //!< discretization
-          Core::Elements::LocationArray& la                                     //!< location array
-          ) override;
+      void extract_node_values(const Core::FE::Discretization& discretization,
+          Core::Elements::LocationArray& la) override;
 
-      //! evaluate factor F/RT
       [[nodiscard]] double get_frt() const override;
 
       //! nodal temperature variables associated with time t_{n+1} or t_{n+alpha_f}

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode_utils.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode_utils.cpp
@@ -99,7 +99,7 @@ void Discret::Elements::calculate_butler_volmer_elch_linearizations(const int ki
       const double dF_di_inverse =
           1.0 / (1.0 + j0 * faraday * resistance * frt * (alphaa * expterm1 + alphac * expterm2));
       const double dF_dc_slave = j0 * frt * epdderiv * (alphaa * expterm1 + alphac * expterm2);
-      const double dF_dc_master = 0.0;
+      constexpr double dF_dc_master = 0.0;
       const double dF_dpot_slave = -j0 * frt * (alphaa * expterm1 + alphac * expterm2);
       const double dF_dpot_master = -dF_dpot_slave;
 
@@ -235,8 +235,10 @@ double Discret::Elements::calculate_modified_butler_volmer_mass_flux_density(con
         break;
       }
       else if (iternum == itemax)
+      {
         FOUR_C_THROW(
             "Local Newton-Raphson iteration for Butler-Volmer current density did not converge!");
+      }
 
       // compute linearization of current Newton-Raphson residual w.r.t. Butler-Volmer current
       // density

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_sti_electrode.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_sti_electrode.cpp
@@ -59,7 +59,7 @@ Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<distype,
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
-void Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<distype, probdim>::evaluate_s2_i_coupling(
+void Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<distype, probdim>::evaluate_s2i_coupling(
     const Core::Elements::FaceElement* ele, Teuchos::ParameterList& params,
     Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
     Core::LinAlg::SerialDenseMatrix& eslavematrix, Core::LinAlg::SerialDenseMatrix& emastermatrix,
@@ -117,7 +117,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<distype, probdim>::eva
     const double timefacrhsfac = my::scatraparamstimint_->time_fac_rhs() * fac;
     if (timefacfac < 0. or timefacrhsfac < 0.) FOUR_C_THROW("Integration factor is negative!");
 
-    evaluate_s2_i_coupling_at_integration_point<distype>(*matelectrode, my::ephinp_[0], emastertemp,
+    evaluate_s2i_coupling_at_integration_point<distype>(*matelectrode, my::ephinp_[0], emastertemp,
         eelchnp_, emasterscatra, pseudo_contact_fac, my::funct_, my::funct_,
         my::scatraparamsboundary_, timefacfac, timefacrhsfac, detF, eslavematrix, emastermatrix,
         eslaveresidual);
@@ -129,7 +129,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<distype, probdim>::eva
 template <Core::FE::CellType distype, int probdim>
 template <Core::FE::CellType distype_master>
 void Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<distype,
-    probdim>::evaluate_s2_i_coupling_at_integration_point(const Mat::Electrode& matelectrode,
+    probdim>::evaluate_s2i_coupling_at_integration_point(const Mat::Electrode& matelectrode,
     const Core::LinAlg::Matrix<nen_, 1>& eslavetempnp,
     const Core::LinAlg::Matrix<Core::FE::num_nodes(distype_master), 1>& emastertempnp,
     const std::vector<Core::LinAlg::Matrix<nen_, 1>>& eslavephinp,
@@ -310,7 +310,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<distype,
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
 void Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<distype,
-    probdim>::evaluate_s2_i_coupling_od(const Core::Elements::FaceElement* ele,
+    probdim>::evaluate_s2i_coupling_od(const Core::Elements::FaceElement* ele,
     Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
     Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& eslavematrix,
     Core::LinAlg::SerialDenseMatrix& emastermatrix)
@@ -382,7 +382,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<distype,
       my::evaluate_spatial_derivative_of_area_integration_factor(intpoints, gpid, dsqrtdetg_dd);
     }
 
-    evaluate_s2_i_coupling_od_at_integration_point<distype>(*matelectrode, my::ephinp_[0],
+    evaluate_s2i_coupling_od_at_integration_point<distype>(*matelectrode, my::ephinp_[0],
         emastertemp, eelchnp_, emasterscatra, pseudo_contact_fac, my::funct_, my::funct_,
         my::scatraparamsboundary_, timefacfac, timefacwgt, detF, differentiationtype, dsqrtdetg_dd,
         my::derxy_, eslavematrix, emastermatrix);
@@ -394,7 +394,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<distype,
 template <Core::FE::CellType distype, int probdim>
 template <Core::FE::CellType distype_master>
 void Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<distype,
-    probdim>::evaluate_s2_i_coupling_od_at_integration_point(const Mat::Electrode& matelectrode,
+    probdim>::evaluate_s2i_coupling_od_at_integration_point(const Mat::Electrode& matelectrode,
     const Core::LinAlg::Matrix<nen_, 1>& eslavetempnp,
     const Core::LinAlg::Matrix<Core::FE::num_nodes(distype_master), 1>& emastertempnp,
     const std::vector<Core::LinAlg::Matrix<nen_, 1>>& eslavephinp,
@@ -445,7 +445,6 @@ void Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<distype,
           // access input parameters associated with current condition
           const double faraday =
               Discret::Elements::ScaTraEleParameterElch::instance("scatra")->faraday();
-          Discret::Elements::ScaTraEleParameterElch::instance("scatra")->faraday();
           const double gasconstant =
               Discret::Elements::ScaTraEleParameterElch::instance("scatra")->gas_constant();
 
@@ -721,13 +720,13 @@ int Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<distype, probdim>::eval
   {
     case ScaTra::BoundaryAction::calc_s2icoupling:
     {
-      evaluate_s2_i_coupling(ele, params, discretization, la, elemat1, elemat2, elevec1);
+      evaluate_s2i_coupling(ele, params, discretization, la, elemat1, elemat2, elevec1);
       break;
     }
 
     case ScaTra::BoundaryAction::calc_s2icoupling_od:
     {
-      evaluate_s2_i_coupling_od(ele, params, discretization, la, elemat1, elemat2);
+      evaluate_s2i_coupling_od(ele, params, discretization, la, elemat1, elemat2);
       break;
     }
 
@@ -770,7 +769,7 @@ template class Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<Core::FE::Ce
 
 // explicit instantiation of template methods
 template void Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<Core::FE::CellType::quad4>::
-    evaluate_s2_i_coupling_at_integration_point<Core::FE::CellType::quad4>(const Mat::Electrode&,
+    evaluate_s2i_coupling_at_integration_point<Core::FE::CellType::quad4>(const Mat::Electrode&,
         const Core::LinAlg::Matrix<nen_, 1>&,
         const Core::LinAlg::Matrix<Core::FE::num_nodes(Core::FE::CellType::quad4), 1>&,
         const std::vector<Core::LinAlg::Matrix<nen_, 1>>&,
@@ -781,7 +780,7 @@ template void Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<Core::FE::Cel
         const double, Core::LinAlg::SerialDenseMatrix&, Core::LinAlg::SerialDenseMatrix&,
         Core::LinAlg::SerialDenseVector&);
 template void Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<Core::FE::CellType::quad4>::
-    evaluate_s2_i_coupling_at_integration_point<Core::FE::CellType::tri3>(const Mat::Electrode&,
+    evaluate_s2i_coupling_at_integration_point<Core::FE::CellType::tri3>(const Mat::Electrode&,
         const Core::LinAlg::Matrix<nen_, 1>&,
         const Core::LinAlg::Matrix<Core::FE::num_nodes(Core::FE::CellType::tri3), 1>&,
         const std::vector<Core::LinAlg::Matrix<nen_, 1>>&,
@@ -792,7 +791,7 @@ template void Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<Core::FE::Cel
         const double, Core::LinAlg::SerialDenseMatrix&, Core::LinAlg::SerialDenseMatrix&,
         Core::LinAlg::SerialDenseVector&);
 template void Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<Core::FE::CellType::tri3>::
-    evaluate_s2_i_coupling_at_integration_point<Core::FE::CellType::quad4>(const Mat::Electrode&,
+    evaluate_s2i_coupling_at_integration_point<Core::FE::CellType::quad4>(const Mat::Electrode&,
         const Core::LinAlg::Matrix<nen_, 1>&,
         const Core::LinAlg::Matrix<Core::FE::num_nodes(Core::FE::CellType::quad4), 1>&,
         const std::vector<Core::LinAlg::Matrix<nen_, 1>>&,
@@ -803,7 +802,7 @@ template void Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<Core::FE::Cel
         const double, Core::LinAlg::SerialDenseMatrix&, Core::LinAlg::SerialDenseMatrix&,
         Core::LinAlg::SerialDenseVector&);
 template void Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<Core::FE::CellType::tri3>::
-    evaluate_s2_i_coupling_at_integration_point<Core::FE::CellType::tri3>(const Mat::Electrode&,
+    evaluate_s2i_coupling_at_integration_point<Core::FE::CellType::tri3>(const Mat::Electrode&,
         const Core::LinAlg::Matrix<nen_, 1>&,
         const Core::LinAlg::Matrix<Core::FE::num_nodes(Core::FE::CellType::tri3), 1>&,
         const std::vector<Core::LinAlg::Matrix<nen_, 1>>&,
@@ -814,7 +813,7 @@ template void Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<Core::FE::Cel
         const double, Core::LinAlg::SerialDenseMatrix&, Core::LinAlg::SerialDenseMatrix&,
         Core::LinAlg::SerialDenseVector&);
 template void Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<Core::FE::CellType::quad4>::
-    evaluate_s2_i_coupling_od_at_integration_point<Core::FE::CellType::quad4>(const Mat::Electrode&,
+    evaluate_s2i_coupling_od_at_integration_point<Core::FE::CellType::quad4>(const Mat::Electrode&,
         const Core::LinAlg::Matrix<nen_, 1>&,
         const Core::LinAlg::Matrix<Core::FE::num_nodes(Core::FE::CellType::quad4), 1>&,
         const std::vector<Core::LinAlg::Matrix<nen_, 1>>&,
@@ -826,7 +825,7 @@ template void Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<Core::FE::Cel
         const Core::LinAlg::Matrix<nsd_, nen_>&, Core::LinAlg::SerialDenseMatrix&,
         Core::LinAlg::SerialDenseMatrix&);
 template void Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<Core::FE::CellType::quad4>::
-    evaluate_s2_i_coupling_od_at_integration_point<Core::FE::CellType::tri3>(const Mat::Electrode&,
+    evaluate_s2i_coupling_od_at_integration_point<Core::FE::CellType::tri3>(const Mat::Electrode&,
         const Core::LinAlg::Matrix<nen_, 1>&,
         const Core::LinAlg::Matrix<Core::FE::num_nodes(Core::FE::CellType::tri3), 1>&,
         const std::vector<Core::LinAlg::Matrix<nen_, 1>>&,
@@ -838,7 +837,7 @@ template void Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<Core::FE::Cel
         const Core::LinAlg::Matrix<nsd_, nen_>&, Core::LinAlg::SerialDenseMatrix&,
         Core::LinAlg::SerialDenseMatrix&);
 template void Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<Core::FE::CellType::tri3>::
-    evaluate_s2_i_coupling_od_at_integration_point<Core::FE::CellType::quad4>(const Mat::Electrode&,
+    evaluate_s2i_coupling_od_at_integration_point<Core::FE::CellType::quad4>(const Mat::Electrode&,
         const Core::LinAlg::Matrix<nen_, 1>&,
         const Core::LinAlg::Matrix<Core::FE::num_nodes(Core::FE::CellType::quad4), 1>&,
         const std::vector<Core::LinAlg::Matrix<nen_, 1>>&,
@@ -850,7 +849,7 @@ template void Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<Core::FE::Cel
         const Core::LinAlg::Matrix<nsd_, nen_>&, Core::LinAlg::SerialDenseMatrix&,
         Core::LinAlg::SerialDenseMatrix&);
 template void Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<Core::FE::CellType::tri3>::
-    evaluate_s2_i_coupling_od_at_integration_point<Core::FE::CellType::tri3>(const Mat::Electrode&,
+    evaluate_s2i_coupling_od_at_integration_point<Core::FE::CellType::tri3>(const Mat::Electrode&,
         const Core::LinAlg::Matrix<nen_, 1>&,
         const Core::LinAlg::Matrix<Core::FE::num_nodes(Core::FE::CellType::tri3), 1>&,
         const std::vector<Core::LinAlg::Matrix<nen_, 1>>&,

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_sti_electrode.hpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_sti_electrode.hpp
@@ -44,7 +44,7 @@ namespace Discret
      public:
       //! singleton access method
       static ScaTraEleBoundaryCalcSTIElectrode<distype, probdim>* instance(
-          const int numdofpernode, const int numscal, const std::string& disname);
+          int numdofpernode, int numscal, const std::string& disname);
 
       /*!
        * \brief evaluate scatra-scatra interface coupling condition at integration point
@@ -74,7 +74,7 @@ namespace Discret
        * \tparam distype_master  This method is templated on the master-side discretization type.
        */
       template <Core::FE::CellType distype_master>
-      static void evaluate_s2_i_coupling_at_integration_point(const Mat::Electrode& matelectrode,
+      static void evaluate_s2i_coupling_at_integration_point(const Mat::Electrode& matelectrode,
           const Core::LinAlg::Matrix<nen_, 1>& eslavetempnp,
           const Core::LinAlg::Matrix<Core::FE::num_nodes(distype_master), 1>& emastertempnp,
           const std::vector<Core::LinAlg::Matrix<nen_, 1>>& eslavephinp,
@@ -112,7 +112,7 @@ namespace Discret
        * @param[out] k_sm         linearizations of slave-side residuals w.r.t. master-side dofs
        */
       template <Core::FE::CellType distype_master>
-      static void evaluate_s2_i_coupling_od_at_integration_point(const Mat::Electrode& matelectrode,
+      static void evaluate_s2i_coupling_od_at_integration_point(const Mat::Electrode& matelectrode,
           const Core::LinAlg::Matrix<nen_, 1>& eslavetempnp,
           const Core::LinAlg::Matrix<Core::FE::num_nodes(distype_master), 1>& emastertempnp,
           const std::vector<Core::LinAlg::Matrix<nen_, 1>>& eslavephinp,
@@ -129,12 +129,11 @@ namespace Discret
 
      private:
       //! private constructor for singletons
-      ScaTraEleBoundaryCalcSTIElectrode(
-          const int numdofpernode, const int numscal, const std::string& disname);
+      ScaTraEleBoundaryCalcSTIElectrode(int numdofpernode, int numscal, const std::string& disname);
 
       //! evaluate main-diagonal system matrix contributions associated with scatra-scatra interface
       //! coupling condition
-      void evaluate_s2_i_coupling(
+      void evaluate_s2i_coupling(
           const Core::Elements::FaceElement* ele,          ///< current boundary element
           Teuchos::ParameterList& params,                  ///< parameter list
           Core::FE::Discretization& discretization,        ///< discretization
@@ -146,7 +145,7 @@ namespace Discret
 
       //! evaluate off-diagonal system matrix contributions associated with scatra-scatra interface
       //! coupling condition
-      void evaluate_s2_i_coupling_od(
+      void evaluate_s2i_coupling_od(
           const Core::Elements::FaceElement* ele,         ///< current boundary element
           Teuchos::ParameterList& params,                 ///< parameter list
           Core::FE::Discretization& discretization,       ///< discretization

--- a/src/scatra_ele/4C_scatra_ele_parameter_elch.hpp
+++ b/src/scatra_ele/4C_scatra_ele_parameter_elch.hpp
@@ -30,33 +30,33 @@ namespace Discret
 
       //! return flag for coupling of lithium-ion flux density and electric current density at
       //! Dirichlet and Neumann boundaries
-      bool boundary_flux_coupling() const { return boundaryfluxcoupling_; };
+      [[nodiscard]] bool boundary_flux_coupling() const { return boundaryfluxcoupling_; }
 
       //! set parameters
       void set_parameters(Teuchos::ParameterList& parameters  //!< parameter list
           ) override;
 
       //! return type of closing equation for electric potential
-      ElCh::EquPot equ_pot() const { return equpot_; };
+      [[nodiscard]] ElCh::EquPot equ_pot() const { return equpot_; }
 
       //! return Faraday constant
-      double faraday() const { return faraday_; };
+      [[nodiscard]] double faraday() const { return faraday_; }
 
       //! return the (universal) gas constant
-      double gas_constant() const { return gas_constant_; };
+      [[nodiscard]] double gas_constant() const { return gas_constant_; }
 
       //! return dielectric constant
-      double epsilon() const { return epsilon_; };
+      [[nodiscard]] double epsilon() const { return epsilon_; }
 
       //! return constant F/RT
-      double frt() const { return frt_; };
+      [[nodiscard]] double frt() const { return frt_; }
 
       //! return the homogeneous temperature in the scatra field (can be time dependent)
-      double temperature() const { return temperature_; }
+      [[nodiscard]] double temperature() const { return temperature_; }
 
      private:
       //! private constructor for singletons
-      ScaTraEleParameterElch(const std::string& disname  //!< name of discretization
+      explicit ScaTraEleParameterElch(const std::string& disname  //!< name of discretization
       );
 
       //! flag for coupling of lithium-ion flux density and electric current density at Dirichlet


### PR DESCRIPTION
## Description and Context
I need to implement some additional mechanics dependence for the scatra-scatra interface (s2i) kinetics and decided to kick this off with a little clean-up.

It mainly consists of:
- renaming s2_i to s2i (renaming mistake from global renaming to consistent naming)
- renaming *_rh_sand_* to *_rhs_and_* (renaming mistake from global renaming to consistent naming)
- add consts, nodiscard where reasonable
- remove unnecessary doc (in cpp, due to override)


## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
