### PR TITLE
Docker update more robust dependencies hash

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -16,7 +16,7 @@ jobs:
   gcc13_assertions_build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:bf9c337f
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:b5f7e17b
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/main'
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:bf9c337f
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:b5f7e17b
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     strategy:
       fail-fast: false
@@ -104,7 +104,7 @@ jobs:
   clang18_build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:bf9c337f
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:b5f7e17b
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -164,7 +164,7 @@ jobs:
     needs: clang18_build
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:bf9c337f
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:b5f7e17b
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -190,7 +190,7 @@ jobs:
     needs: clang18_build
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:bf9c337f
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:b5f7e17b
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -254,7 +254,7 @@ jobs:
   gcc13_no_optional_dependencies_build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:bf9c337f
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:b5f7e17b
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -290,7 +290,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/main'
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:bf9c337f
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:b5f7e17b
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:

--- a/.github/workflows/buildtest_kokkosparallel.yml
+++ b/.github/workflows/buildtest_kokkosparallel.yml
@@ -16,7 +16,7 @@ jobs:
   kokkosopenmp_build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-trilinos-kokkosparallel:7580ff55
+      image: ghcr.io/4c-multiphysics/4c-dependencies-trilinos-kokkosparallel:0bcb6660
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -44,7 +44,7 @@ jobs:
     needs: kokkosopenmp_build
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-trilinos-kokkosparallel:7580ff55
+      image: ghcr.io/4c-multiphysics/4c-dependencies-trilinos-kokkosparallel:0bcb6660
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -76,7 +76,7 @@ jobs:
   kokkoscuda_build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-trilinos-kokkosparallel:7580ff55
+      image: ghcr.io/4c-multiphysics/4c-dependencies-trilinos-kokkosparallel:0bcb6660
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:

--- a/.github/workflows/checkcode.yml
+++ b/.github/workflows/checkcode.yml
@@ -31,7 +31,7 @@ jobs:
   clang-tidy:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:bf9c337f
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:b5f7e17b
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -57,7 +57,7 @@ jobs:
   verify-headers:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:bf9c337f
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:b5f7e17b
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,7 +10,7 @@ jobs:
   clang18_coverage_build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:bf9c337f
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:b5f7e17b
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -47,7 +47,7 @@ jobs:
     needs: clang18_coverage_build
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:bf9c337f
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:b5f7e17b
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     strategy:
       fail-fast: false
@@ -114,7 +114,7 @@ jobs:
     needs: [clang18_coverage_test, clang18_coverage_build]
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:bf9c337f
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:b5f7e17b
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,7 +20,7 @@ jobs:
   doxygen:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:bf9c337f
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:b5f7e17b
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -46,7 +46,7 @@ jobs:
   documentation:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:bf9c337f
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:b5f7e17b
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:

--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -10,7 +10,7 @@ jobs:
   gcc13_assertions_build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:bf9c337f
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:b5f7e17b
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -45,7 +45,7 @@ jobs:
     needs: gcc13_assertions_build
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:bf9c337f
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:b5f7e17b
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     strategy:
       fail-fast: false
@@ -97,7 +97,7 @@ jobs:
   clang18_build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:bf9c337f
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:b5f7e17b
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -202,7 +202,7 @@ jobs:
     needs: clang18_build
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:bf9c337f
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:b5f7e17b
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     strategy:
       fail-fast: false
@@ -254,7 +254,7 @@ jobs:
   clang18_build_oldest_supported_dependencies:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04-oldest-supported:bf9c337f
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04-oldest-supported:b5f7e17b
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -289,7 +289,7 @@ jobs:
     needs: clang18_build_oldest_supported_dependencies
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04-oldest-supported:bf9c337f
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04-oldest-supported:b5f7e17b
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     strategy:
       fail-fast: false
@@ -328,7 +328,7 @@ jobs:
   gcc13_no_optional_dependencies_build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:bf9c337f
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:b5f7e17b
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -363,7 +363,7 @@ jobs:
     needs: gcc13_no_optional_dependencies_build
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:bf9c337f
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:b5f7e17b
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     strategy:
       fail-fast: false
@@ -415,7 +415,7 @@ jobs:
   gcc13_asan_build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:bf9c337f
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:b5f7e17b
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -450,7 +450,7 @@ jobs:
     needs: gcc13_asan_build
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:bf9c337f
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:b5f7e17b
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     strategy:
       fail-fast: false
