### PR TITLE
[bugfix] Fix two flaws regarding strain energy output in the hyperelastic framework

### DIFF
--- a/src/mat/elast/4C_mat_elast_coupblatzko.cpp
+++ b/src/mat/elast/4C_mat_elast_coupblatzko.cpp
@@ -9,6 +9,8 @@
 
 #include "4C_material_parameter_base.hpp"
 
+#include <cmath>
+
 FOUR_C_NAMESPACE_OPEN
 
 
@@ -40,12 +42,13 @@ void Mat::Elastic::CoupBlatzKo::add_strain_energy(double& psi,
   //         C}}{III_{\boldsymbol C}}-3 \right) + \frac 1 {\beta}
   //         (III_{\boldsymbol C}^{\beta}-1)\right]
 
-  double psiadd =
-      f * mue * 0.5 * (prinv(0) - 3.) + (1. - f) * mue * 0.5 * (prinv(1) / prinv(2) - 3.);
-  if (beta != 0)  // take care of possible division by zero in case of Poisson's ratio nu = 0.0
+  const double log_i3 = std::log(prinv(2));
+  const double negative_power_term = beta == 0.0 ? -log_i3 : std::expm1(-beta * log_i3) / beta;
+  const double positive_power_term = beta == 0.0 ? log_i3 : std::expm1(beta * log_i3) / beta;
 
-    // add to overall strain energy
-    psi += psiadd;
+  psi += 0.5 * mue *
+         (f * (prinv(0) - 3.0 + negative_power_term) +
+             (1.0 - f) * (prinv(1) / prinv(2) - 3.0 + positive_power_term));
 }
 
 void Mat::Elastic::CoupBlatzKo::add_derivatives_principal(Core::LinAlg::Matrix<3, 1>& dPI,

--- a/src/mat/elast/4C_mat_elast_volpow.cpp
+++ b/src/mat/elast/4C_mat_elast_volpow.cpp
@@ -30,7 +30,7 @@ void Mat::Elastic::VolPow::add_strain_energy(double& psi, const Core::LinAlg::Ma
 
   // strain energy: Psi = \frac{a}{expon-1} J^(-expon+1) + aJ
   // add to overall strain energy
-  psi += a / (expon - 1.) * std::pow(modinv(2), -expon - 1.) + a * modinv(2);
+  psi += a / (expon - 1.) * std::pow(modinv(2), -expon + 1.) + a * modinv(2);
 }
 
 void Mat::Elastic::VolPow::add_derivatives_modified(Core::LinAlg::Matrix<3, 1>& dPmodI,

--- a/unittests/mat/elast/4C_elast_strain_energy_test.cpp
+++ b/unittests/mat/elast/4C_elast_strain_energy_test.cpp
@@ -1,0 +1,116 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "4C_mat_elast_coupblatzko.hpp"
+#include "4C_mat_elast_volpow.hpp"
+#include "4C_material_parameter_base.hpp"
+
+#include <cmath>
+
+namespace
+{
+  using namespace FourC;
+
+  double evaluate_blatz_ko_energy(
+      Mat::Elastic::CoupBlatzKo& summand, Core::LinAlg::Matrix<3, 1> prinv)
+  {
+    const Core::LinAlg::Matrix<3, 1> modinv(Core::LinAlg::Initialization::zero);
+    const Core::LinAlg::SymmetricTensor<double, 3, 3> glstrain{};
+    double psi = 0.0;
+    summand.add_strain_energy(psi, prinv, modinv, glstrain, 0, 0);
+    return psi;
+  }
+
+  TEST(ElasticStrainEnergyTest, BlatzKoEnergyIsConsistentWithPrincipalDerivative)
+  {
+    Core::IO::InputParameterContainer parameters;
+    parameters.add("MUE", 2.3);
+    parameters.add("NUE", 0.2);
+    parameters.add("F", 0.35);
+    Mat::Elastic::PAR::CoupBlatzKo material_parameters(
+        Core::Mat::PAR::Parameter::Data{.parameters = parameters});
+    Mat::Elastic::CoupBlatzKo summand(&material_parameters);
+
+    Core::LinAlg::Matrix<3, 1> prinv(Core::LinAlg::Initialization::zero);
+    prinv(0) = 4.2;
+    prinv(1) = 5.1;
+    prinv(2) = 1.44;
+
+    Core::LinAlg::Matrix<3, 1> dpsi(Core::LinAlg::Initialization::zero);
+    Core::LinAlg::Matrix<6, 1> ddpsi(Core::LinAlg::Initialization::zero);
+    summand.add_derivatives_principal(dpsi, ddpsi, prinv, 0, 0);
+
+    constexpr double step = 1.0e-6;
+    auto prinv_minus = prinv;
+    auto prinv_plus = prinv;
+    prinv_minus(2) -= step;
+    prinv_plus(2) += step;
+    const double numerical_derivative = (evaluate_blatz_ko_energy(summand, prinv_plus) -
+                                            evaluate_blatz_ko_energy(summand, prinv_minus)) /
+                                        (2.0 * step);
+
+    EXPECT_NEAR(numerical_derivative, dpsi(2), 1.0e-9);
+  }
+
+  TEST(ElasticStrainEnergyTest, BlatzKoEnergyUsesLogarithmicLimitAtZeroPoissonRatio)
+  {
+    Core::IO::InputParameterContainer parameters;
+    parameters.add("MUE", 2.3);
+    parameters.add("NUE", 0.0);
+    parameters.add("F", 0.35);
+    Mat::Elastic::PAR::CoupBlatzKo material_parameters(
+        Core::Mat::PAR::Parameter::Data{.parameters = parameters});
+    Mat::Elastic::CoupBlatzKo summand(&material_parameters);
+
+    Core::LinAlg::Matrix<3, 1> prinv(Core::LinAlg::Initialization::zero);
+    prinv(0) = 4.2;
+    prinv(1) = 5.1;
+    prinv(2) = 1.44;
+
+    const double expected = 0.5 * 2.3 *
+                            (0.35 * (prinv(0) - 3.0 - std::log(prinv(2))) +
+                                0.65 * (prinv(1) / prinv(2) - 3.0 + std::log(prinv(2))));
+
+    EXPECT_NEAR(evaluate_blatz_ko_energy(summand, prinv), expected, 1.0e-14);
+  }
+
+  TEST(ElasticStrainEnergyTest, VolPowEnergyIsConsistentWithFirstDerivative)
+  {
+    Core::IO::InputParameterContainer parameters;
+    parameters.add("A", 2.5);
+    parameters.add("EXPON", 4.0);
+    Mat::Elastic::PAR::VolPow material_parameters(
+        Core::Mat::PAR::Parameter::Data{.parameters = parameters});
+    Mat::Elastic::VolPow summand(&material_parameters);
+
+    const Core::LinAlg::Matrix<3, 1> prinv(Core::LinAlg::Initialization::zero);
+    Core::LinAlg::Matrix<3, 1> modinv(Core::LinAlg::Initialization::zero);
+    modinv(2) = 1.2;
+    const Core::LinAlg::SymmetricTensor<double, 3, 3> glstrain{};
+
+    Core::LinAlg::Matrix<3, 1> dpsi(Core::LinAlg::Initialization::zero);
+    Core::LinAlg::Matrix<6, 1> ddpsi(Core::LinAlg::Initialization::zero);
+    summand.add_derivatives_modified(dpsi, ddpsi, modinv, 0, 0);
+
+    const auto evaluate_energy = [&](const double j)
+    {
+      auto evaluation_modinv = modinv;
+      evaluation_modinv(2) = j;
+      double psi = 0.0;
+      summand.add_strain_energy(psi, prinv, evaluation_modinv, glstrain, 0, 0);
+      return psi;
+    };
+
+    constexpr double step = 1.0e-6;
+    const double numerical_derivative =
+        (evaluate_energy(modinv(2) + step) - evaluate_energy(modinv(2) - step)) / (2.0 * step);
+
+    EXPECT_NEAR(numerical_derivative, dpsi(2), 1.0e-9);
+  }
+}  // namespace


### PR DESCRIPTION
## Description and Context

When creating the documentation of the hyperelastic framework, see PR #2146 , the LLM noted two flaws in the strain energy output of hyperelastic parts, namely in

```
ELAST_CoupBlatzKo
ELAST_VolPow
```

This PR is to fix those two.

## Related Issues and Pull Requests
PR: #2148
