### PR TITLE
Find libbacktrace by name, not hardcoded suffix

### DIFF
--- a/cmake/modules/FindBacktrace.cmake
+++ b/cmake/modules/FindBacktrace.cmake
@@ -23,7 +23,7 @@ endif(Backtrace_INCLUDE_DIR)
 
 find_path(Backtrace_INCLUDE_DIR NAMES backtrace.h)
 
-find_library(Backtrace_LIBRARY NAMES libbacktrace.a libbacktrace.so)
+find_library(Backtrace_LIBRARY NAMES backtrace)
 
 # handle the QUIETLY and REQUIRED arguments and set Backtrace_FOUND to TRUE if
 # all listed variables are TRUE


### PR DESCRIPTION
find_library() used explicit libbacktrace.a/.so names, which does not work for other operating systems. LLM could not identify a reason why there would be a need to hard code the order (which was .a first in the old version).

## Interested parties
@sebproell 

