### PR TITLE
Detect inconsistent fiber entry and throw an error

### DIFF
--- a/doc/documentation/src/analysis_guide_templates/geometrydefinition.rst.j2
+++ b/doc/documentation/src/analysis_guide_templates/geometrydefinition.rst.j2
@@ -53,9 +53,9 @@ The nodes are read in by the section ``NODE COORDS``.
 
 Within this section, the nodes are read one per line. There are different types of nodes:
 
-- General nodes (NODE)
-- Control points for nurbs geometry (CP)
-- Nodes with addition fiber information (FNODE)
+- General nodes (`NODE`)
+- Control points for nurbs geometry (`CP`)
+- Nodes with addition fiber information  (`FNODE`)
 
 All node coordinates must be given with three coordinates, even if the problem is 1D or 2D:
 
@@ -64,13 +64,14 @@ All node coordinates must be given with three coordinates, even if the problem i
    NODE COORDS:
    - "NODE <ID> COORD <coord-x> <coord-y> <coord-z> [ROTANGLE <coord-yz> <coord-xz> <coord-xy>]"
    - "CP <ID> COORD <coord-x> <coord-y> <coord-z> <weight>"
-   - "FNODE <ID> COORD <coord-x> <coord-y> <coord-z> [FIBER1|FIBER2|FIBER3|CIR|TAN|RAD|HELIX|TRANS] <further parameters>"
+   - "FNODE <ID> COORD <coord-x> <coord-y> <coord-z> FIBER1 <x y z> [FIBER2 <x y z> [FIBER3 <x y z>]]"
+   - "FNODE <ID> "COORD <coord-x> <coord-y> <coord-z> CIR <x y z> TAN <x y z> HELIX <angle> TRANS <angle>"
 
-For ``FNODE``, explicit fiber directions must be numbered consecutively starting with ``FIBER1``.
-They cannot be combined with cardiac fiber directions. Cardiac fiber directions require ``CIR``,
-``TAN``, ``HELIX``, and ``TRANS``; ``RAD`` is optional. All nodes of an element must provide the
-same set of parameters, either explicit or cardiac fiber directions. Their direction
-vectors and angle values may vary between nodes.
+For ``FNODE`` in combination with fiber directions, the directions must be numbered consecutively starting with ``FIBER1``.
+For the problemtype `Cardiac_Monodomain`, the fiber directions can be entered alternatively
+using ``CIR``, ``TAN``, ``HELIX``, and ``TRANS``.
+All nodes of an element must provide the same set of parameters, either explicit or cardiac fiber directions.
+Their direction vectors and angle values may vary between nodes.
 
 .. _geometrysets:
 

--- a/doc/documentation/src/analysis_guide_templates/geometrydefinition.rst.j2
+++ b/doc/documentation/src/analysis_guide_templates/geometrydefinition.rst.j2
@@ -66,6 +66,11 @@ All node coordinates must be given with three coordinates, even if the problem i
    - "CP <ID> COORD <coord-x> <coord-y> <coord-z> <weight>"
    - "FNODE <ID> COORD <coord-x> <coord-y> <coord-z> [FIBER1|FIBER2|FIBER3|CIR|TAN|RAD|HELIX|TRANS] <further parameters>"
 
+For ``FNODE``, explicit fiber directions must be numbered consecutively starting with ``FIBER1``.
+They cannot be combined with cardiac fiber directions. Cardiac fiber directions require ``CIR``,
+``TAN``, ``HELIX``, and ``TRANS``; ``RAD`` is optional. All nodes of an element must provide the
+same set of parameters, either explicit or cardiac fiber directions. Their direction
+vectors and angle values may vary between nodes.
 
 .. _geometrysets:
 
@@ -177,4 +182,3 @@ while the parameter :math:`\sigma` is defined by the parameter ``RADIUSDISTRIBUT
     PARTICLE DYNAMIC/DEM:
       INITIAL_RADIUS: RadiusFromParticleInput|NormalRadiusDistribution|LogNormalRadiusDistribution
       RADIUSDISTRIBUTION_SIGMA: <variation>   # variation sigma for a radius distribution
-

--- a/src/core/fem/src/general/node/4C_fem_general_fiber_node_holder.cpp
+++ b/src/core/fem/src/general/node/4C_fem_general_fiber_node_holder.cpp
@@ -9,6 +9,7 @@
 
 #include "4C_comm_parobject.hpp"
 #include "4C_fem_general_fiber_node.hpp"
