### PR TITLE
Particle Writable State Access

### DIFF
--- a/src/particle/src/algorithm/4C_particle_algorithm_constraints.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_constraints.cpp
@@ -47,8 +47,8 @@ void Particle::ConstraintsProjectionBase::apply(
     // get pointer to particle velocity and acceleration
     double* vel = container->get_ptr_to_state_writable(Particle::Velocity, 0);
     double* acc = container->get_ptr_to_state_writable(Particle::Acceleration, 0);
-    double* modvel = container->cond_get_ptr_to_state_writable(Particle::ModifiedVelocity, 0);
-    double* modacc = container->cond_get_ptr_to_state_writable(Particle::ModifiedAcceleration, 0);
+    double* modvel = container->try_get_ptr_to_state_writable(Particle::ModifiedVelocity, 0);
+    double* modacc = container->try_get_ptr_to_state_writable(Particle::ModifiedAcceleration, 0);
 
     // get particle state dimension
     const int pos_state_dim = container->get_state_dim(Particle::Position);

--- a/src/particle/src/algorithm/4C_particle_algorithm_constraints.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_constraints.cpp
@@ -45,16 +45,10 @@ void Particle::ConstraintsProjectionBase::apply(
     if (n_particle_stored <= 0) continue;
 
     // get pointer to particle velocity and acceleration
-    double* vel = container->get_ptr_to_state(Particle::Velocity, 0);
-    double* acc = container->get_ptr_to_state(Particle::Acceleration, 0);
-
-    double* modvel = nullptr;
-    if (container->have_stored_state(Particle::ModifiedVelocity))
-      modvel = container->get_ptr_to_state(Particle::ModifiedVelocity, 0);
-
-    double* modacc = nullptr;
-    if (container->have_stored_state(Particle::ModifiedAcceleration))
-      modacc = container->get_ptr_to_state(Particle::ModifiedAcceleration, 0);
+    double* vel = container->get_ptr_to_state_writable(Particle::Velocity, 0);
+    double* acc = container->get_ptr_to_state_writable(Particle::Acceleration, 0);
+    double* modvel = container->cond_get_ptr_to_state_writable(Particle::ModifiedVelocity, 0);
+    double* modacc = container->cond_get_ptr_to_state_writable(Particle::ModifiedAcceleration, 0);
 
     // get particle state dimension
     const int pos_state_dim = container->get_state_dim(Particle::Position);

--- a/src/particle/src/algorithm/4C_particle_algorithm_dirichlet_bc.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_dirichlet_bc.cpp
@@ -208,9 +208,9 @@ void Particle::DirichletBoundaryConditionHandler::evaluate_dirichlet_boundary_co
 
     // get pointer to particle states
     const double* refpos = container->get_ptr_to_state(Particle::ReferencePosition, 0);
-    double* pos = container->get_ptr_to_state(Particle::Position, 0);
-    double* vel = container->get_ptr_to_state(Particle::Velocity, 0);
-    double* acc = container->get_ptr_to_state(Particle::Acceleration, 0);
+    double* pos = container->get_ptr_to_state_writable(Particle::Position, 0);
+    double* vel = container->get_ptr_to_state_writable(Particle::Velocity, 0);
+    double* acc = container->get_ptr_to_state_writable(Particle::Acceleration, 0);
 
     // iterate over owned particles of current type and apply dbc values to particle states
     for (int i = 0; i < particlestored; ++i)
@@ -239,9 +239,9 @@ void Particle::DirichletBoundaryConditionHandler::evaluate_dirichlet_boundary_co
     const double* dirichlet_function_id =
         container->get_ptr_to_state(Particle::DirichletFunctionId, 0);
     const double* refpos = container->get_ptr_to_state(Particle::ReferencePosition, 0);
-    double* pos = container->get_ptr_to_state(Particle::Position, 0);
-    double* vel = container->get_ptr_to_state(Particle::Velocity, 0);
-    double* acc = container->get_ptr_to_state(Particle::Acceleration, 0);
+    double* pos = container->get_ptr_to_state_writable(Particle::Position, 0);
+    double* vel = container->get_ptr_to_state_writable(Particle::Velocity, 0);
+    double* acc = container->get_ptr_to_state_writable(Particle::Acceleration, 0);
 
     // iterate over owned particles of current type
     for (int i = 0; i < particlestored; ++i)

--- a/src/particle/src/algorithm/4C_particle_algorithm_initial_field.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_initial_field.cpp
@@ -93,7 +93,7 @@ void Particle::InitialFieldHandler::set_initial_fields()
 
       // get pointer to particle states
       const double* pos = container->get_ptr_to_state(Particle::Position, 0);
-      double* state = container->get_ptr_to_state(particleState, 0);
+      double* state = container->get_ptr_to_state_writable(particleState, 0);
 
       // get particle state dimensions
       int posstatedim = container->get_state_dim(Particle::Position);

--- a/src/particle/src/algorithm/4C_particle_algorithm_temperature_bc.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_temperature_bc.cpp
@@ -105,7 +105,7 @@ void Particle::TemperatureBoundaryConditionHandler::evaluate_temperature_boundar
 
     // get pointer to particle states
     const double* refpos = container->get_ptr_to_state(Particle::ReferencePosition, 0);
-    double* temp = container->get_ptr_to_state(Particle::Temperature, 0);
+    double* temp = container->get_ptr_to_state_writable(Particle::Temperature, 0);
 
     // get particle state dimension
     int statedim = container->get_state_dim(Particle::Position);

--- a/src/particle/src/algorithm/4C_particle_algorithm_timint.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_timint.cpp
@@ -205,7 +205,7 @@ void Particle::TimInt::add_initial_random_noise_to_position()
     if (particlestored <= 0) continue;
 
     // get pointer to particle state
-    double* pos = container->get_ptr_to_state(Particle::Position, 0);
+    double* pos = container->get_ptr_to_state_writable(Particle::Position, 0);
 
     // get particle state dimension
     int statedim = container->get_state_dim(Particle::Position);

--- a/src/particle/src/engine/4C_particle_engine.cpp
+++ b/src/particle/src/engine/4C_particle_engine.cpp
@@ -1275,7 +1275,7 @@ void Particle::ParticleEngine::check_particles_at_boundaries(
       ParticleContainer* container = particlecontainerbundle_->get_specific_container(type, Owned);
 
       // get position of particle
-      double* currpos = container->get_ptr_to_state(Position, ownedindex);
+      const double* currpos = container->get_ptr_to_state(Position, ownedindex);
 
       // get global id of bin
       const int gidofbin = binning_->binstrategy_->convert_pos_to_gid(currpos);
@@ -1310,6 +1310,7 @@ void Particle::ParticleEngine::check_particles_at_boundaries(
                 dim))
         {
           // binning domain length in current spatial direction
+          double* currpos = container->get_ptr_to_state_writable(Position, ownedindex);
           double binningdomainlength =
               binning_->binstrategy_->length_of_binning_domain_in_a_spatial_direction(dim);
 
@@ -1973,7 +1974,7 @@ void Particle::ParticleEngine::store_positions_after_particle_transfer()
 
     // get pointer to particle states
     const double* pos = container->get_ptr_to_state(Position, 0);
-    double* lasttransferpos = container->get_ptr_to_state(LastTransferPosition, 0);
+    double* lasttransferpos = container->get_ptr_to_state_writable(LastTransferPosition, 0);
 
     // get particle state dimension
     int statedim = container->get_state_dim(Position);

--- a/src/particle/src/engine/4C_particle_engine.cpp
+++ b/src/particle/src/engine/4C_particle_engine.cpp
@@ -1304,21 +1304,24 @@ void Particle::ParticleEngine::check_particles_at_boundaries(
       if (not binning_->binstrategy_->have_periodic_boundary_conditions_applied()) continue;
 
       // check for periodic boundary in each spatial directions
-      for (int dim = 0; dim < 3; ++dim)
       {
-        if (binning_->binstrategy_->have_periodic_boundary_conditions_applied_in_spatial_direction(
-                dim))
-        {
-          // binning domain length in current spatial direction
-          double* currpos = container->get_ptr_to_state_writable(Position, ownedindex);
-          double binningdomainlength =
-              binning_->binstrategy_->length_of_binning_domain_in_a_spatial_direction(dim);
+        double* currpos = container->get_ptr_to_state_writable(Position, ownedindex);
 
-          // shift position by periodic length
-          if (currpos[dim] < boundingbox(dim, 0))
-            currpos[dim] += binningdomainlength;
-          else if (currpos[dim] > boundingbox(dim, 1))
-            currpos[dim] -= binningdomainlength;
+        for (int dim = 0; dim < 3; ++dim)
+        {
+          if (binning_->binstrategy_
+                  ->have_periodic_boundary_conditions_applied_in_spatial_direction(dim))
+          {
+            // binning domain length in current spatial direction
+            double binningdomainlength =
+                binning_->binstrategy_->length_of_binning_domain_in_a_spatial_direction(dim);
+
+            // shift position by periodic length
+            if (currpos[dim] < boundingbox(dim, 0))
+              currpos[dim] += binningdomainlength;
+            else if (currpos[dim] > boundingbox(dim, 1))
+              currpos[dim] -= binningdomainlength;
+          }
         }
       }
     }

--- a/src/particle/src/engine/4C_particle_engine_container.cpp
+++ b/src/particle/src/engine/4C_particle_engine_container.cpp
@@ -94,42 +94,48 @@ void Particle::ParticleContainer::decrease_container_size()
 void Particle::ParticleContainer::add_particle(
     int& index, int globalid, const ParticleStates& states)
 {
+#ifdef FOUR_C_ENABLE_ASSERTIONS
+  // check states in container
+  for (const auto& state : storedstates_)
+  {
+    if (state < static_cast<int>(states.size()) and not states[state].empty() and
+        static_cast<int>(states[state].size()) != statedim_[state])
+      FOUR_C_THROW("can not add particle: dimensions of state '{}' do not match!",
+          enum_to_state_name(state));
+  }
+#endif
+
   // increase size of container
   if (particlestored_ == containersize_) increase_container_size();
 
-  // store global id
-  globalids_[particlestored_] = globalid;
-
-  // iterate over states stored in container
-  for (const auto& state : storedstates_)
-  {
-    // state not handed over
-    if (states.size() <= state or states[state].empty())
-    {
-      // initialize to zero
-      for (int dim = 0; dim < statedim_[state]; ++dim)
-        (states_[state])[particlestored_ * statedim_[state] + dim] = 0.0;
-    }
-    // state handed over
-    else
-    {
-#ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (static_cast<int>(states[state].size()) != statedim_[state])
-        FOUR_C_THROW("can not add particle: dimensions of state '{}' do not match!",
-            enum_to_state_name(state));
-#endif
-
-      // store state in container
-      for (int dim = 0; dim < statedim_[state]; ++dim)
-        (states_[state])[particlestored_ * statedim_[state] + dim] = states[state][dim];
-    }
-  }
-
-  // set index of added particle
+  // store local index before incrementing
   index = particlestored_;
 
   // increase counter of stored particles
   particlestored_++;
+
+  // store global id
+  globalids_[index] = globalid;
+
+  // iterate over states stored in container
+  for (const auto& state : storedstates_)
+  {
+    // get pointer to particle state
+    double* state_ptr = get_ptr_to_state_writable(state, index);
+
+    // state not handed over
+    if (states.size() <= state or states[state].empty())
+    {
+      // initialize to zero
+      for (int dim = 0; dim < statedim_[state]; ++dim) state_ptr[dim] = 0.0;
+    }
+    // state handed over
+    else
+    {
+      // store state in container
+      for (int dim = 0; dim < statedim_[state]; ++dim) state_ptr[dim] = states[state][dim];
+    }
+  }
 }
 
 void Particle::ParticleContainer::replace_particle(
@@ -160,9 +166,11 @@ void Particle::ParticleContainer::replace_particle(
             enum_to_state_name(state));
 #endif
 
+      // get pointer to particle state
+      double* state_ptr = get_ptr_to_state_writable(state, index);
+
       // replace state in container
-      for (int dim = 0; dim < statedim_[state]; ++dim)
-        (states_[state])[index * statedim_[state] + dim] = states[state][dim];
+      for (int dim = 0; dim < statedim_[state]; ++dim) state_ptr[dim] = states[state][dim];
     }
   }
 }
@@ -185,7 +193,7 @@ void Particle::ParticleContainer::get_particle(
   for (const auto& state : storedstates_)
   {
     // get pointer to particle state
-    const double* state_ptr = &((states_[state])[index * statedim_[state]]);
+    const double* state_ptr = get_ptr_to_state(state, index);
 
     // fill particle state
     states[state].assign(state_ptr, state_ptr + statedim_[state]);
@@ -199,21 +207,57 @@ void Particle::ParticleContainer::remove_particle(int index)
     FOUR_C_THROW("can not remove particle as index {} out of bounds!", index);
 #endif
 
-  // decrease counter of stored particles
-  --particlestored_;
+  // index of last particle
+  auto last_index = particlestored_ - 1;
+
+  if (index == last_index)
+  {
+    --particlestored_;
+    return;
+  }
 
   // overwrite global id in container
-  globalids_[index] = globalids_[particlestored_];
+  globalids_[index] = globalids_[last_index];
 
   // iterate over states stored in container
   for (const auto& state : storedstates_)
   {
-    // overwrite state in container
-    for (int dim = 0; dim < statedim_[state]; ++dim)
-      (states_[state])[index * statedim_[state] + dim] =
-          (states_[state])[particlestored_ * statedim_[state] + dim];
+    // get pointers to particle state
+    double* state_ptr_index = get_ptr_to_state_writable(state, index);
+    double* state_ptr_last = get_ptr_to_state_writable(state, last_index);
+
+    for (int dim = 0; dim < statedim_[state]; ++dim) state_ptr_index[dim] = state_ptr_last[dim];
   }
+
+  // decrease counter of stored particles
+  --particlestored_;
 }
+
+const double* Particle::ParticleContainer::get_ptr_to_state(ParticleState state, int index) const
+{
+#ifdef FOUR_C_ENABLE_ASSERTIONS
+  if (not storedstates_.contains(state))
+    FOUR_C_THROW("particle state '{}' not stored in container!", enum_to_state_name(state));
+
+  if (index < 0 or index > (particlestored_ - 1))
+    FOUR_C_THROW("can not return pointer to state of particle as index {} out of bounds!", index);
+#endif
+
+  return &((states_[state])[index * statedim_[state]]);
+};
+
+double* Particle::ParticleContainer::get_ptr_to_state_writable(ParticleState state, int index)
+{
+#ifdef FOUR_C_ENABLE_ASSERTIONS
+  if (not storedstates_.contains(state))
+    FOUR_C_THROW("particle state '{}' not stored in container!", enum_to_state_name(state));
+
+  if (index < 0 or index > (particlestored_ - 1))
+    FOUR_C_THROW("can not return pointer to state of particle as index {} out of bounds!", index);
+#endif
+
+  return &((states_[state])[index * statedim_[state]]);
+};
 
 double Particle::ParticleContainer::get_min_value_of_state(ParticleState state) const
 {
@@ -224,10 +268,10 @@ double Particle::ParticleContainer::get_min_value_of_state(ParticleState state) 
 
   if (particlestored_ <= 0) return 0.0;
 
-  double min = (states_[state])[0];
+  const double* state_ptr = get_ptr_to_state(state, 0);
+  double min = state_ptr[0];
 
-  for (int i = 0; i < (particlestored_ * statedim_[state]); ++i)
-    min = std::min(min, states_[state][i]);
+  for (int i = 1; i < (particlestored_ * statedim_[state]); ++i) min = std::min(min, state_ptr[i]);
 
   return min;
 }
@@ -241,10 +285,10 @@ double Particle::ParticleContainer::get_max_value_of_state(ParticleState state) 
 
   if (particlestored_ <= 0) return 0.0;
 
-  double max = (states_[state])[0];
+  const double* state_ptr = get_ptr_to_state(state, 0);
+  double max = state_ptr[0];
 
-  for (int i = 0; i < (particlestored_ * statedim_[state]); ++i)
-    max = std::max(max, states_[state][i]);
+  for (int i = 1; i < (particlestored_ * statedim_[state]); ++i) max = std::max(max, state_ptr[i]);
 
   return max;
 }

--- a/src/particle/src/engine/4C_particle_engine_container.cpp
+++ b/src/particle/src/engine/4C_particle_engine_container.cpp
@@ -223,6 +223,7 @@ void Particle::ParticleContainer::remove_particle(int index)
   for (const auto& state : storedstates_)
   {
     // get pointers to particle state
+    // note - this is the same underlying array, so using same access pattern
     double* state_ptr_index = get_ptr_to_state_writable(state, index);
     double* state_ptr_last = get_ptr_to_state_writable(state, last_index);
 

--- a/src/particle/src/engine/4C_particle_engine_container.cpp
+++ b/src/particle/src/engine/4C_particle_engine_container.cpp
@@ -249,15 +249,8 @@ const double* Particle::ParticleContainer::get_ptr_to_state(ParticleState state,
 
 double* Particle::ParticleContainer::get_ptr_to_state_writable(ParticleState state, int index)
 {
-#ifdef FOUR_C_ENABLE_ASSERTIONS
-  if (not storedstates_.contains(state))
-    FOUR_C_THROW("particle state '{}' not stored in container!", enum_to_state_name(state));
-
-  if (index < 0 or index > (particlestored_ - 1))
-    FOUR_C_THROW("can not return pointer to state of particle as index {} out of bounds!", index);
-#endif
-
-  return &((states_[state])[index * statedim_[state]]);
+  return const_cast<double*>(
+      const_cast<const ParticleContainer&>(*this).get_ptr_to_state(state, index));
 };
 
 double Particle::ParticleContainer::get_min_value_of_state(ParticleState state) const

--- a/src/particle/src/engine/4C_particle_engine_container.hpp
+++ b/src/particle/src/engine/4C_particle_engine_container.hpp
@@ -203,7 +203,7 @@ namespace Particle
      *
      * \return pointer with read-only access to particle state or nullptr
      */
-    inline const double* cond_get_ptr_to_state(ParticleState state, int index) const
+    inline const double* try_get_ptr_to_state(ParticleState state, int index) const
     {
       if (storedstates_.contains(state)) return get_ptr_to_state(state, index);
 
@@ -243,7 +243,7 @@ namespace Particle
      *
      * \return pointer with writable access to particle state or nullptr
      */
-    inline double* cond_get_ptr_to_state_writable(ParticleState state, int index)
+    inline double* try_get_ptr_to_state_writable(ParticleState state, int index)
     {
       if (storedstates_.contains(state)) return get_ptr_to_state_writable(state, index);
 

--- a/src/particle/src/engine/4C_particle_engine_container.hpp
+++ b/src/particle/src/engine/4C_particle_engine_container.hpp
@@ -171,10 +171,10 @@ namespace Particle
     //! @{
 
     /*!
-     * \brief get pointer to state of a particle at index
+     * \brief get read-only pointer to state of a particle at index
      *
-     * This is the default method to be used to get a pointer to the state of a particle at a
-     * certain index.
+     * This is the default method to be used to get a pointer with read-only access to the state of
+     * a particle at a certain index.
      *
      * \note Throws an error in the debug version in case the requested state is not stored in the
      *       particle container.
@@ -183,29 +183,17 @@ namespace Particle
      * \param[in] state particle state
      * \param[in] index index of particle in container
      *
-     * \return pointer to particle state
+     * \return pointer with read-only access to particle state
      */
-    inline double* get_ptr_to_state(ParticleState state, int index)
-    {
-#ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (not storedstates_.contains(state))
-        FOUR_C_THROW("particle state '{}' not stored in container!", enum_to_state_name(state));
-
-      if (index < 0 or index > (particlestored_ - 1))
-        FOUR_C_THROW(
-            "can not return pointer to state of particle as index {} out of bounds!", index);
-#endif
-
-      return &((states_[state])[index * statedim_[state]]);
-    };
+    const double* get_ptr_to_state(ParticleState state, int index) const;
 
     /*!
-     * \brief conditionally get pointer to state of a particle at index
+     * \brief conditionally get read-only pointer to state of a particle at index
      *
-     * This method to get a pointer to the state of a particle at a certain index is used in cases
-     * when a state may not be stored in the particle container. Conditionally, a pointer is
-     * returned in case the state is stored in the particle container, otherwise, a nullptr is
-     * returned.
+     * This method to get a pointer with read-only access to the state of a particle at a certain
+     * index is used in cases when a state may not be stored in the particle container.
+     * Conditionally, a pointer is returned in case the state is stored in the particle container,
+     * otherwise, a nullptr is returned.
      *
      * \note The returned pointer may not be used to access memory without checking for a nullptr.
      *
@@ -213,17 +201,51 @@ namespace Particle
      * \param[in] state particle state
      * \param[in] index index of particle in container
      *
-     * \return pointer to particle state or nullptr
+     * \return pointer with read-only access to particle state or nullptr
      */
-    inline double* cond_get_ptr_to_state(ParticleState state, int index)
+    inline const double* cond_get_ptr_to_state(ParticleState state, int index) const
     {
-#ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (index < 0 or index > (particlestored_ - 1))
-        FOUR_C_THROW(
-            "can not return pointer to state of particle as index {} out of bounds!", index);
-#endif
+      if (storedstates_.contains(state)) return get_ptr_to_state(state, index);
 
-      if (storedstates_.contains(state)) return &((states_[state])[index * statedim_[state]]);
+      return nullptr;
+    };
+
+    /*!
+     * \brief get writable pointer to state of a particle at index
+     *
+     * This is the default method to be used to get a pointer with writable access to the state of
+     * a particle at a certain index.
+     *
+     * \note Throws an error in the debug version in case the requested state is not stored in the
+     *       particle container.
+     *
+     *
+     * \param[in] state particle state
+     * \param[in] index index of particle in container
+     *
+     * \return pointer with writable access to particle state
+     */
+    double* get_ptr_to_state_writable(ParticleState state, int index);
+
+    /*!
+     * \brief conditionally get writable pointer to state of a particle at index
+     *
+     * This method to get a pointer with writable access to the state of a particle at a certain
+     * index is used in cases when a state may not be stored in the particle container.
+     * Conditionally, a pointer is returned in case the state is stored in the particle container,
+     * otherwise, a nullptr is returned.
+     *
+     * \note The returned pointer may not be used to access memory without checking for a nullptr.
+     *
+     *
+     * \param[in] state particle state
+     * \param[in] index index of particle in container
+     *
+     * \return pointer with writable access to particle state or nullptr
+     */
+    inline double* cond_get_ptr_to_state_writable(ParticleState state, int index)
+    {
+      if (storedstates_.contains(state)) return get_ptr_to_state_writable(state, index);
 
       return nullptr;
     };
@@ -266,7 +288,11 @@ namespace Particle
         FOUR_C_THROW("particle state '{}' not stored in container!", enum_to_state_name(state));
 #endif
 
-      for (int i = 0; i < (particlestored_ * statedim_[state]); ++i) (states_[state])[i] *= fac;
+      if (particlestored_ <= 0) return;
+
+      double* state_ptr = get_ptr_to_state_writable(state, 0);
+
+      for (int i = 0; i < (particlestored_ * statedim_[state]); ++i) state_ptr[i] *= fac;
     };
 
     /*!
@@ -281,6 +307,9 @@ namespace Particle
     inline void update_state(double facA, ParticleState stateA, double facB, ParticleState stateB)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
+      if (stateA == stateB)
+        FOUR_C_THROW("adding scaled particle state '{}' to itself!", enum_to_state_name(stateA));
+
       if (not storedstates_.contains(stateA))
         FOUR_C_THROW("particle state '{}' not stored in container!", enum_to_state_name(stateA));
 
@@ -291,8 +320,13 @@ namespace Particle
         FOUR_C_THROW("dimensions of states do not match!");
 #endif
 
+      if (particlestored_ <= 0) return;
+
+      const double* state_b_ptr = get_ptr_to_state(stateB, 0);
+      double* state_a_ptr = get_ptr_to_state_writable(stateA, 0);
+
       for (int i = 0; i < (particlestored_ * statedim_[stateA]); ++i)
-        (states_[stateA])[i] = facA * (states_[stateA])[i] + facB * (states_[stateB])[i];
+        state_a_ptr[i] = facA * state_a_ptr[i] + facB * state_b_ptr[i];
     };
 
     /*!
@@ -312,9 +346,13 @@ namespace Particle
         FOUR_C_THROW("dimensions of states do not match!");
 #endif
 
+      if (particlestored_ <= 0) return;
+
+      double* state_ptr = get_ptr_to_state_writable(state, 0);
+
       for (int i = 0; i < particlestored_; ++i)
         for (int dim = 0; dim < statedim_[state]; ++dim)
-          (states_[state])[i * statedim_[state] + dim] = val[dim];
+          state_ptr[i * statedim_[state] + dim] = val[dim];
     };
 
     /*!
@@ -330,7 +368,11 @@ namespace Particle
         FOUR_C_THROW("particle state '{}' not stored in container!", enum_to_state_name(state));
 #endif
 
-      for (int i = 0; i < (particlestored_ * statedim_[state]); ++i) (states_[state])[i] = 0.0;
+      if (particlestored_ <= 0) return;
+
+      double* state_ptr = get_ptr_to_state_writable(state, 0);
+
+      for (int i = 0; i < (particlestored_ * statedim_[state]); ++i) state_ptr[i] = 0.0;
     };
 
     //! @}

--- a/src/particle/src/engine/4C_particle_engine_container.hpp
+++ b/src/particle/src/engine/4C_particle_engine_container.hpp
@@ -320,7 +320,9 @@ namespace Particle
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
       if (stateA == stateB)
-        FOUR_C_THROW("adding scaled particle state '{}' to itself!", enum_to_state_name(stateA));
+        FOUR_C_THROW(
+            "adding scaled particle state '{}' to itself is not allowed. Use scale_state instead!",
+            enum_to_state_name(stateA));
 
       if (not storedstates_.contains(stateA))
         FOUR_C_THROW("particle state '{}' not stored in container!", enum_to_state_name(stateA));

--- a/src/particle/src/engine/4C_particle_engine_container.hpp
+++ b/src/particle/src/engine/4C_particle_engine_container.hpp
@@ -205,6 +205,12 @@ namespace Particle
      */
     inline const double* try_get_ptr_to_state(ParticleState state, int index) const
     {
+#ifdef FOUR_C_ENABLE_ASSERTIONS
+      if (index < 0 or index > (particlestored_ - 1))
+        FOUR_C_THROW(
+            "can not return pointer to state of particle as index {} out of bounds!", index);
+#endif
+
       if (storedstates_.contains(state)) return get_ptr_to_state(state, index);
 
       return nullptr;
@@ -245,6 +251,12 @@ namespace Particle
      */
     inline double* try_get_ptr_to_state_writable(ParticleState state, int index)
     {
+#ifdef FOUR_C_ENABLE_ASSERTIONS
+      if (index < 0 or index > (particlestored_ - 1))
+        FOUR_C_THROW(
+            "can not return pointer to state of particle as index {} out of bounds!", index);
+#endif
+
       if (storedstates_.contains(state)) return get_ptr_to_state_writable(state, index);
 
       return nullptr;

--- a/src/particle/src/interaction/4C_particle_interaction_dem.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_dem.cpp
@@ -334,7 +334,7 @@ void Particle::ParticleInteractionDEM::set_initial_radius()
             particlematerial_->get_ptr_to_particle_mat_parameter(type_i);
 
         // get pointer to particle state
-        double* radius = container->get_ptr_to_state(Particle::Radius, 0);
+        double* radius = container->get_ptr_to_state_writable(Particle::Radius, 0);
 
         // determine mu of random particle radius distribution
         const double mu = (radiusdistributiontype == Particle::NormalRadiusDistribution)
@@ -393,7 +393,7 @@ void Particle::ParticleInteractionDEM::set_initial_mass()
 
     // get pointer to particle states
     const double* radius = container->get_ptr_to_state(Particle::Radius, 0);
-    double* mass = container->get_ptr_to_state(Particle::Mass, 0);
+    double* mass = container->get_ptr_to_state_writable(Particle::Mass, 0);
 
     // compute mass via particle volume and initial density
     const double fac = material->initDensity_ * 4.0 / 3.0 * std::numbers::pi;
@@ -422,7 +422,7 @@ void Particle::ParticleInteractionDEM::set_initial_inertia()
     // get pointer to particle states
     const double* radius = container->get_ptr_to_state(Particle::Radius, 0);
     const double* mass = container->get_ptr_to_state(Particle::Mass, 0);
-    double* inertia = container->get_ptr_to_state(Particle::Inertia, 0);
+    double* inertia = container->get_ptr_to_state_writable(Particle::Inertia, 0);
 
     // compute mass via particle volume and initial density
     for (int i = 0; i < particlestored; ++i)
@@ -472,8 +472,8 @@ void Particle::ParticleInteractionDEM::compute_acceleration() const
     const double* mass = container->get_ptr_to_state(Particle::Mass, 0);
     const double* force = container->get_ptr_to_state(Particle::Force, 0);
     const double* moment = container->cond_get_ptr_to_state(Particle::Moment, 0);
-    double* acc = container->get_ptr_to_state(Particle::Acceleration, 0);
-    double* angacc = container->cond_get_ptr_to_state(Particle::AngularAcceleration, 0);
+    double* acc = container->get_ptr_to_state_writable(Particle::Acceleration, 0);
+    double* angacc = container->cond_get_ptr_to_state_writable(Particle::AngularAcceleration, 0);
 
     // compute acceleration
     for (int i = 0; i < particlestored; ++i)
@@ -551,7 +551,7 @@ void Particle::ParticleInteractionDEM::evaluate_particle_kinetic_energy(double& 
     const double* radius = container->get_ptr_to_state(Particle::Radius, 0);
     const double* mass = container->get_ptr_to_state(Particle::Mass, 0);
     const double* vel = container->get_ptr_to_state(Particle::Velocity, 0);
-    double* angvel = container->cond_get_ptr_to_state(Particle::AngularVelocity, 0);
+    double* angvel = container->cond_get_ptr_to_state_writable(Particle::AngularVelocity, 0);
 
     // add translational kinetic energy contribution
     for (int i = 0; i < particlestored; ++i)

--- a/src/particle/src/interaction/4C_particle_interaction_dem.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_dem.cpp
@@ -471,9 +471,9 @@ void Particle::ParticleInteractionDEM::compute_acceleration() const
     const double* radius = container->get_ptr_to_state(Particle::Radius, 0);
     const double* mass = container->get_ptr_to_state(Particle::Mass, 0);
     const double* force = container->get_ptr_to_state(Particle::Force, 0);
-    const double* moment = container->cond_get_ptr_to_state(Particle::Moment, 0);
+    const double* moment = container->try_get_ptr_to_state(Particle::Moment, 0);
     double* acc = container->get_ptr_to_state_writable(Particle::Acceleration, 0);
-    double* angacc = container->cond_get_ptr_to_state_writable(Particle::AngularAcceleration, 0);
+    double* angacc = container->try_get_ptr_to_state_writable(Particle::AngularAcceleration, 0);
 
     // compute acceleration
     for (int i = 0; i < particlestored; ++i)
@@ -551,7 +551,7 @@ void Particle::ParticleInteractionDEM::evaluate_particle_kinetic_energy(double& 
     const double* radius = container->get_ptr_to_state(Particle::Radius, 0);
     const double* mass = container->get_ptr_to_state(Particle::Mass, 0);
     const double* vel = container->get_ptr_to_state(Particle::Velocity, 0);
-    double* angvel = container->cond_get_ptr_to_state_writable(Particle::AngularVelocity, 0);
+    double* angvel = container->try_get_ptr_to_state_writable(Particle::AngularVelocity, 0);
 
     // add translational kinetic energy contribution
     for (int i = 0; i < particlestored; ++i)

--- a/src/particle/src/interaction/4C_particle_interaction_dem.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_dem.cpp
@@ -551,7 +551,7 @@ void Particle::ParticleInteractionDEM::evaluate_particle_kinetic_energy(double& 
     const double* radius = container->get_ptr_to_state(Particle::Radius, 0);
     const double* mass = container->get_ptr_to_state(Particle::Mass, 0);
     const double* vel = container->get_ptr_to_state(Particle::Velocity, 0);
-    double* angvel = container->try_get_ptr_to_state_writable(Particle::AngularVelocity, 0);
+    const double* angvel = container->try_get_ptr_to_state(Particle::AngularVelocity, 0);
 
     // add translational kinetic energy contribution
     for (int i = 0; i < particlestored; ++i)

--- a/src/particle/src/interaction/4C_particle_interaction_dem_adhesion.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_dem_adhesion.cpp
@@ -171,11 +171,11 @@ void Particle::DEMAdhesion::evaluate_particle_adhesion()
     // get pointer to particle states
     const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
     const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
-    double* force_i = container_i->get_ptr_to_state(Particle::Force, particle_i);
+    double* force_i = container_i->get_ptr_to_state_writable(Particle::Force, particle_i);
 
     const double* vel_j = container_j->get_ptr_to_state(Particle::Velocity, particle_j);
     const double* rad_j = container_j->get_ptr_to_state(Particle::Radius, particle_j);
-    double* force_j = container_j->get_ptr_to_state(Particle::Force, particle_j);
+    double* force_j = container_j->get_ptr_to_state_writable(Particle::Force, particle_j);
 
     // relative velocity in contact point c between particle i and j (neglecting angular velocity)
     double vel_rel[3];
@@ -291,7 +291,7 @@ void Particle::DEMAdhesion::evaluate_particle_wall_adhesion()
     const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
     const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
     const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
-    double* force_i = container_i->get_ptr_to_state(Particle::Force, particle_i);
+    double* force_i = container_i->get_ptr_to_state_writable(Particle::Force, particle_i);
 
     // get pointer to column wall element
     Core::Elements::Element* ele = particlewallpair.ele_;

--- a/src/particle/src/interaction/4C_particle_interaction_dem_adhesion.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_dem_adhesion.cpp
@@ -175,7 +175,9 @@ void Particle::DEMAdhesion::evaluate_particle_adhesion()
 
     const double* vel_j = container_j->get_ptr_to_state(Particle::Velocity, particle_j);
     const double* rad_j = container_j->get_ptr_to_state(Particle::Radius, particle_j);
-    double* force_j = container_j->get_ptr_to_state_writable(Particle::Force, particle_j);
+    double* force_j = nullptr;
+    if (status_j == Particle::Owned)
+      force_j = container_j->get_ptr_to_state_writable(Particle::Force, particle_j);
 
     // relative velocity in contact point c between particle i and j (neglecting angular velocity)
     double vel_rel[3];
@@ -227,7 +229,7 @@ void Particle::DEMAdhesion::evaluate_particle_adhesion()
 
     // add adhesion force contribution
     ParticleUtils::vec_add_scale(force_i, adhesionhistory_ij.adhesion_force_, particlepair.e_ji_);
-    if (status_j == Particle::Owned)
+    if (force_j)
       ParticleUtils::vec_add_scale(
           force_j, -adhesionhistory_ij.adhesion_force_, particlepair.e_ji_);
   }

--- a/src/particle/src/interaction/4C_particle_interaction_dem_contact.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_dem_contact.cpp
@@ -389,26 +389,26 @@ void Particle::DEMContact::evaluate_particle_contact()
     // get pointer to particle states
     const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
     const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
-    double* force_i = container_i->get_ptr_to_state(Particle::Force, particle_i);
+    double* force_i = container_i->get_ptr_to_state_writable(Particle::Force, particle_i);
 
     const double* angvel_i = nullptr;
     double* moment_i = nullptr;
     if (contacttangential_ or contactrolling_)
     {
       angvel_i = container_i->get_ptr_to_state(Particle::AngularVelocity, particle_i);
-      moment_i = container_i->get_ptr_to_state(Particle::Moment, particle_i);
+      moment_i = container_i->get_ptr_to_state_writable(Particle::Moment, particle_i);
     }
 
     const double* vel_j = container_j->get_ptr_to_state(Particle::Velocity, particle_j);
     const double* rad_j = container_j->get_ptr_to_state(Particle::Radius, particle_j);
-    double* force_j = container_j->get_ptr_to_state(Particle::Force, particle_j);
+    double* force_j = container_j->get_ptr_to_state_writable(Particle::Force, particle_j);
 
     const double* angvel_j = nullptr;
     double* moment_j = nullptr;
     if (contacttangential_ or contactrolling_)
     {
       angvel_j = container_j->get_ptr_to_state(Particle::AngularVelocity, particle_j);
-      moment_j = container_j->get_ptr_to_state(Particle::Moment, particle_j);
+      moment_j = container_j->get_ptr_to_state_writable(Particle::Moment, particle_j);
     }
 
     // compute vectors from particle i and j to contact point c
@@ -616,14 +616,14 @@ void Particle::DEMContact::evaluate_particle_wall_contact()
     const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
     const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
     const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
-    double* force_i = container_i->get_ptr_to_state(Particle::Force, particle_i);
+    double* force_i = container_i->get_ptr_to_state_writable(Particle::Force, particle_i);
 
     const double* angvel_i = nullptr;
     double* moment_i = nullptr;
     if (contacttangential_ or contactrolling_)
     {
       angvel_i = container_i->get_ptr_to_state(Particle::AngularVelocity, particle_i);
-      moment_i = container_i->get_ptr_to_state(Particle::Moment, particle_i);
+      moment_i = container_i->get_ptr_to_state_writable(Particle::Moment, particle_i);
     }
 
     // get pointer to column wall element

--- a/src/particle/src/interaction/4C_particle_interaction_dem_contact.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_dem_contact.cpp
@@ -401,14 +401,17 @@ void Particle::DEMContact::evaluate_particle_contact()
 
     const double* vel_j = container_j->get_ptr_to_state(Particle::Velocity, particle_j);
     const double* rad_j = container_j->get_ptr_to_state(Particle::Radius, particle_j);
-    double* force_j = container_j->get_ptr_to_state_writable(Particle::Force, particle_j);
+    double* force_j = nullptr;
+    if (status_j == Particle::Owned)
+      force_j = container_j->get_ptr_to_state_writable(Particle::Force, particle_j);
 
     const double* angvel_j = nullptr;
     double* moment_j = nullptr;
     if (contacttangential_ or contactrolling_)
     {
       angvel_j = container_j->get_ptr_to_state(Particle::AngularVelocity, particle_j);
-      moment_j = container_j->get_ptr_to_state_writable(Particle::Moment, particle_j);
+      if (status_j == Particle::Owned)
+        moment_j = container_j->get_ptr_to_state_writable(Particle::Moment, particle_j);
     }
 
     // compute vectors from particle i and j to contact point c
@@ -447,8 +450,7 @@ void Particle::DEMContact::evaluate_particle_contact()
 
     // add normal contact force contribution
     ParticleUtils::vec_add_scale(force_i, normalcontactforce, particlepair.e_ji_);
-    if (status_j == Particle::Owned)
-      ParticleUtils::vec_add_scale(force_j, -normalcontactforce, particlepair.e_ji_);
+    if (force_j) ParticleUtils::vec_add_scale(force_j, -normalcontactforce, particlepair.e_ji_);
 
     // calculation of tangential contact force
     if (contacttangential_)
@@ -495,12 +497,11 @@ void Particle::DEMContact::evaluate_particle_contact()
 
       // add tangential contact force contribution
       ParticleUtils::vec_add(force_i, tangentialcontactforce);
-      if (status_j == Particle::Owned) ParticleUtils::vec_sub(force_j, tangentialcontactforce);
+      if (force_j) ParticleUtils::vec_sub(force_j, tangentialcontactforce);
 
       // add tangential contact moment contribution
       ParticleUtils::vec_add_cross(moment_i, r_ci, tangentialcontactforce);
-      if (status_j == Particle::Owned)
-        ParticleUtils::vec_add_cross(moment_j, tangentialcontactforce, r_cj);
+      if (moment_j) ParticleUtils::vec_add_cross(moment_j, tangentialcontactforce, r_cj);
     }
 
     // calculation of rolling contact moment
@@ -551,7 +552,7 @@ void Particle::DEMContact::evaluate_particle_contact()
 
       // add rolling contact moment contribution
       ParticleUtils::vec_add(moment_i, rollingcontactmoment);
-      if (status_j == Particle::Owned) ParticleUtils::vec_sub(moment_j, rollingcontactmoment);
+      if (moment_j) ParticleUtils::vec_sub(moment_j, rollingcontactmoment);
     }
   }
 }

--- a/src/particle/src/interaction/4C_particle_interaction_sph_boundary_particle.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_boundary_particle.cpp
@@ -201,9 +201,9 @@ void Particle::SPHBoundaryParticleAdami::init_boundary_particle_states(std::vect
         const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
         const double* acc_i = container_i->get_ptr_to_state(Particle::Acceleration, particle_i);
         double* boundarypress_i =
-            container_i->get_ptr_to_state(Particle::BoundaryPressure, particle_i);
+            container_i->get_ptr_to_state_writable(Particle::BoundaryPressure, particle_i);
         double* boundaryvel_i =
-            container_i->get_ptr_to_state(Particle::BoundaryVelocity, particle_i);
+            container_i->get_ptr_to_state_writable(Particle::BoundaryVelocity, particle_i);
 
         // get relative acceleration of boundary particle
         double relacc[3];

--- a/src/particle/src/interaction/4C_particle_interaction_sph_density.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_density.cpp
@@ -180,14 +180,15 @@ void Particle::SPHDensityBase::sum_weighted_mass_particle_contribution() const
         container_i->cond_get_ptr_to_state_writable(Particle::DensitySum, particle_i);
 
     const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
-    double* denssum_j =
-        container_j->cond_get_ptr_to_state_writable(Particle::DensitySum, particle_j);
+    double* denssum_j = nullptr;
+    if (status_j == Particle::Owned)
+      denssum_j = container_j->cond_get_ptr_to_state_writable(Particle::DensitySum, particle_j);
 
     // sum contribution of neighboring particle j
     if (denssum_i) denssum_i[0] += particlepair.Wij_ * mass_i[0];
 
     // sum contribution of neighboring particle i
-    if (denssum_j and status_j == Particle::Owned) denssum_j[0] += particlepair.Wji_ * mass_j[0];
+    if (denssum_j) denssum_j[0] += particlepair.Wji_ * mass_j[0];
   }
 }
 
@@ -364,15 +365,15 @@ void Particle::SPHDensityBase::sum_colorfield_particle_contribution() const
                                ? container_j->get_ptr_to_state(Particle::Density, particle_j)
                                : &(material_i->initDensity_);
 
-    double* colorfield_j =
-        container_j->cond_get_ptr_to_state_writable(Particle::Colorfield, particle_j);
+    double* colorfield_j = nullptr;
+    if (status_j == Particle::Owned)
+      colorfield_j = container_j->cond_get_ptr_to_state_writable(Particle::Colorfield, particle_j);
 
     // sum contribution of neighboring particle j
     if (colorfield_i) colorfield_i[0] += (particlepair.Wij_ / dens_j[0]) * mass_j[0];
 
     // sum contribution of neighboring particle i
-    if (colorfield_j and status_j == Particle::Owned)
-      colorfield_j[0] += (particlepair.Wji_ / dens_i[0]) * mass_i[0];
+    if (colorfield_j) colorfield_j[0] += (particlepair.Wji_ / dens_i[0]) * mass_i[0];
   }
 }
 
@@ -535,8 +536,9 @@ void Particle::SPHDensityBase::continuity_equation_particle_contribution() const
                                ? container_j->get_ptr_to_state(Particle::Density, particle_j)
                                : &(material_i->initDensity_);
 
-    double* densdot_j =
-        container_j->cond_get_ptr_to_state_writable(Particle::DensityDot, particle_j);
+    double* densdot_j = nullptr;
+    if (status_j == Particle::Owned)
+      densdot_j = container_j->cond_get_ptr_to_state_writable(Particle::DensityDot, particle_j);
 
     // relative velocity (use modified velocities in case of transport velocity formulation)
     double vel_ij[3];
@@ -550,7 +552,7 @@ void Particle::SPHDensityBase::continuity_equation_particle_contribution() const
       densdot_i[0] += dens_i[0] * (mass_j[0] / dens_j[0]) * particlepair.dWdrij_ * e_ij_vel_ij;
 
     // sum contribution of neighboring particle i
-    if (densdot_j and status_j == Particle::Owned)
+    if (densdot_j)
       densdot_j[0] += dens_j[0] * (mass_i[0] / dens_i[0]) * particlepair.dWdrji_ * e_ij_vel_ij;
   }
 }

