### PR TITLE
Rename master/slave to target/source in poro, structure, and TSI modules

### DIFF
--- a/src/constraint/4C_constraint_element3.hpp
+++ b/src/constraint/4C_constraint_element3.hpp
@@ -297,19 +297,19 @@ namespace Discret
           const Core::LinAlg::Matrix<3, 1>& elenormal  ///< element normal
       );
 
-      /// Compute difference of nodal displacement to masternode in given direction
+      /// Compute difference of nodal displacement to anchor node in given direction
       double compute_weighted_distance(
-          const std::vector<double> disp,   ///< displacement vector of current node and masternode
+          const std::vector<double> disp,   ///< displacement vector of current node and anchor node
           const std::vector<double> direct  ///< direction to weight with
       );
 
-      /// Compute first derivatives nodal displacement to masternode in given direction
+      /// Compute first derivatives nodal displacement to anchor node in given direction
       void compute_first_deriv_weighted_distance(
           Core::LinAlg::SerialDenseVector& elevector,  ///< vector to store results into
           const std::vector<double> direct             ///< direction to weight with
       );
 
-      /// Compute difference of spatial configuration to masternode in given direction
+      /// Compute difference of spatial configuration to anchor node in given direction
       double compute_weighted_distance(
           const Core::LinAlg::Matrix<2, 3> disp, const std::vector<double> direct);
     };  // class ConstraintElement3

--- a/src/constraint/4C_constraint_element3_evaluate.cpp
+++ b/src/constraint/4C_constraint_element3_evaluate.cpp
@@ -126,7 +126,7 @@ int Discret::Elements::ConstraintElement3::evaluate(Teuchos::ParameterList& para
         const std::vector<double>& direct =
             condition->parameters().get<std::vector<double>>("direction");
 
-        // Compute weighted difference between masternode and other node and it's derivative
+        // Compute weighted difference between anchor node and other node and it's derivative
         compute_first_deriv_weighted_distance(elevec1, direct);
         elevec2 = elevec1;
 

--- a/src/constraint/4C_constraint_manager.hpp
+++ b/src/constraint/4C_constraint_manager.hpp
@@ -336,7 +336,7 @@ namespace Constraints
     std::shared_ptr<MPConstraint3> mpconplane3d_;   ///< 3d multipoint constraint prescribing the
                                                     ///< motion of a node relatively to a plane
     std::shared_ptr<MPConstraint3> mpcnormcomp3d_;  ///< 3d multipoint constraint prescribing the
-                                                    ///< motion of a node to a plane masternode
+                                                    ///< motion of a node to a plane anchor node
     std::shared_ptr<MPConstraint2>
         mpconline2d_;  ///< 2d multipoint constraint prescribing the motion
                        ///< of a node relatively to a straight line

--- a/src/constraint/4C_constraint_multipointconstraint3.cpp
+++ b/src/constraint/4C_constraint_multipointconstraint3.cpp
@@ -242,7 +242,7 @@ Constraints::MPConstraint3::create_discretization_from_condition(
       break;
       case mpcnormalcomp3d:
       {
-        // take master node
+        // take anchor node
         const int defn = (*conditer)->parameters().get<int>("masterNode");
         defnv.push_back(defn);
       }

--- a/src/contact/src/4C_contact_lagrange_strategy_tsi.cpp
+++ b/src/contact/src/4C_contact_lagrange_strategy_tsi.cpp
@@ -955,7 +955,7 @@ void CONTACT::LagrangeStrategyTsi::update(std::shared_ptr<const Core::LinAlg::Ve
 
   if (ftcnp_ == nullptr)
     ftcnp_ = std::make_shared<Core::LinAlg::Vector<double>>(
-        *coupST_->target_to_source_map(*gstdofrowmap_));
+        *structure_thermo_coupling_->target_to_source_map(*gstdofrowmap_));
   ftcnp_->put_scalar(0.0);
 
   std::shared_ptr<Core::LinAlg::Vector<double>> tmp =
@@ -970,26 +970,30 @@ void CONTACT::LagrangeStrategyTsi::update(std::shared_ptr<const Core::LinAlg::Ve
 
   CONTACT::AbstractStrategy::update(dis);
 
-  Core::LinAlg::SparseMatrix dThermo(*coupST_->target_to_source_map(*gsdofrowmap_), 100, true,
-      false, Core::LinAlg::SparseMatrix::FE_MATRIX);
+  Core::LinAlg::SparseMatrix dThermo(
+      *structure_thermo_coupling_->target_to_source_map(*gsdofrowmap_), 100, true, false,
+      Core::LinAlg::SparseMatrix::FE_MATRIX);
   Coupling::Adapter::MatrixRowColTransform()(*dmatrix_, 1.,
-      Coupling::Adapter::CouplingTargetConverter(*coupST_),
-      Coupling::Adapter::CouplingTargetConverter(*coupST_), dThermo, false, false);
+      Coupling::Adapter::CouplingTargetConverter(*structure_thermo_coupling_),
+      Coupling::Adapter::CouplingTargetConverter(*structure_thermo_coupling_), dThermo, false,
+      false);
   dThermo.complete();
-  tmp =
-      std::make_shared<Core::LinAlg::Vector<double>>(*coupST_->target_to_source_map(*gsdofrowmap_));
+  tmp = std::make_shared<Core::LinAlg::Vector<double>>(
+      *structure_thermo_coupling_->target_to_source_map(*gsdofrowmap_));
   dThermo.multiply(false, *z_thermo_, *tmp);
   CONTACT::Utils::add_vector(*tmp, *ftcnp_);
 
-  Core::LinAlg::SparseMatrix mThermo(*coupST_->target_to_source_map(*gsdofrowmap_), 100, true,
-      false, Core::LinAlg::SparseMatrix::FE_MATRIX);
+  Core::LinAlg::SparseMatrix mThermo(
+      *structure_thermo_coupling_->target_to_source_map(*gsdofrowmap_), 100, true, false,
+      Core::LinAlg::SparseMatrix::FE_MATRIX);
   Coupling::Adapter::MatrixRowColTransform()(*mmatrix_, 1.,
-      Coupling::Adapter::CouplingTargetConverter(*coupST_),
-      Coupling::Adapter::CouplingTargetConverter(*coupST_), mThermo, false, false);
-  mThermo.complete(
-      *coupST_->target_to_source_map(*gtdofrowmap_), *coupST_->target_to_source_map(*gsdofrowmap_));
-  tmp =
-      std::make_shared<Core::LinAlg::Vector<double>>(*coupST_->target_to_source_map(*gtdofrowmap_));
+      Coupling::Adapter::CouplingTargetConverter(*structure_thermo_coupling_),
+      Coupling::Adapter::CouplingTargetConverter(*structure_thermo_coupling_), mThermo, false,
+      false);
+  mThermo.complete(*structure_thermo_coupling_->target_to_source_map(*gtdofrowmap_),
+      *structure_thermo_coupling_->target_to_source_map(*gsdofrowmap_));
+  tmp = std::make_shared<Core::LinAlg::Vector<double>>(
+      *structure_thermo_coupling_->target_to_source_map(*gtdofrowmap_));
   mThermo.multiply(true, *z_thermo_, *tmp);
   tmp->scale(-1.);
   CONTACT::Utils::add_vector(*tmp, *ftcnp_);
@@ -1004,10 +1008,12 @@ void CONTACT::LagrangeStrategyTsi::update(std::shared_ptr<const Core::LinAlg::Ve
   Core::LinAlg::export_to(*z_, z_act);
   tmp = std::make_shared<Core::LinAlg::Vector<double>>(*gtdofrowmap_);
   m_LinDissContactLM.multiply(false, z_act, *tmp);
-  Core::LinAlg::Vector<double> tmp2(*coupST_->target_dof_map());
+  Core::LinAlg::Vector<double> tmp2(*structure_thermo_coupling_->target_dof_map());
   Core::LinAlg::export_to(*tmp, tmp2);
-  std::shared_ptr<Core::LinAlg::Vector<double>> tmp3 = coupST_->target_to_source(tmp2);
-  Core::LinAlg::Vector<double> tmp4(*coupST_->target_to_source_map(*gtdofrowmap_));
+  std::shared_ptr<Core::LinAlg::Vector<double>> tmp3 =
+      structure_thermo_coupling_->target_to_source(tmp2);
+  Core::LinAlg::Vector<double> tmp4(
+      *structure_thermo_coupling_->target_to_source_map(*gtdofrowmap_));
   Core::LinAlg::export_to(*tmp3, tmp4);
   CONTACT::Utils::add_vector(tmp4, *ftcnp_);
 
@@ -1053,9 +1059,9 @@ void CONTACT::LagrangeStrategyTsi::do_write_restart(
   }
   if (ftcn_ != nullptr)
   {
-    Core::LinAlg::Vector<double> tmp(*coupST_->source_dof_map());
+    Core::LinAlg::Vector<double> tmp(*structure_thermo_coupling_->source_dof_map());
     Core::LinAlg::export_to(*ftcn_, tmp);
-    restart_vectors["last_thermo_force"] = coupST_->source_to_target(tmp);
+    restart_vectors["last_thermo_force"] = structure_thermo_coupling_->source_to_target(tmp);
   }
 }
 
@@ -1072,11 +1078,11 @@ void CONTACT::LagrangeStrategyTsi::do_read_restart(Core::IO::DiscretizationReade
   if (!restartwithcontact) reader.read_vector(fscn_, "last_contact_force");
 
   std::shared_ptr<Core::LinAlg::Vector<double>> tmp =
-      std::make_shared<Core::LinAlg::Vector<double>>(*coupST_->target_dof_map());
+      std::make_shared<Core::LinAlg::Vector<double>>(*structure_thermo_coupling_->target_dof_map());
   if (!restartwithcontact) reader.read_vector(tmp, "last_thermo_force");
-  ftcn_ = coupST_->target_to_source(*tmp);
+  ftcn_ = structure_thermo_coupling_->target_to_source(*tmp);
   tmp = std::make_shared<Core::LinAlg::Vector<double>>(
-      *coupST_->target_to_source_map(*gstdofrowmap_));
+      *structure_thermo_coupling_->target_to_source_map(*gstdofrowmap_));
   Core::LinAlg::export_to(*ftcn_, *tmp);
   ftcn_ = tmp;
 }

