### PR TITLE
[Particle] Do not use ParticleObjShrdPtr for commicating particle data

### DIFF
--- a/src/particle/src/engine/4C_particle_engine.cpp
+++ b/src/particle/src/engine/4C_particle_engine.cpp
@@ -355,19 +355,12 @@ void Particle::ParticleEngine::refresh_particles() const
 {
   TEUCHOS_FUNC_TIME_MONITOR("Particle::ParticleEngine::RefreshParticles");
 
-  std::vector<std::vector<ParticleObjShrdPtr>> particlestosend(
-      Core::Communication::num_mpi_ranks(comm_));
-  std::vector<std::vector<std::pair<int, ParticleObjShrdPtr>>> particlestoinsert(typevectorsize_);
+  // pack particles to be refreshed directly into send buffers
+  std::map<int, std::vector<char>> sdata;
+  pack_particles_to_be_refreshed(sdata);
 
-  // determine particles that need to be refreshed
-  determine_particles_to_be_refreshed(particlestosend);
-
-  // communicate particles using cached communication graph
-  communicate_particles(particlestosend, particlestoinsert, &cached_procs_send_ghost_data_to_,
-      &cached_procs_receive_ghost_data_from_);
-
-  // insert refreshed particles received from other processors
-  insert_refreshed_particles(particlestoinsert);
+  // communicate and unpack refreshed particles directly into containers
+  communicate_refreshed_particles(sdata);
 }
 
 void Particle::ParticleEngine::refresh_particles_of_specific_states_and_types(
@@ -376,20 +369,12 @@ void Particle::ParticleEngine::refresh_particles_of_specific_states_and_types(
   TEUCHOS_FUNC_TIME_MONITOR(
       "Particle::ParticleEngine::refresh_particles_of_specific_states_and_types");
 
-  std::vector<std::vector<ParticleObjShrdPtr>> particlestosend(
-      Core::Communication::num_mpi_ranks(comm_));
-  std::vector<std::vector<std::pair<int, ParticleObjShrdPtr>>> particlestoinsert(typevectorsize_);
+  // pack specific states of particles directly into send buffers
+  std::map<int, std::vector<char>> sdata;
+  pack_specific_states_of_particles_to_be_refreshed(particlestatestotypes, sdata);
 
-  // determine particles that need to be refreshed
-  determine_specific_states_of_particles_of_specific_types_to_be_refreshed(
-      particlestatestotypes, particlestosend);
-
-  // communicate particles using cached communication graph
-  communicate_particles(particlestosend, particlestoinsert, &cached_procs_send_ghost_data_to_,
-      &cached_procs_receive_ghost_data_from_);
-
-  // insert refreshed particles received from other processors
-  insert_refreshed_particles(particlestoinsert);
+  // communicate and unpack refreshed particles directly into containers
+  communicate_refreshed_particles(sdata);
 }
 
 void Particle::ParticleEngine::dynamic_load_balancing()
@@ -1583,8 +1568,8 @@ void Particle::ParticleEngine::determine_particles_to_be_ghosted(
   }
 }
 
-void Particle::ParticleEngine::determine_particles_to_be_refreshed(
-    std::vector<std::vector<ParticleObjShrdPtr>>& particlestosend) const
+void Particle::ParticleEngine::pack_particles_to_be_refreshed(
+    std::map<int, std::vector<char>>& sdata) const
 {
   // safety check
   if (not validdirectghosting_) FOUR_C_THROW("invalid direct ghosting!");
@@ -1603,9 +1588,14 @@ void Particle::ParticleEngine::determine_particles_to_be_refreshed(
     {
       int ownedindex = indexIt.first;
 
+      // get particle states once
       int globalid(0);
       ParticleStates states;
       container->get_particle(ownedindex, globalid, states);
+
+      // pre-pack states data (reused for all targets of this particle)
+      Core::Communication::PackBuffer statesdata;
+      add_to_pack(statesdata, states);
 
       // iterate over target processors
       for (const auto& targetIt : indexIt.second)
@@ -1613,18 +1603,23 @@ void Particle::ParticleEngine::determine_particles_to_be_refreshed(
         int sendtoproc = targetIt.first;
         int ghostedindex = targetIt.second;
 
-        // append particle to be send
-        particlestosend[sendtoproc].emplace_back(
-            std::make_shared<ParticleObject>(type, -1, states, -1, ghostedindex));
+        // pack type and ghosted index header
+        Core::Communication::PackBuffer header;
+        add_to_pack(header, static_cast<int>(type));
+        add_to_pack(header, ghostedindex);
+
+        // append header + pre-packed states to send buffer
+        auto& buf = sdata[sendtoproc];
+        buf.insert(buf.end(), header().begin(), header().end());
+        buf.insert(buf.end(), statesdata().begin(), statesdata().end());
       }
     }
   }
 }
 
