### PR TITLE
Correct variable type

### DIFF
--- a/src/reduced_lung/src/1d_pipe_flow/4C_reduced_lung_1d_pipe_flow_main.cpp
+++ b/src/reduced_lung/src/1d_pipe_flow/4C_reduced_lung_1d_pipe_flow_main.cpp
@@ -471,7 +471,7 @@ namespace ReducedLung1dPipeFlow
 
     // Get local rank
     int mpi_rank = Core::Communication::my_mpi_rank(discretization->get_comm());
-    auto* comm = discretization->get_comm();
+    MPI_Comm comm = discretization->get_comm();
 
     /**************************
      *Geometry check: go through geometry and check for junctions: same coordinates of nodes


### PR DESCRIPTION
Intel compiler rejected the auto* declaration because `get_comm()` does not return a pointer type.