--- a/src/contact/src/4C_contact_lagrange_strategy_tsi.hpp
+++ b/src/contact/src/4C_contact_lagrange_strategy_tsi.hpp
@@ -165,7 +165,10 @@ namespace CONTACT
         std::shared_ptr<const Core::LinAlg::Vector<double>> dis,
         std::shared_ptr<CONTACT::ParamsInterface> cparams_ptr) override;
 
-    void set_coupling(std::shared_ptr<Coupling::Adapter::Coupling> coupST) { coupST_ = coupST; };
+    void set_coupling(std::shared_ptr<Coupling::Adapter::Coupling> coupST)
+    {
+      structure_thermo_coupling_ = coupST;
+    };
 
     //@}
 
@@ -215,7 +218,7 @@ namespace CONTACT
         rt_a_;  // Part of structural residual that corresponds to active source rows
 
     // pointer to TSI coupling object
-    std::shared_ptr<Coupling::Adapter::Coupling> coupST_;
+    std::shared_ptr<Coupling::Adapter::Coupling> structure_thermo_coupling_;
   };  // class LagrangeStrategyTsi
 
   namespace Utils

--- a/src/poroelast/4C_poroelast_base.cpp
+++ b/src/poroelast/4C_poroelast_base.cpp
@@ -479,7 +479,7 @@ void PoroElast::PoroBase::setup_coupling()
       // we use the fact, that we have matching grids and matching gids
       // The node matching search tree is used to find matching structure and fluid nodes.
       // Note, that the structure discretization must be the bigger one (because it is the
-      // masterdis).
+      // target discretization).
       coupling_fluid_structure_->setup_coupling(
           *structdis, *fluiddis, *fluidnoderowmap, *fluidnoderowmap, ndof, false);
     }

--- a/src/poroelast/4C_poroelast_monolithicsplit.cpp
+++ b/src/poroelast/4C_poroelast_monolithicsplit.cpp
@@ -147,7 +147,6 @@ std::shared_ptr<Core::LinAlg::Map> PoroElast::MonolithicSplit::fsidbc_map()
   for (int i = 0; i < mylength; ++i)
   {
     int gid = mygids[i];
-    // FOUR_C_ASSERT(slavemastermap.count(gid),"master gid not found on slave side");
     gidmarker_struct.replace_global_value(gid, 1.0);
   }
 

--- a/src/poroelast/4C_poroelast_monolithicstructuresplit.cpp
+++ b/src/poroelast/4C_poroelast_monolithicstructuresplit.cpp
@@ -225,16 +225,16 @@ void PoroElast::MonolithicStructureSplit::setup_vector(Core::LinAlg::Vector<doub
     {
       const double alpha = -ftiparam + stiparam * (1.0 - ftiparam) / (1.0 - stiparam);
 
-      // lambda contribution from "slave" map
-      auto lambda_structure_slave = structure_to_fluid_at_interface(*lambda_);
+      // lambda contribution from source map
+      auto lambda_structure_source = structure_to_fluid_at_interface(*lambda_);
 
       // ensure lambda_temp matches modfvs map before update
       const auto& modfv_map = modfv->get_map();
-      const auto& lambda_map = lambda_structure_slave->get_map();
+      const auto& lambda_map = lambda_structure_source->get_map();
 
       if (modfv_map.point_same_as(lambda_map))
       {
-        modfv->update(alpha, *lambda_structure_slave, 1.0);
+        modfv->update(alpha, *lambda_structure_source, 1.0);
       }
     }
 

--- a/src/poroelast/4C_poroelast_utils.cpp
+++ b/src/poroelast/4C_poroelast_utils.cpp
@@ -261,11 +261,11 @@ void PoroElast::Utils::reconnect_parent_pointers(Core::FE::Discretization& idisc
     auto* faceele = dynamic_cast<Core::Elements::FaceElement*>(ele);
 
     if (!faceele) FOUR_C_THROW("Cast to FaceElement failed!");
-    set_slave_and_master(voldiscret, voldiscret2, elecolmap, faceele);
+    set_source_and_target(voldiscret, voldiscret2, elecolmap, faceele);
   }
 }
 