-void Particle::ParticleEngine::
-    determine_specific_states_of_particles_of_specific_types_to_be_refreshed(
-        const StatesOfTypesToRefresh& particlestatestotypes,
-        std::vector<std::vector<ParticleObjShrdPtr>>& particlestosend) const
+void Particle::ParticleEngine::pack_specific_states_of_particles_to_be_refreshed(
+    const StatesOfTypesToRefresh& particlestatestotypes,
+    std::map<int, std::vector<char>>& sdata) const
 {
   // safety check
   if (not validdirectghosting_) FOUR_C_THROW("invalid direct ghosting!");
@@ -1666,15 +1661,25 @@ void Particle::ParticleEngine::
         states[state].assign(state_ptr, state_ptr + statedim);
       }
 
+      // pre-pack states data (reused for all targets of this particle)
+      Core::Communication::PackBuffer statesdata;
+      add_to_pack(statesdata, states);
+
       // iterate over target processors
       for (const auto& targetIt : indexIt.second)
       {
         int sendtoproc = targetIt.first;
         int ghostedindex = targetIt.second;
 
-        // append particle to be send
-        particlestosend[sendtoproc].emplace_back(
-            std::make_shared<ParticleObject>(type, -1, states, -1, ghostedindex));
+        // pack type and ghosted index header
+        Core::Communication::PackBuffer header;
+        add_to_pack(header, static_cast<int>(type));
+        add_to_pack(header, ghostedindex);
+
+        // append header + pre-packed states to send buffer
+        auto& buf = sdata[sendtoproc];
+        buf.insert(buf.end(), header().begin(), header().end());
+        buf.insert(buf.end(), statesdata().begin(), statesdata().end());
       }
     }
   }
@@ -1682,44 +1687,30 @@ void Particle::ParticleEngine::
 
 void Particle::ParticleEngine::communicate_particles(
     std::vector<std::vector<ParticleObjShrdPtr>>& particlestosend,
-    std::vector<std::vector<std::pair<int, ParticleObjShrdPtr>>>& particlestoreceive,
-    const std::set<int>* send_to_procs, const std::set<int>* receive_from_procs) const
+    std::vector<std::vector<std::pair<int, ParticleObjShrdPtr>>>& particlestoreceive) const
 {
-  FOUR_C_ASSERT_ALWAYS(
-      (send_to_procs && receive_from_procs) || (!send_to_procs && !receive_from_procs),
-      "Either both senders and receivers must be specified or none of them!");
-
   // prepare buffer for sending and receiving
   std::map<int, std::vector<char>> sdata;
   std::map<int, std::vector<char>> rdata;
 
   // pack data for sending
-  auto pack_for_rank = [&](int torank)
+  for (int torank = 0; torank < Core::Communication::num_mpi_ranks(comm_); ++torank)
   {
-    if (particlestosend[torank].empty()) return;
+    if (particlestosend[torank].empty()) continue;
+
     for (const auto& iter : particlestosend[torank])
     {
       Core::Communication::PackBuffer data;
       iter->pack(data);
       sdata[torank].insert(sdata[torank].end(), data().begin(), data().end());
     }
-  };
-
-  if (send_to_procs)
-    for (int torank : *send_to_procs) pack_for_rank(torank);
-  else
-    for (int torank = 0; torank < Core::Communication::num_mpi_ranks(comm_); ++torank)
-      pack_for_rank(torank);
+  }
 
   // clear after all particles are packed
   particlestosend.clear();
 
-  // communicate data
-  if (send_to_procs && receive_from_procs)
-    ParticleUtils::immediate_send_recv_known_procs(
-        comm_, sdata, rdata, *send_to_procs, *receive_from_procs);
-  else
-    ParticleUtils::immediate_recv_blocking_send(comm_, sdata, rdata);
+  // communicate data via non-buffered send from proc to proc
+  ParticleUtils::immediate_recv_blocking_send(comm_, sdata, rdata);
 
   // unpack and store received data
   for (const auto& p : rdata)