@@ -502,7 +502,7 @@ jobs:
   clang18_performance_tests_build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:bf9c337f
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:b5f7e17b
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -533,7 +533,7 @@ jobs:
     needs: clang18_performance_tests_build
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:bf9c337f
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:b5f7e17b
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,7 +1,12 @@
 # Docker
 
 This folder contains Dockerfiles for different configurations. The `Dockerfile` in the folder `dependencies` is the Dockerfile to
-build the project with the current dependencies. Other configurations reside in different subfolders.
+build the project with the current dependencies. Other configurations reside in different subfolders. The other configurations are:
+- oldest supported: dependencies image with the oldest supported dependencies (currently only Trilinos).
+- prebuilt 4C: docker image with ready-to-use 4C executable
+- minimal prebuilt 4C: prebuilt 4C docker image with everything removed not need to execute 4C
+- trilinos develop: dependencies image with Trilinos develop installation. Currently not working due to Epetra removal.
+- kokkos parallel: dependencies image with Trilinos installation with Kokkos OpenMP and Cuda.
 
 ## Build docker images locally
 
@@ -16,7 +21,7 @@ docker build --tag 4c-dependencies --file docker/dependencies/Dockerfile .
 ## How to update the docker images for the Github Actions
 
 1. Make your changes to the Dockerfile or dependencies
-2. Compute the sha1 of the docker and dependencies folder.
+2. Compute the sha1 of the docker and dependencies folder. Make sure that no unwanted files are in these folders.
 
 ```bash
 cd <project_root>

--- a/docker/dependencies/compute_dependencies_hash.sh
+++ b/docker/dependencies/compute_dependencies_hash.sh
@@ -9,4 +9,9 @@
 # Exit the script at the first failure
 set -e
 
-find dependencies/current dependencies/testing docker/dependencies -type f -exec sha1sum {} \; | sort | sha1sum | cut -c -8
+# Calculate a hash from our dependencies. Call the script from the project root directory.
+# - Find all files and exclude hidden files (like .DS_Store on macOS). Hidden files should not be part of the dependencies.
+# - Calculate the SHA1 of every file. The SHA1 is good enough as we don't use it for cryptographic security. No need for SHA256
+# - Calculate the final SHA1 from the filenames and their respective SHA1. We include the filename and not only the content to track changes to the dependency structure.
+# - Use the first 8 characters of the SHA1 as hash. There is only a low collision probability with 8 characters as the hash is rarely updated.
+find dependencies/current dependencies/testing docker/dependencies -type f -not -name '.*' -exec sha1sum {} \; | sort | sha1sum | cut -c -8

--- a/docker/kokkosparallel/compute_dependencies_hash.sh
+++ b/docker/kokkosparallel/compute_dependencies_hash.sh
@@ -9,4 +9,9 @@
 # Exit the script at the first failure
 set -e
 
-find dependencies/current/{backtrace,cmake,dealii,gmsh,superlu_dist} dependencies/testing dependencies/kokkosparallel docker/kokkosparallel -type f -exec sha1sum {} \; | sort | sha1sum | cut -c -8
+# Calculate a hash from our dependencies. Call the script from the project root directory.
+# - Find all files and exclude hidden files (like .DS_Store on macOS). Hidden files should not be part of the dependencies.
+# - Calculate the SHA1 of every file. The SHA1 is good enough as we don't use it for cryptographic security. No need for SHA256
+# - Calculate the final SHA1 from the filenames and their respective SHA1. We include the filename and not only the content to track changes to the dependency structure.
+# - Use the first 8 characters of the SHA1 as hash. There is only a low collision probability with 8 characters as the hash is rarely updated.
+find dependencies/current/{backtrace,cmake,dealii,gmsh,superlu_dist} dependencies/testing dependencies/kokkosparallel docker/kokkosparallel -type f -not -name '.*' -exec sha1sum {} \; | sort | sha1sum | cut -c -8


### PR DESCRIPTION
The dependencies hash is computed from the SHA1 of every file in the specified folders. Hidden files (like the macOS .DS_Store) can unintentionally change the computed hash and will lead to a failing pipeline. Hidden files should not be used for the dependencies build. If at some point hidden files are needed for the build, e.g., a .dockerignore, the check needs to be adapted.