--- a/src/particle/src/interaction/4C_particle_interaction_sph_density.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_density.cpp
@@ -138,7 +138,7 @@ void Particle::SPHDensityBase::sum_weighted_mass_self_contribution() const
       // get pointer to particle states
       const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
       const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
-      double* denssum_i = container_i->get_ptr_to_state(Particle::DensitySum, particle_i);
+      double* denssum_i = container_i->get_ptr_to_state_writable(Particle::DensitySum, particle_i);
 
       // evaluate kernel
       const double Wii = kernel_->w0(rad_i[0]);
@@ -176,10 +176,12 @@ void Particle::SPHDensityBase::sum_weighted_mass_particle_contribution() const
 
     // get pointer to particle states
     const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
-    double* denssum_i = container_i->cond_get_ptr_to_state(Particle::DensitySum, particle_i);
+    double* denssum_i =
+        container_i->cond_get_ptr_to_state_writable(Particle::DensitySum, particle_i);
 
     const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
-    double* denssum_j = container_j->cond_get_ptr_to_state(Particle::DensitySum, particle_j);
+    double* denssum_j =
+        container_j->cond_get_ptr_to_state_writable(Particle::DensitySum, particle_j);
 
     // sum contribution of neighboring particle j
     if (denssum_i) denssum_i[0] += particlepair.Wij_ * mass_i[0];