-void PoroElast::Utils::set_slave_and_master(const Core::FE::Discretization& voldiscret,
+void PoroElast::Utils::set_source_and_target(const Core::FE::Discretization& voldiscret,
     const Core::FE::Discretization* voldiscret2, const Core::LinAlg::Map* elecolmap,
     Core::Elements::FaceElement* faceele)
 {

--- a/src/poroelast/4C_poroelast_utils.hpp
+++ b/src/poroelast/4C_poroelast_utils.hpp
@@ -99,8 +99,8 @@ namespace PoroElast
         const Core::LinAlg::Vector<double>& vect                    //!< the vector of interest
     );
 
-    //! Set the slave and master elements of the face element
-    void set_slave_and_master(const Core::FE::Discretization& voldiscret,
+    //! Set the source and target elements of the face element
+    void set_source_and_target(const Core::FE::Discretization& voldiscret,
         const Core::FE::Discretization* voldiscret2, const Core::LinAlg::Map* elecolmap,
         Core::Elements::FaceElement* faceele);
 

--- a/src/poroelast_scatra/4C_poroelast_scatra_utils.hpp
+++ b/src/poroelast_scatra/4C_poroelast_scatra_utils.hpp
@@ -114,11 +114,6 @@ namespace PoroElastScaTra
         const std::shared_ptr<const Core::LinAlg::Vector<double>> vect  //!< the vector of interest
     );
 
-    //! Set the slave and master elements of the face element
-    void set_slave_and_master(const Core::FE::Discretization& voldiscret,
-        const Core::FE::Discretization* voldiscret2, const Core::LinAlg::Map* elecolmap,
-        Core::Elements::FaceElement* faceele);
-
     //! strategy for material assignment for non matching meshes with poro
 
     //! Helper class for assigning materials for volumetric coupling of non conforming meshes (poro)

--- a/src/structure/4C_structure_timint.cpp
+++ b/src/structure/4C_structure_timint.cpp
@@ -472,12 +472,12 @@ void Solid::TimInt::prepare_contact_meshtying(const Teuchos::ParameterList& sdyn
     if (mesh_relocation_parameter == Mortar::relocation_initial)
     {
       // (2) perform mesh initialization for rotational invariance (interface)
-      // and return the modified slave node positions in vector Xslavemod
-      std::shared_ptr<const Core::LinAlg::Vector<double>> Xslavemod =
+      // and return the modified source node positions in vector X_source_mod
+      std::shared_ptr<const Core::LinAlg::Vector<double>> X_source_mod =
           cmtbridge_->mt_manager()->get_strategy().mesh_initialization();
 
       // (3) apply result of mesh initialization to underlying problem discretization
-      apply_mesh_initialization(Xslavemod);
+      apply_mesh_initialization(X_source_mod);
     }
   }
 
@@ -805,29 +805,30 @@ void Solid::TimInt::prepare_contact_meshtying(const Teuchos::ParameterList& sdyn
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 void Solid::TimInt::apply_mesh_initialization(
-    std::shared_ptr<const Core::LinAlg::Vector<double>> Xslavemod)
+    std::shared_ptr<const Core::LinAlg::Vector<double>> X_source_mod)
 {
   // check modified positions vector
-  if (Xslavemod == nullptr) return;
+  if (X_source_mod == nullptr) return;
 
-  // create fully overlapping slave node map
-  std::shared_ptr<const Core::LinAlg::Map> slavemap =
+  // create fully overlapping source node map
+  std::shared_ptr<const Core::LinAlg::Map> source_map =
       cmtbridge_->mt_manager()->get_strategy().source_row_nodes_ptr();
-  std::shared_ptr<Core::LinAlg::Map> allreduceslavemap = Core::LinAlg::allreduce_e_map(*slavemap);
+  std::shared_ptr<Core::LinAlg::Map> allreducesource_map =
+      Core::LinAlg::allreduce_e_map(*source_map);
 
   // export modified node positions to column map of problem discretization
-  std::shared_ptr<Core::LinAlg::Vector<double>> Xslavemodcol =
+  std::shared_ptr<Core::LinAlg::Vector<double>> X_source_modcol =
       std::make_shared<Core::LinAlg::Vector<double>>(*discret_->dof_col_map(), false);
-  Core::LinAlg::export_to(*Xslavemod, *Xslavemodcol);
+  Core::LinAlg::export_to(*X_source_mod, *X_source_modcol);
 
-  const int numnode = allreduceslavemap->num_my_elements();
+  const int numnode = allreducesource_map->num_my_elements();
   const int numdim = Global::Problem::instance()->n_dim();
-  const Core::LinAlg::Vector<double>& gvector = *Xslavemodcol;
+  const Core::LinAlg::Vector<double>& gvector = *X_source_modcol;
 
-  // loop over all slave nodes (for all procs)
+  // loop over all source nodes (for all procs)
   for (int index = 0; index < numnode; ++index)
   {
-    int gid = allreduceslavemap->gid(index);
+    int gid = allreducesource_map->gid(index);
 
     // only do something for nodes in my column map
     int ilid = discret_->node_col_map()->lid(gid);
@@ -1196,14 +1197,14 @@ void Solid::TimInt::update_step_contact_vum()
       const Core::LinAlg::Map* dofmap = discret_->dof_row_map();
       std::shared_ptr<Core::LinAlg::Map> activenodemap =
           std::make_shared<Core::LinAlg::Map>(*cmtbridge_->get_strategy().active_row_nodes());
-      std::shared_ptr<const Core::LinAlg::Map> slavenodemap =
+      std::shared_ptr<const Core::LinAlg::Map> source_node_map =
           cmtbridge_->get_strategy().source_row_nodes_ptr();
-      std::shared_ptr<const Core::LinAlg::Map> notredistslavedofmap =
+      std::shared_ptr<const Core::LinAlg::Map> non_redist_source_dof_map =
           cmtbridge_->get_strategy().non_redist_source_row_dofs();
-      std::shared_ptr<const Core::LinAlg::Map> notredistmasterdofmap =
+      std::shared_ptr<const Core::LinAlg::Map> non_redist_target_dof_map =
           cmtbridge_->get_strategy().non_redist_target_row_dofs();
       std::shared_ptr<Core::LinAlg::Map> notactivenodemap =
-          Core::LinAlg::split_map(*slavenodemap, *activenodemap);
+          Core::LinAlg::split_map(*source_node_map, *activenodemap);
 
       // the lumped mass matrix and its inverse
       if (lumpmass_ == false)
@@ -1232,18 +1233,18 @@ void Solid::TimInt::update_step_contact_vum()
           cmtbridge_->get_strategy().m_matrix();
       std::shared_ptr<const Core::LinAlg::SparseMatrix> Dmat =
           cmtbridge_->get_strategy().d_matrix();
-      Core::LinAlg::Map slavedofmap(Dmat->range_map());
+      Core::LinAlg::Map source_dof_map(Dmat->range_map());
       Core::LinAlg::SparseMatrix Bc(*dofmap, 10);
       std::shared_ptr<const Core::LinAlg::SparseMatrix> M =
-          std::make_shared<Core::LinAlg::SparseMatrix>(slavedofmap, 10);
+          std::make_shared<Core::LinAlg::SparseMatrix>(source_dof_map, 10);
       std::shared_ptr<const Core::LinAlg::SparseMatrix> D =
-          std::make_shared<Core::LinAlg::SparseMatrix>(slavedofmap, 10);
+          std::make_shared<Core::LinAlg::SparseMatrix>(source_dof_map, 10);
       if (Teuchos::getIntegralValue<Mortar::ParallelRedist>(
               cmtbridge_->get_strategy().params().sublist("PARALLEL REDISTRIBUTION"),
               "PARALLEL_REDIST") != Mortar::ParallelRedist::redist_none)
       {
-        M = Core::LinAlg::matrix_col_transform(*Mmat, *notredistmasterdofmap);
-        D = Core::LinAlg::matrix_col_transform(*Dmat, *notredistslavedofmap);
+        M = Core::LinAlg::matrix_col_transform(*Mmat, *non_redist_target_dof_map);
+        D = Core::LinAlg::matrix_col_transform(*Dmat, *non_redist_source_dof_map);
       }
       else
       {
@@ -1252,7 +1253,7 @@ void Solid::TimInt::update_step_contact_vum()
       }
       Core::LinAlg::matrix_add(*M, true, -1.0, Bc, 1.0);
       Core::LinAlg::matrix_add(*D, true, 1.0, Bc, 1.0);
-      Bc.complete(slavedofmap, *dofmap);
+      Bc.complete(source_dof_map, *dofmap);
       Bc.apply_dirichlet(*(dbcmaps_->cond_map()), false);
 
       // matrix of the normal vectors
@@ -1263,7 +1264,7 @@ void Solid::TimInt::update_step_contact_vum()
       std::shared_ptr<const Core::LinAlg::Vector<double>> LM =
           cmtbridge_->get_strategy().lagrange_multiplier();
       std::shared_ptr<Core::LinAlg::Vector<double>> Z =
-          std::make_shared<Core::LinAlg::Vector<double>>(*slavenodemap, true);
+          std::make_shared<Core::LinAlg::Vector<double>>(*source_node_map, true);
       std::shared_ptr<Core::LinAlg::Vector<double>> z =
           std::make_shared<Core::LinAlg::Vector<double>>(*activenodemap, true);
       N->multiply(false, *LM, *Z);
@@ -1296,7 +1297,7 @@ void Solid::TimInt::update_step_contact_vum()
       std::shared_ptr<Core::LinAlg::Vector<double>> btemp1 =
           std::make_shared<Core::LinAlg::Vector<double>>(*dofmap, true);
       std::shared_ptr<Core::LinAlg::Vector<double>> btemp2 =
-          std::make_shared<Core::LinAlg::Vector<double>>(*slavenodemap, true);
+          std::make_shared<Core::LinAlg::Vector<double>>(*source_node_map, true);
       std::shared_ptr<Core::LinAlg::Vector<double>> b =
           std::make_shared<Core::LinAlg::Vector<double>>(*activenodemap, true);
       btemp1->update(R1, *Dd, 0.0);
@@ -1307,7 +1308,7 @@ void Solid::TimInt::update_step_contact_vum()
 
       // operator c
       std::shared_ptr<Core::LinAlg::Vector<double>> ctemp =
-          std::make_shared<Core::LinAlg::Vector<double>>(*slavenodemap, true);
+          std::make_shared<Core::LinAlg::Vector<double>>(*source_node_map, true);
       std::shared_ptr<Core::LinAlg::Vector<double>> c =
           std::make_shared<Core::LinAlg::Vector<double>>(*activenodemap, true);
       BN->multiply(true, *Dd, *ctemp);
@@ -1589,7 +1590,7 @@ void Solid::TimInt::update_step_contact_vum()
 
       // (4) VelocityUpdate
       std::shared_ptr<Core::LinAlg::Vector<double>> ptemp1 =
-          std::make_shared<Core::LinAlg::Vector<double>>(*slavenodemap, true);
+          std::make_shared<Core::LinAlg::Vector<double>>(*source_node_map, true);
       std::shared_ptr<Core::LinAlg::Vector<double>> ptemp2 =
           std::make_shared<Core::LinAlg::Vector<double>>(*dofmap, true);
       std::shared_ptr<Core::LinAlg::Vector<double>> VU =

--- a/src/structure/4C_structure_timint.hpp
+++ b/src/structure/4C_structure_timint.hpp
@@ -912,12 +912,13 @@ namespace Solid
 
     \note This is only necessary in case of a mortar method.
 
-    \warning This routine modifies the reference coordinates of slave nodes at the meshtying
+    \warning This routine modifies the reference coordinates of source nodes at the meshtying
     interface.
 
-    @param[in] Xslavemod Vector with modified nodal positions
+    @param[in] X_source_mod Vector with modified nodal positions
     */
-    void apply_mesh_initialization(std::shared_ptr<const Core::LinAlg::Vector<double>> Xslavemod);
+    void apply_mesh_initialization(
+        std::shared_ptr<const Core::LinAlg::Vector<double>> X_source_mod);
 
     //! Prepare contact at the beginning of each new time step
     //! (call dynamic redistribution of contact interface(s) AND

--- a/src/structure/4C_structure_timint_impl.cpp
+++ b/src/structure/4C_structure_timint_impl.cpp
@@ -88,10 +88,10 @@ Solid::TimIntImpl::TimIntImpl(const Teuchos::ParameterList& timeparams,
       normpres_(0.0),
       normcontconstr_(0.0),  // < norm of contact constraints (saddlepoint formulation)
       normlagr_(0.0),        // < norm of lagrange multiplier increment (saddlepoint formulation)
-      normw_(0.0),
-      normwrhs_(0.0),
-      normwm_(0.0),
-      normwmrhs_(0.0),
+      norm_wear_(0.0),
+      norm_wear_rhs_(0.0),
+      norm_wear_target_(0.0),
+      norm_wear_target_rhs_(0.0),
       alpha_ls_(sdynparams.get<double>("ALPHA_LS")),
       sigma_ls_(sdynparams.get<double>("SIGMA_LS")),
       ls_maxiter_(sdynparams.get<int>("LSMAXITER")),
@@ -111,7 +111,6 @@ Solid::TimIntImpl::TimIntImpl(const Teuchos::ParameterList& timeparams,
   // redistribution of elements. Only then call the setup to this class. This will call the setup to
   // all classes in the inheritance hierarchy. This way, this class may also override a method that
   // is called during setup() in a base class. general variable verifications:
-  return;
 }
 
 /*----------------------------------------------------------------------------------------------*
@@ -159,9 +158,6 @@ void Solid::TimIntImpl::init(const Teuchos::ParameterList& timeparams,
     FOUR_C_THROW("LSMAXITER has to be greater than or equal to zero. Fix your input file.");
 
   if (ptcdt_ <= 0) FOUR_C_THROW("PTCDT has to be greater than zero. Fix your input file.");
-
-  // done so far
-  return;
 }
 
 /*----------------------------------------------------------------------------------------------*
@@ -264,8 +260,6 @@ void Solid::TimIntImpl::setup()
   // iterative displacement increments IncD_{n+1}
   // also known as residual displacements
   disi_ = std::make_shared<Core::LinAlg::Vector<double>>(*dof_row_map_view(), true);
-
-  return;
 }
 
 /*----------------------------------------------------------------------*/
@@ -435,12 +429,8 @@ void Solid::TimIntImpl::predict()
   normchardis_ = calc_ref_norm_displacement();
   if (normchardis_ == 0.0) normchardis_ = toldisi_;
 
-
   // output
   print_predictor();
-
-  // enjoy your meal
-  return;
 }
 
 /*----------------------------------------------------------------------*/
@@ -497,12 +487,8 @@ void Solid::TimIntImpl::prepare_partition_step()
   normchardis_ = calc_ref_norm_displacement();
   if (normchardis_ == 0.0) normchardis_ = toldisi_;
 
-
   // output
   print_predictor();
-
-  // enjoy your meal
-  return;
 }
 
 
@@ -528,7 +514,6 @@ void Solid::TimIntImpl::prepare_line_search()
     fresn_str_ = std::make_shared<Core::LinAlg::Vector<double>>(*dof_row_map_view(), true);
     fintn_str_ = std::make_shared<Core::LinAlg::Vector<double>>(*dof_row_map_view(), true);
   }
-  return;
 }
 /*----------------------------------------------------------------------*/
 /* predict solution as constant displacements, velocities
@@ -540,9 +525,6 @@ void Solid::TimIntImpl::predict_const_dis_vel_acc()
   veln_->update(1.0, *(*vel_)(0), 0.0);
   accn_->update(1.0, *(*acc_)(0), 0.0);
   disi_->put_scalar(0.0);
-
-  // see you next time step
-  return;
 }
 
 /*----------------------------------------------------------------------*/
