### PR TITLE
[Particle] Make sdata const and return rdata in particle utils

### DIFF
--- a/src/particle/src/engine/4C_particle_engine.cpp
+++ b/src/particle/src/engine/4C_particle_engine.cpp
@@ -357,7 +357,7 @@ void Particle::ParticleEngine::refresh_particles() const
   TEUCHOS_FUNC_TIME_MONITOR("Particle::ParticleEngine::RefreshParticles");
 
   // pack particles to be refreshed directly into send buffers
-  auto sdata = pack_particles_to_be_refreshed();
+  const auto sdata = pack_particles_to_be_refreshed();
 
   // communicate and unpack refreshed particles directly into containers
   communicate_refreshed_particles(sdata);
@@ -370,7 +370,7 @@ void Particle::ParticleEngine::refresh_particles_of_specific_states_and_types(
       "Particle::ParticleEngine::refresh_particles_of_specific_states_and_types");
 
   // pack specific states of particles directly into send buffers
-  auto sdata = pack_specific_states_of_particles_to_be_refreshed(particlestatestotypes);
+  const auto sdata = pack_specific_states_of_particles_to_be_refreshed(particlestatestotypes);
 
   // communicate and unpack refreshed particles directly into containers
   communicate_refreshed_particles(sdata);
@@ -1143,7 +1143,6 @@ void Particle::ParticleEngine::determine_ghosting_dependent_maps_and_sets()
 
   // prepare buffer for sending and receiving
   std::map<int, std::vector<char>> sdata;
-  std::map<int, std::vector<char>> rdata;
 
   // pack data for sending
   Core::Communication::PackBuffer data;
@@ -1158,19 +1157,15 @@ void Particle::ParticleEngine::determine_ghosting_dependent_maps_and_sets()
   }
 
   // communicate data via non-buffered send from proc to proc
-  ParticleUtils::immediate_recv_blocking_send(comm_, sdata, rdata);
+  const std::map<int, std::vector<char>> rdata =
+      ParticleUtils::immediate_recv_blocking_send(comm_, sdata);
 
   // init receiving vector
   std::set<int> receivedbins;
 
   // unpack and store received data