+#include "4C_utils_exceptions.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -60,7 +61,13 @@ void Core::Nodes::NodalFiberHolder::set_angle(AngleType type, const std::vector<
 const std::vector<double>& Core::Nodes::NodalFiberHolder::get_angle(
     Core::Nodes::AngleType type) const
 {
-  return angles_.at(type);
+  const auto angle = angles_.find(type);
+  if (angle == angles_.end())
+  {
+    FOUR_C_THROW("Nodal fiber data does not contain the requested {} angle.",
+        type == AngleType::Helix ? "HELIX" : "TRANS");
+  }
+  return angle->second;
 }
 
 std::size_t Core::Nodes::NodalFiberHolder::fibers_size() const { return fibers_.size(); }

--- a/src/core/fem/src/general/node/4C_fem_general_fiber_node_utils.cpp
+++ b/src/core/fem/src/general/node/4C_fem_general_fiber_node_utils.cpp
@@ -36,6 +36,43 @@ void Core::Nodes::project_fibers_to_gauss_points(const Core::Nodes::Node* const*
       FOUR_C_THROW("At least one node of the element does not provide fibers.");
     }
 
+    if (inode > 0)
+    {
+      if (fiberNodes[inode]->fibers().size() != fiberNodes[0]->fibers().size())
+      {
+        FOUR_C_THROW(
+            "All nodes of an element must define the same number of FIBER directions. Node {} "
+            "defines {}, but node {} defines {}.",
+            fiberNodes[inode]->id(), fiberNodes[inode]->fibers().size(), fiberNodes[0]->id(),
+            fiberNodes[0]->fibers().size());
+      }
+
+      const auto& reference_directions = fiberNodes[0]->coordinate_system_directions();
+      const auto& node_directions = fiberNodes[inode]->coordinate_system_directions();
+      const bool same_coordinate_directions =
+          reference_directions.size() == node_directions.size() &&
+          std::all_of(reference_directions.begin(), reference_directions.end(),
+              [&node_directions](const auto& direction)
+              { return node_directions.contains(direction.first); });
+      if (!same_coordinate_directions)
+      {
+        FOUR_C_THROW(
+            "All nodes of an element must define the same set of coordinate system direction "
+            "types (CIR, TAN, and optionally RAD).");
+      }
+
+      const auto& reference_angles = fiberNodes[0]->angles();
+      const auto& node_angles = fiberNodes[inode]->angles();
+      const bool same_angles =
+          reference_angles.size() == node_angles.size() &&
+          std::all_of(reference_angles.begin(), reference_angles.end(),
+              [&node_angles](const auto& angle) { return node_angles.contains(angle.first); });
+      if (!same_angles)
+      {
+        FOUR_C_THROW("All nodes of an element must define the same angle types.");
+      }
+    }
+
     for (const auto& pair : fiberNodes[inode]->coordinate_system_directions())
     {
       coordinateSystemDirections[pair.first][inode] = pair.second;

--- a/src/core/fem/src/general/node/4C_fem_general_fiber_node_utils.cpp
+++ b/src/core/fem/src/general/node/4C_fem_general_fiber_node_utils.cpp
@@ -58,7 +58,7 @@ void Core::Nodes::project_fibers_to_gauss_points(const Core::Nodes::Node* const*
       {
         FOUR_C_THROW(
             "All nodes of an element must define the same set of coordinate system direction "
-            "types (CIR, TAN, and optionally RAD).");
+            "types (CIR and TAN).");
       }
 
       const auto& reference_angles = fiberNodes[0]->angles();
@@ -156,21 +156,6 @@ void Core::Nodes::project_fibers_to_gauss_points(const Core::Nodes::Node* const*
       double tancir = tan[gp] * cir[gp];
       tan[gp] += -tancir * cir[gp];
       tan[gp] *= 1.0 / Core::LinAlg::norm2(tan[gp]);
-    }
-
-    // orthogonalize radial vector, preserve circular and tangential direction
-    if (gpFiberHolder.contains_coordinate_system_direction(CoordinateSystemDirection::Radial))
-    {
-      std::vector<Core::LinAlg::Tensor<double, 3>>& rad =
-          gpFiberHolder.get_coordinate_system_direction_mutual(CoordinateSystemDirection::Radial);
-      for (std::size_t gp = 0; gp < tan.size(); ++gp)
-      {
-        double radcir = rad[gp] * cir[gp];
-        double radtan = rad[gp] * tan[gp];
-        // double
-        rad[gp] += -radcir * cir[gp] - radtan * tan[gp];
-        rad[gp] *= 1.0 / Core::LinAlg::norm2(rad[gp]);
-      }
     }
   }
 }