@@ -704,9 +686,6 @@ void Solid::TimIntImpl::predict_tang_dis_consist_vel_acc()
     discret_->evaluate(p, nullptr, nullptr, nullptr, nullptr, nullptr);
     discret_->clear_state();
   }
-
-  // shalom
-  return;
 }
 
 /*--------------------------------------------------------------------------*
@@ -816,9 +795,6 @@ void Solid::TimIntImpl::apply_force_stiff_external(const double time,  //!< eval
     discret_->set_state(0, "displacement new", disn);
     discret_->evaluate_neumann(p, fext, fextlin.get());
   }
-
-  // go away
-  return;
 }
 
 /*----------------------------------------------------------------------*/
@@ -915,8 +891,6 @@ void Solid::TimIntImpl::apply_force_stiff_internal_and_inertial(const double tim
   discret_->clear_state();
 
   mass->complete();
-
-  return;
 };
 
 /*----------------------------------------------------------------------*/
@@ -931,8 +905,6 @@ void Solid::TimIntImpl::apply_force_stiff_constraint(const double time,
   {
     conman_->evaluate_force_stiff(time, dis, disn, fint, stiff, pcon);
   }
-
-  return;
 }
 
 /*----------------------------------------------------------------------*/
@@ -950,8 +922,6 @@ void Solid::TimIntImpl::apply_force_stiff_spring_dashpot(
     if (stiff_sparse == nullptr) FOUR_C_THROW("Cannot cast stiffness matrix to sparse matrix!");
     springman_->stiffness_and_internal_forces(stiff_sparse, fint, disn, veln, psprdash);
   }