@@ -1737,6 +1728,46 @@ void Particle::ParticleEngine::communicate_particles(
       // store received particle
       particlestoreceive[particleobject->return_particle_type()].push_back(
           std::make_pair(msgsource, particleobject));
+    }
+  }
+}
+
+void Particle::ParticleEngine::communicate_refreshed_particles(
+    std::map<int, std::vector<char>>& sdata) const
+{
+  // communicate data via cached send/receive graph
+  std::map<int, std::vector<char>> rdata;
+  ParticleUtils::immediate_send_recv_known_procs(
+      comm_, sdata, rdata, cached_procs_send_ghost_data_to_, cached_procs_receive_ghost_data_from_);
+
+  // clear after all particles are communicated
+  sdata.clear();
+
+  // unpack received data directly into ghosted particle containers
+  for (const auto& p : rdata)
+  {
+    const std::vector<char>& rmsg = p.second;
+
+    Core::Communication::UnpackBuffer buffer(rmsg);
+    while (!buffer.at_end())
+    {
+      // unpack particle type
+      int type_int;
+      extract_from_pack(buffer, type_int);
+      ParticleType type = static_cast<ParticleType>(type_int);
+
+      // unpack ghosted index
+      int ghostedindex;
+      extract_from_pack(buffer, ghostedindex);
+
+      // unpack states
+      ParticleStates states;
+      extract_from_pack(buffer, states);
+
+      // replace particle directly in container of ghosted particles
+      ParticleContainer* container =
+          particlecontainerbundle_->get_specific_container(type, Ghosted);
+      container->replace_particle(ghostedindex, -1, states);
     }
   }
 }
@@ -1943,39 +1974,6 @@ void Particle::ParticleEngine::insert_ghosted_particles(
   validparticleneighbors_ = false;
   validglobalidtolocalindex_ = false;
   validdirectghosting_ = false;
-}
-
-void Particle::ParticleEngine::insert_refreshed_particles(
-    std::vector<std::vector<std::pair<int, ParticleObjShrdPtr>>>& particlestoinsert) const
-{
-  // iterate over particle types
-  for (const auto& type : particlecontainerbundle_->get_particle_types())
-  {
-    // check for particles of current type
-    if (particlestoinsert[type].empty()) continue;
-
-    // get container of ghosted particles of current particle type
-    ParticleContainer* container = particlecontainerbundle_->get_specific_container(type, Ghosted);
-
-    // iterate over particle objects pairs
-    for (const auto& objectpair : particlestoinsert[type])
-    {
-      // get particle object
-      ParticleObjShrdPtr particleobject = objectpair.second;
-
-      // get states of particle
-      const ParticleStates& states = particleobject->return_particle_states();
-
-      // get local index of particle in container of ghosted particles on this processor
-      int ghostedindex = particleobject->return_container_index();
-
-      // replace particle in container of ghosted particles
-      container->replace_particle(ghostedindex, -1, states);
-    }
-  }
-
-  // clear after all particles are inserted
-  particlestoinsert.clear();
 }
 
 void Particle::ParticleEngine::remove_particles_from_containers(

--- a/src/particle/src/engine/4C_particle_engine.cpp
+++ b/src/particle/src/engine/4C_particle_engine.cpp
@@ -21,6 +21,7 @@
 #include "4C_particle_engine_container.hpp"
 #include "4C_particle_engine_container_bundle.hpp"
 #include "4C_particle_engine_object.hpp"
+#include "4C_particle_engine_refresh_entry.hpp"
 #include "4C_particle_engine_runtime_vtp_writer.hpp"
 #include "4C_particle_engine_unique_global_id.hpp"
 #include "4C_particle_input.hpp"
@@ -1603,23 +1604,13 @@ void Particle::ParticleEngine::pack_states_and_append_to_send_buffers(ParticleTy
     const std::vector<std::pair<int, int>>& targets, const ParticleStates& states,
     std::map<int, std::vector<char>>& sdata) const
 {
-  // pre-pack states data (reused for all targets of this particle)
+  // pre-pack states data once (reused for all targets of this particle)
   Core::Communication::PackBuffer statesdata;
   add_to_pack(statesdata, states);
 
   // iterate over target processors
   for (const auto& [sendtoproc, ghostedindex] : targets)
-  {
-    // pack type and ghosted index header
-    Core::Communication::PackBuffer header;
-    add_to_pack(header, static_cast<int>(type));
-    add_to_pack(header, ghostedindex);
-
-    // append header + pre-packed states to send buffer
-    auto& buf = sdata[sendtoproc];
-    buf.insert(buf.end(), header().begin(), header().end());
-    buf.insert(buf.end(), statesdata().begin(), statesdata().end());
-  }
+    ParticleRefreshEntry::pack(type, ghostedindex, statesdata, sdata[sendtoproc]);
 }
 
 std::map<int, std::vector<char>>
@@ -1738,23 +1729,13 @@ void Particle::ParticleEngine::communicate_refreshed_particles(
     Core::Communication::UnpackBuffer buffer(rmsg);
     while (!buffer.at_end())
     {
-      // unpack particle type
-      int type_int;
-      extract_from_pack(buffer, type_int);
-      ParticleType type = static_cast<ParticleType>(type_int);
-
-      // unpack ghosted index
-      int ghostedindex;
-      extract_from_pack(buffer, ghostedindex);
-
-      // unpack states
-      ParticleStates states;
-      extract_from_pack(buffer, states);
+      // unpack refresh entry packed by ParticleRefreshEntry::pack()
+      ParticleRefreshEntry entry = ParticleRefreshEntry::unpack(buffer);
 
       // replace particle directly in container of ghosted particles
       ParticleContainer* container =
-          particlecontainerbundle_->get_specific_container(type, Ghosted);
-      container->replace_particle(ghostedindex, -1, states);
+          particlecontainerbundle_->get_specific_container(entry.type, Ghosted);
+      container->replace_particle(entry.ghostedindex, -1, entry.states);
     }
   }
 }