--- a/src/core/io/src/4C_io_meshreader.cpp
+++ b/src/core/io/src/4C_io_meshreader.cpp
@@ -97,11 +97,6 @@ namespace Core::IO::Internal
         data.coordinate_system_directions[Core::Nodes::CoordinateSystemDirection::Tangential] =
             parser.read<std::array<double, 3>>();
       }
-      else if (next == "RAD")
-      {
-        data.coordinate_system_directions[Core::Nodes::CoordinateSystemDirection::Radial] =
-            parser.read<std::array<double, 3>>();
-      }
       else if (next == "HELIX")
       {
         data.angles[Core::Nodes::AngleType::Helix] = parser.read<double>();
@@ -120,12 +115,10 @@ namespace Core::IO::Internal
         Core::Nodes::CoordinateSystemDirection::Circular);
     const bool has_tangential = data.coordinate_system_directions.contains(
         Core::Nodes::CoordinateSystemDirection::Tangential);
-    const bool has_radial =
-        data.coordinate_system_directions.contains(Core::Nodes::CoordinateSystemDirection::Radial);
     const bool has_helix = data.angles.contains(Core::Nodes::AngleType::Helix);
     const bool has_transverse = data.angles.contains(Core::Nodes::AngleType::Transverse);
     const bool has_cardiac_directions =
-        has_circular || has_tangential || has_radial || has_helix || has_transverse;
+        has_circular || has_tangential || has_helix || has_transverse;
 
     if (!data.fibers.empty() && has_cardiac_directions)
     {
@@ -136,9 +129,7 @@ namespace Core::IO::Internal
 
     if (has_cardiac_directions && !(has_circular && has_tangential && has_helix && has_transverse))
     {
-      FOUR_C_THROW(
-          "Cardiac fiber directions in FNODE require all of CIR, TAN, HELIX, and TRANS. RAD is "
-          "optional.");
+      FOUR_C_THROW("Cardiac fiber directions in FNODE require all of CIR, TAN, HELIX, and TRANS.");
     }
 
     return data;

--- a/src/core/io/src/4C_io_meshreader.cpp
+++ b/src/core/io/src/4C_io_meshreader.cpp
@@ -66,6 +66,83 @@ namespace Core::IO::Internal
      */
     std::optional<Core::IO::MeshInput::Mesh<3>> filtered_mesh_on_rank_zero{};
   };
+
+  FiberNodeData read_fiber_node_data(Core::IO::ValueParser& parser)
+  {
+    FiberNodeData data;
+
+    while (!parser.at_end())
+    {
+      const auto next = parser.read<std::string>();
+
+      if (next.starts_with("FIBER"))
+      {
+        const std::string expected = "FIBER" + std::to_string(data.fibers.size() + 1);
+        if (next != expected)
+        {
+          FOUR_C_THROW(
+              "Fiber directions in FNODE must be numbered consecutively. Expected '{}', found "
+              "'{}'.",
+              expected, next);
+        }
+        data.fibers.emplace_back(parser.read<std::array<double, 3>>());
+      }
+      else if (next == "CIR")
+      {
+        data.coordinate_system_directions[Core::Nodes::CoordinateSystemDirection::Circular] =
+            parser.read<std::array<double, 3>>();
+      }
+      else if (next == "TAN")
+      {
+        data.coordinate_system_directions[Core::Nodes::CoordinateSystemDirection::Tangential] =
+            parser.read<std::array<double, 3>>();
+      }
+      else if (next == "RAD")
+      {
+        data.coordinate_system_directions[Core::Nodes::CoordinateSystemDirection::Radial] =
+            parser.read<std::array<double, 3>>();
+      }
+      else if (next == "HELIX")
+      {
+        data.angles[Core::Nodes::AngleType::Helix] = parser.read<double>();
+      }
+      else if (next == "TRANS")
+      {
+        data.angles[Core::Nodes::AngleType::Transverse] = parser.read<double>();
+      }
+      else
+      {
+        FOUR_C_THROW("Unknown FNODE parameter '{}'.", next);
+      }
+    }
+
+    const bool has_circular = data.coordinate_system_directions.contains(
+        Core::Nodes::CoordinateSystemDirection::Circular);
+    const bool has_tangential = data.coordinate_system_directions.contains(
+        Core::Nodes::CoordinateSystemDirection::Tangential);
+    const bool has_radial =
+        data.coordinate_system_directions.contains(Core::Nodes::CoordinateSystemDirection::Radial);
+    const bool has_helix = data.angles.contains(Core::Nodes::AngleType::Helix);
+    const bool has_transverse = data.angles.contains(Core::Nodes::AngleType::Transverse);
+    const bool has_cardiac_directions =
+        has_circular || has_tangential || has_radial || has_helix || has_transverse;
+
+    if (!data.fibers.empty() && has_cardiac_directions)
+    {
+      FOUR_C_THROW(
+          "Fiber directions in FNODE must be defined either by CIR/TAN/HELIX/TRANS or by FIBER1, "
+          "FIBER2, etc., but not by both.");
+    }
+
+    if (has_cardiac_directions && !(has_circular && has_tangential && has_helix && has_transverse))
+    {
+      FOUR_C_THROW(
+          "Cardiac fiber directions in FNODE require all of CIR, TAN, HELIX, and TRANS. RAD is "
+          "optional.");
+    }
+
+    return data;
+  }
 }  // namespace Core::IO::Internal
 
 namespace
