### PR TITLE
Insert Global::Problem at porofluidelast/-scatra algorithm boundary

### DIFF
--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_artery_coupling.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_artery_coupling.cpp
@@ -38,8 +38,8 @@ FOUR_C_NAMESPACE_OPEN
  | constructor                                         kremheller 05/18 |
  *----------------------------------------------------------------------*/
 PoroPressureBased::PorofluidElastArteryCouplingAlgorithm::PorofluidElastArteryCouplingAlgorithm(
-    MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams)
-    : PorofluidElastMonolithicAlgorithm(comm, globaltimeparams)
+    Global::Problem& problem, MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams)
+    : PorofluidElastMonolithicAlgorithm(problem, comm, globaltimeparams)
 {
   blockrowdofmap_artporo_ = std::make_shared<Core::LinAlg::MultiMapExtractor>();
 

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_artery_coupling.hpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_artery_coupling.hpp
@@ -16,6 +16,11 @@
 
 FOUR_C_NAMESPACE_OPEN
 
+namespace Global
+{
+  class Problem;
+}  // namespace Global
+
 namespace PoroPressureBased
 {
   ///! Monolithic solution scheme for porofluid-elasticity problems with artery coupling
@@ -23,7 +28,7 @@ namespace PoroPressureBased
   {
    public:
     PorofluidElastArteryCouplingAlgorithm(
-        MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams);
+        Global::Problem& problem, MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams);
 
     //! extract the field vectors from a given composed vector.
     /*!

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_base.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_base.cpp
@@ -25,8 +25,8 @@ FOUR_C_NAMESPACE_OPEN
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 PoroPressureBased::PorofluidElastAlgorithm::PorofluidElastAlgorithm(
-    MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams)
-    : AlgorithmBase(*Global::Problem::instance(), comm, globaltimeparams),
+    Global::Problem& problem, MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams)
+    : AlgorithmBase(problem, comm, globaltimeparams),
       structure_algo_(nullptr),
       porofluid_algo_(nullptr),
       solve_structure_(true)
@@ -54,7 +54,7 @@ void PoroPressureBased::PorofluidElastAlgorithm::init(
 
   // build underlying structure algorithm
   std::shared_ptr<Adapter::StructureBaseAlgorithmNew> structure_adapter_algo =
-      Adapter::build_structure_algorithm(*Global::Problem::instance(), structure_params);
+      Adapter::build_structure_algorithm(problem(), structure_params);
 
   // Translate updated porofluid input format to old structure format
   Teuchos::ParameterList structure_global_time_params;

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_base.hpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_base.hpp
@@ -34,13 +34,19 @@ namespace Core::FE
   class Discretization;
 }  // namespace Core::FE
 
+namespace Global
+{
+  class Problem;
+}  // namespace Global
+
 namespace PoroPressureBased
 {
   //! Base class of porofluid-elasticity algorithms
   class PorofluidElastAlgorithm : public Adapter::AlgorithmBase
   {
    public:
-    PorofluidElastAlgorithm(MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams);
+    PorofluidElastAlgorithm(
+        Global::Problem& problem, MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams);
 
     /// initialization
     virtual void init(const Teuchos::ParameterList& global_time_params,

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_dyn.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_dyn.cpp
@@ -75,7 +75,7 @@ void porofluid_elast_dyn(int restart)
 
   std::shared_ptr<PoroPressureBased::PorofluidElastAlgorithm> algo =
       PoroPressureBased::create_algorithm_porofluid_elast(
-          solscheme, poroparams, comm, algorithm_deps);
+          *problem, solscheme, poroparams, comm, algorithm_deps);
 
   // initialize
   algo->init(poroparams, poroparams, structdyn, fluiddyn, struct_disname, fluid_disname, true,

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_monolithic.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_monolithic.cpp
@@ -37,8 +37,8 @@ FOUR_C_NAMESPACE_OPEN
  | constructor                                          kremheller 03/17 |
  *----------------------------------------------------------------------*/
 PoroPressureBased::PorofluidElastMonolithicAlgorithm::PorofluidElastMonolithicAlgorithm(
-    MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams)
-    : PorofluidElastAlgorithm(comm, globaltimeparams),
+    Global::Problem& problem, MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams)
+    : PorofluidElastAlgorithm(problem, comm, globaltimeparams),
       ittolinc_(0.0),
       ittolres_(0.0),
       itmax_(0),

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_monolithic.hpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_monolithic.hpp
@@ -38,6 +38,11 @@ namespace Core::Conditions
   class LocsysManager;
 }
 