@@ -217,7 +219,7 @@ void Particle::SPHDensityBase::sum_weighted_mass_particle_wall_contribution() co
     // get pointer to particle states
     const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
     const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
-    double* denssum_i = container_i->get_ptr_to_state(Particle::DensitySum, particle_i);
+    double* denssum_i = container_i->get_ptr_to_state_writable(Particle::DensitySum, particle_i);
 
     // compute vector from wall contact point j to particle i
     double r_ij[3];
@@ -302,7 +304,8 @@ void Particle::SPHDensityBase::sum_colorfield_self_contribution() const
       const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
       const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
       const double* dens_i = container_i->get_ptr_to_state(Particle::Density, particle_i);
-      double* colorfield_i = container_i->get_ptr_to_state(Particle::Colorfield, particle_i);
+      double* colorfield_i =
+          container_i->get_ptr_to_state_writable(Particle::Colorfield, particle_i);
 
       // evaluate kernel
       const double Wii = kernel_->w0(rad_i[0]);
@@ -352,7 +355,8 @@ void Particle::SPHDensityBase::sum_colorfield_particle_contribution() const
                                ? container_i->get_ptr_to_state(Particle::Density, particle_i)
                                : &(material_j->initDensity_);
 
-    double* colorfield_i = container_i->cond_get_ptr_to_state(Particle::Colorfield, particle_i);
+    double* colorfield_i =
+        container_i->cond_get_ptr_to_state_writable(Particle::Colorfield, particle_i);
 
     const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
 