--- a/src/particle/src/engine/4C_particle_engine.cpp
+++ b/src/particle/src/engine/4C_particle_engine.cpp
@@ -356,8 +356,7 @@ void Particle::ParticleEngine::refresh_particles() const
   TEUCHOS_FUNC_TIME_MONITOR("Particle::ParticleEngine::RefreshParticles");
 
   // pack particles to be refreshed directly into send buffers
-  std::map<int, std::vector<char>> sdata;
-  pack_particles_to_be_refreshed(sdata);
+  auto sdata = pack_particles_to_be_refreshed();
 
   // communicate and unpack refreshed particles directly into containers
   communicate_refreshed_particles(sdata);
@@ -370,8 +369,7 @@ void Particle::ParticleEngine::refresh_particles_of_specific_states_and_types(
       "Particle::ParticleEngine::refresh_particles_of_specific_states_and_types");
 
   // pack specific states of particles directly into send buffers
-  std::map<int, std::vector<char>> sdata;
-  pack_specific_states_of_particles_to_be_refreshed(particlestatestotypes, sdata);
+  auto sdata = pack_specific_states_of_particles_to_be_refreshed(particlestatestotypes);
 
   // communicate and unpack refreshed particles directly into containers
   communicate_refreshed_particles(sdata);
@@ -1568,11 +1566,12 @@ void Particle::ParticleEngine::determine_particles_to_be_ghosted(
   }
 }
 
-void Particle::ParticleEngine::pack_particles_to_be_refreshed(
-    std::map<int, std::vector<char>>& sdata) const
+std::map<int, std::vector<char>> Particle::ParticleEngine::pack_particles_to_be_refreshed() const
 {
   // safety check
-  if (not validdirectghosting_) FOUR_C_THROW("invalid direct ghosting!");
+  FOUR_C_ASSERT_ALWAYS(validdirectghosting_, "invalid direct ghosting!");
+
+  std::map<int, std::vector<char>> sdata;
 
   // iterate over particle types
   for (const auto& type : particlecontainerbundle_->get_particle_types())
@@ -1593,36 +1592,44 @@ void Particle::ParticleEngine::pack_particles_to_be_refreshed(
       ParticleStates states;
       container->get_particle(ownedindex, globalid, states);
 
-      // pre-pack states data (reused for all targets of this particle)
-      Core::Communication::PackBuffer statesdata;
-      add_to_pack(statesdata, states);
-
-      // iterate over target processors
-      for (const auto& targetIt : indexIt.second)
-      {
-        int sendtoproc = targetIt.first;
-        int ghostedindex = targetIt.second;
-
-        // pack type and ghosted index header
-        Core::Communication::PackBuffer header;
-        add_to_pack(header, static_cast<int>(type));
-        add_to_pack(header, ghostedindex);
-
-        // append header + pre-packed states to send buffer
-        auto& buf = sdata[sendtoproc];
-        buf.insert(buf.end(), header().begin(), header().end());
-        buf.insert(buf.end(), statesdata().begin(), statesdata().end());
-      }
+      pack_states_and_append_to_send_buffers(type, indexIt.second, states, sdata);
     }
+  }
+
+  return sdata;
+}
+
+void Particle::ParticleEngine::pack_states_and_append_to_send_buffers(ParticleType type,
+    const std::vector<std::pair<int, int>>& targets, const ParticleStates& states,
+    std::map<int, std::vector<char>>& sdata) const
+{
+  // pre-pack states data (reused for all targets of this particle)
+  Core::Communication::PackBuffer statesdata;
+  add_to_pack(statesdata, states);
+
+  // iterate over target processors
+  for (const auto& [sendtoproc, ghostedindex] : targets)
+  {
+    // pack type and ghosted index header
+    Core::Communication::PackBuffer header;
+    add_to_pack(header, static_cast<int>(type));
+    add_to_pack(header, ghostedindex);
+
+    // append header + pre-packed states to send buffer
+    auto& buf = sdata[sendtoproc];
+    buf.insert(buf.end(), header().begin(), header().end());
+    buf.insert(buf.end(), statesdata().begin(), statesdata().end());
   }
 }
 