-  for (const auto& p : rdata)
+  for (const auto& [msgsource, rmsg] : rdata)
   {
-    const int msgsource = p.first;
-    const std::vector<char>& rmsg = p.second;
-
-
-
     Core::Communication::UnpackBuffer buffer(rmsg);
     while (!buffer.at_end())
     {
@@ -1672,7 +1667,6 @@ void Particle::ParticleEngine::communicate_particles(
 {
   // prepare buffer for sending and receiving
   std::map<int, std::vector<char>> sdata;
-  std::map<int, std::vector<char>> rdata;
 
   // pack data for sending
   for (int torank = 0; torank < Core::Communication::num_mpi_ranks(comm_); ++torank)
@@ -1691,14 +1685,12 @@ void Particle::ParticleEngine::communicate_particles(
   particlestosend.clear();
 
   // communicate data via non-buffered send from proc to proc
-  ParticleUtils::immediate_recv_blocking_send(comm_, sdata, rdata);
+  const std::map<int, std::vector<char>> rdata =
+      ParticleUtils::immediate_recv_blocking_send(comm_, sdata);
 
   // unpack and store received data
-  for (const auto& p : rdata)
+  for (const auto& [msgsource, rmsg] : rdata)
   {
-    const int msgsource = p.first;
-    const std::vector<char>& rmsg = p.second;
-
     Core::Communication::UnpackBuffer buffer(rmsg);
     while (!buffer.at_end())
     {
@@ -1714,17 +1706,16 @@ void Particle::ParticleEngine::communicate_particles(
 }
 
 void Particle::ParticleEngine::communicate_refreshed_particles(
-    std::map<int, std::vector<char>>& sdata) const
+    const std::map<int, std::vector<char>>& sdata) const
 {
   // communicate data via cached send/receive graph
-  std::map<int, std::vector<char>> rdata;
-  ParticleUtils::immediate_send_recv_known_procs(
-      comm_, sdata, rdata, cached_procs_send_ghost_data_to_, cached_procs_receive_ghost_data_from_);
+  const std::map<int, std::vector<char>> rdata = ParticleUtils::immediate_send_recv_known_procs(
+      comm_, sdata, cached_procs_send_ghost_data_to_, cached_procs_receive_ghost_data_from_);
 
   // unpack received data directly into ghosted particle containers
-  for (const auto& p : rdata)
+  for (const auto& [msgsource, rmsg] : rdata)
   {
-    const std::vector<char>& rmsg = p.second;
+    (void)msgsource;
 
     Core::Communication::UnpackBuffer buffer(rmsg);
     while (!buffer.at_end())
@@ -1741,7 +1732,7 @@ void Particle::ParticleEngine::communicate_refreshed_particles(
 }
 
 void Particle::ParticleEngine::communicate_direct_ghosting_map(
-    std::map<int, std::map<ParticleType, std::map<int, std::pair<int, int>>>>& directghosting)
+    const std::map<int, std::map<ParticleType, std::map<int, std::pair<int, int>>>>& directghosting)
 {
   // iterate over particle types
   for (const auto& type : particlecontainerbundle_->get_particle_types())
@@ -1757,7 +1748,6 @@ void Particle::ParticleEngine::communicate_direct_ghosting_map(
 
   // prepare buffer for sending and receiving
   std::map<int, std::vector<char>> sdata;
-  std::map<int, std::vector<char>> rdata;
 
   // pack data for sending
   for (const auto& p : directghosting)
@@ -1767,19 +1757,17 @@ void Particle::ParticleEngine::communicate_direct_ghosting_map(
     std::swap(sdata[p.first], data());
   }
 
-  // clear after all ghosting information is packed
-  directghosting.clear();
-
   // communicate data via non-buffered send from proc to proc
-  ParticleUtils::immediate_recv_blocking_send(comm_, sdata, rdata);
+  const std::map<int, std::vector<char>> rdata =
+      ParticleUtils::immediate_recv_blocking_send(comm_, sdata);
 
   // init receiving map
   std::map<ParticleType, std::map<int, std::pair<int, int>>> receiveddirectghosting;
 
   // unpack and store received data
-  for (const auto& p : rdata)
+  for (const auto& [msgsource, rmsg] : rdata)
   {
-    const std::vector<char>& rmsg = p.second;
+    (void)msgsource;
 
     Core::Communication::UnpackBuffer buffer(rmsg);
     while (!buffer.at_end())

--- a/src/particle/src/engine/4C_particle_engine.hpp
+++ b/src/particle/src/engine/4C_particle_engine.hpp
@@ -632,7 +632,7 @@ namespace Particle
      *
      * \param[in] sdata pre-packed send buffers indexed by target processor rank
      */
-    void communicate_refreshed_particles(std::map<int, std::vector<char>>& sdata) const;
+    void communicate_refreshed_particles(const std::map<int, std::vector<char>>& sdata) const;
 
     /*!
      * \brief communicate and build map for direct ghosting
@@ -644,7 +644,8 @@ namespace Particle
      * \param[in] directghosting direct ghosting information
      */
     void communicate_direct_ghosting_map(
-        std::map<int, std::map<ParticleType, std::map<int, std::pair<int, int>>>>& directghosting);
+        const std::map<int, std::map<ParticleType, std::map<int, std::pair<int, int>>>>&
+            directghosting);
 
     /*!
      * \brief insert owned particles received from other processors

--- a/src/particle/src/engine/4C_particle_engine_communication_utils.cpp
+++ b/src/particle/src/engine/4C_particle_engine_communication_utils.cpp
@@ -17,9 +17,12 @@ FOUR_C_NAMESPACE_OPEN
 /*---------------------------------------------------------------------------*
  | definitions                                                               |
  *---------------------------------------------------------------------------*/
-void Particle::ParticleUtils::immediate_recv_blocking_send(
-    MPI_Comm comm, std::map<int, std::vector<char>>& sdata, std::map<int, std::vector<char>>& rdata)
+std::map<int, std::vector<char>> Particle::ParticleUtils::immediate_recv_blocking_send(
+    MPI_Comm comm, const std::map<int, std::vector<char>>& sdata)
 {
+  // buffer for receiving
+  std::map<int, std::vector<char>> rdata;
+
   // number of processors
   int const numproc = Core::Communication::num_mpi_ranks(comm);
 
@@ -119,7 +122,7 @@ void Particle::ParticleUtils::immediate_recv_blocking_send(
       if (torank < 0) FOUR_C_THROW("processor can not send messages to processor < 0!");
 
       // reference to send buffer
-      std::vector<char>& sbuffer = sdata[torank];
+      const std::vector<char>& sbuffer = sdata.at(torank);
 
       // perform non-blocking send operation
       MPI_Isend((void*)(sbuffer.data()), static_cast<int>(sbuffer.size()), MPI_CHAR, torank, 5678,
@@ -132,17 +135,19 @@ void Particle::ParticleUtils::immediate_recv_blocking_send(
   // ---- wait for completion of send operations ----
   MPI_Waitall(numsendtoprocs, sendrequest.data(), MPI_STATUSES_IGNORE);
 
-  // clear send buffer after successful communication
-  sdata.clear();
-
   // ---- wait for completion of receive operations ----
   MPI_Waitall(numrecvfromprocs, recvrequest.data(), MPI_STATUSES_IGNORE);
+
+  return rdata;
 }
 
-void Particle::ParticleUtils::immediate_send_recv_known_procs(MPI_Comm comm,
-    std::map<int, std::vector<char>>& sdata, std::map<int, std::vector<char>>& rdata,
+std::map<int, std::vector<char>> Particle::ParticleUtils::immediate_send_recv_known_procs(
+    MPI_Comm comm, const std::map<int, std::vector<char>>& sdata,
     const std::set<int>& send_to_procs, const std::set<int>& receive_from_procs)
 {
+  // buffer for receiving
+  std::map<int, std::vector<char>> rdata;
+
   const int numsendtoprocs = static_cast<int>(send_to_procs.size());
   const int numrecvfromprocs = static_cast<int>(receive_from_procs.size());
 
@@ -204,10 +209,11 @@ void Particle::ParticleUtils::immediate_send_recv_known_procs(MPI_Comm comm,
   // ---- wait for completion of send operations ----
   if (!sendrequest.empty())
     MPI_Waitall(static_cast<int>(sendrequest.size()), sendrequest.data(), MPI_STATUSES_IGNORE);
-  sdata.clear();
 
   // ---- wait for completion of receive operations ----
   MPI_Waitall(numrecvfromprocs, recvrequest.data(), MPI_STATUSES_IGNORE);
+
+  return rdata;
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/particle/src/engine/4C_particle_engine_communication_utils.hpp
+++ b/src/particle/src/engine/4C_particle_engine_communication_utils.hpp
@@ -37,10 +37,10 @@ namespace Particle::ParticleUtils
    *
    * \param[in]  comm  communicator
    * \param[in]  sdata send buffers related to corresponding target processors
-   * \param[out] rdata receive buffers related to corresponding source processors
+   * \return           receive buffers related to corresponding source processors
    */
-  void immediate_recv_blocking_send(MPI_Comm comm, std::map<int, std::vector<char>>& sdata,
-      std::map<int, std::vector<char>>& rdata);
+  std::map<int, std::vector<char>> immediate_recv_blocking_send(
+      MPI_Comm comm, const std::map<int, std::vector<char>>& sdata);
 
   /*!
    * \brief communicate data using a cached communication graph
@@ -57,12 +57,12 @@ namespace Particle::ParticleUtils
    *
    * \param[in]  comm                communicator
    * \param[in]  sdata               send buffers related to corresponding target processors
-   * \param[out] rdata               receive buffers related to corresponding source processors
    * \param[in]  send_to_procs       set of processors to send data to
    * \param[in]  receive_from_procs  set of processors to receive data from
+   * \return                         receive buffers related to corresponding source processors
    */
-  void immediate_send_recv_known_procs(MPI_Comm comm, std::map<int, std::vector<char>>& sdata,
-      std::map<int, std::vector<char>>& rdata, const std::set<int>& send_to_procs,
+  std::map<int, std::vector<char>> immediate_send_recv_known_procs(MPI_Comm comm,
+      const std::map<int, std::vector<char>>& sdata, const std::set<int>& send_to_procs,
       const std::set<int>& receive_from_procs);
 
   //@}

--- a/src/particle/src/engine/4C_particle_engine_unique_global_id.cpp
+++ b/src/particle/src/engine/4C_particle_engine_unique_global_id.cpp
@@ -112,7 +112,6 @@ void Particle::UniqueGlobalIdHandler::gather_reusable_global_ids_from_all_procs_
 {
   // prepare buffer for sending and receiving
   std::map<int, std::vector<char>> sdata;
-  std::map<int, std::vector<char>> rdata;
 
   if (myrank_ != masterrank_)
   {
@@ -128,16 +127,14 @@ void Particle::UniqueGlobalIdHandler::gather_reusable_global_ids_from_all_procs_
   }
 
   // communicate data via non-buffered send from proc to proc
-  ParticleUtils::immediate_recv_blocking_send(comm_, sdata, rdata);
+  const std::map<int, std::vector<char>> rdata =
+      ParticleUtils::immediate_recv_blocking_send(comm_, sdata);
 
 #ifdef FOUR_C_ENABLE_ASSERTIONS
   if (myrank_ != masterrank_)
   {
-    for (const auto& p : rdata)
+    for (const auto& [msgsource, rmsg] : rdata)
     {
-      const int msgsource = p.first;
-      const std::vector<char>& rmsg = p.second;
-
       if (rmsg.size() != 0)
         FOUR_C_THROW(
             "not expected to received reusable global ids on processor {} from processor {}!",
@@ -152,11 +149,9 @@ void Particle::UniqueGlobalIdHandler::gather_reusable_global_ids_from_all_procs_
     std::vector<int> receivedreusableglobalids;
 
     // unpack and store received data
-    for (const auto& p : rdata)
+    for (const auto& [msgsource, rmsg] : rdata)
     {
-      const std::vector<char>& rmsg = p.second;
-
-
+      (void)msgsource;
       Core::Communication::UnpackBuffer buffer(rmsg);
       while (!buffer.at_end())
       {
@@ -262,7 +257,6 @@ void Particle::UniqueGlobalIdHandler::distribute_requested_global_ids_from_maste
 {
   // prepare buffer for sending and receiving
   std::map<int, std::vector<char>> sdata;
-  std::map<int, std::vector<char>> rdata;
 
   if (myrank_ == masterrank_)
   {
@@ -280,14 +274,12 @@ void Particle::UniqueGlobalIdHandler::distribute_requested_global_ids_from_maste
   }
 
   // communicate data via non-buffered send from proc to proc
-  ParticleUtils::immediate_recv_blocking_send(comm_, sdata, rdata);
+  const std::map<int, std::vector<char>> rdata =
+      ParticleUtils::immediate_recv_blocking_send(comm_, sdata);
 
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-  for (const auto& p : rdata)
+  for (const auto& [msgsource, rmsg] : rdata)
   {
-    const int msgsource = p.first;
-    const std::vector<char>& rmsg = p.second;
-
     if (msgsource != masterrank_ and rmsg.size() != 0)
       FOUR_C_THROW("not expected to received global ids on processor {} from processor {}!",
           myrank_, msgsource);
@@ -298,8 +290,7 @@ void Particle::UniqueGlobalIdHandler::distribute_requested_global_ids_from_maste
   {
     // unpack and store received data
     {
-      std::vector<char>& rmsg = rdata[masterrank_];
-
+      const std::vector<char>& rmsg = rdata.at(masterrank_);
 
       Core::Communication::UnpackBuffer buffer(rmsg);
       while (!buffer.at_end())

--- a/src/particle/src/engine/4C_particle_engine_unique_global_id.cpp
+++ b/src/particle/src/engine/4C_particle_engine_unique_global_id.cpp
@@ -289,8 +289,10 @@ void Particle::UniqueGlobalIdHandler::distribute_requested_global_ids_from_maste
   if (myrank_ != masterrank_)
   {
     // unpack and store received data
+    const auto rit = rdata.find(masterrank_);
+    if (rit != rdata.end())
     {
-      const std::vector<char>& rmsg = rdata.at(masterrank_);
+      const std::vector<char>& rmsg = rit->second;
 
       Core::Communication::UnpackBuffer buffer(rmsg);
       while (!buffer.at_end())

--- a/src/particle/src/interaction/4C_particle_interaction_dem_history_pairs.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_dem_history_pairs.cpp
@@ -248,7 +248,6 @@ void Particle::DEMHistoryPairs::communicate_specific_history_pairs(
 {
   // prepare buffer for sending and receiving
   std::map<int, std::vector<char>> sdata;
-  std::map<int, std::vector<char>> rdata;
 
   // pack history pairs
   for (int torank = 0; torank < Core::Communication::num_mpi_ranks(comm_); ++torank)
@@ -272,10 +271,11 @@ void Particle::DEMHistoryPairs::communicate_specific_history_pairs(
   }
 
   // communicate data via non-buffered send from proc to proc
-  ParticleUtils::immediate_recv_blocking_send(comm_, sdata, rdata);
+  const std::map<int, std::vector<char>> rdata =
+      ParticleUtils::immediate_recv_blocking_send(comm_, sdata);
 
   // unpack history pairs
-  for (auto& p : rdata) unpack_history_pairs(p.second, historydata);
+  for (const auto& p : rdata) unpack_history_pairs(p.second, historydata);
 }
 
 template <typename Historypairtype>

--- a/src/particle/src/interaction/4C_particle_interaction_pd_neighbor_pairs.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_pd_neighbor_pairs.cpp
@@ -491,7 +491,6 @@ void Particle::PDNeighborPairs::communicate_bond_list(
 {
   // prepare buffer for sending and receiving
   std::map<int, std::vector<char>> sdata;
-  std::map<int, std::vector<char>> rdata;
   std::vector<std::set<std::pair<int, int>>> communicated_bonds_per_target(
       Core::Communication::num_mpi_ranks(comm_));
 
@@ -539,12 +538,13 @@ void Particle::PDNeighborPairs::communicate_bond_list(
   }
 
   // communicate data via non-buffered send from proc to proc
-  ParticleUtils::immediate_recv_blocking_send(comm_, sdata, rdata);
+  const std::map<int, std::vector<char>> rdata =
+      ParticleUtils::immediate_recv_blocking_send(comm_, sdata);
 
   std::set<long> known_bond_hashes = build_known_peridynamic_bond_hashes(bondlist_);
 
   // unpack global ids and initialize remaining bond data
-  for (auto& p : rdata) unpack_peridynamic_bond_list_data(p.second, known_bond_hashes);
+  for (const auto& p : rdata) unpack_peridynamic_bond_list_data(p.second, known_bond_hashes);
 }
 
 void Particle::PDNeighborPairs::unpack_peridynamic_bond_list_data(

--- a/src/particle/src/rigidbody/4C_particle_rigidbody.cpp
+++ b/src/particle/src/rigidbody/4C_particle_rigidbody.cpp
@@ -584,7 +584,6 @@ void Particle::RigidBodyHandler::relate_owned_rigid_bodies_to_hosting_procs()
 
   // prepare buffer for sending and receiving
   std::map<int, std::vector<char>> sdata;
-  std::map<int, std::vector<char>> rdata;
 
   // iterate over hosted rigid bodies
   for (const int rigidbody_k : hostedrigidbodies_)
@@ -605,16 +604,12 @@ void Particle::RigidBodyHandler::relate_owned_rigid_bodies_to_hosting_procs()
   }
 
   // communicate data via non-buffered send from proc to proc
-  ParticleUtils::immediate_recv_blocking_send(comm_, sdata, rdata);
+  const std::map<int, std::vector<char>> rdata =
+      ParticleUtils::immediate_recv_blocking_send(comm_, sdata);
 
   // unpack and store received data
-  for (auto& p : rdata)
+  for (const auto& [msgsource, rmsg] : rdata)
   {
-    int msgsource = p.first;
-    std::vector<char>& rmsg = p.second;
-
-
-
     Core::Communication::UnpackBuffer buffer(rmsg);
     while (!buffer.at_end())
     {
@@ -632,7 +627,6 @@ void Particle::RigidBodyHandler::communicate_rigid_body_states(
 {
   // prepare buffer for sending and receiving
   std::map<int, std::vector<char>> sdata;
-  std::map<int, std::vector<char>> rdata;
 
   // iterate over previously owned rigid bodies
   for (const int rigidbody_k : previouslyownedrigidbodies)
@@ -673,14 +667,13 @@ void Particle::RigidBodyHandler::communicate_rigid_body_states(
   }
 
   // communicate data via non-buffered send from proc to proc
-  ParticleUtils::immediate_recv_blocking_send(comm_, sdata, rdata);
+  const std::map<int, std::vector<char>> rdata =
+      ParticleUtils::immediate_recv_blocking_send(comm_, sdata);
 
   // unpack and store received data
-  for (auto& p : rdata)
+  for (const auto& [msgsource, rmsg] : rdata)
   {
-    std::vector<char>& rmsg = p.second;
-
-
+    (void)msgsource;
 
     Core::Communication::UnpackBuffer buffer(rmsg);
     while (!buffer.at_end())
@@ -861,7 +854,6 @@ void Particle::RigidBodyHandler::gather_partial_mass_quantities(
 {
   // prepare buffer for sending and receiving
   std::map<int, std::vector<char>> sdata;
-  std::map<int, std::vector<char>> rdata;
 
   // iterate over hosted rigid bodies
   for (const int rigidbody_k : hostedrigidbodies_)
@@ -898,14 +890,13 @@ void Particle::RigidBodyHandler::gather_partial_mass_quantities(
   }
 
   // communicate data via non-buffered send from proc to proc
-  ParticleUtils::immediate_recv_blocking_send(comm_, sdata, rdata);
+  const std::map<int, std::vector<char>> rdata =
+      ParticleUtils::immediate_recv_blocking_send(comm_, sdata);
 
   // unpack and store received data
-  for (auto& p : rdata)
+  for (const auto& [msgsource, rmsg] : rdata)
   {
-    std::vector<char>& rmsg = p.second;
-
-
+    (void)msgsource;
 
     Core::Communication::UnpackBuffer buffer(rmsg);
     while (!buffer.at_end())
@@ -1097,7 +1088,6 @@ void Particle::RigidBodyHandler::gather_partial_and_compute_full_force_and_torqu
 {
   // prepare buffer for sending and receiving
   std::map<int, std::vector<char>> sdata;
-  std::map<int, std::vector<char>> rdata;
 
   // iterate over hosted rigid bodies
   for (const int rigidbody_k : hostedrigidbodies_)
@@ -1124,14 +1114,13 @@ void Particle::RigidBodyHandler::gather_partial_and_compute_full_force_and_torqu
   }
 
   // communicate data via non-buffered send from proc to proc
-  ParticleUtils::immediate_recv_blocking_send(comm_, sdata, rdata);
+  const std::map<int, std::vector<char>> rdata =
+      ParticleUtils::immediate_recv_blocking_send(comm_, sdata);
 
   // unpack and store received data
-  for (auto& p : rdata)
+  for (const auto& [msgsource, rmsg] : rdata)
   {
-    std::vector<char>& rmsg = p.second;
-
-
+    (void)msgsource;
 
     Core::Communication::UnpackBuffer buffer(rmsg);
     while (!buffer.at_end())
@@ -1293,7 +1282,6 @@ void Particle::RigidBodyHandler::broadcast_rigid_body_positions()
 {
   // prepare buffer for sending and receiving
   std::map<int, std::vector<char>> sdata;
-  std::map<int, std::vector<char>> rdata;
 
   // iterate over owned rigid bodies
   for (const int rigidbody_k : ownedrigidbodies_)
@@ -1318,14 +1306,13 @@ void Particle::RigidBodyHandler::broadcast_rigid_body_positions()
   }
 
   // communicate data via non-buffered send from proc to proc
-  ParticleUtils::immediate_recv_blocking_send(comm_, sdata, rdata);
+  const std::map<int, std::vector<char>> rdata =
+      ParticleUtils::immediate_recv_blocking_send(comm_, sdata);
 
   // unpack and store received data
-  for (auto& p : rdata)
+  for (const auto& [msgsource, rmsg] : rdata)
   {
-    std::vector<char>& rmsg = p.second;
-
-
+    (void)msgsource;
 
     Core::Communication::UnpackBuffer buffer(rmsg);
     while (!buffer.at_end())
@@ -1347,7 +1334,6 @@ void Particle::RigidBodyHandler::broadcast_rigid_body_velocities()
 {
   // prepare buffer for sending and receiving
   std::map<int, std::vector<char>> sdata;
-  std::map<int, std::vector<char>> rdata;
 
   // iterate over owned rigid bodies
   for (const int rigidbody_k : ownedrigidbodies_)
@@ -1373,14 +1359,13 @@ void Particle::RigidBodyHandler::broadcast_rigid_body_velocities()
   }
 
   // communicate data via non-buffered send from proc to proc
-  ParticleUtils::immediate_recv_blocking_send(comm_, sdata, rdata);
+  const std::map<int, std::vector<char>> rdata =
+      ParticleUtils::immediate_recv_blocking_send(comm_, sdata);
 
   // unpack and store received data
-  for (auto& p : rdata)
+  for (const auto& [msgsource, rmsg] : rdata)
   {
-    std::vector<char>& rmsg = p.second;
-
-
+    (void)msgsource;
 
     Core::Communication::UnpackBuffer buffer(rmsg);
     while (!buffer.at_end())
@@ -1402,7 +1387,6 @@ void Particle::RigidBodyHandler::broadcast_rigid_body_accelerations()
 {
   // prepare buffer for sending and receiving
   std::map<int, std::vector<char>> sdata;
-  std::map<int, std::vector<char>> rdata;
 
   // iterate over owned rigid bodies
   for (const int rigidbody_k : ownedrigidbodies_)
@@ -1428,14 +1412,13 @@ void Particle::RigidBodyHandler::broadcast_rigid_body_accelerations()
   }
 
   // communicate data via non-buffered send from proc to proc
-  ParticleUtils::immediate_recv_blocking_send(comm_, sdata, rdata);
+  const std::map<int, std::vector<char>> rdata =
+      ParticleUtils::immediate_recv_blocking_send(comm_, sdata);
 
   // unpack and store received data
-  for (auto& p : rdata)
+  for (const auto& [msgsource, rmsg] : rdata)
   {
-    std::vector<char>& rmsg = p.second;
-
-
+    (void)msgsource;
 
     Core::Communication::UnpackBuffer buffer(rmsg);
     while (!buffer.at_end())

--- a/src/particle/src/rigidbody/4C_particle_rigidbody_affiliation_pairs.cpp
+++ b/src/particle/src/rigidbody/4C_particle_rigidbody_affiliation_pairs.cpp
@@ -103,7 +103,6 @@ void Particle::RigidBodyAffiliationPairs::communicate_specific_affiliation_pairs
 {
   // prepare buffer for sending and receiving
   std::map<int, std::vector<char>> sdata;
-  std::map<int, std::vector<char>> rdata;
 
   // pack affiliation pairs
   for (int torank = 0; torank < Core::Communication::num_mpi_ranks(comm_); ++torank)
@@ -126,10 +125,11 @@ void Particle::RigidBodyAffiliationPairs::communicate_specific_affiliation_pairs
   }
 
   // communicate data via non-buffered send from proc to proc
-  ParticleUtils::immediate_recv_blocking_send(comm_, sdata, rdata);
+  const std::map<int, std::vector<char>> rdata =
+      ParticleUtils::immediate_recv_blocking_send(comm_, sdata);
 
   // unpack affiliation pairs
-  for (auto& p : rdata) unpack_affiliation_pairs(p.second);
+  for (const auto& p : rdata) unpack_affiliation_pairs(p.second);
 }
 
 void Particle::RigidBodyAffiliationPairs::pack_all_affiliation_pairs(


### PR DESCRIPTION
As proposed in the discussion of #2117, I have decided to refactor the declarations of `immediate_recv_blocking_send()` and  `immediate_send_recv_known_procs()` such that these methods would receive constant references to `sdata` and also explicitly return `rdata` instead of filling it via an output parameter. This allowed to subsequently simplify the callers.

## Related Issues and Pull Requests
#2117