@@ -360,7 +364,8 @@ void Particle::SPHDensityBase::sum_colorfield_particle_contribution() const
                                ? container_j->get_ptr_to_state(Particle::Density, particle_j)
                                : &(material_i->initDensity_);
 
-    double* colorfield_j = container_j->cond_get_ptr_to_state(Particle::Colorfield, particle_j);
+    double* colorfield_j =
+        container_j->cond_get_ptr_to_state_writable(Particle::Colorfield, particle_j);
 
     // sum contribution of neighboring particle j
     if (colorfield_i) colorfield_i[0] += (particlepair.Wij_ / dens_j[0]) * mass_j[0];
@@ -401,7 +406,7 @@ void Particle::SPHDensityBase::sum_colorfield_particle_wall_contribution() const
 
     // get pointer to particle states
     const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
-    double* colorfield_i = container_i->get_ptr_to_state(Particle::Colorfield, particle_i);
+    double* colorfield_i = container_i->get_ptr_to_state_writable(Particle::Colorfield, particle_i);
 
     // get pointer to virtual particle states
     const double* mass_k = container_i->get_ptr_to_state(Particle::Mass, particle_i);
@@ -516,7 +521,8 @@ void Particle::SPHDensityBase::continuity_equation_particle_contribution() const
                                ? container_i->get_ptr_to_state(Particle::Density, particle_i)
                                : &(material_j->initDensity_);
 
-    double* densdot_i = container_i->cond_get_ptr_to_state(Particle::DensityDot, particle_i);
+    double* densdot_i =
+        container_i->cond_get_ptr_to_state_writable(Particle::DensityDot, particle_i);
 
     const double* vel_j =
         container_j->have_stored_state(Particle::ModifiedVelocity)
@@ -529,7 +535,8 @@ void Particle::SPHDensityBase::continuity_equation_particle_contribution() const
                                ? container_j->get_ptr_to_state(Particle::Density, particle_j)
                                : &(material_i->initDensity_);
 
-    double* densdot_j = container_j->cond_get_ptr_to_state(Particle::DensityDot, particle_j);
+    double* densdot_j =
+        container_j->cond_get_ptr_to_state_writable(Particle::DensityDot, particle_j);
 
     // relative velocity (use modified velocities in case of transport velocity formulation)
     double vel_ij[3];
@@ -589,7 +596,7 @@ void Particle::SPHDensityBase::continuity_equation_particle_wall_contribution() 
 
     const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
     const double* dens_i = container_i->get_ptr_to_state(Particle::Density, particle_i);
-    double* densdot_i = container_i->get_ptr_to_state(Particle::DensityDot, particle_i);
+    double* densdot_i = container_i->get_ptr_to_state_writable(Particle::DensityDot, particle_i);
 
     // get pointer to column wall element
     Core::Elements::Element* ele = particlewallpair.ele_;
@@ -907,9 +914,9 @@ void Particle::SPHDensityPredictCorrect::correct_density() const
     if (particlestored <= 0) continue;
 
     // get pointer to particle state
-    double* dens = container_i->get_ptr_to_state(Particle::Density, 0);
     const double* denssum = container_i->get_ptr_to_state(Particle::DensitySum, 0);
     const double* colorfield = container_i->get_ptr_to_state(Particle::Colorfield, 0);
+    double* dens = container_i->get_ptr_to_state_writable(Particle::Density, 0);
 
     // get material for current particle type
     const Mat::PAR::ParticleMaterialBase* material =

--- a/src/particle/src/interaction/4C_particle_interaction_sph_density.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_density.cpp
@@ -177,12 +177,12 @@ void Particle::SPHDensityBase::sum_weighted_mass_particle_contribution() const
     // get pointer to particle states
     const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
     double* denssum_i =
-        container_i->cond_get_ptr_to_state_writable(Particle::DensitySum, particle_i);
+        container_i->try_get_ptr_to_state_writable(Particle::DensitySum, particle_i);
 
     const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
     double* denssum_j = nullptr;
     if (status_j == Particle::Owned)
-      denssum_j = container_j->cond_get_ptr_to_state_writable(Particle::DensitySum, particle_j);
+      denssum_j = container_j->try_get_ptr_to_state_writable(Particle::DensitySum, particle_j);
 
     // sum contribution of neighboring particle j
     if (denssum_i) denssum_i[0] += particlepair.Wij_ * mass_i[0];
@@ -357,7 +357,7 @@ void Particle::SPHDensityBase::sum_colorfield_particle_contribution() const
                                : &(material_j->initDensity_);
 
     double* colorfield_i =
-        container_i->cond_get_ptr_to_state_writable(Particle::Colorfield, particle_i);
+        container_i->try_get_ptr_to_state_writable(Particle::Colorfield, particle_i);
 
     const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
 
@@ -367,7 +367,7 @@ void Particle::SPHDensityBase::sum_colorfield_particle_contribution() const
 
     double* colorfield_j = nullptr;
     if (status_j == Particle::Owned)
-      colorfield_j = container_j->cond_get_ptr_to_state_writable(Particle::Colorfield, particle_j);
+      colorfield_j = container_j->try_get_ptr_to_state_writable(Particle::Colorfield, particle_j);
 
     // sum contribution of neighboring particle j
     if (colorfield_i) colorfield_i[0] += (particlepair.Wij_ / dens_j[0]) * mass_j[0];
@@ -523,7 +523,7 @@ void Particle::SPHDensityBase::continuity_equation_particle_contribution() const
                                : &(material_j->initDensity_);
 
     double* densdot_i =
-        container_i->cond_get_ptr_to_state_writable(Particle::DensityDot, particle_i);
+        container_i->try_get_ptr_to_state_writable(Particle::DensityDot, particle_i);
 
     const double* vel_j =
         container_j->have_stored_state(Particle::ModifiedVelocity)
@@ -538,7 +538,7 @@ void Particle::SPHDensityBase::continuity_equation_particle_contribution() const
 
     double* densdot_j = nullptr;
     if (status_j == Particle::Owned)
-      densdot_j = container_j->cond_get_ptr_to_state_writable(Particle::DensityDot, particle_j);
+      densdot_j = container_j->try_get_ptr_to_state_writable(Particle::DensityDot, particle_j);
 
     // relative velocity (use modified velocities in case of transport velocity formulation)
     double vel_ij[3];

--- a/src/particle/src/interaction/4C_particle_interaction_sph_heatloss_evaporation.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_heatloss_evaporation.cpp
@@ -77,7 +77,8 @@ void Particle::SPHHeatLossEvaporation::evaluate_evaporation_induced_heat_loss() 
     const double* temp_i = container_i->get_ptr_to_state(Particle::Temperature, particle_i);
     const double* cfg_i = container_i->get_ptr_to_state(Particle::ColorfieldGradient, particle_i);
     const double* ifn_i = container_i->get_ptr_to_state(Particle::InterfaceNormal, particle_i);
-    double* tempdot_i = container_i->get_ptr_to_state(Particle::TemperatureDot, particle_i);
+    double* tempdot_i =
+        container_i->get_ptr_to_state_writable(Particle::TemperatureDot, particle_i);
 
     // evaluation only for non-zero interface normal
     if (not(ParticleUtils::vec_norm_two(ifn_i) > 0.0)) continue;

--- a/src/particle/src/interaction/4C_particle_interaction_sph_heatsource.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_heatsource.cpp
@@ -127,7 +127,8 @@ void Particle::SPHHeatSourceVolume::evaluate_heat_source(const double& evaltime)
                                  : &(basematerial_i->initDensity_);
 
       const double* pos_i = container_i->get_ptr_to_state(Particle::Position, particle_i);
-      double* tempdot_i = container_i->get_ptr_to_state(Particle::TemperatureDot, particle_i);
+      double* tempdot_i =
+          container_i->get_ptr_to_state_writable(Particle::TemperatureDot, particle_i);
 
       // evaluate function defining heat source
       funct = function.evaluate_time_derivative(std::span(pos_i, 3), evaltime, 0, 0);