-void Particle::ParticleEngine::pack_specific_states_of_particles_to_be_refreshed(
-    const StatesOfTypesToRefresh& particlestatestotypes,
-    std::map<int, std::vector<char>>& sdata) const
+std::map<int, std::vector<char>>
+Particle::ParticleEngine::pack_specific_states_of_particles_to_be_refreshed(
+    const StatesOfTypesToRefresh& particlestatestotypes) const
 {
   // safety check
-  if (not validdirectghosting_) FOUR_C_THROW("invalid direct ghosting!");
+  FOUR_C_ASSERT_ALWAYS(validdirectghosting_, "invalid direct ghosting!");
+
+  std::map<int, std::vector<char>> sdata;
 
   // iterate over particle types
   for (const auto& typeIt : particlestatestotypes)
@@ -1661,28 +1668,11 @@ void Particle::ParticleEngine::pack_specific_states_of_particles_to_be_refreshed
         states[state].assign(state_ptr, state_ptr + statedim);
       }
 
-      // pre-pack states data (reused for all targets of this particle)
-      Core::Communication::PackBuffer statesdata;
-      add_to_pack(statesdata, states);
-
-      // iterate over target processors
-      for (const auto& targetIt : indexIt.second)
-      {
-        int sendtoproc = targetIt.first;
-        int ghostedindex = targetIt.second;
-
-        // pack type and ghosted index header
-        Core::Communication::PackBuffer header;
-        add_to_pack(header, static_cast<int>(type));
-        add_to_pack(header, ghostedindex);
-
-        // append header + pre-packed states to send buffer
-        auto& buf = sdata[sendtoproc];
-        buf.insert(buf.end(), header().begin(), header().end());
-        buf.insert(buf.end(), statesdata().begin(), statesdata().end());
-      }
+      pack_states_and_append_to_send_buffers(type, indexIt.second, states, sdata);
     }
   }
