### PR TITLE
Silence Clang-23 Unused Warnings

### DIFF
--- a/src/fluid_turbulence/4C_fluid_turbulence_statistic_manager.hpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_statistic_manager.hpp
@@ -166,7 +166,7 @@ namespace FLD
     void setup();
 
     //! time step size
-    double dt_;
+    [[maybe_unused]] double dt_;
 
     //! parameters for sampling/dumping period
     //! start of sampling at step samstart

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_meshtying_strategy_artery.hpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_meshtying_strategy_artery.hpp
@@ -115,7 +115,7 @@ namespace PoroPressureBased
     PorofluidAlgorithm* porofluid_algorithm_;
 
     //! global parameter list of the algorithm
-    const Teuchos::ParameterList& params_;
+    [[maybe_unused]] const Teuchos::ParameterList& params_;
 
     //! parameter list of porofluid algorithm
     const Teuchos::ParameterList& porofluid_params_;


### PR DESCRIPTION
## Description and Context

I ran into some issues with unused variables when compiling with Clang-23. Adding the attribute `[[maybe_unused]]` from c++17 standard fixes this issue.

## Related Issues and Pull Requests

None that I could find