@@ -453,56 +530,11 @@ namespace
       // this is a special node with additional fiber information
       else if (type == "FNODE")
       {
-        enum class FiberType
-        {
-          Unknown,
-          Angle,
-          Fiber,
-          CosyDirection
-        };
-
-        // read fiber node
-        std::map<Core::Nodes::CoordinateSystemDirection, std::array<double, 3>> cosyDirections;
-        std::vector<std::array<double, 3>> fibers;
-        std::map<Core::Nodes::AngleType, double> angles;
-
         int nodeid = parser.read<int>() - 1;
         parser.consume("COORD");
         auto coords = parser.read<std::vector<double>>(3);
         max_node_id = std::max(max_node_id, nodeid) + 1;
-
-        while (!parser.at_end())
-        {
-          auto next = parser.read<std::string>();
-
-          if (next == "FIBER" + std::to_string(1 + fibers.size()))
-          {
-            fibers.emplace_back(parser.read<std::array<double, 3>>());
-          }
-          else if (next == "CIR")
-          {
-            cosyDirections[Core::Nodes::CoordinateSystemDirection::Circular] =
-                parser.read<std::array<double, 3>>();
-          }
-          else if (next == "TAN")
-          {
-            cosyDirections[Core::Nodes::CoordinateSystemDirection::Tangential] =
-                parser.read<std::array<double, 3>>();
-          }
-          else if (next == "RAD")
-          {
-            cosyDirections[Core::Nodes::CoordinateSystemDirection::Radial] =
-                parser.read<std::array<double, 3>>();
-          }
-          else if (next == "HELIX")
-          {
-            angles[Core::Nodes::AngleType::Helix] = parser.read<double>();
-          }
-          else if (next == "TRANS")
-          {
-            angles[Core::Nodes::AngleType::Transverse] = parser.read<double>();
-          }
-        }
+        auto fiber_node_data = Core::IO::Internal::read_fiber_node_data(parser);
 
         // add fiber information to node
         std::vector<std::shared_ptr<Core::FE::Discretization>> discretizations =
@@ -510,8 +542,9 @@ namespace
         for (auto& dis : discretizations)
         {
           sanitize_node_coordinates(nodeid, dis->n_dim(), coords);
-          auto node = std::make_shared<Core::Nodes::FiberNode>(
-              nodeid, coords, cosyDirections, fibers, angles, myrank);
+          auto node = std::make_shared<Core::Nodes::FiberNode>(nodeid, coords,
+              fiber_node_data.coordinate_system_directions, fiber_node_data.fibers,
+              fiber_node_data.angles, myrank);
           dis->add_node(coords, nodeid, node);
         }
       }

--- a/src/core/io/src/4C_io_meshreader.hpp
+++ b/src/core/io/src/4C_io_meshreader.hpp
@@ -10,11 +10,13 @@
 
 #include "4C_config.hpp"
 
+#include "4C_fem_general_fiber_node.hpp"
 #include "4C_linalg_graph.hpp"
 #include "4C_rebalance.hpp"
 
 #include <Teuchos_ParameterList.hpp>
 
+#include <array>
 #include <map>
 #include <string>
 #include <vector>