@@ -313,7 +314,8 @@ void Particle::SPHHeatSourceSurface::evaluate_heat_source(const double& evaltime
                                  : &(basematerial_i->initDensity_);
 
       const double* pos_i = container_i->get_ptr_to_state(Particle::Position, particle_i);
-      double* tempdot_i = container_i->get_ptr_to_state(Particle::TemperatureDot, particle_i);
+      double* tempdot_i =
+          container_i->get_ptr_to_state_writable(Particle::TemperatureDot, particle_i);
 
       // evaluate function defining heat source
       funct = function.evaluate_time_derivative(std::span(pos_i, 3), evaltime, 0, 0);

--- a/src/particle/src/interaction/4C_particle_interaction_sph_momentum.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_momentum.cpp
@@ -257,12 +257,12 @@ void Particle::SPHMomentum::momentum_equation_particle_contribution() const
 
     double* acc_i = nullptr;
     if (intfluidtypes_.contains(type_i))
-      acc_i = container_i->get_ptr_to_state(Particle::Acceleration, particle_i);
+      acc_i = container_i->get_ptr_to_state_writable(Particle::Acceleration, particle_i);
 
     const double* mod_vel_i =
         container_i->cond_get_ptr_to_state(Particle::ModifiedVelocity, particle_i);
     double* mod_acc_i =
-        container_i->cond_get_ptr_to_state(Particle::ModifiedAcceleration, particle_i);
+        container_i->cond_get_ptr_to_state_writable(Particle::ModifiedAcceleration, particle_i);
 
     // get pointer to particle states
     const double* rad_j = container_j->get_ptr_to_state(Particle::Radius, particle_j);
@@ -273,14 +273,15 @@ void Particle::SPHMomentum::momentum_equation_particle_contribution() const
 
     double* acc_j = nullptr;
     if (intfluidtypes_.contains(type_j) and status_j == Particle::Owned)
-      acc_j = container_j->get_ptr_to_state(Particle::Acceleration, particle_j);
+      acc_j = container_j->get_ptr_to_state_writable(Particle::Acceleration, particle_j);
 
     const double* mod_vel_j =
         container_j->cond_get_ptr_to_state(Particle::ModifiedVelocity, particle_j);
 
     double* mod_acc_j = nullptr;
     if (status_j == Particle::Owned)
-      mod_acc_j = container_j->cond_get_ptr_to_state(Particle::ModifiedAcceleration, particle_j);
+      mod_acc_j =
+          container_j->cond_get_ptr_to_state_writable(Particle::ModifiedAcceleration, particle_j);
 
     // evaluate specific coefficient
     double speccoeff_ij(0.0);
@@ -438,14 +439,15 @@ void Particle::SPHMomentum::momentum_equation_particle_boundary_contribution() c
 
     double* acc_i = nullptr;
     if (status_i == Particle::Owned)
-      acc_i = container_i->get_ptr_to_state(Particle::Acceleration, particle_i);
+      acc_i = container_i->get_ptr_to_state_writable(Particle::Acceleration, particle_i);
 
     const double* mod_vel_i =
         container_i->cond_get_ptr_to_state(Particle::ModifiedVelocity, particle_i);
 
     double* mod_acc_i = nullptr;
     if (status_i == Particle::Owned)
-      mod_acc_i = container_i->cond_get_ptr_to_state(Particle::ModifiedAcceleration, particle_i);
+      mod_acc_i =
+          container_i->cond_get_ptr_to_state_writable(Particle::ModifiedAcceleration, particle_i);
 
     // get pointer to boundary particle states
     const double* mass_j = container_i->get_ptr_to_state(Particle::Mass, particle_i);
@@ -458,7 +460,7 @@ void Particle::SPHMomentum::momentum_equation_particle_boundary_contribution() c
 
     double* force_j = nullptr;
     if (status_j == Particle::Owned)
-      force_j = container_j->cond_get_ptr_to_state(Particle::Force, particle_j);
+      force_j = container_j->cond_get_ptr_to_state_writable(Particle::Force, particle_j);
 
     // contribution from neighboring boundary particle j
     double acc_ij[3] = {0.0, 0.0, 0.0};
@@ -624,12 +626,12 @@ void Particle::SPHMomentum::momentum_equation_particle_wall_contribution() const
     const double* dens_i = container_i->get_ptr_to_state(Particle::Density, particle_i);
     const double* press_i = container_i->get_ptr_to_state(Particle::Pressure, particle_i);
     const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
-    double* acc_i = container_i->get_ptr_to_state(Particle::Acceleration, particle_i);
+    double* acc_i = container_i->get_ptr_to_state_writable(Particle::Acceleration, particle_i);
 
     const double* mod_vel_i =
         container_i->cond_get_ptr_to_state(Particle::ModifiedVelocity, particle_i);
     double* mod_acc_i =
-        container_i->cond_get_ptr_to_state(Particle::ModifiedAcceleration, particle_i);
+        container_i->cond_get_ptr_to_state_writable(Particle::ModifiedAcceleration, particle_i);
 
     // get pointer to column wall element
     Core::Elements::Element* ele = particlewallpair.ele_;

--- a/src/particle/src/interaction/4C_particle_interaction_sph_momentum.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_momentum.cpp
@@ -260,9 +260,9 @@ void Particle::SPHMomentum::momentum_equation_particle_contribution() const
       acc_i = container_i->get_ptr_to_state_writable(Particle::Acceleration, particle_i);
 
     const double* mod_vel_i =
-        container_i->cond_get_ptr_to_state(Particle::ModifiedVelocity, particle_i);
+        container_i->try_get_ptr_to_state(Particle::ModifiedVelocity, particle_i);
     double* mod_acc_i =
-        container_i->cond_get_ptr_to_state_writable(Particle::ModifiedAcceleration, particle_i);
+        container_i->try_get_ptr_to_state_writable(Particle::ModifiedAcceleration, particle_i);
 
     // get pointer to particle states
     const double* rad_j = container_j->get_ptr_to_state(Particle::Radius, particle_j);
@@ -276,12 +276,12 @@ void Particle::SPHMomentum::momentum_equation_particle_contribution() const
       acc_j = container_j->get_ptr_to_state_writable(Particle::Acceleration, particle_j);
 
     const double* mod_vel_j =
-        container_j->cond_get_ptr_to_state(Particle::ModifiedVelocity, particle_j);
+        container_j->try_get_ptr_to_state(Particle::ModifiedVelocity, particle_j);
 
     double* mod_acc_j = nullptr;
     if (status_j == Particle::Owned)
       mod_acc_j =
-          container_j->cond_get_ptr_to_state_writable(Particle::ModifiedAcceleration, particle_j);
+          container_j->try_get_ptr_to_state_writable(Particle::ModifiedAcceleration, particle_j);
 
     // evaluate specific coefficient
     double speccoeff_ij(0.0);
@@ -442,12 +442,12 @@ void Particle::SPHMomentum::momentum_equation_particle_boundary_contribution() c
       acc_i = container_i->get_ptr_to_state_writable(Particle::Acceleration, particle_i);
 
     const double* mod_vel_i =
-        container_i->cond_get_ptr_to_state(Particle::ModifiedVelocity, particle_i);
+        container_i->try_get_ptr_to_state(Particle::ModifiedVelocity, particle_i);
 
     double* mod_acc_i = nullptr;
     if (status_i == Particle::Owned)
       mod_acc_i =
-          container_i->cond_get_ptr_to_state_writable(Particle::ModifiedAcceleration, particle_i);
+          container_i->try_get_ptr_to_state_writable(Particle::ModifiedAcceleration, particle_i);
 
     // get pointer to boundary particle states
     const double* mass_j = container_i->get_ptr_to_state(Particle::Mass, particle_i);
@@ -460,7 +460,7 @@ void Particle::SPHMomentum::momentum_equation_particle_boundary_contribution() c
 
     double* force_j = nullptr;
     if (status_j == Particle::Owned)
-      force_j = container_j->cond_get_ptr_to_state_writable(Particle::Force, particle_j);
+      force_j = container_j->try_get_ptr_to_state_writable(Particle::Force, particle_j);
 
     // contribution from neighboring boundary particle j
     double acc_ij[3] = {0.0, 0.0, 0.0};
@@ -629,9 +629,9 @@ void Particle::SPHMomentum::momentum_equation_particle_wall_contribution() const
     double* acc_i = container_i->get_ptr_to_state_writable(Particle::Acceleration, particle_i);
 
     const double* mod_vel_i =
-        container_i->cond_get_ptr_to_state(Particle::ModifiedVelocity, particle_i);
+        container_i->try_get_ptr_to_state(Particle::ModifiedVelocity, particle_i);
     double* mod_acc_i =
-        container_i->cond_get_ptr_to_state_writable(Particle::ModifiedAcceleration, particle_i);
+        container_i->try_get_ptr_to_state_writable(Particle::ModifiedAcceleration, particle_i);
 
     // get pointer to column wall element
     Core::Elements::Element* ele = particlewallpair.ele_;

--- a/src/particle/src/interaction/4C_particle_interaction_sph_open_boundary.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_open_boundary.cpp
@@ -104,7 +104,7 @@ void Particle::SPHOpenBoundaryBase::check_open_boundary_phase_change(
     if (static_cast<int>(*boundary_id_i) != boundary_id_) continue;
 
     // get pointer to particle states
-    double* pos_i = container_i->get_ptr_to_state(Particle::Position, particle_i);
+    double* pos_i = container_i->get_ptr_to_state_writable(Particle::Position, particle_i);
 
     // compute distance of open boundary particle from plane
     std::vector<double> temp(3);
@@ -151,7 +151,7 @@ void Particle::SPHOpenBoundaryBase::check_open_boundary_phase_change(
   for (int particle_j = 0; particle_j < container_j->particles_stored(); ++particle_j)
   {
     // get pointer to particle states
-    double* pos_j = container_j->get_ptr_to_state(Particle::Position, particle_j);
+    double* pos_j = container_j->get_ptr_to_state_writable(Particle::Position, particle_j);
 
     // compute distance of fluid particle from plane
     std::vector<double> temp(3);
@@ -277,7 +277,7 @@ void Particle::SPHOpenBoundaryDirichlet::prescribe_open_boundary_states(const do
 
     // get pointer to particle states
     const double* pos_i = container_i->get_ptr_to_state(Particle::Position, particle_i);
-    double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
+    double* vel_i = container_i->get_ptr_to_state_writable(Particle::Velocity, particle_i);
 
     // evaluate function to set velocity
     ParticleUtils::vec_set_scale(
@@ -370,8 +370,8 @@ void Particle::SPHOpenBoundaryDirichlet::interpolate_open_boundary_states()
     if (static_cast<int>(*boundary_id_k) != boundary_id_) continue;
 
     // get pointer to particle states
-    double* dens_k = container_k->get_ptr_to_state(Particle::Density, particle_k);
-    double* press_k = container_k->get_ptr_to_state(Particle::Pressure, particle_k);
+    double* dens_k = container_k->get_ptr_to_state_writable(Particle::Density, particle_k);
+    double* press_k = container_k->get_ptr_to_state_writable(Particle::Pressure, particle_k);
 
     // interpolate pressure
     press_k[0] = (sumj_Vj_Wij[particle_k] > 0.0)
@@ -472,7 +472,7 @@ void Particle::SPHOpenBoundaryNeumann::prescribe_open_boundary_states(const doub
 
       // get pointer to particle states
       const double* pos_i = container_i->get_ptr_to_state(Particle::Position, particle_i);
-      double* press_i = container_i->get_ptr_to_state(Particle::Pressure, particle_i);
+      double* press_i = container_i->get_ptr_to_state_writable(Particle::Pressure, particle_i);
 
       // evaluate function to set pressure
       press_i[0] = function.evaluate(std::span(pos_i, 3), evaltime, 0);
@@ -494,7 +494,7 @@ void Particle::SPHOpenBoundaryNeumann::prescribe_open_boundary_states(const doub
 
     // get pointer to particle states
     const double* press_i = container_i->get_ptr_to_state(Particle::Pressure, particle_i);
-    double* dens_i = container_i->get_ptr_to_state(Particle::Density, particle_i);
+    double* dens_i = container_i->get_ptr_to_state_writable(Particle::Density, particle_i);
 
     // compute density
     dens_i[0] = equationofstate_i->pressure_to_density(press_i[0], material_i->initDensity_);

--- a/src/particle/src/interaction/4C_particle_interaction_sph_peridynamic.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_peridynamic.cpp
@@ -221,16 +221,16 @@ void Particle::SPHPeridynamic::init_peridynamic_bondlist()
     const double* pos_i = container_i->get_ptr_to_state(Particle::Position, particle_i);
     const double* pdbodyid_i = container_i->get_ptr_to_state(Particle::PDBodyId, particle_i);
     double* initialconnectedbonds_i =
-        container_i->get_ptr_to_state(Particle::InitialConnectedBonds, particle_i);
+        container_i->get_ptr_to_state_writable(Particle::InitialConnectedBonds, particle_i);
     double* currentconnectedbonds_i =
-        container_i->get_ptr_to_state(Particle::CurrentConnectedBonds, particle_i);
+        container_i->get_ptr_to_state_writable(Particle::CurrentConnectedBonds, particle_i);
 
     const double* pos_j = container_j->get_ptr_to_state(Particle::Position, particle_j);
     const double* pdbodyid_j = container_j->get_ptr_to_state(Particle::PDBodyId, particle_j);
     double* initialconnectedbonds_j =
-        container_j->get_ptr_to_state(Particle::InitialConnectedBonds, particle_j);
+        container_j->get_ptr_to_state_writable(Particle::InitialConnectedBonds, particle_j);
     double* currentconnectedbonds_j =
-        container_j->get_ptr_to_state(Particle::CurrentConnectedBonds, particle_j);
+        container_j->get_ptr_to_state_writable(Particle::CurrentConnectedBonds, particle_j);
 
     // vector from particle i to j
     double r_ji[3];
@@ -333,7 +333,7 @@ void Particle::SPHPeridynamic::compute_interaction_forces() const
 
     const double* pos_i = container_i->get_ptr_to_state(Particle::Position, particle_i);
     const double* young_i = container_i->get_ptr_to_state(Particle::Young, particle_i);
-    double* force_i = container_i->cond_get_ptr_to_state(Particle::Force, particle_i);
+    double* force_i = container_i->cond_get_ptr_to_state_writable(Particle::Force, particle_i);
     const double* critical_stretch_i =
         container_i->get_ptr_to_state(Particle::CriticalStretch, particle_i);
 
@@ -341,7 +341,7 @@ void Particle::SPHPeridynamic::compute_interaction_forces() const
         container_j->get_ptr_to_state(Particle::ReferencePosition, particle_j);
     const double* pos_j = container_j->get_ptr_to_state(Particle::Position, particle_j);
     const double* young_j = container_j->get_ptr_to_state(Particle::Young, particle_j);
-    double* force_j = container_j->get_ptr_to_state(Particle::Force, particle_j);
+    double* force_j = container_j->get_ptr_to_state_writable(Particle::Force, particle_j);
 
     const double* critical_stretch_j =
         container_j->get_ptr_to_state(Particle::CriticalStretch, particle_j);
@@ -404,9 +404,9 @@ void Particle::SPHPeridynamic::compute_interaction_forces() const
     else
     {
       double* currentconnectedbonds_i =
-          container_i->get_ptr_to_state(Particle::CurrentConnectedBonds, particle_i);
+          container_i->get_ptr_to_state_writable(Particle::CurrentConnectedBonds, particle_i);
       double* currentconnectedbonds_j =
-          container_j->get_ptr_to_state(Particle::CurrentConnectedBonds, particle_j);
+          container_j->get_ptr_to_state_writable(Particle::CurrentConnectedBonds, particle_j);
 
       currentconnectedbonds_i[0] -= 1.0;
       currentconnectedbonds_j[0] -= 1.0;
@@ -442,14 +442,14 @@ void Particle::SPHPeridynamic::compute_interaction_forces() const
 
     // get pointer to particle states
     const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
-    double* force_i = container_i->cond_get_ptr_to_state(Particle::Force, particle_i);
+    double* force_i = container_i->cond_get_ptr_to_state_writable(Particle::Force, particle_i);
 
     // get pointer to particle states
     const double* vel_j = container_j->get_ptr_to_state(Particle::Velocity, particle_j);
 
     double* force_j = nullptr;
     if (status_j == Particle::Owned)
-      force_j = container_j->cond_get_ptr_to_state(Particle::Force, particle_j);
+      force_j = container_j->cond_get_ptr_to_state_writable(Particle::Force, particle_j);
 
     // compute normal gap and rate of normal gap
     const double gap = particlepair.gap_;
@@ -487,8 +487,8 @@ void Particle::SPHPeridynamic::compute_acceleration() const
   const double* mass = container->get_ptr_to_state(Particle::Mass, 0);
   const double* force = container->get_ptr_to_state(Particle::Force, 0);
   const double* moment = container->cond_get_ptr_to_state(Particle::Moment, 0);
-  double* acc = container->get_ptr_to_state(Particle::Acceleration, 0);
-  double* angacc = container->cond_get_ptr_to_state(Particle::AngularAcceleration, 0);
+  double* acc = container->get_ptr_to_state_writable(Particle::Acceleration, 0);
+  double* angacc = container->cond_get_ptr_to_state_writable(Particle::AngularAcceleration, 0);
 
   // compute acceleration
   for (int i = 0; i < particlestored; ++i)
@@ -524,7 +524,7 @@ void Particle::SPHPeridynamic::damage_evaluation()
         container->get_ptr_to_state(Particle::CurrentConnectedBonds, particle_i);
 
     double* pddamagevariable_i =
-        container->get_ptr_to_state(Particle::PDDamageVariable, particle_i);
+        container->get_ptr_to_state_writable(Particle::PDDamageVariable, particle_i);
 
     pddamagevariable_i[0] = 1.0 - currentconnectedbonds_i[0] / initialconnectedbonds_i[0];
   }

--- a/src/particle/src/interaction/4C_particle_interaction_sph_peridynamic.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_peridynamic.cpp
@@ -333,7 +333,7 @@ void Particle::SPHPeridynamic::compute_interaction_forces() const
 
     const double* pos_i = container_i->get_ptr_to_state(Particle::Position, particle_i);
     const double* young_i = container_i->get_ptr_to_state(Particle::Young, particle_i);
-    double* force_i = container_i->cond_get_ptr_to_state_writable(Particle::Force, particle_i);
+    double* force_i = container_i->try_get_ptr_to_state_writable(Particle::Force, particle_i);
     const double* critical_stretch_i =
         container_i->get_ptr_to_state(Particle::CriticalStretch, particle_i);
 
@@ -444,14 +444,14 @@ void Particle::SPHPeridynamic::compute_interaction_forces() const
 
     // get pointer to particle states
     const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
-    double* force_i = container_i->cond_get_ptr_to_state_writable(Particle::Force, particle_i);
+    double* force_i = container_i->try_get_ptr_to_state_writable(Particle::Force, particle_i);
 
     // get pointer to particle states
     const double* vel_j = container_j->get_ptr_to_state(Particle::Velocity, particle_j);
 
     double* force_j = nullptr;
     if (status_j == Particle::Owned)
-      force_j = container_j->cond_get_ptr_to_state_writable(Particle::Force, particle_j);
+      force_j = container_j->try_get_ptr_to_state_writable(Particle::Force, particle_j);
 
     // compute normal gap and rate of normal gap
     const double gap = particlepair.gap_;
@@ -488,9 +488,9 @@ void Particle::SPHPeridynamic::compute_acceleration() const
   const double* radius = container->get_ptr_to_state(Particle::Radius, 0);
   const double* mass = container->get_ptr_to_state(Particle::Mass, 0);
   const double* force = container->get_ptr_to_state(Particle::Force, 0);
-  const double* moment = container->cond_get_ptr_to_state(Particle::Moment, 0);
+  const double* moment = container->try_get_ptr_to_state(Particle::Moment, 0);
   double* acc = container->get_ptr_to_state_writable(Particle::Acceleration, 0);
-  double* angacc = container->cond_get_ptr_to_state_writable(Particle::AngularAcceleration, 0);
+  double* angacc = container->try_get_ptr_to_state_writable(Particle::AngularAcceleration, 0);
 
   // compute acceleration
   for (int i = 0; i < particlestored; ++i)

--- a/src/particle/src/interaction/4C_particle_interaction_sph_peridynamic.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_peridynamic.cpp
@@ -341,7 +341,9 @@ void Particle::SPHPeridynamic::compute_interaction_forces() const
         container_j->get_ptr_to_state(Particle::ReferencePosition, particle_j);
     const double* pos_j = container_j->get_ptr_to_state(Particle::Position, particle_j);
     const double* young_j = container_j->get_ptr_to_state(Particle::Young, particle_j);
-    double* force_j = container_j->get_ptr_to_state_writable(Particle::Force, particle_j);
+    double* force_j = nullptr;
+    if (status_j == Particle::Owned)
+      force_j = container_j->get_ptr_to_state_writable(Particle::Force, particle_j);
 
     const double* critical_stretch_j =
         container_j->get_ptr_to_state(Particle::CriticalStretch, particle_j);
@@ -397,7 +399,7 @@ void Particle::SPHPeridynamic::compute_interaction_forces() const
 
       // add bond force contribution
       ParticleUtils::vec_add_scale(force_i, fac, m);
-      if (status_j == Particle::Owned) ParticleUtils::vec_add_scale(force_j, -fac, m);
+      if (force_j) ParticleUtils::vec_add_scale(force_j, -fac, m);
 
       ++iter;
     }

--- a/src/particle/src/interaction/4C_particle_interaction_sph_pressure.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_pressure.cpp
@@ -74,7 +74,7 @@ void Particle::SPHPressure::compute_pressure() const
 
     // get pointer to particle state
     const double* dens = container->get_ptr_to_state(Particle::Density, 0);
-    double* press = container->get_ptr_to_state(Particle::Pressure, 0);
+    double* press = container->get_ptr_to_state_writable(Particle::Pressure, 0);
 
     // get material for current particle type
     const Mat::PAR::ParticleMaterialBase* material =

--- a/src/particle/src/interaction/4C_particle_interaction_sph_rigid_particle_contact.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_rigid_particle_contact.cpp
@@ -157,14 +157,14 @@ void Particle::SPHRigidParticleContactElastic::elastic_contact_particle_contribu
 
     // get pointer to particle states
     const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
-    double* force_i = container_i->cond_get_ptr_to_state_writable(Particle::Force, particle_i);
+    double* force_i = container_i->try_get_ptr_to_state_writable(Particle::Force, particle_i);
 
     // get pointer to particle states
     const double* vel_j = container_j->get_ptr_to_state(Particle::Velocity, particle_j);
 
     double* force_j = nullptr;
     if (status_j == Particle::Owned)
-      force_j = container_j->cond_get_ptr_to_state_writable(Particle::Force, particle_j);
+      force_j = container_j->try_get_ptr_to_state_writable(Particle::Force, particle_j);
 
     // compute normal gap and rate of normal gap
     const double gap = particlepair.absdist_ - initialparticlespacing;
@@ -242,7 +242,7 @@ void Particle::SPHRigidParticleContactElastic::elastic_contact_particle_wall_con
     // get pointer to particle states
     const double* pos_i = container_i->get_ptr_to_state(Particle::Position, particle_i);
     const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
-    double* force_i = container_i->cond_get_ptr_to_state_writable(Particle::Force, particle_i);
+    double* force_i = container_i->try_get_ptr_to_state_writable(Particle::Force, particle_i);
 
     // get pointer to column wall element
     Core::Elements::Element* ele = particlewallpair.ele_;

--- a/src/particle/src/interaction/4C_particle_interaction_sph_rigid_particle_contact.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_rigid_particle_contact.cpp
@@ -157,14 +157,14 @@ void Particle::SPHRigidParticleContactElastic::elastic_contact_particle_contribu
 
     // get pointer to particle states
     const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
-    double* force_i = container_i->cond_get_ptr_to_state(Particle::Force, particle_i);
+    double* force_i = container_i->cond_get_ptr_to_state_writable(Particle::Force, particle_i);
 
     // get pointer to particle states
     const double* vel_j = container_j->get_ptr_to_state(Particle::Velocity, particle_j);
 
     double* force_j = nullptr;
     if (status_j == Particle::Owned)
-      force_j = container_j->cond_get_ptr_to_state(Particle::Force, particle_j);
+      force_j = container_j->cond_get_ptr_to_state_writable(Particle::Force, particle_j);
 
     // compute normal gap and rate of normal gap
     const double gap = particlepair.absdist_ - initialparticlespacing;
@@ -242,7 +242,7 @@ void Particle::SPHRigidParticleContactElastic::elastic_contact_particle_wall_con
     // get pointer to particle states
     const double* pos_i = container_i->get_ptr_to_state(Particle::Position, particle_i);
     const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
-    double* force_i = container_i->cond_get_ptr_to_state(Particle::Force, particle_i);
+    double* force_i = container_i->cond_get_ptr_to_state_writable(Particle::Force, particle_i);
 
     // get pointer to column wall element
     Core::Elements::Element* ele = particlewallpair.ele_;

--- a/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension.cpp
@@ -281,11 +281,13 @@ void Particle::SPHSurfaceTension::compute_colorfield_gradient() const
     // get pointer to particle states
     const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
     const double* dens_i = container_i->get_ptr_to_state(Particle::Density, particle_i);
-    double* cfg_i = container_i->get_ptr_to_state(Particle::ColorfieldGradient, particle_i);
+    double* cfg_i =
+        container_i->get_ptr_to_state_writable(Particle::ColorfieldGradient, particle_i);
 
     const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
     const double* dens_j = container_j->get_ptr_to_state(Particle::Density, particle_j);
-    double* cfg_j = container_j->get_ptr_to_state(Particle::ColorfieldGradient, particle_j);
+    double* cfg_j =
+        container_j->get_ptr_to_state_writable(Particle::ColorfieldGradient, particle_j);
 
     // (current) volume of particle i and j
     const double V_i = mass_i[0] / dens_i[0];
@@ -316,7 +318,8 @@ void Particle::SPHSurfaceTension::compute_colorfield_gradient() const
     {
       // get pointer to particle state
       const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
-      double* cfg_i = container_i->get_ptr_to_state(Particle::ColorfieldGradient, particle_i);
+      double* cfg_i =
+          container_i->get_ptr_to_state_writable(Particle::ColorfieldGradient, particle_i);
 
       // norm of colorfield gradient
       const double cfg_i_norm = ParticleUtils::vec_norm_two(cfg_i);
@@ -345,7 +348,7 @@ void Particle::SPHSurfaceTension::compute_interface_normal() const
       // get pointer to particle states
       const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
       const double* cfg_i = container_i->get_ptr_to_state(Particle::ColorfieldGradient, particle_i);
-      double* ifn_i = container_i->get_ptr_to_state(Particle::InterfaceNormal, particle_i);
+      double* ifn_i = container_i->get_ptr_to_state_writable(Particle::InterfaceNormal, particle_i);
 
       // norm of colorfield gradient
       const double cfg_i_norm = ParticleUtils::vec_norm_two(cfg_i);
@@ -412,8 +415,10 @@ void Particle::SPHSurfaceTension::compute_wall_colorfield_and_wall_interface_nor
       // get pointer to particle states
       const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
       const double* dens_i = container_i->get_ptr_to_state(Particle::Density, particle_i);
-      double* wallcf_i = container_i->get_ptr_to_state(Particle::WallColorfield, particle_i);
-      double* wallifn_i = container_i->get_ptr_to_state(Particle::WallInterfaceNormal, particle_i);
+      double* wallcf_i =
+          container_i->get_ptr_to_state_writable(Particle::WallColorfield, particle_i);
+      double* wallifn_i =
+          container_i->get_ptr_to_state_writable(Particle::WallInterfaceNormal, particle_i);
 
       const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
       const double* temp_j = container_j->cond_get_ptr_to_state(Particle::Temperature, particle_j);
@@ -450,8 +455,10 @@ void Particle::SPHSurfaceTension::compute_wall_colorfield_and_wall_interface_nor
       // get pointer to particle states
       const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
       const double* dens_j = container_j->get_ptr_to_state(Particle::Density, particle_j);
-      double* wallcf_j = container_j->get_ptr_to_state(Particle::WallColorfield, particle_j);
-      double* wallifn_j = container_j->get_ptr_to_state(Particle::WallInterfaceNormal, particle_j);
+      double* wallcf_j =
+          container_j->get_ptr_to_state_writable(Particle::WallColorfield, particle_j);
+      double* wallifn_j =
+          container_j->get_ptr_to_state_writable(Particle::WallInterfaceNormal, particle_j);
 
       const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
       const double* temp_i = container_i->cond_get_ptr_to_state(Particle::Temperature, particle_i);
@@ -490,7 +497,8 @@ void Particle::SPHSurfaceTension::compute_wall_colorfield_and_wall_interface_nor
     {
       // get pointer to particle state
       const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
-      double* wallifn_i = container_i->get_ptr_to_state(Particle::WallInterfaceNormal, particle_i);
+      double* wallifn_i =
+          container_i->get_ptr_to_state_writable(Particle::WallInterfaceNormal, particle_i);
 
       // norm of wall interface normal
       const double wallifn_i_norm = ParticleUtils::vec_norm_two(wallifn_i);
@@ -528,7 +536,7 @@ void Particle::SPHSurfaceTension::correct_triple_point_normal() const
       const double* wallifn_i =
           container_i->get_ptr_to_state(Particle::WallInterfaceNormal, particle_i);
       const double* wallcf_i = container_i->get_ptr_to_state(Particle::WallColorfield, particle_i);
-      double* ifn_i = container_i->get_ptr_to_state(Particle::InterfaceNormal, particle_i);
+      double* ifn_i = container_i->get_ptr_to_state_writable(Particle::InterfaceNormal, particle_i);
 
       // evaluation only for non-zero wall interface normal
       if (not(ParticleUtils::vec_norm_two(wallifn_i) > 0.0)) continue;
@@ -731,7 +739,7 @@ void Particle::SPHSurfaceTension::compute_curvature() const
       // get pointer to particle states
       const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
       const double* ifn_i = container_i->get_ptr_to_state(Particle::InterfaceNormal, particle_i);
-      double* curv_i = container_i->get_ptr_to_state(Particle::Curvature, particle_i);
+      double* curv_i = container_i->get_ptr_to_state_writable(Particle::Curvature, particle_i);
 
       // evaluation only for non-zero interface normal
       if (not(ParticleUtils::vec_norm_two(ifn_i) > 0.0)) continue;
@@ -770,7 +778,7 @@ void Particle::SPHSurfaceTension::compute_surface_tension_contribution() const
       const double* cfg_i = container_i->get_ptr_to_state(Particle::ColorfieldGradient, particle_i);
       const double* ifn_i = container_i->get_ptr_to_state(Particle::InterfaceNormal, particle_i);
       const double* temp_i = container_i->cond_get_ptr_to_state(Particle::Temperature, particle_i);
-      double* acc_i = container_i->get_ptr_to_state(Particle::Acceleration, particle_i);
+      double* acc_i = container_i->get_ptr_to_state_writable(Particle::Acceleration, particle_i);
 
       // evaluation only for non-zero interface normal
       if (not(ParticleUtils::vec_norm_two(ifn_i) > 0.0)) continue;
@@ -825,7 +833,7 @@ void Particle::SPHSurfaceTension::compute_temp_grad_driven_contribution() const
       const double* temp_i = container_i->get_ptr_to_state(Particle::Temperature, particle_i);
       const double* tempgrad_i =
           container_i->get_ptr_to_state(Particle::temperature_gradient, particle_i);
-      double* acc_i = container_i->get_ptr_to_state(Particle::Acceleration, particle_i);
+      double* acc_i = container_i->get_ptr_to_state_writable(Particle::Acceleration, particle_i);
 
       // evaluation only for non-zero interface normal
       if (not(ParticleUtils::vec_norm_two(ifn_i) > 0.0)) continue;

--- a/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension.cpp
@@ -286,8 +286,9 @@ void Particle::SPHSurfaceTension::compute_colorfield_gradient() const
 
     const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
     const double* dens_j = container_j->get_ptr_to_state(Particle::Density, particle_j);
-    double* cfg_j =
-        container_j->get_ptr_to_state_writable(Particle::ColorfieldGradient, particle_j);
+    double* cfg_j = nullptr;
+    if (status_j == Particle::Owned)
+      cfg_j = container_j->get_ptr_to_state_writable(Particle::ColorfieldGradient, particle_j);
 
     // (current) volume of particle i and j
     const double V_i = mass_i[0] / dens_i[0];
@@ -301,7 +302,7 @@ void Particle::SPHSurfaceTension::compute_colorfield_gradient() const
         cfg_i, dens_i[0] / V_i * fac * particlepair.dWdrij_, particlepair.e_ij_);
 
     // sum contribution of neighboring particle i
-    if (status_j == Particle::Owned)
+    if (cfg_j)
       ParticleUtils::vec_add_scale(
           cfg_j, -dens_j[0] / V_j * fac * particlepair.dWdrji_, particlepair.e_ij_);
   }

--- a/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension.cpp
@@ -422,7 +422,7 @@ void Particle::SPHSurfaceTension::compute_wall_colorfield_and_wall_interface_nor
           container_i->get_ptr_to_state_writable(Particle::WallInterfaceNormal, particle_i);
 
       const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
-      const double* temp_j = container_j->cond_get_ptr_to_state(Particle::Temperature, particle_j);
+      const double* temp_j = container_j->try_get_ptr_to_state(Particle::Temperature, particle_j);
 
       // (current) volume of particle i
       const double V_i = mass_i[0] / dens_i[0];
@@ -462,7 +462,7 @@ void Particle::SPHSurfaceTension::compute_wall_colorfield_and_wall_interface_nor
           container_j->get_ptr_to_state_writable(Particle::WallInterfaceNormal, particle_j);
 
       const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
-      const double* temp_i = container_i->cond_get_ptr_to_state(Particle::Temperature, particle_i);
+      const double* temp_i = container_i->try_get_ptr_to_state(Particle::Temperature, particle_i);
 
       // (initial) volume of boundary particle i
       const double V_i = mass_i[0] / material_i->initDensity_;
@@ -617,7 +617,7 @@ void Particle::SPHSurfaceTension::compute_curvature() const
       const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
       const double* dens_i = container_i->get_ptr_to_state(Particle::Density, particle_i);
       const double* ifn_i = container_i->get_ptr_to_state(Particle::InterfaceNormal, particle_i);
-      const double* temp_i = container_i->cond_get_ptr_to_state(Particle::Temperature, particle_i);
+      const double* temp_i = container_i->try_get_ptr_to_state(Particle::Temperature, particle_i);
 
       // evaluation only for non-zero interface normal
       if (not(ParticleUtils::vec_norm_two(ifn_i) > 0.0)) continue;
@@ -671,12 +671,12 @@ void Particle::SPHSurfaceTension::compute_curvature() const
     const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
     const double* dens_i = container_i->get_ptr_to_state(Particle::Density, particle_i);
     const double* ifn_i = container_i->get_ptr_to_state(Particle::InterfaceNormal, particle_i);
-    const double* temp_i = container_i->cond_get_ptr_to_state(Particle::Temperature, particle_i);
+    const double* temp_i = container_i->try_get_ptr_to_state(Particle::Temperature, particle_i);
 
     const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
     const double* dens_j = container_j->get_ptr_to_state(Particle::Density, particle_j);
     const double* ifn_j = container_j->get_ptr_to_state(Particle::InterfaceNormal, particle_j);
-    const double* temp_j = container_j->cond_get_ptr_to_state(Particle::Temperature, particle_j);
+    const double* temp_j = container_j->try_get_ptr_to_state(Particle::Temperature, particle_j);
 
     // evaluation only for non-zero interface normals
     if (not(ParticleUtils::vec_norm_two(ifn_i) > 0.0) or
@@ -778,7 +778,7 @@ void Particle::SPHSurfaceTension::compute_surface_tension_contribution() const
       const double* curv_i = container_i->get_ptr_to_state(Particle::Curvature, particle_i);
       const double* cfg_i = container_i->get_ptr_to_state(Particle::ColorfieldGradient, particle_i);
       const double* ifn_i = container_i->get_ptr_to_state(Particle::InterfaceNormal, particle_i);
-      const double* temp_i = container_i->cond_get_ptr_to_state(Particle::Temperature, particle_i);
+      const double* temp_i = container_i->try_get_ptr_to_state(Particle::Temperature, particle_i);
       double* acc_i = container_i->get_ptr_to_state_writable(Particle::Acceleration, particle_i);
 
       // evaluation only for non-zero interface normal

--- a/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_barrier_force.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_barrier_force.cpp
@@ -120,12 +120,12 @@ void Particle::SPHBarrierForce::compute_barrier_force_particle_contribution() co
     const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
     const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
     const double* temp_i = container_i->cond_get_ptr_to_state(Particle::Temperature, particle_i);
-    double* acc_i = container_i->get_ptr_to_state(Particle::Acceleration, particle_i);
+    double* acc_i = container_i->get_ptr_to_state_writable(Particle::Acceleration, particle_i);
 
     const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
     const double* vel_j = container_j->get_ptr_to_state(Particle::Velocity, particle_j);
     const double* temp_j = container_j->cond_get_ptr_to_state(Particle::Temperature, particle_j);
-    double* acc_j = container_j->get_ptr_to_state(Particle::Acceleration, particle_j);
+    double* acc_j = container_j->get_ptr_to_state_writable(Particle::Acceleration, particle_j);
 
     // evaluate transition factor above reference temperature
     double tempfac_i = 0.0;
@@ -218,7 +218,7 @@ void Particle::SPHBarrierForce::compute_barrier_force_particle_boundary_contribu
 
     double* acc_i = nullptr;
     if (status_i == Particle::Owned)
-      acc_i = container_i->get_ptr_to_state(Particle::Acceleration, particle_i);
+      acc_i = container_i->get_ptr_to_state_writable(Particle::Acceleration, particle_i);
 
     // get pointer to boundary particle states
     const double* vel_j = container_j->get_ptr_to_state(Particle::Velocity, particle_j);

--- a/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_barrier_force.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_barrier_force.cpp
@@ -119,12 +119,12 @@ void Particle::SPHBarrierForce::compute_barrier_force_particle_contribution() co
     // get pointer to particle states
     const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
     const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
-    const double* temp_i = container_i->cond_get_ptr_to_state(Particle::Temperature, particle_i);
+    const double* temp_i = container_i->try_get_ptr_to_state(Particle::Temperature, particle_i);
     double* acc_i = container_i->get_ptr_to_state_writable(Particle::Acceleration, particle_i);
 
     const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
     const double* vel_j = container_j->get_ptr_to_state(Particle::Velocity, particle_j);
-    const double* temp_j = container_j->cond_get_ptr_to_state(Particle::Temperature, particle_j);
+    const double* temp_j = container_j->try_get_ptr_to_state(Particle::Temperature, particle_j);
     double* acc_j = nullptr;
     if (status_j == Particle::Owned)
       acc_j = container_j->get_ptr_to_state_writable(Particle::Acceleration, particle_j);
@@ -215,7 +215,7 @@ void Particle::SPHBarrierForce::compute_barrier_force_particle_boundary_contribu
     // get pointer to particle states
     const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
     const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
-    const double* temp_i = container_i->cond_get_ptr_to_state(Particle::Temperature, particle_i);
+    const double* temp_i = container_i->try_get_ptr_to_state(Particle::Temperature, particle_i);
 
     double* acc_i = nullptr;
     if (status_i == Particle::Owned)
@@ -223,7 +223,7 @@ void Particle::SPHBarrierForce::compute_barrier_force_particle_boundary_contribu
 
     // get pointer to boundary particle states
     const double* vel_j = container_j->get_ptr_to_state(Particle::Velocity, particle_j);
-    const double* temp_j = container_j->cond_get_ptr_to_state(Particle::Temperature, particle_j);
+    const double* temp_j = container_j->try_get_ptr_to_state(Particle::Temperature, particle_j);
 
     // evaluate transition factor above reference temperature
     double tempfac_i = 0.0;

--- a/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_barrier_force.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_barrier_force.cpp
@@ -125,7 +125,9 @@ void Particle::SPHBarrierForce::compute_barrier_force_particle_contribution() co
     const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
     const double* vel_j = container_j->get_ptr_to_state(Particle::Velocity, particle_j);
     const double* temp_j = container_j->cond_get_ptr_to_state(Particle::Temperature, particle_j);
-    double* acc_j = container_j->get_ptr_to_state_writable(Particle::Acceleration, particle_j);
+    double* acc_j = nullptr;
+    if (status_j == Particle::Owned)
+      acc_j = container_j->get_ptr_to_state_writable(Particle::Acceleration, particle_j);
 
     // evaluate transition factor above reference temperature
     double tempfac_i = 0.0;
@@ -158,8 +160,7 @@ void Particle::SPHBarrierForce::compute_barrier_force_particle_contribution() co
       ParticleUtils::vec_add_scale(acc_i, -fac / mass_i[0], particlepair.e_ij_);
 
       // sum contribution of neighboring particle i
-      if (status_j == Particle::Owned)
-        ParticleUtils::vec_add_scale(acc_j, fac / mass_j[0], particlepair.e_ij_);
+      if (acc_j) ParticleUtils::vec_add_scale(acc_j, fac / mass_j[0], particlepair.e_ij_);
     }
   }
 }

--- a/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_interface_viscosity.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_interface_viscosity.cpp
@@ -155,7 +155,7 @@ void Particle::SPHInterfaceViscosity::compute_interface_viscosity_particle_contr
     const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
     const double* cfg_i = container_i->get_ptr_to_state(Particle::ColorfieldGradient, particle_i);
     const double* temp_i = container_i->cond_get_ptr_to_state(Particle::Temperature, particle_i);
-    double* acc_i = container_i->get_ptr_to_state(Particle::Acceleration, particle_i);
+    double* acc_i = container_i->get_ptr_to_state_writable(Particle::Acceleration, particle_i);
 
     const double* rad_j = container_j->get_ptr_to_state(Particle::Radius, particle_j);
     const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
@@ -163,7 +163,7 @@ void Particle::SPHInterfaceViscosity::compute_interface_viscosity_particle_contr
     const double* vel_j = container_j->get_ptr_to_state(Particle::Velocity, particle_j);
     const double* cfg_j = container_j->get_ptr_to_state(Particle::ColorfieldGradient, particle_j);
     const double* temp_j = container_j->cond_get_ptr_to_state(Particle::Temperature, particle_j);
-    double* acc_j = container_j->get_ptr_to_state(Particle::Acceleration, particle_j);
+    double* acc_j = container_j->get_ptr_to_state_writable(Particle::Acceleration, particle_j);
 
     // get smoothing length
     const double h_i = kernel_->smoothing_length(rad_i[0]);
@@ -278,7 +278,7 @@ void Particle::SPHInterfaceViscosity::compute_interface_viscosity_particle_bound
 
     double* acc_i = nullptr;
     if (status_i == Particle::Owned)
-      acc_i = container_i->get_ptr_to_state(Particle::Acceleration, particle_i);
+      acc_i = container_i->get_ptr_to_state_writable(Particle::Acceleration, particle_i);
 
     // get pointer to boundary particle states
     const double* mass_j = container_i->get_ptr_to_state(Particle::Mass, particle_i);

--- a/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_interface_viscosity.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_interface_viscosity.cpp
@@ -154,7 +154,7 @@ void Particle::SPHInterfaceViscosity::compute_interface_viscosity_particle_contr
     const double* dens_i = container_i->get_ptr_to_state(Particle::Density, particle_i);
     const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
     const double* cfg_i = container_i->get_ptr_to_state(Particle::ColorfieldGradient, particle_i);
-    const double* temp_i = container_i->cond_get_ptr_to_state(Particle::Temperature, particle_i);
+    const double* temp_i = container_i->try_get_ptr_to_state(Particle::Temperature, particle_i);
     double* acc_i = container_i->get_ptr_to_state_writable(Particle::Acceleration, particle_i);
 
     const double* rad_j = container_j->get_ptr_to_state(Particle::Radius, particle_j);
@@ -162,7 +162,7 @@ void Particle::SPHInterfaceViscosity::compute_interface_viscosity_particle_contr
     const double* dens_j = container_j->get_ptr_to_state(Particle::Density, particle_j);
     const double* vel_j = container_j->get_ptr_to_state(Particle::Velocity, particle_j);
     const double* cfg_j = container_j->get_ptr_to_state(Particle::ColorfieldGradient, particle_j);
-    const double* temp_j = container_j->cond_get_ptr_to_state(Particle::Temperature, particle_j);
+    const double* temp_j = container_j->try_get_ptr_to_state(Particle::Temperature, particle_j);
     double* acc_j = container_j->get_ptr_to_state_writable(Particle::Acceleration, particle_j);
 
     // get smoothing length
@@ -274,7 +274,7 @@ void Particle::SPHInterfaceViscosity::compute_interface_viscosity_particle_bound
     const double* dens_i = container_i->get_ptr_to_state(Particle::Density, particle_i);
     const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
     const double* cfg_i = container_i->get_ptr_to_state(Particle::ColorfieldGradient, particle_i);
-    const double* temp_i = container_i->cond_get_ptr_to_state(Particle::Temperature, particle_i);
+    const double* temp_i = container_i->try_get_ptr_to_state(Particle::Temperature, particle_i);
 
     double* acc_i = nullptr;
     if (status_i == Particle::Owned)

--- a/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_recoilpressure_evaporation.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_recoilpressure_evaporation.cpp
@@ -52,7 +52,7 @@ void Particle::SPHRecoilPressureEvaporation::compute_recoil_pressure_contributio
     const double* temp_i = container_i->get_ptr_to_state(Particle::Temperature, particle_i);
     const double* cfg_i = container_i->get_ptr_to_state(Particle::ColorfieldGradient, particle_i);
     const double* ifn_i = container_i->get_ptr_to_state(Particle::InterfaceNormal, particle_i);
-    double* acc_i = container_i->get_ptr_to_state(Particle::Acceleration, particle_i);
+    double* acc_i = container_i->get_ptr_to_state_writable(Particle::Acceleration, particle_i);
 
     // evaluation only for non-zero interface normal
     if (not(ParticleUtils::vec_norm_two(ifn_i) > 0.0)) continue;

--- a/src/particle/src/interaction/4C_particle_interaction_sph_temperature.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_temperature.cpp
@@ -257,8 +257,9 @@ void Particle::SPHTemperature::energy_equation() const
                                : &(basematerial_j->initDensity_);
 
     const double* temp_j = container_j->get_ptr_to_state(Particle::Temperature, particle_j);
-    double* tempdot_j =
-        container_j->cond_get_ptr_to_state_writable(Particle::TemperatureDot, particle_j);
+    double* tempdot_j = nullptr;
+    if (status_j == Particle::Owned)
+      tempdot_j = container_j->cond_get_ptr_to_state_writable(Particle::TemperatureDot, particle_j);
 
     // thermal conductivities
     const double& k_i = thermomaterial_i->thermalConductivity_;
@@ -274,7 +275,7 @@ void Particle::SPHTemperature::energy_equation() const
           mass_j[0] * fac * particlepair.dWdrij_ * thermomaterial_i->invThermalCapacity_;
 
     // sum contribution of neighboring particle i
-    if (tempdot_j and status_j == Particle::Owned)
+    if (tempdot_j)
       tempdot_j[0] -=
           mass_i[0] * fac * particlepair.dWdrji_ * thermomaterial_j->invThermalCapacity_;
   }
@@ -340,8 +341,10 @@ void Particle::SPHTemperature::temperature_gradient() const
                                : &(basematerial_j->initDensity_);
 
     const double* temp_j = container_j->get_ptr_to_state(Particle::Temperature, particle_j);
-    double* tempgrad_j =
-        container_j->cond_get_ptr_to_state_writable(Particle::temperature_gradient, particle_j);
+    double* tempgrad_j = nullptr;
+    if (status_j == Particle::Owned)
+      tempgrad_j =
+          container_j->cond_get_ptr_to_state_writable(Particle::temperature_gradient, particle_j);
 
     const double temp_ji = temp_j[0] - temp_i[0];
 
@@ -351,7 +354,7 @@ void Particle::SPHTemperature::temperature_gradient() const
           tempgrad_i, (mass_j[0] / dens_j[0]) * temp_ji * particlepair.dWdrij_, particlepair.e_ij_);
 
     // sum contribution of neighboring particle i
-    if (tempgrad_j and status_j == Particle::Owned)
+    if (tempgrad_j)
       ParticleUtils::vec_add_scale(
           tempgrad_j, (mass_i[0] / dens_i[0]) * temp_ji * particlepair.dWdrji_, particlepair.e_ij_);
   }

--- a/src/particle/src/interaction/4C_particle_interaction_sph_temperature.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_temperature.cpp
@@ -248,7 +248,7 @@ void Particle::SPHTemperature::energy_equation() const
 
     const double* temp_i = container_i->get_ptr_to_state(Particle::Temperature, particle_i);
     double* tempdot_i =
-        container_i->cond_get_ptr_to_state_writable(Particle::TemperatureDot, particle_i);
+        container_i->try_get_ptr_to_state_writable(Particle::TemperatureDot, particle_i);
 
     const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
 
@@ -259,7 +259,7 @@ void Particle::SPHTemperature::energy_equation() const
     const double* temp_j = container_j->get_ptr_to_state(Particle::Temperature, particle_j);
     double* tempdot_j = nullptr;
     if (status_j == Particle::Owned)
-      tempdot_j = container_j->cond_get_ptr_to_state_writable(Particle::TemperatureDot, particle_j);
+      tempdot_j = container_j->try_get_ptr_to_state_writable(Particle::TemperatureDot, particle_j);
 
     // thermal conductivities
     const double& k_i = thermomaterial_i->thermalConductivity_;
@@ -332,7 +332,7 @@ void Particle::SPHTemperature::temperature_gradient() const
 
     const double* temp_i = container_i->get_ptr_to_state(Particle::Temperature, particle_i);
     double* tempgrad_i =
-        container_i->cond_get_ptr_to_state_writable(Particle::temperature_gradient, particle_i);
+        container_i->try_get_ptr_to_state_writable(Particle::temperature_gradient, particle_i);
 
     const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
 
@@ -344,7 +344,7 @@ void Particle::SPHTemperature::temperature_gradient() const
     double* tempgrad_j = nullptr;
     if (status_j == Particle::Owned)
       tempgrad_j =
-          container_j->cond_get_ptr_to_state_writable(Particle::temperature_gradient, particle_j);
+          container_j->try_get_ptr_to_state_writable(Particle::temperature_gradient, particle_j);
 
     const double temp_ji = temp_j[0] - temp_i[0];
 

--- a/src/particle/src/interaction/4C_particle_interaction_sph_temperature.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_temperature.cpp
@@ -247,7 +247,8 @@ void Particle::SPHTemperature::energy_equation() const
                                : &(basematerial_i->initDensity_);
 
     const double* temp_i = container_i->get_ptr_to_state(Particle::Temperature, particle_i);
-    double* tempdot_i = container_i->cond_get_ptr_to_state(Particle::TemperatureDot, particle_i);
+    double* tempdot_i =
+        container_i->cond_get_ptr_to_state_writable(Particle::TemperatureDot, particle_i);
 
     const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
 
@@ -256,7 +257,8 @@ void Particle::SPHTemperature::energy_equation() const
                                : &(basematerial_j->initDensity_);
 
     const double* temp_j = container_j->get_ptr_to_state(Particle::Temperature, particle_j);
-    double* tempdot_j = container_j->cond_get_ptr_to_state(Particle::TemperatureDot, particle_j);
+    double* tempdot_j =
+        container_j->cond_get_ptr_to_state_writable(Particle::TemperatureDot, particle_j);
 
     // thermal conductivities
     const double& k_i = thermomaterial_i->thermalConductivity_;
@@ -329,7 +331,7 @@ void Particle::SPHTemperature::temperature_gradient() const
 
     const double* temp_i = container_i->get_ptr_to_state(Particle::Temperature, particle_i);
     double* tempgrad_i =
-        container_i->cond_get_ptr_to_state(Particle::temperature_gradient, particle_i);
+        container_i->cond_get_ptr_to_state_writable(Particle::temperature_gradient, particle_i);
 
     const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
 
@@ -339,7 +341,7 @@ void Particle::SPHTemperature::temperature_gradient() const
 
     const double* temp_j = container_j->get_ptr_to_state(Particle::Temperature, particle_j);
     double* tempgrad_j =
-        container_j->cond_get_ptr_to_state(Particle::temperature_gradient, particle_j);
+        container_j->cond_get_ptr_to_state_writable(Particle::temperature_gradient, particle_j);
 
     const double temp_ji = temp_j[0] - temp_i[0];
 

--- a/src/particle/src/rigidbody/4C_particle_rigidbody.cpp
+++ b/src/particle/src/rigidbody/4C_particle_rigidbody.cpp
@@ -1479,7 +1479,7 @@ void Particle::RigidBodyHandler::set_rigid_particle_relative_position_in_body_fr
     // get pointer to particle states
     const double* pos_i = container_i->get_ptr_to_state(Particle::Position, particle_i);
     double* relposbody_i =
-        container_i->get_ptr_to_state(Particle::RelativePositionBodyFrame, particle_i);
+        container_i->get_ptr_to_state_writable(Particle::RelativePositionBodyFrame, particle_i);
 
     ParticleUtils::vec_set(relposbody_i, pos_i);
     ParticleUtils::vec_sub(relposbody_i, pos_k);
@@ -1528,7 +1528,8 @@ void Particle::RigidBodyHandler::update_rigid_particle_relative_position()
     // get pointer to particle states
     const double* relposbody_i =
         container_i->get_ptr_to_state(Particle::RelativePositionBodyFrame, particle_i);
-    double* relpos_i = container_i->get_ptr_to_state(Particle::RelativePosition, particle_i);
+    double* relpos_i =
+        container_i->get_ptr_to_state_writable(Particle::RelativePosition, particle_i);
 
     // update relative position of particle i
     ParticleUtils::quaternion_rotate_vector(relpos_i, rot_k, relposbody_i);
@@ -1576,7 +1577,7 @@ void Particle::RigidBodyHandler::set_rigid_particle_position()
 
     // get pointer to particle states
     const double* relpos_i = container_i->get_ptr_to_state(Particle::RelativePosition, particle_i);
-    double* pos_i = container_i->get_ptr_to_state(Particle::Position, particle_i);
+    double* pos_i = container_i->get_ptr_to_state_writable(Particle::Position, particle_i);
 
     // set position of particle i
     ParticleUtils::vec_set(pos_i, pos_k);
@@ -1626,8 +1627,9 @@ void Particle::RigidBodyHandler::set_rigid_particle_velocities()
 
     // get pointer to particle states
     const double* relpos_i = container_i->get_ptr_to_state(Particle::RelativePosition, particle_i);
-    double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
-    double* angvel_i = container_i->cond_get_ptr_to_state(Particle::AngularVelocity, particle_i);
+    double* vel_i = container_i->get_ptr_to_state_writable(Particle::Velocity, particle_i);
+    double* angvel_i =
+        container_i->cond_get_ptr_to_state_writable(Particle::AngularVelocity, particle_i);
 
     // set velocities of particle i
     ParticleUtils::vec_set(vel_i, vel_k);
@@ -1680,9 +1682,9 @@ void Particle::RigidBodyHandler::set_rigid_particle_accelerations()
 
     // get pointer to particle states
     const double* relpos_i = container_i->get_ptr_to_state(Particle::RelativePosition, particle_i);
-    double* acc_i = container_i->get_ptr_to_state(Particle::Acceleration, particle_i);
+    double* acc_i = container_i->get_ptr_to_state_writable(Particle::Acceleration, particle_i);
     double* angacc_i =
-        container_i->cond_get_ptr_to_state(Particle::AngularAcceleration, particle_i);
+        container_i->cond_get_ptr_to_state_writable(Particle::AngularAcceleration, particle_i);
 
     // evaluate relative velocity of particle i
     double relvel_i[3];
@@ -1782,7 +1784,7 @@ void Particle::RigidBodyHandler::evaluate_rigid_body_solidification(
       // get pointer to particle states
       const double* pos_i = container_i->get_ptr_to_state(Particle::Position, particle_i);
       double* rigidbodycolor_i =
-          container_i->get_ptr_to_state(Particle::RigidBodyColor, particle_i);
+          container_i->get_ptr_to_state_writable(Particle::RigidBodyColor, particle_i);
 
       // get particles within radius
       std::vector<Particle::LocalIndexTuple> neighboringparticles;

--- a/src/particle/src/rigidbody/4C_particle_rigidbody.cpp
+++ b/src/particle/src/rigidbody/4C_particle_rigidbody.cpp
@@ -1629,7 +1629,7 @@ void Particle::RigidBodyHandler::set_rigid_particle_velocities()
     const double* relpos_i = container_i->get_ptr_to_state(Particle::RelativePosition, particle_i);
     double* vel_i = container_i->get_ptr_to_state_writable(Particle::Velocity, particle_i);
     double* angvel_i =
-        container_i->cond_get_ptr_to_state_writable(Particle::AngularVelocity, particle_i);
+        container_i->try_get_ptr_to_state_writable(Particle::AngularVelocity, particle_i);
 
     // set velocities of particle i
     ParticleUtils::vec_set(vel_i, vel_k);
@@ -1684,7 +1684,7 @@ void Particle::RigidBodyHandler::set_rigid_particle_accelerations()
     const double* relpos_i = container_i->get_ptr_to_state(Particle::RelativePosition, particle_i);
     double* acc_i = container_i->get_ptr_to_state_writable(Particle::Acceleration, particle_i);
     double* angacc_i =
-        container_i->cond_get_ptr_to_state_writable(Particle::AngularAcceleration, particle_i);
+        container_i->try_get_ptr_to_state_writable(Particle::AngularAcceleration, particle_i);
 
     // evaluate relative velocity of particle i
     double relvel_i[3];

--- a/src/particle/tests/4C_particle_container_test.cpp
+++ b/src/particle/tests/4C_particle_container_test.cpp
@@ -339,20 +339,20 @@ namespace
         mass[0] = 0.5;
       }
 
-      double* currpos = container_->cond_get_ptr_to_state(Particle::Position, index);
+      const double* currpos = container_->cond_get_ptr_to_state(Particle::Position, index);
       FOUR_C_EXPECT_ITERABLE_NEAR(currpos, pos.begin(), 3, 1.0e-14);
 
-      double* currvel = container_->cond_get_ptr_to_state(Particle::Velocity, index);
+      const double* currvel = container_->cond_get_ptr_to_state(Particle::Velocity, index);
       FOUR_C_EXPECT_ITERABLE_NEAR(currvel, vel.begin(), 3, 1.0e-14);
 
-      double* currmass = container_->cond_get_ptr_to_state(Particle::Mass, index);
+      const double* currmass = container_->cond_get_ptr_to_state(Particle::Mass, index);
       EXPECT_NEAR(currmass[0], mass[0], 1e-14);
     }
   }
 
   TEST_F(ParticleContainerTest, CondGetPtrToStateNotStored)
   {
-    double* currpos = container_->cond_get_ptr_to_state(Particle::Acceleration, 0);
+    const double* currpos = container_->cond_get_ptr_to_state(Particle::Acceleration, 0);
     EXPECT_EQ(currpos, nullptr);
   }
 

