### PR TITLE
Fix gmsh node reordering for corner cases

### DIFF
--- a/src/core/io/src/4C_io_gmsh_reader.cpp
+++ b/src/core/io/src/4C_io_gmsh_reader.cpp
@@ -14,6 +14,8 @@
 #include "4C_io_mesh.hpp"
 #include "4C_utils_exceptions.hpp"
 
+#include <boost/algorithm/cxx11/iota.hpp>
+
 #include <array>
 #include <iostream>
 #include <map>
@@ -247,14 +249,13 @@ namespace
 
     {
       std::vector<double> parametricCoord;
-      std::vector<std::size_t> nodeTags;
       // get node tags before renumbering
       gmsh::model::mesh::getNodes(externalNodeTags, coord, parametricCoord);
       node_count = externalNodeTags.size();
       // reorder nodes and elements to have contiguous numbering starting from 1
-      gmsh::model::mesh::renumberNodes();
-      // get renumbered nodes
-      gmsh::model::mesh::getNodes(nodeTags, coord, parametricCoord);
+      std::vector<std::size_t> contiguous_node_tags(node_count);
+      boost::algorithm::iota(contiguous_node_tags, gmsh_numbering_offset);
+      gmsh::model::mesh::renumberNodes(externalNodeTags, contiguous_node_tags);
     }
 
     mesh.external_ids = std::vector<int>(externalNodeTags.begin(), externalNodeTags.end());

--- a/src/core/io/src/4C_io_gmsh_reader.cpp
+++ b/src/core/io/src/4C_io_gmsh_reader.cpp
@@ -14,8 +14,6 @@
 #include "4C_io_mesh.hpp"
 #include "4C_utils_exceptions.hpp"
 
-#include <boost/algorithm/cxx11/iota.hpp>
-
 #include <array>
 #include <iostream>
 #include <map>
@@ -254,7 +252,7 @@ namespace
       node_count = externalNodeTags.size();
       // reorder nodes and elements to have contiguous numbering starting from 1
       std::vector<std::size_t> contiguous_node_tags(node_count);
-      boost::algorithm::iota(contiguous_node_tags, gmsh_numbering_offset);
+      std::iota(contiguous_node_tags.begin(), contiguous_node_tags.end(), gmsh_numbering_offset);
       gmsh::model::mesh::renumberNodes(externalNodeTags, contiguous_node_tags);
     }
 


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

Gmsh nodes were not guaranteed to be contiguous for all meshes before. The existing `renumberNodes` only guarantees that nodeTags go from 1 to node_count, not that they are sorted. Now, I explicitly set `1,2,...,node_count` as the new `nodeTags`. I did not add a test because most of the time, gmsh actually also sorts the nodes as desired. I could not reproduce it on a small mesh, and I don't want to upload my large mesh, which caused the problem in the first place. I do think, though, that the new version is explicit enough that it might not require a dedicated test. 

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
