### PR TITLE
Add kokkosparallel docker and workflow

### DIFF
--- a/.github/workflows/docker_kokkosparallel.yml
+++ b/.github/workflows/docker_kokkosparallel.yml
@@ -1,0 +1,96 @@
+name: Docker Kokkos parallel
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/docker_kokkosparallel.yml'
+      - 'dependencies/current/backtrace'
+      - 'dependencies/current/cmake'
+      - 'dependencies/current/dealii'
+      - 'dependencies/current/gmsh'
+      - 'dependencies/current/superlu_dist'
+      - 'dependencies/testing/**'
+      - 'dependencies/kokkosparallel/**'
+      - 'docker/kokkosparallel/**'
+
+env:
+  REGISTRY: ghcr.io
+  PROJECT_NAMESPACE: 4c-multiphysics
+  IMAGE_SUFFIX: dependencies-trilinos-kokkosparallel
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-if-build-dependencies-is-required:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch'
+    outputs:
+      dependencies_hash: ${{ steps.check-docker-build-required.outputs.dependencies_hash }}
+      build_docker_image: ${{ steps.check-docker-build-required.outputs.build_docker_image }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: check-docker-build-required
+        uses: ./.github/actions/check_docker_build_required
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          image-name: ${{ env.REGISTRY }}/${{ env.PROJECT_NAMESPACE }}/4c-${{ env.IMAGE_SUFFIX }}
+          compute-dependencies-hash-script: ./docker/kokkosparallel/compute_dependencies_hash.sh
+
+  build-dependencies:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      #
+    needs: check-if-build-dependencies-is-required
+    if: ${{ github.event_name == 'workflow_dispatch' && needs.check-if-build-dependencies-is-required.outputs.build_docker_image
+      == 'true' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Build and push image
+        uses: ./.github/actions/build_dependencies
+        with:
+          docker-file: docker/kokkosparallel/Dockerfile
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          image-name: ${{ env.REGISTRY }}/${{ env.PROJECT_NAMESPACE }}/4c-${{ env.IMAGE_SUFFIX }}
+          dependencies-hash: ${{ needs.check-if-build-dependencies-is-required.outputs.dependencies_hash
+            }}
+          base-image: "nvidia/cuda:12.8.1-devel-ubuntu24.04"
+
+  tag-images-as-main:
+    runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/main' && github.repository == '4C-multiphysics/4C' }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+      - id: compute-dependencies-hash
+        uses: ./.github/actions/compute-and-check-dependencies-hash
+        with:
+          skip-check: 'true'
+          compute-dependencies-hash-script: ./docker/kokkosparallel/compute_dependencies_hash.sh
+      - name: Log in to the Container registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Pull current Kokkos parallel dependencies image and tag it with main
+        run: |
+          IMAGE_NAME="${{ env.REGISTRY }}/${{ env.PROJECT_NAMESPACE }}/4c-${{ env.IMAGE_SUFFIX }}"
+          docker pull $IMAGE_NAME:${{ steps.compute-dependencies-hash.outputs.computed_dependencies_hash }}
+          docker image tag $IMAGE_NAME:${{ steps.compute-dependencies-hash.outputs.computed_dependencies_hash }} $IMAGE_NAME:main
+          docker push $IMAGE_NAME:main

--- a/.typos.toml
+++ b/.typos.toml
@@ -12,6 +12,7 @@ ser = "ser" # "switched evolution relaxation" (used for pseudo transient continu
 ded = "ded" # derivative w.r.t. electrode variables
 uncomplete = "uncomplete" # used in the context of the uncomplete() call fo a sparse matrix
 Comput = "Comput" # abbreviation Comput. for Computational / Computing (typo fix cannot contain .)
+LOCA = "LOCA" # Trilinos/NOX package name
 Equil = "Equil" # "Equilibration" (used to pre-order a linear system)
 
 # German words we want to keep as is.

--- a/dependencies/kokkosparallel/trilinos/install_with_cuda.sh
+++ b/dependencies/kokkosparallel/trilinos/install_with_cuda.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# This file is part of 4C multiphysics licensed under the
+# GNU Lesser General Public License v3.0 or later.
+#
+# See the LICENSE.md file in the top-level for license information.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+# Install trilinos with the CUDA backend enabled
+# Call with
+# ./install_with_cuda.sh /path/to/install/dir
+
+# Exit the script at the first failure
+set -e
+
+INSTALL_DIR="$1"
+# Number of procs for building (default 4)
+NPROCS=${NPROCS:=4}
+# git sha from Trilinos repository:
+VERSION="1a1fcc4e31940924c247994a4b935603572b0d3a"
+#CHECKSUM=""
+
+CMAKE_COMMAND=cmake
+
+git clone https://github.com/trilinos/Trilinos.git
+cd Trilinos
+git checkout $VERSION
+cd .. && mkdir trilinos_build && cd trilinos_build
+
+MPI_DIR=/usr
+MPI_BIN_DIR=$MPI_DIR/bin
+
+$CMAKE_COMMAND \
+  -D CMAKE_BUILD_TYPE:STRING="RELEASE" \
+  -D CMAKE_CXX_STANDARD:STRING="17" \
+  -D CMAKE_CXX_COMPILER:FILEPATH="$MPI_BIN_DIR/mpic++" \
+  -D CMAKE_C_COMPILER:FILEPATH="$MPI_BIN_DIR/mpicc" \
+  -D CMAKE_Fortran_COMPILER:FILEPATH="$MPI_BIN_DIR/mpif90" \
+  -D CMAKE_INSTALL_PREFIX:STRING=$INSTALL_DIR \
+  -D BUILD_SHARED_LIBS:BOOL=ON \
+  \
+  -D Trilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=OFF \
+  -D Trilinos_ENABLE_EXPLICIT_INSTANTIATION:BOOL=ON \
+  -D Trilinos_ENABLE_ALL_PACKAGES:BOOL=OFF \
+  -D Trilinos_ENABLE_TESTS:BOOL=OFF \
+  -D Trilinos_ENABLE_EXAMPLES:BOOL=OFF \
+  \
+  -D Trilinos_ASSERT_MISSING_PACKAGES=OFF \
+  -D Trilinos_ENABLE_Gtest:BOOL=OFF \
+  -D Trilinos_ENABLE_Amesos:BOOL=ON \
+    -D Amesos_SHOW_DEPRECATED_WARNINGS:BOOL=OFF \
+  -D Trilinos_ENABLE_Amesos2:BOOL=ON \
+  -D Trilinos_ENABLE_AztecOO:BOOL=ON \
+    -D AztecOO_SHOW_DEPRECATED_WARNINGS:BOOL=OFF \
+  -D Trilinos_ENABLE_Belos:BOOL=ON \
+  -D Trilinos_ENABLE_Epetra:BOOL=ON \
+    -D Epetra_SHOW_DEPRECATED_WARNINGS:BOOL=OFF \
+  -D Trilinos_ENABLE_EpetraExt:BOOL=ON \
+    -D EpetraExt_SHOW_DEPRECATED_WARNINGS:BOOL=OFF \
+  -D Trilinos_ENABLE_Intrepid2:BOOL=ON \
+  -D Trilinos_ENABLE_Ifpack:BOOL=ON \
+    -D Ifpack_SHOW_DEPRECATED_WARNINGS:BOOL=OFF \
+  -D Trilinos_ENABLE_Ifpack2:BOOL=ON \
+  -D Trilinos_ENABLE_Kokkos:BOOL=ON \
+  -D Trilinos_ENABLE_ML:BOOL=ON \
+    -D ML_SHOW_DEPRECATED_WARNINGS:BOOL=OFF \
+  -D Trilinos_ENABLE_MueLu:BOOL=ON \
+  -D Trilinos_ENABLE_NOX:BOOL=ON \
+    -D NOX_ENABLE_ABSTRACT_IMPLEMENTATION_EPETRA:BOOL=OFF \
+    -D NOX_ENABLE_STRATIMIKOS_EPETRA_STACK:BOOL=OFF \
+    -D NOX_ENABLE_LOCA:BOOL=OFF \
+  -D Trilinos_ENABLE_Sacado:BOOL=ON \
+  -D Trilinos_ENABLE_SEACASExodus:BOOL=ON \
+  -D Trilinos_ENABLE_SEACASNemesis:BOOL=OFF \
+  -D Trilinos_ENABLE_Shards:BOOL=ON \
+  -D Trilinos_ENABLE_Stratimikos:BOOL=ON \
+  -D Trilinos_ENABLE_Teko:BOOL=ON \
+  -D Trilinos_ENABLE_Teuchos:BOOL=ON \
+  -D Trilinos_ENABLE_Thyra:BOOL=ON \
+    -D Thyra_SHOW_DEPRECATED_WARNINGS:BOOL=OFF \
+  -D Trilinos_ENABLE_ThyraEpetraAdapters:BOOL=ON \
+  -D Trilinos_ENABLE_ThyraEpetraExtAdapters:BOOL=ON \
+  -D Trilinos_ENABLE_Tpetra:BOOL=ON \
+    -D Tpetra_INST_INT_INT:BOOL=ON \
+  -D Trilinos_ENABLE_Xpetra:BOOL=ON \
+    -D Xpetra_ENABLE_Epetra:BOOL=ON \
+    -D Xpetra_ENABLE_EpetraExt:BOOL=ON \
+    -D Xpetra_SHOW_DEPRECATED_WARNINGS:BOOL=OFF \
+  -D Trilinos_ENABLE_Zoltan:BOOL=ON \
+  -D Trilinos_ENABLE_Zoltan2:BOOL=ON \
+  \
+  -D Trilinos_MUST_FIND_ALL_TPL_LIBS=TRUE \
+  -D TPL_ENABLE_DLlib:BOOL=OFF \
+  -D TPL_ENABLE_Netcdf:BOOL=ON \
+  -D TPL_ENABLE_MPI:BOOL=ON \
+  -D TPL_ENABLE_MUMPS:BOOL=ON \
+  -D TPL_ENABLE_ScaLAPACK:BOOL=ON \
+  -D TPL_ENABLE_LAPACK:BOOL=ON \
+  -D TPL_ENABLE_BLAS:BOOL=ON \
+  -D TPL_ENABLE_ParMETIS:BOOL=ON \
+    -D ParMETIS_INCLUDE_DIRS:PATH="/usr/include" \
+  -D TPL_ENABLE_UMFPACK:BOOL=ON \
+    -D UMFPACK_INCLUDE_DIRS:FILEPATH="/usr/include/suitesparse" \
+  -D TPL_ENABLE_SuperLUDist:BOOL=ON \
+    -D SuperLUDist_INCLUDE_DIRS:PATH="$INSTALL_DIR/../include" \
+    -D SuperLUDist_LIBRARY_DIRS:PATH="$INSTALL_DIR/../lib" \
+  \
+  -D Trilinos_ENABLE_KokkosKernels:BOOL=ON \
+  -D KokkosKernels_ENABLE_TPL_BLAS:BOOL=ON \
+  -D KokkosKernels_ENABLE_TPL_LAPACK:BOOL=ON \
+  \
+  -D Kokkos_ENABLE_SERIAL:BOOL=ON \
+  -D Tpetra_INST_SERIAL:BOOL=ON \
+  \
+  -D Trilinos_ENABLE_CUDA:BOOL=ON \
+  -D TPL_ENABLE_CUDA:BOOL=ON \
+  -D Kokkos_ENABLE_CUDA:BOOL=ON \
+  -D Kokkos_ARCH_HOPPER90:BOOL=ON \
+  -D Kokkos_ENABLE_CUDA_CONSTEXPR:BOOL=ON \
+  -D Tpetra_INST_CUDA:BOOL=OFF \
+  -D KokkosKernels_ENABLE_TPL_CUSOLVER:BOOL=ON \
+  \
+  ../Trilinos
+
+make -j${NPROCS} install
+cd ..
+rm -rf Trilinos trilinos_build

--- a/dependencies/kokkosparallel/trilinos/install_with_openmp.sh
+++ b/dependencies/kokkosparallel/trilinos/install_with_openmp.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# This file is part of 4C multiphysics licensed under the
+# GNU Lesser General Public License v3.0 or later.
+#
+# See the LICENSE.md file in the top-level for license information.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+# Install trilinos with the OpenMP backend enabled
+# Call with
+# ./install_with_openmp.sh /path/to/install/dir
+
+# Exit the script at the first failure
+set -e
+
+INSTALL_DIR="$1"
+# Number of procs for building (default 4)
+NPROCS=${NPROCS:=4}
+# git sha from Trilinos repository:
+VERSION="1a1fcc4e31940924c247994a4b935603572b0d3a"
+#CHECKSUM=""
+
+CMAKE_COMMAND=cmake
+
+git clone https://github.com/trilinos/Trilinos.git
+cd Trilinos
+git checkout $VERSION
+cd .. && mkdir trilinos_build && cd trilinos_build
+
+MPI_DIR=/usr
+MPI_BIN_DIR=$MPI_DIR/bin
+
+$CMAKE_COMMAND \
+  -D CMAKE_BUILD_TYPE:STRING="RELEASE" \
+  -D CMAKE_CXX_STANDARD:STRING="17" \
+  -D CMAKE_CXX_COMPILER:FILEPATH="$MPI_BIN_DIR/mpic++" \
+  -D CMAKE_C_COMPILER:FILEPATH="$MPI_BIN_DIR/mpicc" \
+  -D CMAKE_Fortran_COMPILER:FILEPATH="$MPI_BIN_DIR/mpif90" \
+  -D CMAKE_INSTALL_PREFIX:STRING=$INSTALL_DIR \
+  -D BUILD_SHARED_LIBS:BOOL=ON \
+  \
+  -D Trilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=OFF \
+  -D Trilinos_ENABLE_EXPLICIT_INSTANTIATION:BOOL=ON \
+  -D Trilinos_ENABLE_ALL_PACKAGES:BOOL=OFF \
+  -D Trilinos_ENABLE_TESTS:BOOL=OFF \
+  -D Trilinos_ENABLE_EXAMPLES:BOOL=OFF \
+  \
+  -D Trilinos_ASSERT_MISSING_PACKAGES=OFF \
+  -D Trilinos_ENABLE_Gtest:BOOL=OFF \
+  -D Trilinos_ENABLE_Amesos:BOOL=ON \
+    -D Amesos_SHOW_DEPRECATED_WARNINGS:BOOL=OFF \
+  -D Trilinos_ENABLE_Amesos2:BOOL=ON \
+  -D Trilinos_ENABLE_AztecOO:BOOL=ON \
+    -D AztecOO_SHOW_DEPRECATED_WARNINGS:BOOL=OFF \
+  -D Trilinos_ENABLE_Belos:BOOL=ON \
+  -D Trilinos_ENABLE_Epetra:BOOL=ON \
+    -D Epetra_SHOW_DEPRECATED_WARNINGS:BOOL=OFF \
+  -D Trilinos_ENABLE_EpetraExt:BOOL=ON \
+    -D EpetraExt_SHOW_DEPRECATED_WARNINGS:BOOL=OFF \
+  -D Trilinos_ENABLE_Intrepid2:BOOL=ON \
+  -D Trilinos_ENABLE_Ifpack:BOOL=ON \
+    -D Ifpack_SHOW_DEPRECATED_WARNINGS:BOOL=OFF \
+  -D Trilinos_ENABLE_Ifpack2:BOOL=ON \
+  -D Trilinos_ENABLE_Kokkos:BOOL=ON \
+  -D Trilinos_ENABLE_ML:BOOL=ON \
+    -D ML_SHOW_DEPRECATED_WARNINGS:BOOL=OFF \
+  -D Trilinos_ENABLE_MueLu:BOOL=ON \
+  -D Trilinos_ENABLE_NOX:BOOL=ON \
+    -D NOX_ENABLE_ABSTRACT_IMPLEMENTATION_EPETRA:BOOL=OFF \
+    -D NOX_ENABLE_STRATIMIKOS_EPETRA_STACK:BOOL=OFF \
+  -D Trilinos_ENABLE_Sacado:BOOL=ON \
+  -D Trilinos_ENABLE_SEACASExodus:BOOL=ON \
+  -D Trilinos_ENABLE_SEACASNemesis:BOOL=OFF \
+  -D Trilinos_ENABLE_Shards:BOOL=ON \
+  -D Trilinos_ENABLE_Stratimikos:BOOL=ON \
+  -D Trilinos_ENABLE_Teko:BOOL=ON \
+  -D Trilinos_ENABLE_Teuchos:BOOL=ON \
+  -D Trilinos_ENABLE_Thyra:BOOL=ON \
+    -D Thyra_SHOW_DEPRECATED_WARNINGS:BOOL=OFF \
+  -D Trilinos_ENABLE_ThyraEpetraAdapters:BOOL=ON \
+  -D Trilinos_ENABLE_ThyraEpetraExtAdapters:BOOL=ON \
+  -D Trilinos_ENABLE_Tpetra:BOOL=ON \
+    -D Tpetra_INST_INT_INT:BOOL=ON \
+  -D Trilinos_ENABLE_Xpetra:BOOL=ON \
+    -D Xpetra_ENABLE_Epetra:BOOL=ON \
+    -D Xpetra_ENABLE_EpetraExt:BOOL=ON \
+    -D Xpetra_SHOW_DEPRECATED_WARNINGS:BOOL=OFF \
+  -D Trilinos_ENABLE_Zoltan:BOOL=ON \
+  -D Trilinos_ENABLE_Zoltan2:BOOL=ON \
+  \
+  -D Trilinos_MUST_FIND_ALL_TPL_LIBS=TRUE \
+  -D TPL_ENABLE_DLlib:BOOL=OFF \
+  -D TPL_ENABLE_Netcdf:BOOL=ON \
+  -D TPL_ENABLE_MPI:BOOL=ON \
+  -D TPL_ENABLE_MUMPS:BOOL=ON \
+  -D TPL_ENABLE_ScaLAPACK:BOOL=ON \
+  -D TPL_ENABLE_LAPACK:BOOL=ON \
+  -D TPL_ENABLE_BLAS:BOOL=ON \
+  -D TPL_ENABLE_ParMETIS:BOOL=ON \
+    -D ParMETIS_INCLUDE_DIRS:PATH="/usr/include" \
+  -D TPL_ENABLE_UMFPACK:BOOL=ON \
+    -D UMFPACK_INCLUDE_DIRS:FILEPATH="/usr/include/suitesparse" \
+  -D TPL_ENABLE_SuperLUDist:BOOL=ON \
+    -D SuperLUDist_INCLUDE_DIRS:PATH="$INSTALL_DIR/../include" \
+    -D SuperLUDist_LIBRARY_DIRS:PATH="$INSTALL_DIR/../lib" \
+  \
+  -D Trilinos_ENABLE_KokkosKernels:BOOL=ON \
+  -D KokkosKernels_ENABLE_TPL_BLAS:BOOL=ON \
+  -D KokkosKernels_ENABLE_TPL_LAPACK:BOOL=ON \
+  \
+  -D Kokkos_ENABLE_SERIAL:BOOL=ON \
+  -D Tpetra_INST_SERIAL:BOOL=ON \
+  \
+  -D Trilinos_ENABLE_OpenMP:BOOL=ON \
+  -D Kokkos_ENABLE_OPENMP:BOOL=ON \
+  \
+  ../Trilinos
+
+make -j${NPROCS} install
+cd ..
+rm -rf Trilinos trilinos_build

--- a/docker/kokkosparallel/Dockerfile
+++ b/docker/kokkosparallel/Dockerfile
@@ -1,0 +1,130 @@
+# This file is part of 4C multiphysics licensed under the
+# GNU Lesser General Public License v3.0 or later.
+#
+# See the LICENSE.md file in the top-level for license information.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+ARG BASE_IMAGE=nvidia/cuda:12.8.1-devel-ubuntu24.04
+FROM ${BASE_IMAGE}
+LABEL org.opencontainers.image.description="Image containing all the dependencies required for building and testing 4C"
+LABEL org.4c-multiphysics.project=4C
+
+# Prevents tzdata asking for user feedback
+ENV DEBIAN_FRONTEND=noninteractive
+
+USER root
+
+# Set locale information: region and timezone
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      locales \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \
+    && locale-gen en_US.UTF-8 \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      build-essential \
+      ffmpeg \
+      git \
+      libglu1-mesa \
+      python3 \
+      sudo \
+      unzip \
+      vim \
+      wget \
+      && \
+    apt-get update && apt-get install -y \
+      doxygen \
+      graphviz \
+      texinfo \
+      lcov \
+      libblas-dev \
+      libboost-all-dev \
+      libcln-dev \
+      libhdf5-dev \
+      libhdf5-openmpi-dev \
+      libnetcdf-dev \
+      libfftw3-dev \
+      lld \
+      python3-venv \
+      python-is-python3 \
+      liblapack-dev \
+      libopenmpi-dev \
+      libparmetis-dev \
+      libmetis-dev \
+      libsuitesparse-dev \
+      libmumps-dev \
+      libscalapack-mpi-dev \
+      libqhull-dev \
+      mpi-default-dev \
+      ninja-build \
+      libyaml-dev \
+      clang \
+      clang-tidy \
+      clang-tools \
+      libomp-dev \
+      libvtk9-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create directory for dependencies
+ARG NPROCS=12
+ENV NPROCS=$NPROCS \
+    INSTALL_DIR="/opt/4C-dependencies"
+RUN mkdir -p ${INSTALL_DIR}
+
+COPY dependencies /dependencies
+
+# Make `nvcc` available as an environment variable
+ENV PATH=/usr/local/cuda/bin:${PATH}
+
+# Install cmake
+RUN /dependencies/current/cmake/install.sh /usr/local
+
+# Install superLU_dist 7.2.0
+RUN /dependencies/current/superlu_dist/install.sh ${INSTALL_DIR}
+
+# Install Trilinos 2025.6 with Kokkos' CUDA backend enabled
+RUN /dependencies/kokkosparallel/trilinos/install_with_cuda.sh ${INSTALL_DIR}/tk_cuda
+
+# Install Trilinos 2025.6 with Kokkos' OpenMP backend enabled
+RUN /dependencies/kokkosparallel/trilinos/install_with_openmp.sh ${INSTALL_DIR}/tk_openmp
+# Install deal.II (needs to happen after Trilinos and within the same installation directory)
+RUN /dependencies/current/dealii/install.sh ${INSTALL_DIR}/tk_openmp
+
+# Install (optional) backtrace library
+RUN /dependencies/current/backtrace/install.sh ${INSTALL_DIR}
+
+# install (optional) gmsh library
+RUN /dependencies/current/gmsh/install.sh ${INSTALL_DIR}
+
+# Packages for testing
+# Installation directory for dependencies concerning testing
+ENV FOUR_C_TESTING_DEPENDENCIES_DIR="/opt/4C-dependencies-testing/"
+RUN mkdir ${FOUR_C_TESTING_DEPENDENCIES_DIR}
+
+# Install Mathjax
+RUN /dependencies/testing/mathjax/install.sh ${FOUR_C_TESTING_DEPENDENCIES_DIR}
+
+# Add dependencies hash
+# The label is added at the end because the label causes a cache miss
+ARG DEPENDENCIES_HASH
+LABEL org.4c-multiphysics.dependencies_hash="${DEPENDENCIES_HASH}"
+ENV DEPENDENCIES_HASH=${DEPENDENCIES_HASH}
+
+# add and enable the default user
+ENV USER=user
+RUN adduser --disabled-password --shell '/usr/bin/bash' --gecos '' $USER
+RUN adduser $USER sudo; echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+#make sure everything is in place
+RUN chown -R $USER:$USER /home/$USER
+USER $USER
+ENV HOME=/home/$USER
+ENV USER=$USER
+# see https://github.com/open-mpi/ompi/issues/4948
+ENV OMPI_MCA_btl_vader_single_copy_mechanism=none
+WORKDIR $HOME

--- a/docker/kokkosparallel/compute_dependencies_hash.sh
+++ b/docker/kokkosparallel/compute_dependencies_hash.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# This file is part of 4C multiphysics licensed under the
+# GNU Lesser General Public License v3.0 or later.
+#
+# See the LICENSE.md file in the top-level for license information.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+# Exit the script at the first failure
+set -e
+
+find dependencies/current/{backtrace,cmake,dealii,gmsh,superlu_dist} dependencies/testing dependencies/kokkosparallel docker/kokkosparallel -type f -exec sha1sum {} \; | sort | sha1sum | cut -c -8


### PR DESCRIPTION
This PR is related to and should precede #2012. @ppraegla suggested that the docker and related workflow are pushed in a separate PR first (see https://github.com/4C-multiphysics/4C/pull/2012#discussion_r3719322270). Therefore, this PR just adds the new Trilinos installation scripts, dependencies hash computation, dockerfile, and docker_kokkosparallel.yml workflow file.