+
+  return sdata;
 }
 
 void Particle::ParticleEngine::communicate_particles(
@@ -1739,9 +1729,6 @@ void Particle::ParticleEngine::communicate_refreshed_particles(
   std::map<int, std::vector<char>> rdata;
   ParticleUtils::immediate_send_recv_known_procs(
       comm_, sdata, rdata, cached_procs_send_ghost_data_to_, cached_procs_receive_ghost_data_from_);
-
-  // clear after all particles are communicated
-  sdata.clear();
 
   // unpack received data directly into ghosted particle containers
   for (const auto& p : rdata)

--- a/src/particle/src/engine/4C_particle_engine.hpp
+++ b/src/particle/src/engine/4C_particle_engine.hpp
@@ -19,6 +19,8 @@
 #include "4C_particle_engine_interface.hpp"
 #include "4C_utils_parameter_list.fwd.hpp"
 
+#include <map>
+
 FOUR_C_NAMESPACE_OPEN
 
 /*---------------------------------------------------------------------------*
@@ -568,47 +570,55 @@ namespace Particle
         std::vector<std::vector<ParticleObjShrdPtr>>& particlestosend) const;
 
     /*!
-     * \brief determine particles that need to be refreshed
+     * \brief pack particles to be refreshed into send buffers
      *
-     * Determine particles that need to be refreshed on other processors based on the direct
-     * ghosting targets map.
+     * Pack all states of particles that need to be refreshed on other processors directly into
+     * send buffers, bypassing ParticleObject creation.
      *
      *
-     * \param[out] particlestosend particles to be send to other processors
+     * \param[out] sdata send buffers indexed by target processor rank
      */
-    void determine_particles_to_be_refreshed(
-        std::vector<std::vector<ParticleObjShrdPtr>>& particlestosend) const;
+    void pack_particles_to_be_refreshed(std::map<int, std::vector<char>>& sdata) const;
 
     /*!
-     * \brief determine specific states of particles of specific type that need to be refreshed
+     * \brief pack specific states of particles of specific types into send buffers
+     *
+     * Pack the information of specific states of particles of specific types directly into
+     * send buffers, bypassing ParticleObject creation.
      *
      *
      * \param[in]  particlestatestotypes particle types and corresponding particle states to be
      *                                   refreshed
-     * \param[out] particlestosend       particles to be send to other processors
+     * \param[out] sdata                 send buffers indexed by target processor rank
      */
-    void determine_specific_states_of_particles_of_specific_types_to_be_refreshed(
+    void pack_specific_states_of_particles_to_be_refreshed(
         const StatesOfTypesToRefresh& particlestatestotypes,
-        std::vector<std::vector<ParticleObjShrdPtr>>& particlestosend) const;
+        std::map<int, std::vector<char>>& sdata) const;
 
     /*!
      * \brief communicate particles
      *
      * This method communicates particles to be send to other processors and receives particles from
-     * other processors. When send_to_procs and receive_from_procs are provided, the communication
-     * uses the known graph directly without collective communication. Otherwise a collective
-     * communication is used to determine the number of incoming messages.
+     * other processors.
      *
      *
-     * \param[in]  particlestosend      particles to be send to other processors
-     * \param[out] particlestoreceive   particles to be received on this processor
-     * \param[in]  send_to_procs        optional set of processors to send data to
-     * \param[in]  receive_from_procs   optional set of processors to receive data from
+     * \param[in]  particlestosend    particles to be send to other processors
+     * \param[out] particlestoreceive particles to be received on this processor
      */
     void communicate_particles(std::vector<std::vector<ParticleObjShrdPtr>>& particlestosend,
-        std::vector<std::vector<std::pair<int, ParticleObjShrdPtr>>>& particlestoreceive,
-        const std::set<int>* send_to_procs = nullptr,
-        const std::set<int>* receive_from_procs = nullptr) const;
+        std::vector<std::vector<std::pair<int, ParticleObjShrdPtr>>>& particlestoreceive) const;
+
+    /*!
+     * \brief communicate refreshed particles using cached communication graph
+     *
+     * Uses the pre-computed cached_procs_send_ghost_data_to_ and
+     * cached_procs_receive_ghost_data_from_ to exchange refreshed particle data. Unpacks received
+     * data directly into ghosted particle containers without ParticleObject creation.
+     *
+     *
+     * \param[in] sdata pre-packed send buffers indexed by target processor rank
+     */
+    void communicate_refreshed_particles(std::map<int, std::vector<char>>& sdata) const;
 
     /*!
      * \brief communicate and build map for direct ghosting
@@ -641,15 +651,6 @@ namespace Particle
     void insert_ghosted_particles(
         std::vector<std::vector<std::pair<int, ParticleObjShrdPtr>>>& particlestoinsert,
         std::map<int, std::map<ParticleType, std::map<int, std::pair<int, int>>>>& directghosting);
-
-    /*!
-     * \brief insert refreshed particles received from other processors
-     *
-     *
-     * \param[in] particlestoinsert particles to be inserted into containers on this processor
-     */
-    void insert_refreshed_particles(
-        std::vector<std::vector<std::pair<int, ParticleObjShrdPtr>>>& particlestoinsert) const;
 
     /*!
      * \brief remove particles from containers

--- a/src/particle/src/engine/4C_particle_engine.hpp
+++ b/src/particle/src/engine/4C_particle_engine.hpp
@@ -576,9 +576,9 @@ namespace Particle
      * send buffers, bypassing ParticleObject creation.
      *
      *
-     * \param[out] sdata send buffers indexed by target processor rank
+     * \return send buffers indexed by target processor rank
      */
-    void pack_particles_to_be_refreshed(std::map<int, std::vector<char>>& sdata) const;
+    std::map<int, std::vector<char>> pack_particles_to_be_refreshed() const;
 
     /*!
      * \brief pack specific states of particles of specific types into send buffers
@@ -587,12 +587,26 @@ namespace Particle
      * send buffers, bypassing ParticleObject creation.
      *
      *
-     * \param[in]  particlestatestotypes particle types and corresponding particle states to be
-     *                                   refreshed
-     * \param[out] sdata                 send buffers indexed by target processor rank
+     * \param[in] particlestatestotypes particle types and corresponding particle states to be
+     *                                  refreshed
+     * \return send buffers indexed by target processor rank
      */
-    void pack_specific_states_of_particles_to_be_refreshed(
-        const StatesOfTypesToRefresh& particlestatestotypes,
+    std::map<int, std::vector<char>> pack_specific_states_of_particles_to_be_refreshed(
+        const StatesOfTypesToRefresh& particlestatestotypes) const;
+
+    /*!
+     * \brief pack particle states and append to send buffers for all ghosting targets
+     *
+     * Pre-packs the given particle states and appends the type/ghosted-index header together with
+     * the states data to the corresponding send buffers for all target processors.
+     *
+     * \param[in]  type        particle type
+     * \param[in]  targets     map from owned index to list of (target proc, ghosted index) pairs
+     * \param[in]  states      particle states to send
+     * \param[out] sdata       send buffers indexed by target processor rank
+     */
+    void pack_states_and_append_to_send_buffers(ParticleType type,
+        const std::vector<std::pair<int, int>>& targets, const ParticleStates& states,
         std::map<int, std::vector<char>>& sdata) const;
 
     /*!

--- a/src/particle/src/engine/4C_particle_engine_refresh_entry.cpp
+++ b/src/particle/src/engine/4C_particle_engine_refresh_entry.cpp
@@ -1,0 +1,49 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "4C_particle_engine_refresh_entry.hpp"
+
+#include "4C_comm_pack_helpers.hpp"
+
+FOUR_C_NAMESPACE_OPEN
+
+/*---------------------------------------------------------------------------*
+ | definitions                                                               |
+ *---------------------------------------------------------------------------*/
+void Particle::ParticleRefreshEntry::pack(ParticleType type, int ghostedindex,
+    const Core::Communication::PackBuffer& prepacked_states, std::vector<char>& sendbuffer)
+{
+  // pack type and ghosted index header
+  Core::Communication::PackBuffer header;
+  add_to_pack(header, static_cast<int>(type));
+  add_to_pack(header, ghostedindex);
+
+  // append header + pre-packed states to send buffer
+  sendbuffer.insert(sendbuffer.end(), header().begin(), header().end());
+  sendbuffer.insert(sendbuffer.end(), prepacked_states().begin(), prepacked_states().end());
+}
+
+Particle::ParticleRefreshEntry Particle::ParticleRefreshEntry::unpack(
+    Core::Communication::UnpackBuffer& buffer)
+{
+  ParticleRefreshEntry entry;
+
+  // unpack particle type
+  int type_int;
+  extract_from_pack(buffer, type_int);
+  entry.type = static_cast<ParticleType>(type_int);
+
+  // unpack ghosted index
+  extract_from_pack(buffer, entry.ghostedindex);
+
+  // unpack states
+  extract_from_pack(buffer, entry.states);
+
+  return entry;
+}
+
+FOUR_C_NAMESPACE_CLOSE

--- a/src/particle/src/engine/4C_particle_engine_refresh_entry.hpp
+++ b/src/particle/src/engine/4C_particle_engine_refresh_entry.hpp
@@ -1,0 +1,86 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef FOUR_C_PARTICLE_ENGINE_REFRESH_ENTRY_HPP
+#define FOUR_C_PARTICLE_ENGINE_REFRESH_ENTRY_HPP
+
+/*---------------------------------------------------------------------------*
+ | headers                                                                   |
+ *---------------------------------------------------------------------------*/
+#include "4C_config.hpp"
+
+#include "4C_particle_engine_typedefs.hpp"
+
+#include <vector>
+
+FOUR_C_NAMESPACE_OPEN
+
+/*---------------------------------------------------------------------------*
+ | forward declarations                                                      |
+ *---------------------------------------------------------------------------*/
+namespace Core::Communication
+{
+  class PackBuffer;
+  class UnpackBuffer;
+}  // namespace Core::Communication
+
+/*---------------------------------------------------------------------------*
+ | class declarations                                                        |
+ *---------------------------------------------------------------------------*/
+namespace Particle
+{
+  /*!
+   * \brief entry for refreshing the states of a ghosted particle on another processor
+   *
+   * pack() and unpack() together define the wire format used by refresh_particles() and
+   * refresh_particles_of_specific_states_and_types() to update states of ghosted particles.
+   * Both must be kept in sync: unpack() extracts fields in exactly the order pack() writes
+   * them.
+   */
+  struct ParticleRefreshEntry
+  {
+    //! particle type
+    ParticleType type;
+
+    //! local index of the particle in the container of ghosted particles on the target processor
+    int ghostedindex;
+
+    //! states of the particle
+    ParticleStates states;
+
+    /*!
+     * \brief pack header (type, ghosted index) and append pre-packed states to a send buffer
+     *
+     * The states are passed in already packed since, for a single owned particle that is
+     * ghosted on multiple processors, the same packed bytes are appended to every target
+     * processor's send buffer without re-serializing the states for each target.
+     *
+     * \param[in]  type             particle type
+     * \param[in]  ghostedindex     local index of the particle in the container of ghosted
+     *                              particles on the target processor
+     * \param[in]  prepacked_states pre-packed particle states
+     * \param[out] sendbuffer       send buffer of the target processor to append to
+     */
+    static void pack(ParticleType type, int ghostedindex,
+        const Core::Communication::PackBuffer& prepacked_states, std::vector<char>& sendbuffer);
+
+    /*!
+     * \brief unpack one refresh entry previously packed by pack()
+     *
+     *
+     * \param[in,out] buffer buffer to unpack from
+     * \return unpacked refresh entry
+     */
+    static ParticleRefreshEntry unpack(Core::Communication::UnpackBuffer& buffer);
+  };
+
+}  // namespace Particle
+
+/*---------------------------------------------------------------------------*/
+FOUR_C_NAMESPACE_CLOSE
+
+#endif


### PR DESCRIPTION
This PR is the continuation of #2074. It further improves the performance of the SPH+PD benchmark analyzed in that previous PR.

<img width="1155" height="733" alt="Figure_1" src="https://github.com/user-attachments/assets/8cedac15-0328-4e0d-b434-177d7b77df24" />
 
## 2. Avoid `ParticleObject` allocations when communicating refreshed particle data

### Goal

The particle refresh routines (`refresh_particles` and `refresh_particles_of_specific_states_and_types`) previously communicated data by wrapping every particle in a heap-allocated `ParticleObject` (`ParticleObjShrdPtr`), packing it, then reconstructing objects on the receiving side before copying their states into containers. This adds needless allocation, virtual dispatch through the `ParObject` factory, and a temporary object round-trip on a hot communication path that runs every time step.

The goal of this PR is to **eliminate `ParticleObject` creation entirely from the refresh path**, packing and unpacking particle state directly into/out of MPI byte buffers.

### How it is achieved

- **Direct packing into send buffers.** `determine_particles_to_be_refreshed` and `determine_specific_states_of_particles_of_specific_types_to_be_refreshed` are replaced by `pack_particles_to_be_refreshed` and `pack_specific_states_of_particles_to_be_refreshed`. These pack a small header (particle type + ghosted container index) followed by the particle states straight into `std::map<int, std::vector<char>>` send buffers, skipping `ParticleObject` construction.

- **State reuse per particle.** Each particle's states are packed once and appended for every target rank, avoiding repeated serialization when a particle is ghosted on multiple processors.

- **Direct unpacking into containers.** The new `communicate_refreshed_particles(sdata)` exchanges the pre-packed buffers over the cached send/receive graph (`immediate_send_recv_known_procs`) and unpacks type, index, and states directly into the ghosted containers via `replace_particle` — no factory, no `dynamic_pointer_cast`, no intermediate object list.

- **Removed the intermediate insert step.** `insert_refreshed_particles` is deleted, since received data is now written to containers inline during unpacking.

- **`communicate_particles` restored to its original form.** The refresh path no longer piggybacks on `communicate_particles`, so its optional `send_to_procs`/`receive_from_procs` overload parameters are removed, keeping that method focused on the general (collective) particle exchange.

### Result

- Fewer heap allocations and no virtual `ParObject` factory dispatch on the per-timestep refresh path.
- Simpler data flow: pack -> communicate -> unpack-into-container, with one fewer intermediate stage.
- No behavioral change to what data is exchanged; the cached communication graph (`cached_procs_send_ghost_data_to_` / `cached_procs_receive_ghost_data_from_`) is reused as before.
