### PR TITLE
Adapt fluid conditions output

### DIFF
--- a/src/fluid/4C_fluid_timint_red.cpp
+++ b/src/fluid/4C_fluid_timint_red.cpp
@@ -11,6 +11,7 @@
 #include "4C_fem_condition_locsys.hpp"
 #include "4C_fluid_coupling_red_models.hpp"
 #include "4C_fluid_meshtying.hpp"
+#include "4C_fluid_utils_mapextractor.hpp"
 #include "4C_fluid_volumetric_surfaceFlow_condition.hpp"
 #include "4C_global_data.hpp"
 #include "4C_io.hpp"
@@ -314,22 +315,10 @@ void FLD::TimIntRedModels::setup_meshtying()
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void FLD::TimIntRedModels::write_output() const
-{
-  vol_surf_flow_bc_->output(*output_);
-  traction_vel_comp_adder_bc_->output(*output_);
-}
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
 void FLD::TimIntRedModels::write_restart() const
 {
-  const bool solution_is_written = upres_ > 0 && step_ % upres_ == 0;
-  if (!solution_is_written)
-  {
-    vol_surf_flow_bc_->output(*output_);
-    traction_vel_comp_adder_bc_->output(*output_);
-  }
+  vol_surf_flow_bc_->write_restart(*output_);
+  traction_vel_comp_adder_bc_->write_restart(*output_);
 
   // Check if one-dimensional artery network problem exist
   if (ART_timeInt_ != nullptr)
@@ -348,11 +337,7 @@ void FLD::TimIntRedModels::write_restart() const
 void FLD::TimIntRedModels::output()
 {
   FluidImplicitTimeInt::output();
-  // write solution
-  if (upres_ > 0 && step_ % upres_ == 0)
-  {
-    write_output();
-  }
+
   // write restart
   if (uprestart_ > 0 && step_ % uprestart_ == 0)
   {
@@ -360,10 +345,9 @@ void FLD::TimIntRedModels::output()
   }
 
   output_reduced_d();
-}  // TimIntRedModels::Output
+}
 
 /*----------------------------------------------------------------------*
- | read some additional data in restart                         bk 12/13|
  *----------------------------------------------------------------------*/
 void FLD::TimIntRedModels::insert_volumetric_surface_flow_cond_vector(
     std::shared_ptr<Core::LinAlg::Vector<double>> vel,

--- a/src/fluid/4C_fluid_timint_red.hpp
+++ b/src/fluid/4C_fluid_timint_red.hpp
@@ -97,9 +97,6 @@ namespace FLD
     */
     void output() override;
 
-    //! write output for each step as defined in the input file
-    void write_output() const;
-
     //! write restart information for each step as defined in the input file
     void write_restart() const;
     /*!

--- a/src/fluid/4C_fluid_volumetric_surfaceFlow_condition.cpp
+++ b/src/fluid/4C_fluid_volumetric_surfaceFlow_condition.cpp
@@ -9,22 +9,21 @@
 
 #include "4C_fem_condition_utils.hpp"
 #include "4C_fem_general_node.hpp"
+#include "4C_fluid_utils.hpp"
 #include "4C_global_data.hpp"
 #include "4C_linalg_fixedsizematrix.hpp"
 #include "4C_utils_function.hpp"
 #include "4C_utils_function_of_time.hpp"
 
-#include <stdio.h>
+#include <cstdio>
 
 FOUR_C_NAMESPACE_OPEN
 
 /*----------------------------------------------------------------------*
- |  Constructor (public)                                    ismail 09/10|
  *----------------------------------------------------------------------*/
 FLD::Utils::FluidVolumetricSurfaceFlowWrapper::FluidVolumetricSurfaceFlowWrapper(
     std::shared_ptr<Core::FE::Discretization> actdis, double dta)
-    :  // call constructor for "nontrivial" objects
-      discret_(actdis)
+    : discret_(actdis)
 {
   //--------------------------------------------------------------------
   // extract the womersley boundary dof
@@ -88,12 +87,12 @@ FLD::Utils::FluidVolumetricSurfaceFlowWrapper::FluidVolumetricSurfaceFlowWrapper
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void FLD::Utils::FluidVolumetricSurfaceFlowWrapper::output(
+void FLD::Utils::FluidVolumetricSurfaceFlowWrapper::write_restart(
     Core::IO::DiscretizationWriter& output) const
 {
   for (const auto& mapiter : fvsf_map_)
   {
-    mapiter.second->FluidVolumetricSurfaceFlowBc::output(
+    mapiter.second->FluidVolumetricSurfaceFlowBc::write_restart(
         output, "VolumetricSurfaceFlowCond", mapiter.first);
   }
 }
@@ -379,20 +378,20 @@ void FLD::Utils::FluidVolumetricSurfaceFlowBc::center_of_mass_calculation(
   if (myrank_ == 0)
   {
     // print the center of mass
-    printf("center of mass of cond(%d) is evaluated:\n", condid_);
+    std::printf("center of mass of cond(%d) is evaluated:\n", condid_);
     for (unsigned int i = 0; i < coords->size(); i++)
     {
-      printf("| %f |", (*coords)[i]);
+      std::printf("| %f |", (*coords)[i]);
     }
-    printf("\n");
+    std::printf("\n");
 
     // print the average normal
-    printf("average normal of cond(%d) surface is:\n", condid_);
+    std::printf("average normal of cond(%d) surface is:\n", condid_);
     for (unsigned int i = 0; i < coords->size(); i++)
     {
-      printf("| %f |", (*normal)[i]);
+      std::printf("| %f |", (*normal)[i]);
     }
-    printf("\n");
+    std::printf("\n");
   }
 }
 
@@ -765,10 +764,9 @@ void FLD::Utils::FluidVolumetricSurfaceFlowBc::build_condition_dof_row_map(
 
 
 /*----------------------------------------------------------------------*
- |  Output (public)                                         ismail 10/10|
  *----------------------------------------------------------------------*/
-void FLD::Utils::FluidVolumetricSurfaceFlowBc::output(
-    Core::IO::DiscretizationWriter& output, std::string ds_condname, int condnum) const
+void FLD::Utils::FluidVolumetricSurfaceFlowBc::write_restart(
+    Core::IO::DiscretizationWriter& output, const std::string& ds_condname, int condnum) const
 {
   // condnum contains the number of the present condition
   // condition Id numbers must not change at restart!!!!
@@ -794,7 +792,7 @@ void FLD::Utils::FluidVolumetricSurfaceFlowBc::output(
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 void FLD::Utils::FluidVolumetricSurfaceFlowBc::read_restart(
-    Core::IO::DiscretizationReader& reader, std::string ds_condname, int condnum)
+    Core::IO::DiscretizationReader& reader, const std::string& ds_condname, int condnum)
 {
   // condnum contains the number of the present condition
   // condition Id numbers must not change at restart!!!!
@@ -904,7 +902,7 @@ void FLD::Utils::FluidVolumetricSurfaceFlowBc::reset_traction_velocity_comp()
  |  Evaluates the Velocity components of the traction        ismail 05/11|
  *----------------------------------------------------------------------*/
 void FLD::Utils::FluidVolumetricSurfaceFlowBc::evaluate_traction_velocity_comp(
-    Teuchos::ParameterList eleparams, std::string condname, double flowrate, int condid_,
+    Teuchos::ParameterList eleparams, std::string condname, double flowrate, int condid,
     double time, double theta, double dta)
 {
   //  double norm2= 0.0;
@@ -922,7 +920,7 @@ void FLD::Utils::FluidVolumetricSurfaceFlowBc::evaluate_traction_velocity_comp(
 
   eleparams.set<FLD::BoundaryAction>("action", FLD::traction_velocity_component);
   eleparams.set("velocities", cond_velocities_);
-  discret_->evaluate_condition(eleparams, cond_traction_vel_, condname, condid_);
+  discret_->evaluate_condition(eleparams, cond_traction_vel_, condname, condid);
 }
 
 
@@ -1198,8 +1196,8 @@ void FLD::Utils::FluidVolumetricSurfaceFlowBc::correct_flow_rate(
   {
     double flow_error = 0.0;
     flow_error = actflowrate - flowrate;
-    printf("DIR(%f): Flow_estimated = %f : Flow_wanted = %f : Flow_correction = %f\n", flow_dir_,
-        actflowrate, flowrate, flow_error);
+    std::printf("DIR(%f): Flow_estimated = %f : Flow_wanted = %f : Flow_correction = %f\n",
+        flow_dir_, actflowrate, flowrate, flow_error);
   }
 
   // loop over all of the nodes
@@ -1885,11 +1883,11 @@ void FLD::Utils::TotalTractionCorrector::update_residual(Core::LinAlg::Vector<do
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void FLD::Utils::TotalTractionCorrector::output(Core::IO::DiscretizationWriter& output) const
+void FLD::Utils::TotalTractionCorrector::write_restart(Core::IO::DiscretizationWriter& output) const
 {
   for (const auto& mapiter : fvsf_map_)
   {
-    mapiter.second->FluidVolumetricSurfaceFlowBc::output(
+    mapiter.second->FluidVolumetricSurfaceFlowBc::write_restart(
         output, "TotalTractionCorrectionCond", mapiter.first);
   }
 }

--- a/src/fluid/4C_fluid_volumetric_surfaceFlow_condition.hpp
+++ b/src/fluid/4C_fluid_volumetric_surfaceFlow_condition.hpp
@@ -13,8 +13,6 @@
 
 #include "4C_fem_discretization.hpp"
 #include "4C_fluid_ele_action.hpp"
-#include "4C_fluid_utils.hpp"
-#include "4C_fluid_utils_mapextractor.hpp"
 #include "4C_io.hpp"
 #include "4C_linalg_map.hpp"
 #include "4C_linalg_utils_sparse_algebra_create.hpp"
@@ -71,9 +69,9 @@ namespace FLD
 
 
       /*!
-      \brief Wrapper for FluidVolumetricSurfaceFlowBc::Output
+      \brief Wrapper for FluidVolumetricSurfaceFlowBc::write_restart
       */
-      void output(Core::IO::DiscretizationWriter& output) const;
+      void write_restart(Core::IO::DiscretizationWriter& output) const;
 
       /*!
       \brief Wrapper for FluidVolumetricSurfaceFlowBc::read_restart
@@ -129,9 +127,9 @@ namespace FLD
 
 
       /*!
-      \brief Wrapper for FluidVolumetricSurfaceFlowBc::Output
+      \brief Wrapper for FluidVolumetricSurfaceFlowBc::write_restart
       */
-      void output(Core::IO::DiscretizationWriter& output) const;
+      void write_restart(Core::IO::DiscretizationWriter& output) const;
 
       /*!
       \brief Wrapper for FluidVolumetricSurfaceFlowBc::read_restart
@@ -305,16 +303,16 @@ namespace FLD
       double area(double& density, double& viscosity, std::string ds_condname, int condid);
 
       /*!
-      \brief output
+      \brief write restart information
       */
-      void output(
-          Core::IO::DiscretizationWriter& output, std::string ds_condname, int condnum) const;
+      void write_restart(Core::IO::DiscretizationWriter& output, const std::string& ds_condname,
+          int condnum) const;
 
       /*!
       \brief Read restart
       */
       void read_restart(
-          Core::IO::DiscretizationReader& reader, std::string ds_condname, int condnum);
+          Core::IO::DiscretizationReader& reader, const std::string& ds_condname, int condnum);
 
       /*!
       \brief Bessel function of orders 0 and 1


### PR DESCRIPTION
## Description and Context
While working on migrating the fluid output to vtk-based output, I realized that the outputs of TotalTractionCorrectionCond and VolumetricSurfaceFlowCond are only used for restart purposes. This is reflected, e.g., in the fact that no method to post-process these quantities is available. Thus, I renamed the methods to reflect this behavior.

This is the second last PR, so almost done now. 😉 

## Related Issues and Pull Requests
part of #211 
follows #2163 #2164 #2165 #2167

## Disclosure of AI assistance
In this series of PRs, I mainly used AI to figure out why some quantities cannot be written in the new format straightforwardly due to map mismatches.