--- a/src/particle/tests/4C_particle_container_test.cpp
+++ b/src/particle/tests/4C_particle_container_test.cpp
@@ -297,6 +297,15 @@ namespace
 
       const double* currmass = container_->get_ptr_to_state(Particle::Mass, index);
       EXPECT_NEAR(currmass[0], mass[0], 1e-14);
+
+      {
+        double* newmass = container_->get_ptr_to_state_writable(Particle::Mass, index);
+        newmass[0] = newmass[0] * 3.14;
+      }
+      {
+        const double* currmass = container_->get_ptr_to_state(Particle::Mass, index);
+        EXPECT_NEAR(currmass[0], mass[0] * 3.14, 1e-14);
+      }
     }
   }
 

--- a/src/particle/tests/4C_particle_container_test.cpp
+++ b/src/particle/tests/4C_particle_container_test.cpp
@@ -309,7 +309,7 @@ namespace
     }
   }
 
-  TEST_F(ParticleContainerTest, CondGetPtrToState)
+  TEST_F(ParticleContainerTest, TryGetPtrToState)
   {
     std::array<double, 3> pos = {0.0};
     std::array<double, 3> vel = {0.0};
@@ -348,20 +348,20 @@ namespace
         mass[0] = 0.5;
       }
 
-      const double* currpos = container_->cond_get_ptr_to_state(Particle::Position, index);
+      const double* currpos = container_->try_get_ptr_to_state(Particle::Position, index);
       FOUR_C_EXPECT_ITERABLE_NEAR(currpos, pos.begin(), 3, 1.0e-14);
 