-
-  return;
 }
 
 /*----------------------------------------------------------------------*/
@@ -1000,8 +970,6 @@ void Solid::TimIntImpl::apply_force_stiff_contact_meshtying(
     dtcmt_ = timer_->wallTime() - dtcpu;
     // *********** time measurement ***********
   }
-
-  return;
 }
 
 /*----------------------------------------------------------------------*/
@@ -1117,8 +1085,8 @@ bool Solid::TimIntImpl::converged()
       {
         case Inpar::Solid::convnorm_abs:
           convDispLagrIncr = normlagr_ < tollagr_;
-          convDispWIncr = normw_ < 1e-12;    // WEAR
-          convDispWMIncr = normwm_ < 1e-12;  // WEAR
+          convDispWIncr = norm_wear_ < 1e-12;          // WEAR
+          convDispWMIncr = norm_wear_target_ < 1e-12;  // WEAR
           break;
         /*case Inpar::Solid::convnorm_rel:
           convDispLagrIncr = normlagr_ < tollagr_;
@@ -1491,14 +1459,14 @@ int Solid::TimIntImpl::newton_full()
             cmtbridge_->get_strategy().wear_rhs();
 
         if (wearrhs != nullptr)
-          normwrhs_ = Solid::calculate_vector_norm(iternorm_, *wearrhs);
+          norm_wear_rhs_ = Solid::calculate_vector_norm(iternorm_, *wearrhs);
         else
-          normwrhs_ = -1.0;
+          norm_wear_rhs_ = -1.0;
 
         if (wincr != nullptr)
-          normw_ = Solid::calculate_vector_norm(iternorm_, *wincr);
+          norm_wear_ = Solid::calculate_vector_norm(iternorm_, *wincr);
         else
-          normw_ = -1.0;
+          norm_wear_ = -1.0;
 
         if (wside == Wear::wear_both)
         {
@@ -1508,27 +1476,27 @@ int Solid::TimIntImpl::newton_full()
               cmtbridge_->get_strategy().wear_m_rhs();
 
           if (wearmrhs != nullptr)
-            normwmrhs_ = Solid::calculate_vector_norm(iternorm_, *wearmrhs);
+            norm_wear_target_rhs_ = Solid::calculate_vector_norm(iternorm_, *wearmrhs);
           else
-            normwmrhs_ = -1.0;
+            norm_wear_target_rhs_ = -1.0;
 
           if (wmincr != nullptr)
-            normwm_ = Solid::calculate_vector_norm(iternorm_, *wmincr);
+            norm_wear_target_ = Solid::calculate_vector_norm(iternorm_, *wmincr);
           else
-            normwm_ = -1.0;
+            norm_wear_target_ = -1.0;
         }
         else
         {
-          normwm_ = 0.0;
-          normwmrhs_ = 0.0;
+          norm_wear_target_ = 0.0;
+          norm_wear_target_rhs_ = 0.0;
         }
       }
       else
       {
-        normw_ = 0.0;
-        normwrhs_ = 0.0;
-        normwm_ = 0.0;
-        normwmrhs_ = 0.0;
+        norm_wear_ = 0.0;
+        norm_wear_rhs_ = 0.0;
+        norm_wear_target_ = 0.0;
+        norm_wear_target_rhs_ = 0.0;
       }
     }
 
@@ -2024,8 +1992,6 @@ void Solid::TimIntImpl::ls_update_structural_rh_sand_stiff(bool& isexcept, doubl
   ***************************************************************/
   int err = ls_eval_merit_fct(merit_fct);
   isexcept = (isexcept || err);
-
-  return;
 }
 
 
@@ -2642,26 +2608,28 @@ void Solid::TimIntImpl::cmt_linear_solve()
   auto systype =
       Teuchos::getIntegralValue<CONTACT::SystemType>(cmtbridge_->get_strategy().params(), "SYSTEM");
 