+namespace Global
+{
+  class Problem;
+}  // namespace Global
+
 namespace PoroPressureBased
 {
   //! Monolithic solution scheme for porofluid-elasticity problems
@@ -45,7 +50,7 @@ namespace PoroPressureBased
   {
    public:
     PorofluidElastMonolithicAlgorithm(
-        MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams);
+        Global::Problem& problem, MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams);
 
     /// initialization
     void init(const Teuchos::ParameterList& globaltimeparams,

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_partitioned.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_partitioned.cpp
@@ -22,8 +22,8 @@ FOUR_C_NAMESPACE_OPEN
  | constructor                                              vuong 08/16 |
  *----------------------------------------------------------------------*/
 PoroPressureBased::PorofluidElastPartitionedAlgorithm::PorofluidElastPartitionedAlgorithm(
-    MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams)
-    : PorofluidElastAlgorithm(comm, globaltimeparams),
+    Global::Problem& problem, MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams)
+    : PorofluidElastAlgorithm(problem, comm, globaltimeparams),
       phiincnp_(nullptr),
       dispincnp_(nullptr),
       fluidphinp_(nullptr),

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_partitioned.hpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_partitioned.hpp
@@ -15,6 +15,11 @@
 
 FOUR_C_NAMESPACE_OPEN
 
+namespace Global
+{
+  class Problem;
+}  // namespace Global
+
 namespace PoroPressureBased
 {
   //! Partitioned solution scheme of porofluid-elasticity problems
@@ -22,7 +27,7 @@ namespace PoroPressureBased
   {
    public:
     PorofluidElastPartitionedAlgorithm(
-        MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams);
+        Global::Problem& problem, MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams);
 
     /// initialization
     void init(const Teuchos::ParameterList& globaltimeparams,

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_utils.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_utils.cpp
@@ -177,7 +177,7 @@ void PoroPressureBased::assign_material_pointers_porofluid_elast(
  | create algorithm                                                      |
  *----------------------------------------------------------------------*/
 std::shared_ptr<PoroPressureBased::PorofluidElastAlgorithm>
-PoroPressureBased::create_algorithm_porofluid_elast(
+PoroPressureBased::create_algorithm_porofluid_elast(Global::Problem& problem,
     PoroPressureBased::SolutionSchemePorofluidElast solscheme,
     const Teuchos::ParameterList& timeparams, MPI_Comm comm,
     PorofluidElastAlgorithmDeps algorithm_deps)
@@ -200,7 +200,7 @@ PoroPressureBased::create_algorithm_porofluid_elast(
     {
       // call constructor
       algo = std::make_shared<PoroPressureBased::PorofluidElastPartitionedAlgorithm>(
-          comm, adapter_global_time_params);
+          problem, comm, adapter_global_time_params);
       break;
     }
     case SolutionSchemePorofluidElast::twoway_monolithic:
@@ -210,13 +210,13 @@ PoroPressureBased::create_algorithm_porofluid_elast(
       {
         // call constructor
         algo = std::make_shared<PoroPressureBased::PorofluidElastMonolithicAlgorithm>(
-            comm, adapter_global_time_params);
+            problem, comm, adapter_global_time_params);
       }
       else
       {
         // call constructor
         algo = std::make_shared<PoroPressureBased::PorofluidElastArteryCouplingAlgorithm>(
-            comm, adapter_global_time_params);
+            problem, comm, adapter_global_time_params);
       }
       break;
     }

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_utils.hpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_utils.hpp
@@ -25,6 +25,11 @@ namespace Core::FE
   class Discretization;
 }  // namespace Core::FE
 
+namespace Global
+{
+  class Problem;
+}  // namespace Global
+
 namespace PoroPressureBased
 {
   /// setup discretizations and dofsets of porofluid and structure
@@ -42,6 +47,7 @@ namespace PoroPressureBased
 
   /// create solution algorithm depending on input file
   std::shared_ptr<PorofluidElastAlgorithm> create_algorithm_porofluid_elast(
+      Global::Problem& problem,                   //!< global problem instance (i)
       SolutionSchemePorofluidElast solscheme,     //!< solution scheme to build (i)
       const Teuchos::ParameterList& timeparams,   //!< problem parameters (i)
       MPI_Comm comm,                              //!< communicator(i)

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_base.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_base.cpp
@@ -28,8 +28,8 @@ FOUR_C_NAMESPACE_OPEN
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 PoroPressureBased::PorofluidElastScatraBaseAlgorithm::PorofluidElastScatraBaseAlgorithm(
-    MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams)
-    : AlgorithmBase(*Global::Problem::instance(), comm, globaltimeparams),
+    Global::Problem& problem, MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams)
+    : AlgorithmBase(problem, comm, globaltimeparams),
       porofluid_elast_algo_(nullptr),
       scatra_algo_(nullptr),
       flux_reconstruction_active_(false),
@@ -115,9 +115,9 @@ void PoroPressureBased::PorofluidElastScatraBaseAlgorithm::init(
         "approach instead.");
   }
 
-  porofluid_elast_algo_ =
-      PoroPressureBased::create_algorithm_porofluid_elast(solution_scheme_porofluid_elast,
-          global_time_params, get_comm(), porofluid_elast_algorithm_deps);
+  porofluid_elast_algo_ = PoroPressureBased::create_algorithm_porofluid_elast(problem(),
+      solution_scheme_porofluid_elast, global_time_params, get_comm(),
+      porofluid_elast_algorithm_deps);
 
   // initialize
   porofluid_elast_algo_->init(global_time_params, porofluid_elast_params, structure_params,
@@ -141,9 +141,9 @@ void PoroPressureBased::PorofluidElastScatraBaseAlgorithm::init(
       "RESULTSEVERY", global_time_params.sublist("output").get<int>("result_data_every"));
 
   // scatra problem
-  scatra_algo_ = std::make_shared<Adapter::ScaTraBaseAlgorithm>(*Global::Problem::instance(),
-      scatra_global_time_params, scatra_params, algorithm_deps.solver_params_by_id(linsolvernumber),
-      scatra_disname, true);
+  scatra_algo_ =
+      std::make_shared<Adapter::ScaTraBaseAlgorithm>(problem(), scatra_global_time_params,
+          scatra_params, algorithm_deps.solver_params_by_id(linsolvernumber), scatra_disname, true);
 
   // initialize the base algo.
   // scatra time integrator is constructed and initialized inside.

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_base.hpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_base.hpp
@@ -42,6 +42,11 @@ namespace ScaTra
   class MeshtyingStrategyArtery;
 }
 
+namespace Global
+{
+  class Problem;
+}  // namespace Global
+
 namespace PoroPressureBased
 {
   //! Base class of all algorithms for porofluid-elasticity problems with scalar transport and
@@ -50,7 +55,7 @@ namespace PoroPressureBased
   {
    public:
     PorofluidElastScatraBaseAlgorithm(
-        MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams);
+        Global::Problem& problem, MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams);
 
     //! initialization
     virtual void init(const Teuchos::ParameterList& global_time_params,

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_dyn.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_dyn.cpp
@@ -82,7 +82,7 @@ void porofluid_pressure_based_elast_scatra_dyn(int restart)
 
   std::shared_ptr<PoroPressureBased::PorofluidElastScatraBaseAlgorithm> algo =
       PoroPressureBased::create_algorithm_porofluid_elast_scatra(
-          solution_scheme, porofluid_elast_scatra_params, comm);
+          *problem, solution_scheme, porofluid_elast_scatra_params, comm);
   algo->set_algorithm_deps(algorithm_deps);
 
   algo->init(porofluid_elast_scatra_params, porofluid_elast_scatra_params, porofluid_elast_params,

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_monolithic.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_monolithic.cpp
@@ -34,8 +34,8 @@ FOUR_C_NAMESPACE_OPEN
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 PoroPressureBased::PorofluidElastScatraMonolithicAlgorithm::PorofluidElastScatraMonolithicAlgorithm(
-    MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams)
-    : PorofluidElastScatraBaseAlgorithm(comm, globaltimeparams),
+    Global::Problem& problem, MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams)
+    : PorofluidElastScatraBaseAlgorithm(problem, comm, globaltimeparams),
       iter_tol_inc_(0.0),
       iter_tol_res_(0.0),
       iter_max_(0),
@@ -1317,8 +1317,8 @@ void PoroPressureBased::PorofluidElastScatraMonolithicAlgorithm::poro_multi_phas
  *----------------------------------------------------------------------*/
 PoroPressureBased::PorofluidElastScatraMonolithicArteryCouplingAlgorithm::
     PorofluidElastScatraMonolithicArteryCouplingAlgorithm(
-        MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams)
-    : PorofluidElastScatraMonolithicAlgorithm(comm, globaltimeparams)
+        Global::Problem& problem, MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams)
+    : PorofluidElastScatraMonolithicAlgorithm(problem, comm, globaltimeparams)
 {
   blockrowdofmap_artscatra_ = std::make_shared<Core::LinAlg::MultiMapExtractor>();
   blockrowdofmap_artporo_ = std::make_shared<Core::LinAlg::MultiMapExtractor>();

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_monolithic.hpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_monolithic.hpp
@@ -35,6 +35,11 @@ namespace Core::LinearSolver
   enum class SolverType;
 }
 
+namespace Global
+{
+  class Problem;
+}  // namespace Global
+
 namespace PoroPressureBased
 {
   //! Monolithic solution scheme of porofluid-elasticity problems with scalar transport
@@ -42,7 +47,7 @@ namespace PoroPressureBased
   {
    public:
     PorofluidElastScatraMonolithicAlgorithm(
-        MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams);
+        Global::Problem& problem, MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams);
 
     /// initialization
     void init(const Teuchos::ParameterList& globaltimeparams,
@@ -298,7 +303,7 @@ namespace PoroPressureBased
   {
    public:
     PorofluidElastScatraMonolithicArteryCouplingAlgorithm(
-        MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams);
+        Global::Problem& problem, MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams);
 
    private:
     // Setup full map

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_partitioned.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_partitioned.cpp
@@ -23,8 +23,8 @@ FOUR_C_NAMESPACE_OPEN
  *----------------------------------------------------------------------*/
 PoroPressureBased::PorofluidElastScatraPartitionedAlgorithm::
     PorofluidElastScatraPartitionedAlgorithm(
-        MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams)
-    : PorofluidElastScatraBaseAlgorithm(comm, globaltimeparams),
+        Global::Problem& problem, MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams)
+    : PorofluidElastScatraBaseAlgorithm(problem, comm, globaltimeparams),
       scatra_inc_np_(nullptr),
       structure_inc_np_(nullptr),
       porofluid_inc_np_(nullptr),
@@ -354,8 +354,8 @@ bool PoroPressureBased::PorofluidElastScatraPartitionedAlgorithm::convergence_ch
  *----------------------------------------------------------------------*/
 PoroPressureBased::PorofluidElastScatraNestedPartitionedAlgorithm::
     PorofluidElastScatraNestedPartitionedAlgorithm(
-        MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams)
-    : PorofluidElastScatraPartitionedAlgorithm(comm, globaltimeparams)
+        Global::Problem& problem, MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams)
+    : PorofluidElastScatraPartitionedAlgorithm(problem, comm, globaltimeparams)
 {
 }
 
@@ -414,8 +414,8 @@ void PoroPressureBased::PorofluidElastScatraNestedPartitionedAlgorithm::solve()
  *----------------------------------------------------------------------*/
 PoroPressureBased::PorofluidElastScatraSequentialPartitionedAlgorithm::
     PorofluidElastScatraSequentialPartitionedAlgorithm(
-        MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams)
-    : PorofluidElastScatraPartitionedAlgorithm(comm, globaltimeparams)
+        Global::Problem& problem, MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams)
+    : PorofluidElastScatraPartitionedAlgorithm(problem, comm, globaltimeparams)
 {
 }
 

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_partitioned.hpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_partitioned.hpp
@@ -15,6 +15,11 @@
 
 FOUR_C_NAMESPACE_OPEN
 
+namespace Global
+{
+  class Problem;
+}  // namespace Global
+
 namespace PoroPressureBased
 {
   //! Partitioned solution scheme of porofluid-elasticity problems with scalar transport
@@ -22,7 +27,7 @@ namespace PoroPressureBased
   {
    public:
     PorofluidElastScatraPartitionedAlgorithm(
-        MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams);
+        Global::Problem& problem, MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams);
 
     /// initialization
     void init(const Teuchos::ParameterList& globaltimeparams,
@@ -93,7 +98,7 @@ namespace PoroPressureBased
   {
    public:
     PorofluidElastScatraNestedPartitionedAlgorithm(
-        MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams);
+        Global::Problem& problem, MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams);
 
     /// initialization
     void init(const Teuchos::ParameterList& globaltimeparams,
@@ -122,7 +127,7 @@ namespace PoroPressureBased
   {
    public:
     PorofluidElastScatraSequentialPartitionedAlgorithm(
-        MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams);
+        Global::Problem& problem, MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams);
 
     /// initialization
     void init(const Teuchos::ParameterList& globaltimeparams,

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_utils.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_utils.cpp
@@ -31,7 +31,7 @@ FOUR_C_NAMESPACE_OPEN
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 std::shared_ptr<PoroPressureBased::PorofluidElastScatraBaseAlgorithm>
-PoroPressureBased::create_algorithm_porofluid_elast_scatra(
+PoroPressureBased::create_algorithm_porofluid_elast_scatra(Global::Problem& problem,
     PoroPressureBased::SolutionSchemePorofluidElastScatra solscheme,
     const Teuchos::ParameterList& timeparams, MPI_Comm comm)
 {
@@ -57,7 +57,7 @@ PoroPressureBased::create_algorithm_porofluid_elast_scatra(
     {
       // call constructor
       algo = std::make_shared<PoroPressureBased::PorofluidElastScatraNestedPartitionedAlgorithm>(
-          comm, adapter_global_time_params);
+          problem, comm, adapter_global_time_params);
       break;
     }
     case SolutionSchemePorofluidElastScatra::twoway_partitioned_sequential:
@@ -65,7 +65,7 @@ PoroPressureBased::create_algorithm_porofluid_elast_scatra(
       // call constructor
       algo =
           std::make_shared<PoroPressureBased::PorofluidElastScatraSequentialPartitionedAlgorithm>(
-              comm, adapter_global_time_params);
+              problem, comm, adapter_global_time_params);
       break;
     }
     case SolutionSchemePorofluidElastScatra::twoway_monolithic:
@@ -75,7 +75,7 @@ PoroPressureBased::create_algorithm_porofluid_elast_scatra(
       {
         // call constructor
         algo = std::make_shared<PoroPressureBased::PorofluidElastScatraMonolithicAlgorithm>(
-            comm, adapter_global_time_params);
+            problem, comm, adapter_global_time_params);
       }
       else
       {
@@ -83,7 +83,7 @@ PoroPressureBased::create_algorithm_porofluid_elast_scatra(
         algo = std::make_shared<
             PoroPressureBased::PorofluidElastScatraMonolithicArteryCouplingAlgorithm>(
 
-            comm, adapter_global_time_params);
+            problem, comm, adapter_global_time_params);
       }
       break;
     }

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_utils.hpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_utils.hpp
@@ -52,6 +52,7 @@ namespace PoroPressureBased
 
   //! create solution algorithm depending on input file
   std::shared_ptr<PorofluidElastScatraBaseAlgorithm> create_algorithm_porofluid_elast_scatra(
+      Global::Problem& problem,                      //!< global problem instance (i)
       SolutionSchemePorofluidElastScatra solscheme,  //!< solution scheme to build (i)
       const Teuchos::ParameterList& timeparams,      //!< problem parameters (i)
       MPI_Comm comm                                  //!< communicator(i)


### PR DESCRIPTION
## Description and Context

As the title states. Small reduction of internal usage of `Global::Problem::instance()` inside the porofluid algorithms. Instead, it is passed through at the boundary and can be replaced by module-specific context in the future.

## Disclosure of AI assistance
<!--
If AI tools were used in this contribution, we strongly recommend disclosing their use. This may include:

* A brief description of how AI contributed (e.g., code generation, refactoring, documentation, testing)
* The AI agent(s) and/or tool(s) used
* Any notable successes, limitations, or lessons learned

Any AI-assisted code must be reviewed, understood, and validated by the contributing author, who takes full responsibility for the contribution.
-->

The changes in this PR were made by Claude Opus 5