-      const double* currvel = container_->cond_get_ptr_to_state(Particle::Velocity, index);
+      const double* currvel = container_->try_get_ptr_to_state(Particle::Velocity, index);
       FOUR_C_EXPECT_ITERABLE_NEAR(currvel, vel.begin(), 3, 1.0e-14);
 
-      const double* currmass = container_->cond_get_ptr_to_state(Particle::Mass, index);
+      const double* currmass = container_->try_get_ptr_to_state(Particle::Mass, index);
       EXPECT_NEAR(currmass[0], mass[0], 1e-14);
     }
   }
 
-  TEST_F(ParticleContainerTest, CondGetPtrToStateNotStored)
+  TEST_F(ParticleContainerTest, TryGetPtrToStateNotStored)
   {
-    const double* currpos = container_->cond_get_ptr_to_state(Particle::Acceleration, 0);
+    const double* currpos = container_->try_get_ptr_to_state(Particle::Acceleration, 0);
     EXPECT_EQ(currpos, nullptr);
   }
 

--- a/src/particle/tests/4C_particle_container_test.cpp
+++ b/src/particle/tests/4C_particle_container_test.cpp
@@ -356,13 +356,25 @@ namespace
 
       const double* currmass = container_->try_get_ptr_to_state(Particle::Mass, index);
       EXPECT_NEAR(currmass[0], mass[0], 1e-14);