@@ -29,6 +31,7 @@ namespace Core::FE
 namespace Core::IO
 {
   class InputFile;
+  class ValueParser;
 
   namespace MeshInput
   {
@@ -39,7 +42,17 @@ namespace Core::IO
   namespace Internal
   {
     struct MeshReader;
-  }
+
+    struct FiberNodeData
+    {
+      std::map<Core::Nodes::CoordinateSystemDirection, std::array<double, 3>>
+          coordinate_system_directions;
+      std::vector<std::array<double, 3>> fibers;
+      std::map<Core::Nodes::AngleType, double> angles;
+    };
+
+    FiberNodeData read_fiber_node_data(Core::IO::ValueParser& parser);
+  }  // namespace Internal
 
 
   /**

--- a/src/solid_ele/4C_solid_ele_fiber.cpp
+++ b/src/solid_ele/4C_solid_ele_fiber.cpp
@@ -12,7 +12,6 @@
 #include "4C_utils_exceptions.hpp"
 
 #include <algorithm>
-#include <iostream>
 
 FOUR_C_NAMESPACE_OPEN
 namespace
@@ -73,8 +72,6 @@ Discret::Elements::Fibers Discret::Elements::read_fibers(
 
     fibers.element_fibers.emplace_back(tensor);
   }
-  std::cout << "Number of fibers: " << fibers.element_fibers.size() << std::endl;
-
   return fibers;
 }
 

--- a/src/solid_ele/4C_solid_ele_fiber.cpp
+++ b/src/solid_ele/4C_solid_ele_fiber.cpp
@@ -12,13 +12,48 @@
 #include "4C_utils_exceptions.hpp"
 
 #include <algorithm>
+#include <iostream>
 
 FOUR_C_NAMESPACE_OPEN
+namespace
+{
+  bool has_nonempty_optional_vector_parameter(
+      const Core::IO::InputParameterContainer& input_data, const std::string& name)
+  {
+    const auto* parameter = input_data.get_if<std::optional<std::vector<double>>>(name);
+    return parameter != nullptr && parameter->has_value() && !parameter->value().empty();
+  }
 
+  bool has_nonempty_optional_vector(const std::optional<std::vector<double>>* parameter)
+  {
+    return parameter != nullptr && parameter->has_value() && !parameter->value().empty();
+  }
+
+  void validate_direction_input(const Core::IO::InputParameterContainer& input_data)
+  {
+    const bool has_coordinate_system = has_nonempty_optional_vector_parameter(input_data, "RAD") ||
+                                       has_nonempty_optional_vector_parameter(input_data, "AXI") ||
+                                       has_nonempty_optional_vector_parameter(input_data, "CIR");
+    const bool has_fiber1 = has_nonempty_optional_vector_parameter(input_data, "FIBER1");
+    const bool has_fiber2 = has_nonempty_optional_vector_parameter(input_data, "FIBER2");
+    const bool has_fiber3 = has_nonempty_optional_vector_parameter(input_data, "FIBER3");
+    const bool has_fibers = has_fiber1 || has_fiber2 || has_fiber3;
+
+    FOUR_C_ASSERT_ALWAYS(!(has_coordinate_system && has_fibers),
+        "Material directions must be specified either by RAD/AXI/CIR or by FIBER1, FIBER2, "
+        "FIBER3, but not by both.");
+    FOUR_C_ASSERT_ALWAYS(!has_fiber2 || has_fiber1,
+        "Fiber directions must be numbered consecutively: FIBER2 requires FIBER1.");
+    FOUR_C_ASSERT_ALWAYS(!has_fiber3 || has_fiber2,
+        "Fiber directions must be numbered consecutively: FIBER3 requires FIBER2.");
+  }
+}  // namespace
 
 Discret::Elements::Fibers Discret::Elements::read_fibers(
     const Core::IO::InputParameterContainer& input_data)
 {
+  validate_direction_input(input_data);
+
   Fibers fibers{};
 
   // for now only support the old style fiber input via FIBER1, FIBER2, ... keywords
@@ -27,7 +62,7 @@ Discret::Elements::Fibers Discret::Elements::read_fibers(
     const std::string fiber_name = "FIBER" + std::to_string(i);
 
     const auto* fiber_ptr = input_data.get_if<std::optional<std::vector<double>>>(fiber_name);
-    if (!fiber_ptr || !fiber_ptr->has_value())
+    if (!has_nonempty_optional_vector(fiber_ptr))
     {
       break;
     }
@@ -38,6 +73,7 @@ Discret::Elements::Fibers Discret::Elements::read_fibers(
 
     fibers.element_fibers.emplace_back(tensor);
   }
+  std::cout << "Number of fibers: " << fibers.element_fibers.size() << std::endl;
 
   return fibers;
 }
@@ -45,19 +81,20 @@ Discret::Elements::Fibers Discret::Elements::read_fibers(
 std::optional<Discret::Elements::CoordinateSystem> Discret::Elements::read_coordinate_system(
     const Core::IO::InputParameterContainer& input_data)
 {
+  validate_direction_input(input_data);
+
   // for now only support the old style fiber input via RAD, AXI, CIR keywords
   const std::array rad_axi_cir = {input_data.get_if<std::optional<std::vector<double>>>("RAD"),
       input_data.get_if<std::optional<std::vector<double>>>("AXI"),
       input_data.get_if<std::optional<std::vector<double>>>("CIR")};
 
-  if (std::ranges::none_of(rad_axi_cir, [](const auto* p) { return p && p->has_value(); }))
+  if (std::ranges::none_of(rad_axi_cir, has_nonempty_optional_vector))
   {
     // no local coordinate system defined
     return std::nullopt;
   }
 
-  FOUR_C_ASSERT_ALWAYS(
-      std::ranges::all_of(rad_axi_cir, [](const auto* p) { return p && p->has_value(); }),
+  FOUR_C_ASSERT_ALWAYS(std::ranges::all_of(rad_axi_cir, has_nonempty_optional_vector),
       "If you specify a coordinate system, you need to define all of RAD, AXI and CIR!");
 
   CoordinateSystem coord_sys{};

--- a/unittests/io/4C_meshreader_fiber_node_test.cpp
+++ b/unittests/io/4C_meshreader_fiber_node_test.cpp
@@ -1,0 +1,105 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "4C_fem_general_fiber_node.hpp"
+#include "4C_fem_general_fiber_node_holder.hpp"
+#include "4C_fem_general_fiber_node_utils.hpp"
+#include "4C_io_meshreader.hpp"
+#include "4C_io_value_parser.hpp"
+#include "4C_unittest_utils_assertions_test.hpp"
+#include "4C_utils_exceptions.hpp"
+
+namespace
+{
+  using namespace FourC;
+
+  TEST(MeshReaderFiberNodeTest, RejectsFiberNumberingGap)
+  {
+    Core::IO::ValueParser parser("FIBER2 0.0 1.0 0.0");
+
+    FOUR_C_EXPECT_THROW_WITH_MESSAGE(
+        Core::IO::Internal::read_fiber_node_data(parser), Core::Exception, "Expected 'FIBER1'");
+  }
+
+  TEST(MeshReaderFiberNodeTest, RejectsFiberAndCoordinateSystem)
+  {
+    Core::IO::ValueParser parser(
+        "FIBER1 1.0 0.0 0.0 CIR 1.0 0.0 0.0 TAN 0.0 1.0 0.0 HELIX 0.0 TRANS 0.0");
+
+    FOUR_C_EXPECT_THROW_WITH_MESSAGE(Core::IO::Internal::read_fiber_node_data(parser),
+        Core::Exception, "either by CIR/TAN/HELIX/TRANS or by FIBER1");
+  }
+
+  TEST(MeshReaderFiberNodeTest, RejectsIncompleteCardiacFiberDirections)
+  {
+    for (const std::string input : {
+             "TAN 0.0 1.0 0.0 HELIX 0.0 TRANS 0.0",
+             "CIR 1.0 0.0 0.0 HELIX 0.0 TRANS 0.0",
+             "CIR 1.0 0.0 0.0 TAN 0.0 1.0 0.0 TRANS 0.0",
+             "CIR 1.0 0.0 0.0 TAN 0.0 1.0 0.0 HELIX 0.0",
+         })
+    {
+      Core::IO::ValueParser parser(input);
+
+      FOUR_C_EXPECT_THROW_WITH_MESSAGE(Core::IO::Internal::read_fiber_node_data(parser),
+          Core::Exception, "require all of CIR, TAN, HELIX, and TRANS");
+    }
+  }
+
+  TEST(MeshReaderFiberNodeTest, AcceptsConsecutiveFibers)
+  {
+    Core::IO::ValueParser parser("FIBER1 1.0 0.0 0.0 FIBER2 0.0 1.0 0.0 FIBER3 0.0 0.0 1.0");
+
+    const auto data = Core::IO::Internal::read_fiber_node_data(parser);
+
+    EXPECT_EQ(data.fibers.size(), 3);
+    EXPECT_TRUE(data.coordinate_system_directions.empty());
+  }
+
+  TEST(MeshReaderFiberNodeTest, AcceptsCardiacFiberDirectionsWithoutOptionalRadialDirection)
+  {
+    Core::IO::ValueParser parser("CIR 1.0 0.0 0.0 TAN 0.0 1.0 0.0 HELIX 0.0 TRANS 0.0");
+
+    const auto data = Core::IO::Internal::read_fiber_node_data(parser);
+
+    EXPECT_EQ(data.coordinate_system_directions.size(), 2);
+    EXPECT_EQ(data.angles.size(), 2);
+    EXPECT_TRUE(data.fibers.empty());
+  }
+
+  TEST(MeshReaderFiberNodeTest, ReportsMissingNodalFiberAngle)
+  {
+    Core::Nodes::NodalFiberHolder holder;
+
+    FOUR_C_EXPECT_THROW_WITH_MESSAGE(holder.get_angle(Core::Nodes::AngleType::Helix),
+        Core::Exception, "does not contain the requested HELIX angle");
+    FOUR_C_EXPECT_THROW_WITH_MESSAGE(holder.get_angle(Core::Nodes::AngleType::Transverse),
+        Core::Exception, "does not contain the requested TRANS angle");
+  }
+
+  TEST(MeshReaderFiberNodeTest, RejectsDifferentFiberCountsWithinElement)
+  {
+    const std::array<double, 3> coordinates{};
+    const std::array<double, 3> fiber{1.0, 0.0, 0.0};
+    std::array<Core::Nodes::FiberNode, 4> fiber_nodes{
+        Core::Nodes::FiberNode(0, coordinates, {}, {fiber}, {}, 0),
+        Core::Nodes::FiberNode(1, coordinates, {}, {fiber, fiber}, {}, 0),
+        Core::Nodes::FiberNode(2, coordinates, {}, {fiber}, {}, 0),
+        Core::Nodes::FiberNode(3, coordinates, {}, {fiber}, {}, 0)};
+    std::array<const Core::Nodes::Node*, 4> nodes{
+        &fiber_nodes[0], &fiber_nodes[1], &fiber_nodes[2], &fiber_nodes[3]};
+    Core::Nodes::NodalFiberHolder holder;
+    const std::vector<Core::LinAlg::Matrix<4, 1>> shape_functions;
+
+    FOUR_C_EXPECT_THROW_WITH_MESSAGE(
+        Core::Nodes::project_fibers_to_gauss_points<Core::FE::CellType::tet4>(
+            nodes.data(), shape_functions, holder),
+        Core::Exception, "same number of FIBER directions");
+  }
+}  // namespace

--- a/unittests/io/4C_meshreader_fiber_node_test.cpp
+++ b/unittests/io/4C_meshreader_fiber_node_test.cpp
@@ -62,7 +62,7 @@ namespace
     EXPECT_TRUE(data.coordinate_system_directions.empty());
   }
 
-  TEST(MeshReaderFiberNodeTest, AcceptsCardiacFiberDirectionsWithoutOptionalRadialDirection)
+  TEST(MeshReaderFiberNodeTest, AcceptsCardiacFiberDirections)
   {
     Core::IO::ValueParser parser("CIR 1.0 0.0 0.0 TAN 0.0 1.0 0.0 HELIX 0.0 TRANS 0.0");
 

--- a/unittests/solid_ele/4C_solid_ele_fiber_test.cpp
+++ b/unittests/solid_ele/4C_solid_ele_fiber_test.cpp
@@ -1,0 +1,93 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "4C_solid_ele_fibers.hpp"
+#include "4C_unittest_utils_assertions_test.hpp"
+#include "4C_utils_exceptions.hpp"
+
+namespace
+{
+  using namespace FourC;
+
+  Core::IO::InputParameterContainer direction_input_with_fiber_and_coordinate_system()
+  {
+    Core::IO::InputParameterContainer input;
+    input.add("FIBER1", std::optional<std::vector<double>>{{1.0, 0.0, 0.0}});
+    input.add("RAD", std::optional<std::vector<double>>{{1.0, 0.0, 0.0}});
+    input.add("AXI", std::optional<std::vector<double>>{{0.0, 1.0, 0.0}});
+    input.add("CIR", std::optional<std::vector<double>>{{0.0, 0.0, 1.0}});
+    return input;
+  }
+
+  void add_empty_optional_direction_defaults(Core::IO::InputParameterContainer& input)
+  {
+    for (const char* direction : {"RAD", "AXI", "CIR", "FIBER1", "FIBER2", "FIBER3"})
+      input.add(direction, std::optional<std::vector<double>>{std::vector<double>{}});
+  }
+
+  TEST(SolidElementFiberTest, RejectsFiberAndCoordinateSystemWhenReadingFibers)
+  {
+    const auto input = direction_input_with_fiber_and_coordinate_system();
+
+    FOUR_C_EXPECT_THROW_WITH_MESSAGE(Discret::Elements::read_fibers(input), Core::Exception,
+        "either by RAD/AXI/CIR or by FIBER1, FIBER2, FIBER3");
+  }
+
+  TEST(SolidElementFiberTest, RejectsFiberAndCoordinateSystemWhenReadingCoordinateSystem)
+  {
+    const auto input = direction_input_with_fiber_and_coordinate_system();
+
+    FOUR_C_EXPECT_THROW_WITH_MESSAGE(Discret::Elements::read_coordinate_system(input),
+        Core::Exception, "either by RAD/AXI/CIR or by FIBER1, FIBER2, FIBER3");
+  }
+
+  TEST(SolidElementFiberTest, RejectsFiber2WithoutFiber1)
+  {
+    Core::IO::InputParameterContainer input;
+    input.add("FIBER2", std::optional<std::vector<double>>{{0.0, 1.0, 0.0}});
+
+    FOUR_C_EXPECT_THROW_WITH_MESSAGE(
+        Discret::Elements::read_fibers(input), Core::Exception, "FIBER2 requires FIBER1");
+  }
+
+  TEST(SolidElementFiberTest, RejectsFiber3WithoutFiber2)
+  {
+    Core::IO::InputParameterContainer input;
+    input.add("FIBER1", std::optional<std::vector<double>>{{1.0, 0.0, 0.0}});
+    input.add("FIBER3", std::optional<std::vector<double>>{{0.0, 0.0, 1.0}});
+
+    FOUR_C_EXPECT_THROW_WITH_MESSAGE(
+        Discret::Elements::read_fibers(input), Core::Exception, "FIBER3 requires FIBER2");
+  }
+
+  TEST(SolidElementFiberTest, RejectsIncompleteCoordinateSystem)
+  {
+    for (const char* direction : {"RAD", "AXI", "CIR"})
+    {
+      Core::IO::InputParameterContainer input;
+      add_empty_optional_direction_defaults(input);
+      input.add(direction, std::optional<std::vector<double>>{{1.0, 0.0, 0.0}});
+
+      FOUR_C_EXPECT_THROW_WITH_MESSAGE(Discret::Elements::read_coordinate_system(input),
+          Core::Exception, "need to define all of RAD, AXI and CIR");
+    }
+  }
+
+  TEST(SolidElementFiberTest, IgnoresEmptyOptionalFiberDefaults)
+  {
+    Core::IO::InputParameterContainer input;
+    add_empty_optional_direction_defaults(input);
+    input.add("RAD", std::optional<std::vector<double>>{{1.0, 0.0, 0.0}});
+    input.add("AXI", std::optional<std::vector<double>>{{0.0, 1.0, 0.0}});
+    input.add("CIR", std::optional<std::vector<double>>{{0.0, 0.0, 1.0}});
+
+    EXPECT_NO_THROW(Discret::Elements::read_coordinate_system(input));
+    EXPECT_TRUE(Discret::Elements::read_fibers(input).element_fibers.empty());
+  }
+}  // namespace


### PR DESCRIPTION
## Description and Context
When I asked the LLM to help me with the material documentation (PR #2146 ), it wrote "For materials using the default anisotropy framework, this coordinate system [RAD|AXI|CIR] takes precedence over explicit ``FIBER*`` vectors. @lauraengelhardt insisted that this is rather a bug than a feature. So I added a check for giving both `FIBER` and `RAD|AXI|CIR` entries. Since a check for adding `FIBER2` without `FIBER1` (or `FIBER3` without any of them) did not exist as well, I added this, too.

I found that this behavior is similar for element based and node based directions. So I implemented the check for both elements and nodes. For node based fiber directions, they may be defined explicitly or by CIR|TAN|HELIX|ANGLE for cardiac monodomains. An explanation for those parameters would definitely be useful in the documentation ;-)
The parameter RAD is never read, but always calculated from CIR x TAN. Due to the comments I removed this parameter completely.

## Related Issues and Pull Requests
PR #2146

## Disclosure of AI assistance

AI was used for code generation (including the unittests)
I understand what *chatGPT 5.6 sol* did, that is, what the check does and how, but I could barely code it in the same smart way. Particularly, since the legacy dat format style of the element and node definitions include also nonexistent optional parameters as entered but empty (I didn't expect that), which made the if clauses  a bit more complex.

