### PR TITLE
Resolve unreachable code in cut kernel

### DIFF
--- a/src/cut/4C_cut_kernel.hpp
+++ b/src/cut/4C_cut_kernel.hpp
@@ -2200,16 +2200,22 @@ namespace Cut::Kernel
         if (det < 1.0e-16) std::cout << "!!! determinant of jacobian is smaller than 1.0e-16 !!!\n";
       }
 
-      if (det < 1.0e-16 && det > 1.0e-16)
-#if EXTENDED_CUT_DEBUG_OUTPUT
-        std::cout << "Determinant in  compute position is very close to zero" << std::endl;
-#endif
-      if (Core::MathOperations<FloatType>::abs(det) == 0.0)  // here might lie problem for the cln
+      if (det < -1.0e-16)
       {
+        std::stringstream msg;
+        msg << "Determinant in compute position is negative: " << det;
+        FOUR_C_THROW("{}", msg.str());
+      }
+
+      if (Core::MathOperations<FloatType>::abs(det) < 1.0e-16)
+      {
+#if EXTENDED_CUT_DEBUG_OUTPUT
+        std::cout << "Determinant in compute position is very close to zero" << std::endl;
+#endif
         /* then calculation of a normal to a line like this makes no sense at
          * all! */
 #if EXTENDED_CUT_DEBUG_OUTPUT
-        std::cout << "Absolute value of the determinant is zero " << std::endl;
+        std::cout << "Absolute value of the determinant is close to zero" << std::endl;
 #endif
         zeroarea_ = true;
         return false;

--- a/src/cut/4C_cut_kernel.hpp
+++ b/src/cut/4C_cut_kernel.hpp
@@ -2197,17 +2197,18 @@ namespace Cut::Kernel
       if (debug)
       {
         std::cout << "det-metric               = " << det << std::endl;
-        if (det < 1.0e-16) std::cout << "!!! determinant of jacobian is smaller than 1.0e-16 !!!\n";
+        if (det < BASICTOL)
+          std::cout << "!!! determinant of jacobian is smaller than " << BASICTOL << " !!!\n";
       }
 
-      if (det < -1.0e-16)
+      if (det < -BASICTOL)
       {
         std::stringstream msg;
         msg << "Determinant in compute position is negative: " << det;
         FOUR_C_THROW("{}", msg.str());
       }
 
-      if (Core::MathOperations<FloatType>::abs(det) < 1.0e-16)
+      if (Core::MathOperations<FloatType>::abs(det) < BASICTOL)
       {
 #if EXTENDED_CUT_DEBUG_OUTPUT
         std::cout << "Determinant in compute position is very close to zero" << std::endl;


### PR DESCRIPTION
## Description and Context
The Intel compiler pointed me to this line in the cut kernel code 
https://github.com/4C-multiphysics/4C/blob/55490c3d5d25b8ca5bbc653962be8ac2df47931a/src/cut/4C_cut_kernel.hpp#L2203
which evaluates always to false.

I am no expert of this piece of code. Please review my proposed solution.
The failing tests reveal that the proposed changes lead to different behavior. Tests with negative determinant seem to have passed in the past?!

Alternative: Delete the lines of code as they have never been reached in the past.