-  // update information about active slave dofs
+  // update information about active source dofs
   //**********************************************************************
   // feed solver/preconditioner with additional information about the contact/meshtying problem
   //**********************************************************************
   {
     // TODO: maps for merged meshtying and contact problem !!!
 
-    std::shared_ptr<Core::LinAlg::Map> masterDofMap, slaveDofMap, innerDofMap, activeDofMap;
+    std::shared_ptr<Core::LinAlg::Map> target_dof_map, source_dof_map, inner_dof_map,
+        active_dof_map;
     std::shared_ptr<Mortar::StrategyBase> strategy =
         Core::Utils::shared_ptr_from_ref(cmtbridge_->get_strategy());
-    strategy->collect_maps_for_preconditioner(masterDofMap, slaveDofMap, innerDofMap, activeDofMap);
+    strategy->collect_maps_for_preconditioner(
+        target_dof_map, source_dof_map, inner_dof_map, active_dof_map);
 
     // feed Belos based solvers with contact information
     if (contactsolver_->params().isSublist("Belos Parameters"))
     {
       Teuchos::ParameterList& mueluParams = contactsolver_->params().sublist("Belos Parameters");
-      mueluParams.set<std::shared_ptr<Core::LinAlg::Map>>("contact targetDofMap", masterDofMap);
-      mueluParams.set<std::shared_ptr<Core::LinAlg::Map>>("contact sourceDofMap", slaveDofMap);
-      mueluParams.set<std::shared_ptr<Core::LinAlg::Map>>("contact innerDofMap", innerDofMap);
-      mueluParams.set<std::shared_ptr<Core::LinAlg::Map>>("contact activeDofMap", activeDofMap);
+      mueluParams.set<std::shared_ptr<Core::LinAlg::Map>>("contact targetDofMap", target_dof_map);
+      mueluParams.set<std::shared_ptr<Core::LinAlg::Map>>("contact sourceDofMap", source_dof_map);
+      mueluParams.set<std::shared_ptr<Core::LinAlg::Map>>("contact innerDofMap", inner_dof_map);
+      mueluParams.set<std::shared_ptr<Core::LinAlg::Map>>("contact activeDofMap", active_dof_map);
       std::shared_ptr<CONTACT::AbstractStrategy> costrat =
           std::dynamic_pointer_cast<CONTACT::AbstractStrategy>(strategy);
       if (costrat != nullptr)
@@ -2671,12 +2639,12 @@ void Solid::TimIntImpl::cmt_linear_solve()
 
       // construct the mapping of the dual node IDs to primal node IDs
       std::map<int, int> dual2primal_map;
-      const std::shared_ptr<const Core::LinAlg::Map> slave_node_row_map =
+      const std::shared_ptr<const Core::LinAlg::Map> source_node_row_map =
           strategy->source_row_nodes_ptr();
       const Core::LinAlg::Map* solid_node_map = discretization()->node_row_map();
-      for (int dual_lid = 0; dual_lid < slave_node_row_map->num_my_elements(); dual_lid++)
+      for (int dual_lid = 0; dual_lid < source_node_row_map->num_my_elements(); dual_lid++)
       {
-        int dual_gid = slave_node_row_map->gid(dual_lid);
+        int dual_gid = source_node_row_map->gid(dual_lid);
         if (discretization()->have_global_node(dual_gid))
           dual2primal_map[dual_lid] = solid_node_map->lid(dual_gid);
       }
@@ -2799,8 +2767,6 @@ void Solid::TimIntImpl::cmt_linear_solve()
 
   // reset tolerance for contact solver
   contactsolver_->reset_tolerance();
-
-  return;
 }
 
 /*----------------------------------------------------------------------*/
@@ -3052,9 +3018,6 @@ void Solid::TimIntImpl::update_iter(const int iter  //!< iteration counter
   {
     update_iter_iteratively();
   }
-
-  // morning is broken
-  return;
 }
 
 /*----------------------------------------------------------------------*/
@@ -3077,17 +3040,12 @@ void Solid::TimIntImpl::update_iter_incrementally(
 
   // Update using #disi_
   update_iter_incrementally();
-
-  // leave this place
-  return;
 }
 
 /*----------------------------------------------------------------------*/
-/* print to screen
- * lw 12/07 */
 void Solid::TimIntImpl::print_predictor()
 {
-  // only master processor
+  // only root processor (MPI rank 0)
   if ((myrank_ == 0) and printscreen_ and (step_old() % printscreen_ == 0))
   {
     Core::IO::cout << "Structural predictor for field '" << discret_->name() << "' "
@@ -3115,15 +3073,9 @@ void Solid::TimIntImpl::print_predictor()
       FOUR_C_THROW("You should not turn up here.");
     }
   }
-
-  // leave your hat on
-  return;
 }
 
-
 /*----------------------------------------------------------------------*/
-/* print Newton-Raphson iteration to screen and error file
- * originally by lw 12/07, tk 01/08 */
 void Solid::TimIntImpl::print_newton_iter()
 {
   // print to standard out
@@ -3295,14 +3247,11 @@ void Solid::TimIntImpl::print_newton_iter_header(FILE* ofile)
 
   // print it, now
   fflush(ofile);
-
-  // nice to have met you
-  return;
 }
 
+
 /*----------------------------------------------------------------------*/
-/* print Newton-Raphson iteration to screen
- * originally by lw 12/07, tk 01/08 */
+/* print Newton-Raphson iteration to screen*/
 void Solid::TimIntImpl::print_newton_iter_text(FILE* ofile)
 {
   // open outstd::stringstream
@@ -3398,14 +3347,15 @@ void Solid::TimIntImpl::print_newton_iter_text(FILE* ofile)
 
       if (wtype == Wear::wear_primvar)
       {
-        oss << std::setw(20) << std::setprecision(5) << std::scientific << normw_;  // norm wear
+        oss << std::setw(20) << std::setprecision(5) << std::scientific << norm_wear_;  // norm wear
         oss << std::setw(20) << std::setprecision(5) << std::scientific
-            << normwrhs_;  // norm wear rhs
+            << norm_wear_rhs_;  // norm wear rhs
         if (wside == Wear::wear_both)
         {
-          oss << std::setw(20) << std::setprecision(5) << std::scientific << normwm_;  // norm wear
           oss << std::setw(20) << std::setprecision(5) << std::scientific
-              << normwmrhs_;  // norm wear rhs
+              << norm_wear_target_;  // norm wear
+          oss << std::setw(20) << std::setprecision(5) << std::scientific
+              << norm_wear_target_rhs_;  // norm wear rhs
         }
       }
     }
@@ -3448,9 +3398,6 @@ void Solid::TimIntImpl::print_newton_iter_text(FILE* ofile)
 
   // print it, now
   fflush(ofile);
-
-  // nice to have met you
-  return;
 }
 
 /*----------------------------------------------------------------------*/
@@ -3503,8 +3450,6 @@ void Solid::TimIntImpl::export_contact_quantities()
   }
   else
     FOUR_C_THROW("ERROR: File could not be opened.");
-
-  return;
 }
 
 /*----------------------------------------------------------------------*/
@@ -3516,16 +3461,13 @@ void Solid::TimIntImpl::print_newton_conv()
   {
     conman_->print_monitor_values();
   }