+
+      {
+        double* newmass = container_->try_get_ptr_to_state_writable(Particle::Mass, index);
+        newmass[0] = newmass[0] * 3.14;
+      }
+      {
+        const double* currmass = container_->try_get_ptr_to_state(Particle::Mass, index);
+        EXPECT_NEAR(currmass[0], mass[0] * 3.14, 1e-14);
+      }
     }
   }
 
   TEST_F(ParticleContainerTest, TryGetPtrToStateNotStored)
   {
-    const double* currpos = container_->try_get_ptr_to_state(Particle::Acceleration, 0);
-    EXPECT_EQ(currpos, nullptr);
+    const double* acc = container_->try_get_ptr_to_state(Particle::Acceleration, 0);
+    EXPECT_EQ(acc, nullptr);
+
+    double* angacc = container_->try_get_ptr_to_state_writable(Particle::AngularAcceleration, 0);
+    EXPECT_EQ(angacc, nullptr);
   }
 
   TEST_F(ParticleContainerTest, GetPtrToGlobalID)


### PR DESCRIPTION
The Dual View PR is rather big and difficult to review. I have pulled out some of the changes that can be easily reviewed and merged without anything to do about device access.

This PR includes the changes to `*get_ptr_to_state`, specifically

* Split out writable access, we need to know this to minimize device<->host copies, and its just good to only grant writable access when specifically needed and requested
* Rename `cond_*` to `try_*` to better match norms

After this, I want to strip out the enum changes. Then #2136 will only have the Dual View changes.

## Related Issues and Pull Requests
Subset of #2136

## Disclosure of AI assistance

Some local AI review prompting after I wrote the code