### PR TITLE
Fix `get_comm` usage in reduced_lung

### DIFF
--- a/src/reduced_lung/src/1d_pipe_flow/4C_reduced_lung_1d_pipe_flow_main.cpp
+++ b/src/reduced_lung/src/1d_pipe_flow/4C_reduced_lung_1d_pipe_flow_main.cpp
@@ -471,7 +471,7 @@ namespace ReducedLung1dPipeFlow
 
     // Get local rank
     int mpi_rank = Core::Communication::my_mpi_rank(discretization->get_comm());
-    auto* comm = discretization->get_comm();
+    const auto comm = discretization->get_comm();
 
     /**************************
      *Geometry check: go through geometry and check for junctions: same coordinates of nodes


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

Fix the return type of `get_comm` to also work for intel-mpi. This lead to compile problems on coolMUC4

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