-
-  // somebody did the door
-  return;
 }
 
 /*----------------------------------------------------------------------*/
 /* print step summary */
 void Solid::TimIntImpl::print_step()
 {
-  // print out (only on master CPU)
+  // print out (only on root CPU / MPI rank 0)
   if ((myrank_ == 0) and printscreen_ and (step_old() % printscreen_ == 0))
   {
     print_step_text(stdout);
@@ -3554,9 +3496,6 @@ void Solid::TimIntImpl::print_step_text(FILE* ofile)
 
   // print it, now
   fflush(ofile);
-
-  // fall asleep
-  return;
 }
 
 /*----------------------------------------------------------------------*/
@@ -3631,9 +3570,6 @@ void Solid::TimIntImpl::prepare_system_for_newton_solve(const bool preparejacobi
       Core::LinAlg::apply_dirichlet_to_system(
           *stiff_, *disi_, *fres_, *zeros_, *(dbcmaps_->cond_map()));
   }
-
-  // final sip
-  return;
 }
 
 /*----------------------------------------------------------------------*

--- a/src/structure/4C_structure_timint_impl.hpp
+++ b/src/structure/4C_structure_timint_impl.hpp
@@ -816,10 +816,10 @@ namespace Solid
     double normcontconstr_;  //!< norm of contact/meshtying constraint rhs (contact/meshtying in
                              //!< saddlepoint formulation only)
     double normlagr_;        //!< norm of lagrange multipliers
-    double normw_;           //!< norm of wear
-    double normwrhs_;
-    double normwm_;  //!< norm of wear master
-    double normwmrhs_;
+    double norm_wear_;       //!< norm of wear
+    double norm_wear_rhs_;
+    double norm_wear_target_;  //!< norm of wear target
+    double norm_wear_target_rhs_;
     double alpha_ls_;    //!< line search step reduction
     double sigma_ls_;    //!< line search sufficient descent factor
     double ls_maxiter_;  //!< maximum number of line search steps

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_contact.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_contact.cpp
@@ -58,15 +58,15 @@ void Solid::ModelEvaluator::Contact::setup()
   // build the contact interfaces
   // ---------------------------------------------------------------------
   // FixMe Would be great, if we get rid of these poro parameters...
-  bool poroslave = false;
-  bool poromaster = false;
-  factory.build_interfaces(cparams, interfaces, poroslave, poromaster);
+  bool poro_source = false;
+  bool poro_target = false;
+  factory.build_interfaces(cparams, interfaces, poro_source, poro_target);
 
   // ---------------------------------------------------------------------
   // build the solver strategy object
   // ---------------------------------------------------------------------
   strategy_ptr_ = factory.build_strategy(
-      cparams, poroslave, poromaster, dof_offset(), interfaces, eval_contact_ptr_.get());
+      cparams, poro_source, poro_target, dof_offset(), interfaces, eval_contact_ptr_.get());
 
   // build the search tree
   factory.build_search_tree(interfaces);

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_meshtying.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_meshtying.cpp
@@ -81,14 +81,15 @@ void Solid::ModelEvaluator::Meshtying::setup()
   // build the meshtying interfaces
   // ---------------------------------------------------------------------
   // FixMe Would be great, if we get rid of these poro parameters...
-  bool poroslave = false;
-  bool poromaster = false;
-  factory.build_interfaces(cparams, interfaces, poroslave, poromaster);
+  bool poro_source = false;
+  bool poro_target = false;
+  factory.build_interfaces(cparams, interfaces, poro_source, poro_target);
 
   // ---------------------------------------------------------------------
   // build the solver strategy object
   // ---------------------------------------------------------------------
-  strategy_ptr_ = factory.build_strategy(cparams, poroslave, poromaster, dof_offset(), interfaces);
+  strategy_ptr_ =
+      factory.build_strategy(cparams, poro_source, poro_target, dof_offset(), interfaces);
 
   // build the search tree
   factory.build_search_tree(interfaces);
@@ -116,10 +117,10 @@ void Solid::ModelEvaluator::Meshtying::setup()
 
     if (mesh_relocation_parameter == Mortar::relocation_initial)
     {
-      std::shared_ptr<const Core::LinAlg::Vector<double>> Xslavemod =
+      std::shared_ptr<const Core::LinAlg::Vector<double>> X_source_mod =
           dynamic_cast<Mortar::StrategyBase&>(*strategy_ptr_).mesh_initialization();
-      std::shared_ptr<const Core::LinAlg::Vector<double>> Xslavemod_noredist;
-      if (Xslavemod != nullptr)
+      std::shared_ptr<const Core::LinAlg::Vector<double>> X_source_mod_noredist;
+      if (X_source_mod != nullptr)
       {
         mesh_relocation_ =
             std::make_shared<Core::LinAlg::Vector<double>>(*global_state().dof_row_map());
@@ -131,15 +132,15 @@ void Solid::ModelEvaluator::Meshtying::setup()
                   *(strategy_ptr_->non_redist_source_row_dofs()), true);
 
           Core::LinAlg::Export exporter(
-              Xslavemod->get_map(), *strategy_ptr_->non_redist_source_row_dofs());
+              X_source_mod->get_map(), *strategy_ptr_->non_redist_source_row_dofs());
 
-          original_vec->export_to(*Xslavemod, exporter, Core::LinAlg::CombineMode::insert);
+          original_vec->export_to(*X_source_mod, exporter, Core::LinAlg::CombineMode::insert);
 
-          Xslavemod_noredist = original_vec;
+          X_source_mod_noredist = original_vec;
         }
         else
         {
-          Xslavemod_noredist = Xslavemod;
+          X_source_mod_noredist = X_source_mod;
         }
 
         for (const auto& node : gdiscret->my_row_node_range())
@@ -151,12 +152,12 @@ void Solid::ModelEvaluator::Meshtying::setup()
             {
               mesh_relocation_->get_values()[mesh_relocation_->get_map().lid(dof)] =
                   node.x()[d] -
-                  Xslavemod_noredist->get_values()[Xslavemod_noredist->get_map().lid(dof)];
+                  X_source_mod_noredist->get_values()[X_source_mod_noredist->get_map().lid(dof)];
             }
           }
         }
 
-        apply_mesh_initialization(Xslavemod_noredist);
+        apply_mesh_initialization(X_source_mod_noredist);
       }
     }
   }
@@ -389,30 +390,31 @@ bool Solid::ModelEvaluator::Meshtying::evaluate_stiff()
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 void Solid::ModelEvaluator::Meshtying::apply_mesh_initialization(
-    std::shared_ptr<const Core::LinAlg::Vector<double>> Xslavemod)
+    std::shared_ptr<const Core::LinAlg::Vector<double>> X_source_mod)
 {
   // check modified positions vector
-  if (Xslavemod == nullptr) return;
+  if (X_source_mod == nullptr) return;
 
-  // create fully overlapping slave node map
-  std::shared_ptr<const Core::LinAlg::Map> slavemap = strategy_ptr_->source_row_nodes_ptr();
-  std::shared_ptr<Core::LinAlg::Map> allreduceslavemap = Core::LinAlg::allreduce_e_map(*slavemap);
+  // create fully overlapping source node map
+  std::shared_ptr<const Core::LinAlg::Map> source_map = strategy_ptr_->source_row_nodes_ptr();
+  std::shared_ptr<Core::LinAlg::Map> all_reduce_source_map =
+      Core::LinAlg::allreduce_e_map(*source_map);
 
   // export modified node positions to column map of problem discretization
   const Core::LinAlg::Map* dof_colmap = discret_ptr()->dof_col_map();
   const Core::LinAlg::Map* node_colmap = discret_ptr()->node_col_map();
-  std::shared_ptr<Core::LinAlg::Vector<double>> Xslavemodcol =
+  std::shared_ptr<Core::LinAlg::Vector<double>> X_source_mod_col =
       std::make_shared<Core::LinAlg::Vector<double>>(*dof_colmap, false);
-  Core::LinAlg::export_to(*Xslavemod, *Xslavemodcol);
+  Core::LinAlg::export_to(*X_source_mod, *X_source_mod_col);
 
-  const int numnode = allreduceslavemap->num_my_elements();
+  const int numnode = all_reduce_source_map->num_my_elements();
   const int numdim = Global::Problem::instance()->n_dim();
-  const Core::LinAlg::Vector<double>& gvector = *Xslavemodcol;
+  const Core::LinAlg::Vector<double>& gvector = *X_source_mod_col;
 
-  // loop over all slave nodes (for all procs)
+  // loop over all source nodes (for all procs)
   for (int index = 0; index < numnode; ++index)
   {
-    int gid = allreduceslavemap->gid(index);
+    int gid = all_reduce_source_map->gid(index);
 
     // only do something for nodes in my column map
     int ilid = node_colmap->lid(gid);

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_meshtying.hpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_meshtying.hpp
@@ -192,12 +192,13 @@ namespace Solid
 
       \note This is only necessary in case of a mortar method.
 
-      \warning This routine modifies the reference coordinates of slave nodes at the meshtying
+      \warning This routine modifies the reference coordinates of source nodes at the meshtying
       interface.
 
-      @param[in] Xslavemod Vector with modified nodal positions
+      @param[in] X_source_mod Vector with modified nodal positions
       */
-      void apply_mesh_initialization(std::shared_ptr<const Core::LinAlg::Vector<double>> Xslavemod);
+      void apply_mesh_initialization(
+          std::shared_ptr<const Core::LinAlg::Vector<double>> X_source_mod);
 
       //!@}
 

--- a/src/tsi/4C_tsi_algorithm.cpp
+++ b/src/tsi/4C_tsi_algorithm.cpp
@@ -226,10 +226,14 @@ void TSI::Algorithm::apply_thermo_coupling_state(
   }
 
   // set new temperatures to contact
