### PR TITLE
Validate output argument contains a prefix

### DIFF
--- a/apps/global_full/4C_global_full_io.cpp
+++ b/apps/global_full/4C_global_full_io.cpp
@@ -201,6 +201,17 @@ void validate_argument_cross_compatibility(const CommandlineArguments& arguments
             arguments.n_groups);
       }
     }
+
+    for (const auto& [input, output] : arguments.io_pairs)
+    {
+      if (std::filesystem::path(output).filename().empty())
+      {
+        FOUR_C_THROW(
+            "The output argument '{}' does not contain a filename prefix. "
+            "Please specify a file prefix, e.g. 'out/my_sim' instead of 'out/'.",
+            output);
+      }
+    }
   }
 
   if (arguments.nptype != NPT::separate_input_files &&


### PR DESCRIPTION
# Description
When a user passed a directory path without a filename prefix as the output argument (e.g. `out/` instead of `out/my_sim`), 4C would silently proceed and produce malformed output: hidden files like `.control` and `.mesh.scatra.s0`, and files with names starting with `-` like `-scatra.pvd`. No error was reported.

The fix adds a validation check in `validate_argument_cross_compatibility` that rejects any output argument whose `std::filesystem::path::filename()` component is empty -  which is the case for any trailing-slash path. Since both the primary input/output pair and all additional nested parallelism pairs are already assembled into `io_pairs` before this function is called, a single loop covers all cases uniformly, including `separateInputFiles` and `nestedMultiscale` setups.

Thanks to @c-p-schmidt @lauraengelhardt 