+  if (contact_strategy_lagrange_ != nullptr)
   {
-    if (contact_strategy_lagrange_ != nullptr)
-      contact_strategy_lagrange_->set_state(Mortar::state_temperature,
-          *structure_thermo_coupling_->source_to_target(*thermo_field()->tempnp()));
+    FOUR_C_ASSERT_ALWAYS(structure_thermo_coupling_ != nullptr,
+        "Invalid configuration: structure_thermo_coupling_ is required for contact with thermal "
+        "coupling, but is only initialized for matching grids. Either disable TSI contact or use "
+        "matching grids.");
+    contact_strategy_lagrange_->set_state(Mortar::state_temperature,
+        *structure_thermo_coupling_->source_to_target(*thermo_field()->tempnp()));
   }
 }  // apply_thermo_coupling_state()
 
@@ -334,6 +338,10 @@ void TSI::Algorithm::prepare_contact_strategy()
 
     if (contact_strategy_lagrange_ != nullptr)
     {
+      FOUR_C_ASSERT_ALWAYS(structure_thermo_coupling_ != nullptr,
+          "Invalid configuration: structure_thermo_coupling_ is required for contact with thermal "
+          "coupling, but is only initialized for matching grids. Either disable TSI contact or use "
+          "matching grids.");
       contact_strategy_lagrange_->set_alphaf_thermo(problem_->thermal_dynamic_params());
       contact_strategy_lagrange_->set_coupling(structure_thermo_coupling_);
     }

--- a/src/tsi/4C_tsi_algorithm.cpp
+++ b/src/tsi/4C_tsi_algorithm.cpp
@@ -122,9 +122,9 @@ TSI::Algorithm::Algorithm(MPI_Comm comm)
   // setup coupling object for matching discretization
   if (matchinggrid_)
   {
-    coupST_ = std::make_shared<Coupling::Adapter::Coupling>();
-    coupST_->setup_coupling(*structure_field()->discretization(), *thermo_field()->discretization(),
-        *structure_field()->discretization()->node_row_map(),
+    structure_thermo_coupling_ = std::make_shared<Coupling::Adapter::Coupling>();
+    structure_thermo_coupling_->setup_coupling(*structure_field()->discretization(),
+        *thermo_field()->discretization(), *structure_field()->discretization()->node_row_map(),
         *thermo_field()->discretization()->node_row_map(), 1, true);
   }
 
@@ -228,8 +228,8 @@ void TSI::Algorithm::apply_thermo_coupling_state(
   // set new temperatures to contact
   {
     if (contact_strategy_lagrange_ != nullptr)
-      contact_strategy_lagrange_->set_state(
-          Mortar::state_temperature, *coupST_->source_to_target(*thermo_field()->tempnp()));
+      contact_strategy_lagrange_->set_state(Mortar::state_temperature,
+          *structure_thermo_coupling_->source_to_target(*thermo_field()->tempnp()));
   }
 }  // apply_thermo_coupling_state()
 
@@ -298,15 +298,15 @@ void TSI::Algorithm::prepare_contact_strategy()
     // build the contact interfaces
     // ---------------------------------------------------------------------
     // FixMe Would be great, if we get rid of these poro parameters...
-    bool poroslave = false;
-    bool poromaster = false;
-    factory.build_interfaces(cparams, interfaces, poroslave, poromaster);
+    bool poro_source = false;
+    bool poro_target = false;
+    factory.build_interfaces(cparams, interfaces, poro_source, poro_target);
 
     // ---------------------------------------------------------------------
     // build the solver strategy object
     // ---------------------------------------------------------------------
     contact_strategy_lagrange_ = std::dynamic_pointer_cast<CONTACT::LagrangeStrategyTsi>(
-        factory.build_strategy(cparams, poroslave, poromaster, 1e8, interfaces));
+        factory.build_strategy(cparams, poro_source, poro_target, 1e8, interfaces));
 
     // build the search tree
     factory.build_search_tree(interfaces);
@@ -335,7 +335,7 @@ void TSI::Algorithm::prepare_contact_strategy()
     if (contact_strategy_lagrange_ != nullptr)
     {
       contact_strategy_lagrange_->set_alphaf_thermo(problem_->thermal_dynamic_params());
-      contact_strategy_lagrange_->set_coupling(coupST_);
+      contact_strategy_lagrange_->set_coupling(structure_thermo_coupling_);
     }
   }
 }

--- a/src/tsi/4C_tsi_algorithm.hpp
+++ b/src/tsi/4C_tsi_algorithm.hpp
@@ -143,7 +143,7 @@ namespace TSI
     void prepare_contact_strategy();
 
     //! Access to the dof coupling for matching grid TSI
-    Coupling::Adapter::Coupling& structure_thermo_coupling() { return *coupST_; }
+    Coupling::Adapter::Coupling& structure_thermo_coupling() { return *structure_thermo_coupling_; }
     //@}
 
     //! @name Access methods
@@ -183,7 +183,8 @@ namespace TSI
     //! volume coupling (using mortar) adapter
     std::shared_ptr<Coupling::Adapter::MortarVolCoupl> volcoupl_;
 
-    std::shared_ptr<Coupling::Adapter::Coupling> coupST_;  // S: master, T: slave
+    std::shared_ptr<Coupling::Adapter::Coupling>
+        structure_thermo_coupling_;  //! structure (target), thermo (source)
     //@}
 
 

--- a/src/tsi/4C_tsi_monolithic.cpp
+++ b/src/tsi/4C_tsi_monolithic.cpp
@@ -357,8 +357,8 @@ void TSI::Monolithic::newton_full()
 
   // do the thermo contact modifications all at once
   if (contact_strategy_lagrange_ != nullptr)
-    contact_strategy_lagrange_->evaluate(
-        system_matrix(), rhs_, coupST_, structure_field()->dispnp(), thermo_field()->tempnp());
+    contact_strategy_lagrange_->evaluate(system_matrix(), rhs_, structure_thermo_coupling_,
+        structure_field()->dispnp(), thermo_field()->tempnp());
   apply_dbc();
 
   // initialize with predictor values
@@ -432,8 +432,8 @@ void TSI::Monolithic::newton_full()
       double dtcpu = timernewton_.wallTime();
       // *********** time measurement ***********
 
-      contact_strategy_lagrange_->evaluate(
-          system_matrix(), rhs_, coupST_, structure_field()->dispnp(), thermo_field()->tempnp());
+      contact_strategy_lagrange_->evaluate(system_matrix(), rhs_, structure_thermo_coupling_,
+          structure_field()->dispnp(), thermo_field()->tempnp());
 
       // *********** time measurement ***********
       dtcmt_ = timernewton_.wallTime() - dtcpu;
@@ -1897,7 +1897,7 @@ void TSI::Monolithic::recover_struct_therm_lm()
   // extract field vectors
   extract_field_vectors(iterinc_, sx, tx);
 
-  contact_strategy_lagrange_->recover_coupled(sx, tx, coupST_);
+  contact_strategy_lagrange_->recover_coupled(sx, tx, structure_thermo_coupling_);
 
   return;
 }


### PR DESCRIPTION
# Description
This PR continues renaming "master"/"slave" to "target"/"source" (or "anchor node" where appropriate) in:
- Poroelasticity: poroelast, poroelast_scatra
- Structure: structure_new, structure
- TSI

In the constraint module, I used the word "anchor node" as I believe it fits better in this context (multipoint constraint where all nodes of a plane (defined by an "anchor node") are constrained.

Additionally, I removed unused functions discovered during the rename and adjusted some variable names for consistency.