### PR TITLE
Particle Use Enum Class

### DIFF
--- a/src/particle/src/algorithm/4C_particle_algorithm.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm.cpp
@@ -543,7 +543,7 @@ void Particle::ParticleAlgorithm::generate_initial_particles()
 void Particle::ParticleAlgorithm::determine_particle_types()
 {
   // init map relating particle types to dynamic load balance factor
-  std::map<Particle::TypeEnum, double> typetodynloadbal;
+  std::map<Particle::Type, double> typetodynloadbal;
 
   // read parameters relating particle types to values
   ParticleUtils::read_params_types_related_to_values(
@@ -775,15 +775,15 @@ double Particle::ParticleAlgorithm::get_max_particle_position_increment()
         particleengine_->get_particle_container_bundle();
 
     // iterate over particle types
-    for (const auto& typeEnum : particlecontainerbundle->get_particle_types())
+    for (const auto& type : particlecontainerbundle->get_particle_types())
     {
       if (debug_output)
       {
-        debug_output->violating_particles_per_type[typeEnum] = 0;
+        debug_output->violating_particles_per_type[type] = 0;
       }
       // get container of owned particles of current particle type
       Particle::ParticleContainer* container =
-          particlecontainerbundle->get_specific_container(typeEnum, Particle::Status::Owned);
+          particlecontainerbundle->get_specific_container(type, Particle::Status::Owned);
 
       // get number of particles stored in container
       const int particlestored = container->particles_stored();
@@ -819,12 +819,12 @@ double Particle::ParticleAlgorithm::get_max_particle_position_increment()
           }
           if (max_position_increment_of_particle > minimum_bin_size)
           {
-            debug_output->violating_particles_per_type[typeEnum]++;
+            debug_output->violating_particles_per_type[type]++;
             // Save gid and type of particle with maximum position increment
             if (max_position_increment_of_particle > maxpositionincrement)
             {
               debug_output->lid_of_max_position_increment = i;
-              debug_output->particle_type_of_max_position_increment = typeEnum;
+              debug_output->particle_type_of_max_position_increment = type;
             }
           }
         }
@@ -1055,17 +1055,17 @@ void Particle::ParticleAlgorithm::set_gravity_acceleration()
       particleengine_->get_particle_container_bundle();
 
   // iterate over particle types
-  for (auto& typeEnum : particlecontainerbundle->get_particle_types())
+  for (auto& type : particlecontainerbundle->get_particle_types())
   {
     // gravity is not set for boundary or rigid particles
-    if (typeEnum == Particle::BoundaryPhase or typeEnum == Particle::RigidPhase) continue;
+    if (type == Particle::Type::BoundaryPhase or type == Particle::Type::RigidPhase) continue;
 
     // gravity is not set for open boundary particles
-    if (typeEnum == Particle::DirichletPhase or typeEnum == Particle::NeumannPhase) continue;
+    if (type == Particle::Type::DirichletPhase or type == Particle::Type::NeumannPhase) continue;
 
     // set gravity acceleration for all particles of current type
     particlecontainerbundle->set_state_specific_container(
-        scaled_gravity, Particle::Acceleration, typeEnum);
+        scaled_gravity, Particle::Acceleration, type);
   }
 
   // add gravity acceleration

--- a/src/particle/src/algorithm/4C_particle_algorithm.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm.cpp
@@ -551,7 +551,7 @@ void Particle::ParticleAlgorithm::determine_particle_types()
 
   // insert into map of particle types and corresponding states with empty set
   for (auto& typeIt : typetodynloadbal)
-    particlestatestotypes_.insert(std::make_pair(typeIt.first, std::set<Particle::StateEnum>()));
+    particlestatestotypes_.insert(std::make_pair(typeIt.first, std::set<Particle::State>()));
 
   // safety check
   for (auto& particle : particlestodistribute_)
@@ -566,11 +566,11 @@ void Particle::ParticleAlgorithm::determine_particle_states_of_particle_types()
   for (auto& typeIt : particlestatestotypes_)
   {
     // set of particle states for current particle type
-    std::set<Particle::StateEnum>& particlestates = typeIt.second;
+    std::set<Particle::State>& particlestates = typeIt.second;
 
     // insert default particle states
-    particlestates.insert({Particle::Position, Particle::Velocity, Particle::Acceleration,
-        Particle::LastTransferPosition});
+    particlestates.insert({Particle::State::Position, Particle::State::Velocity,
+        Particle::State::Acceleration, Particle::State::LastTransferPosition});
   }
 
   // insert integration dependent states of all particle types
@@ -792,7 +792,7 @@ double Particle::ParticleAlgorithm::get_max_particle_position_increment()
       if (particlestored == 0) continue;
 
       // get particle state dimension
-      int statedim = container->get_state_dim(Particle::Position);
+      int statedim = container->get_state_dim(Particle::State::Position);
 
       // position increment of particle
       double positionincrement[3];
@@ -801,9 +801,9 @@ double Particle::ParticleAlgorithm::get_max_particle_position_increment()
       for (int i = 0; i < particlestored; ++i)
       {
         // get pointer to particle states
-        const double* pos = container->get_ptr_to_state(Particle::Position, i);
+        const double* pos = container->get_ptr_to_state(Particle::State::Position, i);
         const double* lasttransferpos =
-            container->get_ptr_to_state(Particle::LastTransferPosition, i);
+            container->get_ptr_to_state(Particle::State::LastTransferPosition, i);
 
         // position increment of particle considering periodic boundaries
         particleengine_->distance_between_particles(pos, lasttransferpos, positionincrement);
@@ -864,9 +864,9 @@ double Particle::ParticleAlgorithm::get_max_particle_position_increment()
     ParticleContainer* container = particlecontainerbundle->get_specific_container(
         debug_output->particle_type_of_max_position_increment, Status::Owned);
     const double* position =
-        container->get_ptr_to_state(Position, debug_output->lid_of_max_position_increment);
+        container->get_ptr_to_state(State::Position, debug_output->lid_of_max_position_increment);
     const double* velocity =
-        container->get_ptr_to_state(Velocity, debug_output->lid_of_max_position_increment);
+        container->get_ptr_to_state(State::Velocity, debug_output->lid_of_max_position_increment);
     const int gid = *container->get_ptr_to_global_id(debug_output->lid_of_max_position_increment);
     FOUR_C_THROW(
         "{} particle(s) traveled more than one bin on this processor.\n"
@@ -1065,7 +1065,7 @@ void Particle::ParticleAlgorithm::set_gravity_acceleration()
 
     // set gravity acceleration for all particles of current type
     particlecontainerbundle->set_state_specific_container(
-        scaled_gravity, Particle::Acceleration, type);
+        scaled_gravity, Particle::State::Acceleration, type);
   }
 
   // add gravity acceleration

--- a/src/particle/src/algorithm/4C_particle_algorithm.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm.cpp
@@ -783,7 +783,7 @@ double Particle::ParticleAlgorithm::get_max_particle_position_increment()
       }
       // get container of owned particles of current particle type
       Particle::ParticleContainer* container =
-          particlecontainerbundle->get_specific_container(typeEnum, Particle::Owned);
+          particlecontainerbundle->get_specific_container(typeEnum, Particle::Status::Owned);
 
       // get number of particles stored in container
       const int particlestored = container->particles_stored();
@@ -862,7 +862,7 @@ double Particle::ParticleAlgorithm::get_max_particle_position_increment()
     Particle::ParticleContainerBundleShrdPtr particlecontainerbundle =
         particleengine_->get_particle_container_bundle();
     ParticleContainer* container = particlecontainerbundle->get_specific_container(
-        debug_output->particle_type_of_max_position_increment, Owned);
+        debug_output->particle_type_of_max_position_increment, Status::Owned);
     const double* position =
         container->get_ptr_to_state(Position, debug_output->lid_of_max_position_increment);
     const double* velocity =

--- a/src/particle/src/algorithm/4C_particle_algorithm.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm.cpp
@@ -747,13 +747,13 @@ double Particle::ParticleAlgorithm::get_max_particle_position_increment()
   // Struct to collect additional debug information to throw a more informative error message
   struct DebugOutput
   {
-    std::map<ParticleType, std::size_t>
+    std::map<Particle::Type, std::size_t>
         violating_particles_per_type;  //! Map of particle type to number of particles violating the
                                        //! condition (maxpositionincrement < minimum_bin_size)
     int lid_of_max_position_increment;  //! local id of the particle with the maximum position
                                         //! increment
-    ParticleType particle_type_of_max_position_increment;  //! the particle type of the particle
-                                                           //! with the maximum position increment
+    Particle::Type particle_type_of_max_position_increment;  //! the particle type of the particle
+                                                             //! with the maximum position increment
   };
 
   const double minimum_bin_size = particleengine_->min_bin_size();

--- a/src/particle/src/algorithm/4C_particle_algorithm.hpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm.hpp
@@ -407,7 +407,7 @@ namespace Particle
     std::unique_ptr<Particle::ViscousDampingHandler> viscousdamping_;
 
     //! map of particle types and corresponding states
-    std::map<Particle::TypeEnum, std::set<Particle::StateEnum>> particlestatestotypes_;
+    std::map<Particle::Type, std::set<Particle::StateEnum>> particlestatestotypes_;
 
     //! vector of initial or generated particles to distribute
     std::vector<Particle::ParticleObjShrdPtr> particlestodistribute_;

--- a/src/particle/src/algorithm/4C_particle_algorithm.hpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm.hpp
@@ -407,7 +407,7 @@ namespace Particle
     std::unique_ptr<Particle::ViscousDampingHandler> viscousdamping_;
 
     //! map of particle types and corresponding states
-    std::map<Particle::Type, std::set<Particle::StateEnum>> particlestatestotypes_;
+    std::map<Particle::Type, std::set<Particle::State>> particlestatestotypes_;
 
     //! vector of initial or generated particles to distribute
     std::vector<Particle::ParticleObjShrdPtr> particlestodistribute_;

--- a/src/particle/src/algorithm/4C_particle_algorithm_constraints.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_constraints.cpp
@@ -26,7 +26,7 @@ Particle::ConstraintsProjectionBase::ConstraintsProjectionBase(MPI_Comm comm, do
 
 void Particle::ConstraintsProjectionBase::apply(
     Particle::ParticleContainerBundleShrdPtr particle_container_bundle,
-    const std::set<Particle::TypeEnum>& types_to_integrate, const double time) const
+    const std::set<Particle::Type>& types_to_integrate, const double time) const
 {
   // perform setup if needed
   setup(particle_container_bundle, types_to_integrate);
@@ -60,7 +60,7 @@ void Particle::ConstraintsProjectionBase::apply(
 
 int Particle::ConstraintsProjectionBase::calc_primary_axis(
     Particle::ParticleContainerBundleShrdPtr particle_container_bundle,
-    const std::set<Particle::TypeEnum>& types_to_integrate) const
+    const std::set<Particle::Type>& types_to_integrate) const
 {
   int local_result = calc_primary_axis_local(particle_container_bundle, types_to_integrate);
 
@@ -77,7 +77,7 @@ int Particle::ConstraintsProjectionBase::calc_primary_axis(
 
 void Particle::ConstraintsProjectionBase::setup(
     Particle::ParticleContainerBundleShrdPtr particle_container_bundle,
-    const std::set<Particle::TypeEnum>& types_to_integrate) const
+    const std::set<Particle::Type>& types_to_integrate) const
 {
   if (axis_ == axis_invalid_)
   {
@@ -89,7 +89,7 @@ void Particle::ConstraintsProjectionBase::setup(
 
 void Particle::ConstraintsProjectionBase::check_particles(
     Particle::ParticleContainerBundleShrdPtr particle_container_bundle,
-    const std::set<Particle::TypeEnum>& types_to_integrate) const
+    const std::set<Particle::Type>& types_to_integrate) const
 {
   for (auto& particleType : types_to_integrate)
   {
@@ -123,7 +123,7 @@ Particle::ConstraintsProjection2D::ConstraintsProjection2D(MPI_Comm comm)
 
 int Particle::ConstraintsProjection2D::calc_primary_axis_local(
     Particle::ParticleContainerBundleShrdPtr particle_container_bundle,
-    const std::set<Particle::TypeEnum>& types_to_integrate) const
+    const std::set<Particle::Type>& types_to_integrate) const
 {
   int axis_direction = axis_invalid_;
 
@@ -249,7 +249,7 @@ Particle::ConstraintsProjection1D::ConstraintsProjection1D(MPI_Comm comm)
 
 int Particle::ConstraintsProjection1D::calc_primary_axis_local(
     Particle::ParticleContainerBundleShrdPtr particle_container_bundle,
-    const std::set<Particle::TypeEnum>& types_to_integrate) const
+    const std::set<Particle::Type>& types_to_integrate) const
 {
   int axis_direction = axis_invalid_;
 

--- a/src/particle/src/algorithm/4C_particle_algorithm_constraints.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_constraints.cpp
@@ -36,7 +36,7 @@ void Particle::ConstraintsProjectionBase::apply(
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container =
-        particle_container_bundle->get_specific_container(particleType, Particle::Owned);
+        particle_container_bundle->get_specific_container(particleType, Particle::Status::Owned);
 
     // get number of particles stored in container
     const int n_particle_stored = container->particles_stored();
@@ -95,7 +95,7 @@ void Particle::ConstraintsProjectionBase::check_particles(
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container =
-        particle_container_bundle->get_specific_container(particleType, Particle::Owned);
+        particle_container_bundle->get_specific_container(particleType, Particle::Status::Owned);
 
     // get number of particles stored in container
     const int n_particle_stored = container->particles_stored();
@@ -135,7 +135,7 @@ int Particle::ConstraintsProjection2D::calc_primary_axis_local(
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container =
-        particle_container_bundle->get_specific_container(particleType, Particle::Owned);
+        particle_container_bundle->get_specific_container(particleType, Particle::Status::Owned);
 
     // get number of particles stored in container
     const int n_particle_stored = container->particles_stored();
@@ -261,7 +261,7 @@ int Particle::ConstraintsProjection1D::calc_primary_axis_local(
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container =
-        particle_container_bundle->get_specific_container(particleType, Particle::Owned);
+        particle_container_bundle->get_specific_container(particleType, Particle::Status::Owned);
 
     // get number of particles stored in container
     const int n_particle_stored = container->particles_stored();

--- a/src/particle/src/algorithm/4C_particle_algorithm_constraints.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_constraints.cpp
@@ -45,13 +45,14 @@ void Particle::ConstraintsProjectionBase::apply(
     if (n_particle_stored <= 0) continue;
 
     // get pointer to particle velocity and acceleration
-    double* vel = container->get_ptr_to_state_writable(Particle::Velocity, 0);
-    double* acc = container->get_ptr_to_state_writable(Particle::Acceleration, 0);
-    double* modvel = container->try_get_ptr_to_state_writable(Particle::ModifiedVelocity, 0);
-    double* modacc = container->try_get_ptr_to_state_writable(Particle::ModifiedAcceleration, 0);
+    double* vel = container->get_ptr_to_state_writable(Particle::State::Velocity, 0);
+    double* acc = container->get_ptr_to_state_writable(Particle::State::Acceleration, 0);
+    double* modvel = container->try_get_ptr_to_state_writable(Particle::State::ModifiedVelocity, 0);
+    double* modacc =
+        container->try_get_ptr_to_state_writable(Particle::State::ModifiedAcceleration, 0);
 
     // get particle state dimension
-    const int pos_state_dim = container->get_state_dim(Particle::Position);
+    const int pos_state_dim = container->get_state_dim(Particle::State::Position);
 
     // project quantities
     project(n_particle_stored, pos_state_dim, vel, acc, modvel, modacc);
@@ -104,13 +105,13 @@ void Particle::ConstraintsProjectionBase::check_particles(
     if (n_particle_stored <= 0) continue;
 
     // get pointer to particle position
-    const double* pos = container->get_ptr_to_state(Particle::Position, 0);
+    const double* pos = container->get_ptr_to_state(Particle::State::Position, 0);
 
     // get pointer to particle radius
-    const double* rad = container->get_ptr_to_state(Particle::Radius, 0);
+    const double* rad = container->get_ptr_to_state(Particle::State::Radius, 0);
 
     // get particle state dimension
-    const int pos_state_dim = container->get_state_dim(Particle::Position);
+    const int pos_state_dim = container->get_state_dim(Particle::State::Position);
 
     check(n_particle_stored, pos_state_dim, pos, rad);
   }
@@ -144,11 +145,11 @@ int Particle::ConstraintsProjection2D::calc_primary_axis_local(
     if (n_particle_stored < 3) continue;
 
     // get pointer to particle position and radius
-    const double* pos = container->get_ptr_to_state(Particle::Position, 0);
-    const double* rad = container->get_ptr_to_state(Particle::Radius, 0);
+    const double* pos = container->get_ptr_to_state(Particle::State::Position, 0);
+    const double* rad = container->get_ptr_to_state(Particle::State::Radius, 0);
 
     // get particle state dimension
-    const int pos_state_dim = container->get_state_dim(Particle::Position);
+    const int pos_state_dim = container->get_state_dim(Particle::State::Position);
 
     // We already assume that there is not coinciding points
     const auto p0 = pos;
@@ -270,10 +271,10 @@ int Particle::ConstraintsProjection1D::calc_primary_axis_local(
     if (n_particle_stored < 2) continue;
 
     // get pointer to particle position
-    const double* pos = container->get_ptr_to_state(Particle::Position, 0);
+    const double* pos = container->get_ptr_to_state(Particle::State::Position, 0);
 
     // get particle state dimension
-    const int pos_state_dim = container->get_state_dim(Particle::Position);
+    const int pos_state_dim = container->get_state_dim(Particle::State::Position);
 
     // We already assume that there is not coinciding points
     const auto p0 = pos;

--- a/src/particle/src/algorithm/4C_particle_algorithm_constraints.hpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_constraints.hpp
@@ -36,7 +36,7 @@ namespace Particle
      * \param[in] types_to_integrate types to integrate
      */
     virtual void apply(Particle::ParticleContainerBundleShrdPtr particle_container_bundle,
-        const std::set<Particle::TypeEnum>& types_to_integrate, const double time) const = 0;
+        const std::set<Particle::Type>& types_to_integrate, const double time) const = 0;
   };
 
   class ConstraintsProjectionBase : public ConstraintsHandler
@@ -60,7 +60,7 @@ namespace Particle
      * \param[in] types_to_integrate types to integrate
      */
     void apply(Particle::ParticleContainerBundleShrdPtr particle_container_bundle,
-        const std::set<Particle::TypeEnum>& types_to_integrate, const double time) const override;
+        const std::set<Particle::Type>& types_to_integrate, const double time) const override;
 
    private:
     /*!
@@ -73,7 +73,7 @@ namespace Particle
      * \param[in] types_to_integrate types to integrate
      */
     void setup(Particle::ParticleContainerBundleShrdPtr particle_container_bundle,
-        const std::set<Particle::TypeEnum>& types_to_integrate) const;
+        const std::set<Particle::Type>& types_to_integrate) const;
 
     /*!
      * \brief Identify the primary axis for the projection (applies to both 2D and 1D cases). Calls
@@ -84,7 +84,7 @@ namespace Particle
      * \param[in] types_to_integrate types to integrate
      */
     int calc_primary_axis(Particle::ParticleContainerBundleShrdPtr particle_container_bundle,
-        const std::set<Particle::TypeEnum>& types_to_integrate) const;
+        const std::set<Particle::Type>& types_to_integrate) const;
 
     /*!
      * \brief Check if all the particles are properly positioned in the initial configuration with
@@ -95,7 +95,7 @@ namespace Particle
      * \param[in] types_to_integrate types to integrate
      */
     void check_particles(Particle::ParticleContainerBundleShrdPtr particle_container_bundle,
-        const std::set<Particle::TypeEnum>& types_to_integrate) const;
+        const std::set<Particle::Type>& types_to_integrate) const;
 
     /*!
      * \brief Identify the primary axis for the projection within an MPI rank.
@@ -106,7 +106,7 @@ namespace Particle
      */
     virtual int calc_primary_axis_local(
         Particle::ParticleContainerBundleShrdPtr particle_container_bundle,
-        const std::set<Particle::TypeEnum>& types_to_integrate) const = 0;
+        const std::set<Particle::Type>& types_to_integrate) const = 0;
 
     /*!
      * \brief Set the primary axis.
@@ -172,7 +172,7 @@ namespace Particle
      * \param[in] types_to_integrate types to integrate
      */
     int calc_primary_axis_local(Particle::ParticleContainerBundleShrdPtr particle_container_bundle,
-        const std::set<Particle::TypeEnum>& types_to_integrate) const override;
+        const std::set<Particle::Type>& types_to_integrate) const override;
 
     /*!
      * \brief Set the primary axis. The provided axis index is used then to nullify the
@@ -232,7 +232,7 @@ namespace Particle
      * \param[in] types_to_integrate types to integrate
      */
     int calc_primary_axis_local(Particle::ParticleContainerBundleShrdPtr particle_container_bundle,
-        const std::set<Particle::TypeEnum>& types_to_integrate) const override;
+        const std::set<Particle::Type>& types_to_integrate) const override;
 
     /*!
      * \brief Set the primary axis. This method gets the index of the new axis and stores the

--- a/src/particle/src/algorithm/4C_particle_algorithm_dirichlet_bc.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_dirichlet_bc.cpp
@@ -91,7 +91,7 @@ void Particle::DirichletBoundaryConditionHandler::set_particle_reference_positio
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container =
-        particlecontainerbundle->get_specific_container(particle_type, Particle::Owned);
+        particlecontainerbundle->get_specific_container(particle_type, Particle::Status::Owned);
 
     // set particle reference position
     container->update_state(0.0, Particle::ReferencePosition, 1.0, Particle::Position);
@@ -104,7 +104,7 @@ void Particle::DirichletBoundaryConditionHandler::set_particle_reference_positio
 
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container =
-        particlecontainerbundle->get_specific_container(particle_type, Particle::Owned);
+        particlecontainerbundle->get_specific_container(particle_type, Particle::Status::Owned);
 
     // set particle reference position
     container->update_state(0.0, Particle::ReferencePosition, 1.0, Particle::Position);
@@ -191,7 +191,7 @@ void Particle::DirichletBoundaryConditionHandler::evaluate_dirichlet_boundary_co
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container =
-        particle_container_bundle->get_specific_container(particle_type, Particle::Owned);
+        particle_container_bundle->get_specific_container(particle_type, Particle::Status::Owned);
 
     // get number of particles stored in container
     const int particlestored = container->particles_stored();
@@ -222,7 +222,7 @@ void Particle::DirichletBoundaryConditionHandler::evaluate_dirichlet_boundary_co
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container =
-        particle_container_bundle->get_specific_container(particle_type, Particle::Owned);
+        particle_container_bundle->get_specific_container(particle_type, Particle::Status::Owned);
 
     // get number of particles stored in container
     const int particlestored = container->particles_stored();
@@ -278,7 +278,7 @@ void Particle::DirichletBoundaryConditionHandler::build_funct_cache(MPI_Comm com
   for (const auto& particle_type : types_with_per_particle_dirichlet_bc_)
   {
     Particle::ParticleContainer* container =
-        bundle->get_specific_container(particle_type, Particle::Owned);
+        bundle->get_specific_container(particle_type, Particle::Status::Owned);
 
     const int n = container->particles_stored();
     if (n <= 0) continue;

--- a/src/particle/src/algorithm/4C_particle_algorithm_dirichlet_bc.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_dirichlet_bc.cpp
@@ -63,20 +63,20 @@ void Particle::DirichletBoundaryConditionHandler::setup(
 }
 
 void Particle::DirichletBoundaryConditionHandler::insert_particle_states_of_particle_types(
-    std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const
+    std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes) const
 {
   // iterate over particle types subjected to dirichlet boundary conditions
   for (auto& particle_type : types_subjected_to_dirichlet_bc_)
   {
     // insert states for types subjected to dirichlet boundary conditions
-    particlestatestotypes[particle_type].insert(Particle::ReferencePosition);
+    particlestatestotypes[particle_type].insert(Particle::State::ReferencePosition);
   }
 
   // iterate over particle types with per-particle Dirichlet function id
   for (auto& particle_type : types_with_per_particle_dirichlet_bc_)
   {
-    particlestatestotypes[particle_type].insert(Particle::ReferencePosition);
-    particlestatestotypes[particle_type].insert(Particle::DirichletFunctionId);
+    particlestatestotypes[particle_type].insert(Particle::State::ReferencePosition);
+    particlestatestotypes[particle_type].insert(Particle::State::DirichletFunctionId);
   }
 }
 
@@ -94,7 +94,8 @@ void Particle::DirichletBoundaryConditionHandler::set_particle_reference_positio
         particlecontainerbundle->get_specific_container(particle_type, Particle::Status::Owned);
 
     // set particle reference position
-    container->update_state(0.0, Particle::ReferencePosition, 1.0, Particle::Position);
+    container->update_state(
+        0.0, Particle::State::ReferencePosition, 1.0, Particle::State::Position);
   }
 
   // iterate over particle types with per-particle Dirichlet function id (skip if already handled)
@@ -107,7 +108,8 @@ void Particle::DirichletBoundaryConditionHandler::set_particle_reference_positio
         particlecontainerbundle->get_specific_container(particle_type, Particle::Status::Owned);
 
     // set particle reference position
-    container->update_state(0.0, Particle::ReferencePosition, 1.0, Particle::Position);
+    container->update_state(
+        0.0, Particle::State::ReferencePosition, 1.0, Particle::State::Position);
   }
 }
 
@@ -202,15 +204,15 @@ void Particle::DirichletBoundaryConditionHandler::evaluate_dirichlet_boundary_co
     // get function to apply
     const auto& function = *per_particle_function_cache_.at(funct_id);
 
-    FOUR_C_ASSERT_ALWAYS(static_cast<std::size_t>(container->get_state_dim(Particle::Position)) ==
-                             function.number_components(),
+    FOUR_C_ASSERT_ALWAYS(static_cast<std::size_t>(container->get_state_dim(
+                             Particle::State::Position)) == function.number_components(),
         "dimension of function defining dirichlet boundary condition not correct!");
 
     // get pointer to particle states
-    const double* refpos = container->get_ptr_to_state(Particle::ReferencePosition, 0);
-    double* pos = container->get_ptr_to_state_writable(Particle::Position, 0);
-    double* vel = container->get_ptr_to_state_writable(Particle::Velocity, 0);
-    double* acc = container->get_ptr_to_state_writable(Particle::Acceleration, 0);
+    const double* refpos = container->get_ptr_to_state(Particle::State::ReferencePosition, 0);
+    double* pos = container->get_ptr_to_state_writable(Particle::State::Position, 0);
+    double* vel = container->get_ptr_to_state_writable(Particle::State::Velocity, 0);
+    double* acc = container->get_ptr_to_state_writable(Particle::State::Acceleration, 0);
 
     // iterate over owned particles of current type and apply dbc values to particle states
     for (int i = 0; i < particlestored; ++i)
@@ -230,18 +232,18 @@ void Particle::DirichletBoundaryConditionHandler::evaluate_dirichlet_boundary_co
     // no owned particles of current particle type
     if (particlestored <= 0) continue;
 
-    FOUR_C_ASSERT_ALWAYS(container->have_stored_state(Particle::DirichletFunctionId),
+    FOUR_C_ASSERT_ALWAYS(container->have_stored_state(Particle::State::DirichletFunctionId),
         "DirichletFunctionId state is missing. This should not happen.");
 
-    const int statedim = container->get_state_dim(Particle::Position);
+    const int statedim = container->get_state_dim(Particle::State::Position);
 
     // get pointer to particle states
     const double* dirichlet_function_id =
-        container->get_ptr_to_state(Particle::DirichletFunctionId, 0);
-    const double* refpos = container->get_ptr_to_state(Particle::ReferencePosition, 0);
-    double* pos = container->get_ptr_to_state_writable(Particle::Position, 0);
-    double* vel = container->get_ptr_to_state_writable(Particle::Velocity, 0);
-    double* acc = container->get_ptr_to_state_writable(Particle::Acceleration, 0);
+        container->get_ptr_to_state(Particle::State::DirichletFunctionId, 0);
+    const double* refpos = container->get_ptr_to_state(Particle::State::ReferencePosition, 0);
+    double* pos = container->get_ptr_to_state_writable(Particle::State::Position, 0);
+    double* vel = container->get_ptr_to_state_writable(Particle::State::Velocity, 0);
+    double* acc = container->get_ptr_to_state_writable(Particle::State::Acceleration, 0);
 
     // iterate over owned particles of current type
     for (int i = 0; i < particlestored; ++i)
@@ -283,7 +285,8 @@ void Particle::DirichletBoundaryConditionHandler::build_funct_cache(MPI_Comm com
     const int n = container->particles_stored();
     if (n <= 0) continue;
 
-    const double* funct_id_ptr = container->get_ptr_to_state(Particle::DirichletFunctionId, 0);
+    const double* funct_id_ptr =
+        container->get_ptr_to_state(Particle::State::DirichletFunctionId, 0);
     for (int i = 0; i < n; ++i)
     {
       const int funct_id = static_cast<int>(funct_id_ptr[i]);

--- a/src/particle/src/algorithm/4C_particle_algorithm_dirichlet_bc.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_dirichlet_bc.cpp
@@ -46,8 +46,8 @@ Particle::DirichletBoundaryConditionHandler::DirichletBoundaryConditionHandler(
     {
       for (const auto& type_name : *flagged_types)
       {
-        const Particle::TypeEnum particle_type = Particle::enum_from_type_name(type_name);
-        FOUR_C_ASSERT_ALWAYS(particle_type != Particle::RigidPhase,
+        const Particle::Type particle_type = Particle::enum_from_type_name(type_name);
+        FOUR_C_ASSERT_ALWAYS(particle_type != Particle::Type::RigidPhase,
             "per-particle Dirichlet BC is not allowed for rigidphase");
         types_with_per_particle_dirichlet_bc_.insert(particle_type);
       }
@@ -63,7 +63,7 @@ void Particle::DirichletBoundaryConditionHandler::setup(
 }
 
 void Particle::DirichletBoundaryConditionHandler::insert_particle_states_of_particle_types(
-    std::map<Particle::TypeEnum, std::set<Particle::StateEnum>>& particlestatestotypes) const
+    std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const
 {
   // iterate over particle types subjected to dirichlet boundary conditions
   for (auto& particle_type : types_subjected_to_dirichlet_bc_)

--- a/src/particle/src/algorithm/4C_particle_algorithm_dirichlet_bc.hpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_dirichlet_bc.hpp
@@ -95,7 +95,7 @@ namespace Particle
      * \param[out] particlestatestotypes map of particle types and corresponding states
      */
     void insert_particle_states_of_particle_types(
-        std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const;
+        std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes) const;
 
     /*!
      * \brief set particle reference position

--- a/src/particle/src/algorithm/4C_particle_algorithm_dirichlet_bc.hpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_dirichlet_bc.hpp
@@ -72,7 +72,7 @@ namespace Particle
      *
      * \return set of particle types subjected to dirichlet boundary conditions
      */
-    const std::set<Particle::TypeEnum>& get_particle_types_subjected_to_dirichlet_bc_set() const
+    const std::set<Particle::Type>& get_particle_types_subjected_to_dirichlet_bc_set() const
     {
       return types_subjected_to_dirichlet_bc_;
     };
@@ -83,8 +83,7 @@ namespace Particle
      *
      * \return set of particle types with per-particle dirichlet boundary conditions
      */
-    const std::set<Particle::TypeEnum>& get_particle_types_with_per_particle_dirichlet_bc_set()
-        const
+    const std::set<Particle::Type>& get_particle_types_with_per_particle_dirichlet_bc_set() const
     {
       return types_with_per_particle_dirichlet_bc_;
     };
@@ -96,7 +95,7 @@ namespace Particle
      * \param[out] particlestatestotypes map of particle types and corresponding states
      */
     void insert_particle_states_of_particle_types(
-        std::map<Particle::TypeEnum, std::set<Particle::StateEnum>>& particlestatestotypes) const;
+        std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const;
 
     /*!
      * \brief set particle reference position
@@ -124,13 +123,13 @@ namespace Particle
     std::shared_ptr<Particle::ParticleEngineInterface> particle_engine_interface_;
 
     //! relating particle types to function ids of dirichlet boundary conditions
-    std::map<Particle::TypeEnum, int> dirichlet_bc_type_to_funct_id_;
+    std::map<Particle::Type, int> dirichlet_bc_type_to_funct_id_;
 
     //! set of particle types subjected to dirichlet boundary conditions
-    std::set<Particle::TypeEnum> types_subjected_to_dirichlet_bc_;
+    std::set<Particle::Type> types_subjected_to_dirichlet_bc_;
 
     //! set of particle types with per-particle Dirichlet function id
-    std::set<Particle::TypeEnum> types_with_per_particle_dirichlet_bc_;
+    std::set<Particle::Type> types_with_per_particle_dirichlet_bc_;
 
     //! cache of per-particle Dirichlet functions, keyed by function id
     mutable std::map<int, const Core::Utils::FunctionOfSpaceTime*> per_particle_function_cache_;

--- a/src/particle/src/algorithm/4C_particle_algorithm_initial_field.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_initial_field.cpp
@@ -28,12 +28,12 @@ Particle::InitialFieldHandler::InitialFieldHandler(const Teuchos::ParameterList&
       params_.sublist("INITIAL AND BOUNDARY CONDITIONS");
 
   // relate particle state to input name
-  std::map<std::string, Particle::StateEnum> initialfieldtostateenum = {
-      std::make_pair("INITIAL_TEMP_FIELD", Particle::Temperature),
-      std::make_pair("INITIAL_VELOCITY_FIELD", Particle::Velocity),
-      std::make_pair("INITIAL_ANGULAR_VELOCITY_FIELD", Particle::AngularVelocity),
-      std::make_pair("INITIAL_ACCELERATION_FIELD", Particle::Acceleration),
-      std::make_pair("INITIAL_ANGULAR_ACCELERATION_FIELD", Particle::AngularAcceleration)};
+  std::map<std::string, Particle::State> initialfieldtostateenum = {
+      std::make_pair("INITIAL_TEMP_FIELD", Particle::State::Temperature),
+      std::make_pair("INITIAL_VELOCITY_FIELD", Particle::State::Velocity),
+      std::make_pair("INITIAL_ANGULAR_VELOCITY_FIELD", Particle::State::AngularVelocity),
+      std::make_pair("INITIAL_ACCELERATION_FIELD", Particle::State::Acceleration),
+      std::make_pair("INITIAL_ANGULAR_ACCELERATION_FIELD", Particle::State::AngularAcceleration)};
 
   // iterate over particle states
   for (auto& stateIt : initialfieldtostateenum)
@@ -64,7 +64,7 @@ void Particle::InitialFieldHandler::set_initial_fields()
   for (auto& stateIt : statetotypetofunctidmap_)
   {
     // get state of particles
-    Particle::StateEnum particleState = stateIt.first;
+    Particle::State particleState = stateIt.first;
 
     // iterate over particle types
     for (auto& initialFieldIt : stateIt.second)
@@ -92,11 +92,11 @@ void Particle::InitialFieldHandler::set_initial_fields()
           Global::Problem::instance()->function_by_id<Core::Utils::FunctionOfSpaceTime>(functid);
 
       // get pointer to particle states
-      const double* pos = container->get_ptr_to_state(Particle::Position, 0);
+      const double* pos = container->get_ptr_to_state(Particle::State::Position, 0);
       double* state = container->get_ptr_to_state_writable(particleState, 0);
 
       // get particle state dimensions
-      int posstatedim = container->get_state_dim(Particle::Position);
+      int posstatedim = container->get_state_dim(Particle::State::Position);
       int statedim = container->get_state_dim(particleState);
 
       // safety check

--- a/src/particle/src/algorithm/4C_particle_algorithm_initial_field.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_initial_field.cpp
@@ -74,7 +74,7 @@ void Particle::InitialFieldHandler::set_initial_fields()
 
       // get container of owned particles of current particle type
       Particle::ParticleContainer* container =
-          particlecontainerbundle->get_specific_container(particleType, Particle::Owned);
+          particlecontainerbundle->get_specific_container(particleType, Particle::Status::Owned);
 
       // get number of particles stored in container
       const int particlestored = container->particles_stored();

--- a/src/particle/src/algorithm/4C_particle_algorithm_initial_field.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_initial_field.cpp
@@ -39,7 +39,7 @@ Particle::InitialFieldHandler::InitialFieldHandler(const Teuchos::ParameterList&
   for (auto& stateIt : initialfieldtostateenum)
   {
     // get reference to sub-map
-    std::map<Particle::TypeEnum, int>& currentstatetypetofunctidmap =
+    std::map<Particle::Type, int>& currentstatetypetofunctidmap =
         statetotypetofunctidmap_[stateIt.second];
 
     // read parameters relating particle types to values
@@ -70,7 +70,7 @@ void Particle::InitialFieldHandler::set_initial_fields()
     for (auto& initialFieldIt : stateIt.second)
     {
       // get type of particles
-      Particle::TypeEnum particleType = initialFieldIt.first;
+      Particle::Type particleType = initialFieldIt.first;
 
       // get container of owned particles of current particle type
       Particle::ParticleContainer* container =

--- a/src/particle/src/algorithm/4C_particle_algorithm_initial_field.hpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_initial_field.hpp
@@ -68,7 +68,7 @@ namespace Particle
     std::shared_ptr<Particle::ParticleEngineInterface> particleengineinterface_;
 
     //! relating particle types to function ids
-    std::map<Particle::StateEnum, std::map<Particle::TypeEnum, int>> statetotypetofunctidmap_;
+    std::map<Particle::StateEnum, std::map<Particle::Type, int>> statetotypetofunctidmap_;
   };
 
 }  // namespace Particle

--- a/src/particle/src/algorithm/4C_particle_algorithm_initial_field.hpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_initial_field.hpp
@@ -68,7 +68,7 @@ namespace Particle
     std::shared_ptr<Particle::ParticleEngineInterface> particleengineinterface_;
 
     //! relating particle types to function ids
-    std::map<Particle::StateEnum, std::map<Particle::Type, int>> statetotypetofunctidmap_;
+    std::map<Particle::State, std::map<Particle::Type, int>> statetotypetofunctidmap_;
   };
 
 }  // namespace Particle

--- a/src/particle/src/algorithm/4C_particle_algorithm_input_generator.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_input_generator.cpp
@@ -37,10 +37,10 @@ void Particle::InputGenerator::add_generated_particle(const std::vector<double>&
 
   // allocate memory to hold particle states
   Particle::ParticleStates particlestates;
-  particlestates.assign((Particle::Position + 1), std::vector<double>(0));
+  particlestates.assign((static_cast<int>(Particle::State::Position) + 1), std::vector<double>(0));
 
   // set position state
-  particlestates[Particle::Position] = position;
+  particlestates[static_cast<int>(Particle::State::Position)] = position;
 
   // construct and store generated particle object
   particlesgenerated.emplace_back(

--- a/src/particle/src/algorithm/4C_particle_algorithm_input_generator.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_input_generator.cpp
@@ -28,7 +28,7 @@ void Particle::InputGenerator::generate_particles(
 }
 
 void Particle::InputGenerator::add_generated_particle(const std::vector<double>& position,
-    const Particle::TypeEnum particletype,
+    const Particle::Type particletype,
     std::vector<Particle::ParticleObjShrdPtr>& particlesgenerated) const
 {
   // safety check

--- a/src/particle/src/algorithm/4C_particle_algorithm_input_generator.hpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_input_generator.hpp
@@ -82,7 +82,7 @@ namespace Particle
      * \param[out] particlesgenerated particle objects generated
      */
     void add_generated_particle(const std::vector<double>& position,
-        const Particle::TypeEnum particletype,
+        const Particle::Type particletype,
         std::vector<Particle::ParticleObjShrdPtr>& particlesgenerated) const;
 
     //! processor id

--- a/src/particle/src/algorithm/4C_particle_algorithm_result_test.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_result_test.cpp
@@ -167,7 +167,7 @@ void Particle::ParticleResultTest::test_special(
       else if (quantity == "tempgradx" or quantity == "tempgrady" or quantity == "tempgradz")
       {
         // get enum of particle state
-        particleState = Particle::State::temperature_gradient;
+        particleState = Particle::State::TemperatureGradient;
 
         // get component of result
         if (quantity == "tempgradx")

--- a/src/particle/src/algorithm/4C_particle_algorithm_result_test.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_result_test.cpp
@@ -69,13 +69,13 @@ void Particle::ParticleResultTest::test_special(
       int dim = 0;
 
       // declare enum of particle state
-      Particle::StateEnum particleState;
+      Particle::State particleState;
 
       // position
       if (quantity == "posx" or quantity == "posy" or quantity == "posz")
       {
         // get enum of particle state
-        particleState = Particle::Position;
+        particleState = Particle::State::Position;
 
         // get component of result
         if (quantity == "posx")
@@ -89,7 +89,7 @@ void Particle::ParticleResultTest::test_special(
       else if (quantity == "velx" or quantity == "vely" or quantity == "velz")
       {
         // get enum of particle state
-        particleState = Particle::Velocity;
+        particleState = Particle::State::Velocity;
 
         // get component of result
         if (quantity == "velx")
@@ -103,7 +103,7 @@ void Particle::ParticleResultTest::test_special(
       else if (quantity == "accx" or quantity == "accy" or quantity == "accz")
       {
         // get enum of particle state
-        particleState = Particle::Acceleration;
+        particleState = Particle::State::Acceleration;
 
         // get component of result
         if (quantity == "accx")
@@ -117,7 +117,7 @@ void Particle::ParticleResultTest::test_special(
       else if (quantity == "angvelx" or quantity == "angvely" or quantity == "angvelz")
       {
         // get enum of particle state
-        particleState = Particle::AngularVelocity;
+        particleState = Particle::State::AngularVelocity;
 
         // get component of result
         if (quantity == "angvelx")
@@ -131,7 +131,7 @@ void Particle::ParticleResultTest::test_special(
       else if (quantity == "radius")
       {
         // get enum of particle state
-        particleState = Particle::Radius;
+        particleState = Particle::State::Radius;
 
         // get component of result
         dim = 0;
@@ -140,7 +140,7 @@ void Particle::ParticleResultTest::test_special(
       else if (quantity == "density")
       {
         // get enum of particle state
-        particleState = Particle::Density;
+        particleState = Particle::State::Density;
 
         // get component of result
         dim = 0;
@@ -149,7 +149,7 @@ void Particle::ParticleResultTest::test_special(
       else if (quantity == "pressure")
       {
         // get enum of particle state
-        particleState = Particle::Pressure;
+        particleState = Particle::State::Pressure;
 
         // get component of result
         dim = 0;
@@ -158,7 +158,7 @@ void Particle::ParticleResultTest::test_special(
       else if (quantity == "temperature")
       {
         // get enum of particle state
-        particleState = Particle::Temperature;
+        particleState = Particle::State::Temperature;
 
         // get component of result
         dim = 0;
@@ -167,7 +167,7 @@ void Particle::ParticleResultTest::test_special(
       else if (quantity == "tempgradx" or quantity == "tempgrady" or quantity == "tempgradz")
       {
         // get enum of particle state
-        particleState = Particle::temperature_gradient;
+        particleState = Particle::State::temperature_gradient;
 
         // get component of result
         if (quantity == "tempgradx")
@@ -181,7 +181,7 @@ void Particle::ParticleResultTest::test_special(
       else if (quantity == "pd_damage_phi")
       {
         // get enum of particle state
-        particleState = Particle::PDDamageVariable;
+        particleState = Particle::State::PDDamageVariable;
 
         // get component of result
         dim = 0;

--- a/src/particle/src/algorithm/4C_particle_algorithm_result_test.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_result_test.cpp
@@ -44,12 +44,12 @@ void Particle::ParticleResultTest::test_special(
   {
     // access values of local index tuple
     Particle::TypeEnum particleType;
-    Particle::StatusEnum particleStatus;
+    Particle::Status particleStatus;
     int index;
     std::tie(particleType, particleStatus, index) = *localindextuple;
 
     // consider only owned particle
-    if (particleStatus == Particle::Owned)
+    if (particleStatus == Particle::Status::Owned)
     {
       // get particle container bundle
       Particle::ParticleContainerBundleShrdPtr particlecontainerbundle =
@@ -57,7 +57,7 @@ void Particle::ParticleResultTest::test_special(
 
       // get container of owned particles of current particle type
       Particle::ParticleContainer* container =
-          particlecontainerbundle->get_specific_container(particleType, Particle::Owned);
+          particlecontainerbundle->get_specific_container(particleType, Particle::Status::Owned);
 
       // get result
       std::string quantity = result_container.get<std::string>("QUANTITY");

--- a/src/particle/src/algorithm/4C_particle_algorithm_result_test.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_result_test.cpp
@@ -43,7 +43,7 @@ void Particle::ParticleResultTest::test_special(
   if (localindextuple)
   {
     // access values of local index tuple
-    Particle::TypeEnum particleType;
+    Particle::Type particleType;
     Particle::Status particleStatus;
     int index;
     std::tie(particleType, particleStatus, index) = *localindextuple;

--- a/src/particle/src/algorithm/4C_particle_algorithm_temperature_bc.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_temperature_bc.cpp
@@ -45,7 +45,7 @@ void Particle::TemperatureBoundaryConditionHandler::setup(
 }
 
 void Particle::TemperatureBoundaryConditionHandler::insert_particle_states_of_particle_types(
-    std::map<Particle::TypeEnum, std::set<Particle::StateEnum>>& particlestatestotypes) const
+    std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const
 {
   // iterate over particle types subjected to temperature boundary conditions
   for (auto& particleType : typessubjectedtotemperaturebc_)
@@ -84,7 +84,7 @@ void Particle::TemperatureBoundaryConditionHandler::evaluate_temperature_boundar
   for (auto& typeIt : temperaturebctypetofunctid_)
   {
     // get type of particles
-    Particle::TypeEnum particleType = typeIt.first;
+    Particle::Type particleType = typeIt.first;
 
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container =

--- a/src/particle/src/algorithm/4C_particle_algorithm_temperature_bc.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_temperature_bc.cpp
@@ -66,7 +66,7 @@ void Particle::TemperatureBoundaryConditionHandler::set_particle_reference_posit
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container =
-        particlecontainerbundle->get_specific_container(particleType, Particle::Owned);
+        particlecontainerbundle->get_specific_container(particleType, Particle::Status::Owned);
 
     // set particle reference position
     container->update_state(0.0, Particle::ReferencePosition, 1.0, Particle::Position);
@@ -88,7 +88,7 @@ void Particle::TemperatureBoundaryConditionHandler::evaluate_temperature_boundar
 
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container =
-        particlecontainerbundle->get_specific_container(particleType, Particle::Owned);
+        particlecontainerbundle->get_specific_container(particleType, Particle::Status::Owned);
 
     // get number of particles stored in container
     const int particlestored = container->particles_stored();

--- a/src/particle/src/algorithm/4C_particle_algorithm_temperature_bc.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_temperature_bc.cpp
@@ -45,13 +45,13 @@ void Particle::TemperatureBoundaryConditionHandler::setup(
 }
 
 void Particle::TemperatureBoundaryConditionHandler::insert_particle_states_of_particle_types(
-    std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const
+    std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes) const
 {
   // iterate over particle types subjected to temperature boundary conditions
   for (auto& particleType : typessubjectedtotemperaturebc_)
   {
     // insert states for types subjected to temperature boundary conditions
-    particlestatestotypes[particleType].insert(Particle::ReferencePosition);
+    particlestatestotypes[particleType].insert(Particle::State::ReferencePosition);
   }
 }
 
@@ -69,7 +69,8 @@ void Particle::TemperatureBoundaryConditionHandler::set_particle_reference_posit
         particlecontainerbundle->get_specific_container(particleType, Particle::Status::Owned);
 
     // set particle reference position
-    container->update_state(0.0, Particle::ReferencePosition, 1.0, Particle::Position);
+    container->update_state(
+        0.0, Particle::State::ReferencePosition, 1.0, Particle::State::Position);
   }
 }
 
@@ -104,11 +105,11 @@ void Particle::TemperatureBoundaryConditionHandler::evaluate_temperature_boundar
         Global::Problem::instance()->function_by_id<Core::Utils::FunctionOfSpaceTime>(functid);
 
     // get pointer to particle states
-    const double* refpos = container->get_ptr_to_state(Particle::ReferencePosition, 0);
-    double* temp = container->get_ptr_to_state_writable(Particle::Temperature, 0);
+    const double* refpos = container->get_ptr_to_state(Particle::State::ReferencePosition, 0);
+    double* temp = container->get_ptr_to_state_writable(Particle::State::Temperature, 0);
 
     // get particle state dimension
-    int statedim = container->get_state_dim(Particle::Position);
+    int statedim = container->get_state_dim(Particle::State::Position);
 
     // safety check
     if (function.number_components() != 1)

--- a/src/particle/src/algorithm/4C_particle_algorithm_temperature_bc.hpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_temperature_bc.hpp
@@ -60,7 +60,7 @@ namespace Particle
      *
      * \return set of particle types subjected to temperature boundary conditions
      */
-    const std::set<Particle::TypeEnum>& get_particle_types_subjected_to_temperature_bc_set() const
+    const std::set<Particle::Type>& get_particle_types_subjected_to_temperature_bc_set() const
     {
       return typessubjectedtotemperaturebc_;
     };
@@ -72,7 +72,7 @@ namespace Particle
      * \param[out] particlestatestotypes map of particle types and corresponding states
      */
     void insert_particle_states_of_particle_types(
-        std::map<Particle::TypeEnum, std::set<Particle::StateEnum>>& particlestatestotypes) const;
+        std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const;
 
     /*!
      * \brief set particle reference position
@@ -96,10 +96,10 @@ namespace Particle
     std::shared_ptr<Particle::ParticleEngineInterface> particleengineinterface_;
 
     //! relating particle types to function ids of temperature boundary conditions
-    std::map<Particle::TypeEnum, int> temperaturebctypetofunctid_;
+    std::map<Particle::Type, int> temperaturebctypetofunctid_;
 
     //! set of particle types subjected to temperature boundary conditions
-    std::set<Particle::TypeEnum> typessubjectedtotemperaturebc_;
+    std::set<Particle::Type> typessubjectedtotemperaturebc_;
   };
 
 }  // namespace Particle

--- a/src/particle/src/algorithm/4C_particle_algorithm_temperature_bc.hpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_temperature_bc.hpp
@@ -72,7 +72,7 @@ namespace Particle
      * \param[out] particlestatestotypes map of particle types and corresponding states
      */
     void insert_particle_states_of_particle_types(
-        std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const;
+        std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes) const;
 
     /*!
      * \brief set particle reference position

--- a/src/particle/src/algorithm/4C_particle_algorithm_timint.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_timint.cpp
@@ -60,25 +60,26 @@ void Particle::TimInt::setup(
       particleengineinterface_->get_particle_container_bundle();
 
   // set of particle types being excluded from time integration
-  std::set<Particle::TypeEnum> typesexludedfromtimeintegration;
+  std::set<Particle::Type> typesexludedfromtimeintegration;
 
   // boundary and rigid particles are not integrated in time
-  typesexludedfromtimeintegration.insert({Particle::BoundaryPhase, Particle::RigidPhase});
+  typesexludedfromtimeintegration.insert(
+      {Particle::Type::BoundaryPhase, Particle::Type::RigidPhase});
 
   if (dirichletboundarycondition_)
   {
     // get reference to set of particle types subjected to dirichlet boundary conditions
-    const std::set<Particle::TypeEnum>& typessubjectedtodirichletbc =
+    const std::set<Particle::Type>& typessubjectedtodirichletbc =
         dirichletboundarycondition_->get_particle_types_subjected_to_dirichlet_bc_set();
 
     // particles subjected to dirichlet boundary conditions are not integrated in time
-    for (Particle::TypeEnum currtype : typessubjectedtodirichletbc)
+    for (Particle::Type currtype : typessubjectedtodirichletbc)
       typesexludedfromtimeintegration.insert(currtype);
   }
 
   // determine set of particle types to be integrated in time
-  for (auto& typeEnum : particlecontainerbundle->get_particle_types())
-    if (not typesexludedfromtimeintegration.contains(typeEnum)) typestointegrate_.insert(typeEnum);
+  for (auto& type : particlecontainerbundle->get_particle_types())
+    if (not typesexludedfromtimeintegration.contains(type)) typestointegrate_.insert(type);
 
   // set constraints handler
   constraints_ = constraints;
@@ -90,7 +91,7 @@ void Particle::TimInt::build_dirichlet_bc_funct_cache(MPI_Comm comm)
 }
 
 void Particle::TimInt::insert_particle_states_of_particle_types(
-    std::map<Particle::TypeEnum, std::set<Particle::StateEnum>>& particlestatestotypes) const
+    std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const
 {
   // insert dbc dependent states of all particle types
   if (dirichletboundarycondition_)
@@ -145,7 +146,7 @@ void Particle::TimInt::init_temperature_boundary_condition()
       std::make_unique<Particle::TemperatureBoundaryConditionHandler>(params_);
 
   // get reference to set of particle types subjected to temperature boundary conditions
-  const std::set<Particle::TypeEnum>& typessubjectedtotempbc =
+  const std::set<Particle::Type>& typessubjectedtotempbc =
       temperatureboundarycondition_->get_particle_types_subjected_to_temperature_bc_set();
 
   // no particle types are subjected to temperature boundary conditions

--- a/src/particle/src/algorithm/4C_particle_algorithm_timint.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_timint.cpp
@@ -91,7 +91,7 @@ void Particle::TimInt::build_dirichlet_bc_funct_cache(MPI_Comm comm)
 }
 
 void Particle::TimInt::insert_particle_states_of_particle_types(
-    std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const
+    std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes) const
 {
   // insert dbc dependent states of all particle types
   if (dirichletboundarycondition_)
@@ -206,10 +206,10 @@ void Particle::TimInt::add_initial_random_noise_to_position()
     if (particlestored <= 0) continue;
 
     // get pointer to particle state
-    double* pos = container->get_ptr_to_state_writable(Particle::Position, 0);
+    double* pos = container->get_ptr_to_state_writable(Particle::State::Position, 0);
 
     // get particle state dimension
-    int statedim = container->get_state_dim(Particle::Position);
+    int statedim = container->get_state_dim(Particle::State::Position);
 
     // iterate over owned particles of current type
     for (int i = 0; i < particlestored; ++i)
@@ -253,8 +253,8 @@ void Particle::TimIntSemiImplicitEuler::setup(
         particlecontainerbundle->get_specific_container(particleType, Particle::Status::Owned);
 
     // safety check
-    if (container->have_stored_state(Particle::ModifiedVelocity) or
-        container->have_stored_state(Particle::ModifiedAcceleration))
+    if (container->have_stored_state(Particle::State::ModifiedVelocity) or
+        container->have_stored_state(Particle::State::ModifiedAcceleration))
       FOUR_C_THROW(
           "modified velocity and acceleration states not implemented yet for semi-implicit Euler "
           "time integration scheme!");
@@ -283,24 +283,25 @@ void Particle::TimIntSemiImplicitEuler::pre_interaction_routine()
         particlecontainerbundle->get_specific_container(particleType, Particle::Status::Owned);
 
     // update velocity of all particles
-    container->update_state(1.0, Particle::Velocity, dt_, Particle::Acceleration);
+    container->update_state(1.0, Particle::State::Velocity, dt_, Particle::State::Acceleration);
 
     // clear acceleration of all particles
-    container->clear_state(Particle::Acceleration);
+    container->clear_state(Particle::State::Acceleration);
 
     // angular velocity and acceleration states
-    if (container->have_stored_state(Particle::AngularVelocity) and
-        container->have_stored_state(Particle::AngularAcceleration))
+    if (container->have_stored_state(Particle::State::AngularVelocity) and
+        container->have_stored_state(Particle::State::AngularAcceleration))
     {
       // update angular velocity of all particles
-      container->update_state(1.0, Particle::AngularVelocity, dt_, Particle::AngularAcceleration);
+      container->update_state(
+          1.0, Particle::State::AngularVelocity, dt_, Particle::State::AngularAcceleration);
 
       // clear angular acceleration of all particles
-      container->clear_state(Particle::AngularAcceleration);
+      container->clear_state(Particle::State::AngularAcceleration);
     }
 
     // update position of all particles
-    container->update_state(1.0, Particle::Position, dt_, Particle::Velocity);
+    container->update_state(1.0, Particle::State::Position, dt_, Particle::State::Velocity);
   }
 
   if (particlerigidbodyinterface_)
@@ -352,10 +353,11 @@ void Particle::TimIntVelocityVerlet::set_initial_states()
         particlecontainerbundle->get_specific_container(particleType, Particle::Status::Owned);
 
     // modified velocity states
-    if (container->have_stored_state(Particle::ModifiedVelocity))
+    if (container->have_stored_state(Particle::State::ModifiedVelocity))
     {
       // update modified velocity of all particles
-      container->update_state(0.0, Particle::ModifiedVelocity, 1.0, Particle::Velocity);
+      container->update_state(
+          0.0, Particle::State::ModifiedVelocity, 1.0, Particle::State::Velocity);
     }
   }
 }
@@ -379,42 +381,44 @@ void Particle::TimIntVelocityVerlet::pre_interaction_routine()
         particlecontainerbundle->get_specific_container(particleType, Particle::Status::Owned);
 
     // update velocity of all particles
-    container->update_state(1.0, Particle::Velocity, dthalf_, Particle::Acceleration);
+    container->update_state(1.0, Particle::State::Velocity, dthalf_, Particle::State::Acceleration);
 
     // clear acceleration of all particles
-    container->clear_state(Particle::Acceleration);
+    container->clear_state(Particle::State::Acceleration);
 
     // angular velocity and acceleration states
-    if (container->have_stored_state(Particle::AngularVelocity) and
-        container->have_stored_state(Particle::AngularAcceleration))
+    if (container->have_stored_state(Particle::State::AngularVelocity) and
+        container->have_stored_state(Particle::State::AngularAcceleration))
     {
       // update angular velocity of all particles
       container->update_state(
-          1.0, Particle::AngularVelocity, dthalf_, Particle::AngularAcceleration);
+          1.0, Particle::State::AngularVelocity, dthalf_, Particle::State::AngularAcceleration);
 
       // clear angular acceleration of all particles
-      container->clear_state(Particle::AngularAcceleration);
+      container->clear_state(Particle::State::AngularAcceleration);
     }
 
     // modified velocity and acceleration states
-    if (container->have_stored_state(Particle::ModifiedVelocity) and
-        container->have_stored_state(Particle::ModifiedAcceleration))
+    if (container->have_stored_state(Particle::State::ModifiedVelocity) and
+        container->have_stored_state(Particle::State::ModifiedAcceleration))
     {
       // update modified velocity of all particles
-      container->update_state(0.0, Particle::ModifiedVelocity, 1.0, Particle::Velocity);
       container->update_state(
-          1.0, Particle::ModifiedVelocity, dthalf_, Particle::ModifiedAcceleration);
+          0.0, Particle::State::ModifiedVelocity, 1.0, Particle::State::Velocity);
+      container->update_state(
+          1.0, Particle::State::ModifiedVelocity, dthalf_, Particle::State::ModifiedAcceleration);
 
       // clear modified acceleration of all particles
-      container->clear_state(Particle::ModifiedAcceleration);
+      container->clear_state(Particle::State::ModifiedAcceleration);
 
       // update position of all particles
-      container->update_state(1.0, Particle::Position, dt_, Particle::ModifiedVelocity);
+      container->update_state(
+          1.0, Particle::State::Position, dt_, Particle::State::ModifiedVelocity);
     }
     else
     {
       // update position of all particles
-      container->update_state(1.0, Particle::Position, dt_, Particle::Velocity);
+      container->update_state(1.0, Particle::State::Position, dt_, Particle::State::Velocity);
     }
   }
 
@@ -459,15 +463,15 @@ void Particle::TimIntVelocityVerlet::post_interaction_routine()
         particlecontainerbundle->get_specific_container(particleType, Particle::Status::Owned);
 
     // update velocity of all particles
-    container->update_state(1.0, Particle::Velocity, dthalf_, Particle::Acceleration);
+    container->update_state(1.0, Particle::State::Velocity, dthalf_, Particle::State::Acceleration);
 
     // angular velocity and acceleration states
-    if (container->have_stored_state(Particle::AngularVelocity) and
-        container->have_stored_state(Particle::AngularAcceleration))
+    if (container->have_stored_state(Particle::State::AngularVelocity) and
+        container->have_stored_state(Particle::State::AngularAcceleration))
     {
       // update angular velocity of all particles
       container->update_state(
-          1.0, Particle::AngularVelocity, dthalf_, Particle::AngularAcceleration);
+          1.0, Particle::State::AngularVelocity, dthalf_, Particle::State::AngularAcceleration);
     }
   }
 

--- a/src/particle/src/algorithm/4C_particle_algorithm_timint.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_timint.cpp
@@ -196,7 +196,7 @@ void Particle::TimInt::add_initial_random_noise_to_position()
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container =
-        particlecontainerbundle->get_specific_container(particleType, Particle::Owned);
+        particlecontainerbundle->get_specific_container(particleType, Particle::Status::Owned);
 
     // get number of particles stored in container
     const int particlestored = container->particles_stored();
@@ -249,7 +249,7 @@ void Particle::TimIntSemiImplicitEuler::setup(
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container =
-        particlecontainerbundle->get_specific_container(particleType, Particle::Owned);
+        particlecontainerbundle->get_specific_container(particleType, Particle::Status::Owned);
 
     // safety check
     if (container->have_stored_state(Particle::ModifiedVelocity) or
@@ -279,7 +279,7 @@ void Particle::TimIntSemiImplicitEuler::pre_interaction_routine()
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container =
-        particlecontainerbundle->get_specific_container(particleType, Particle::Owned);
+        particlecontainerbundle->get_specific_container(particleType, Particle::Status::Owned);
 
     // update velocity of all particles
     container->update_state(1.0, Particle::Velocity, dt_, Particle::Acceleration);
@@ -348,7 +348,7 @@ void Particle::TimIntVelocityVerlet::set_initial_states()
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container =
-        particlecontainerbundle->get_specific_container(particleType, Particle::Owned);
+        particlecontainerbundle->get_specific_container(particleType, Particle::Status::Owned);
 
     // modified velocity states
     if (container->have_stored_state(Particle::ModifiedVelocity))
@@ -375,7 +375,7 @@ void Particle::TimIntVelocityVerlet::pre_interaction_routine()
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container =
-        particlecontainerbundle->get_specific_container(particleType, Particle::Owned);
+        particlecontainerbundle->get_specific_container(particleType, Particle::Status::Owned);
 
     // update velocity of all particles
     container->update_state(1.0, Particle::Velocity, dthalf_, Particle::Acceleration);
@@ -455,7 +455,7 @@ void Particle::TimIntVelocityVerlet::post_interaction_routine()
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container =
-        particlecontainerbundle->get_specific_container(particleType, Particle::Owned);
+        particlecontainerbundle->get_specific_container(particleType, Particle::Status::Owned);
 
     // update velocity of all particles
     container->update_state(1.0, Particle::Velocity, dthalf_, Particle::Acceleration);

--- a/src/particle/src/algorithm/4C_particle_algorithm_timint.hpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_timint.hpp
@@ -85,7 +85,7 @@ namespace Particle
      * \param[out] particlestatestotypes map of particle types and corresponding states
      */
     void insert_particle_states_of_particle_types(
-        std::map<Particle::TypeEnum, std::set<Particle::StateEnum>>& particlestatestotypes) const;
+        std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const;
 
     /*!
      * \brief time integration scheme specific initialization routine
@@ -152,7 +152,7 @@ namespace Particle
     std::shared_ptr<Particle::ConstraintsHandler> constraints_;
 
     //! set of particle types to integrate in time
-    std::set<Particle::TypeEnum> typestointegrate_;
+    std::set<Particle::Type> typestointegrate_;
 
     //! current time
     double time_;

--- a/src/particle/src/algorithm/4C_particle_algorithm_timint.hpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_timint.hpp
@@ -85,7 +85,7 @@ namespace Particle
      * \param[out] particlestatestotypes map of particle types and corresponding states
      */
     void insert_particle_states_of_particle_types(
-        std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const;
+        std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes) const;
 
     /*!
      * \brief time integration scheme specific initialization routine

--- a/src/particle/src/algorithm/4C_particle_algorithm_utils.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_utils.cpp
@@ -19,7 +19,7 @@ FOUR_C_NAMESPACE_OPEN
 template <typename Valtype>
 void Particle::ParticleUtils::read_params_types_related_to_values(
     const Teuchos::ParameterList& params, const std::string& name,
-    std::map<Particle::TypeEnum, Valtype>& typetovalmap)
+    std::map<Particle::Type, Valtype>& typetovalmap)
 {
   // read from input file
   std::vector<std::string> typetoval;
@@ -43,7 +43,7 @@ void Particle::ParticleUtils::read_params_types_related_to_values(
     valstring = typetoval[2 * i + 1];
 
     // get enum of particle types
-    Particle::TypeEnum particleType = Particle::enum_from_type_name(typestring);
+    Particle::Type particleType = Particle::enum_from_type_name(typestring);
 
     // get numeric value
     Valtype val;
@@ -73,10 +73,10 @@ void Particle::ParticleUtils::read_params_types_related_to_values(
  *---------------------------------------------------------------------------*/
 template void Particle::ParticleUtils::read_params_types_related_to_values<int>(
     const Teuchos::ParameterList& params, const std::string& name,
-    std::map<Particle::TypeEnum, int>& typetovalmap);
+    std::map<Particle::Type, int>& typetovalmap);
 
 template void Particle::ParticleUtils::read_params_types_related_to_values<double>(
     const Teuchos::ParameterList& params, const std::string& name,
-    std::map<Particle::TypeEnum, double>& typetovalmap);
+    std::map<Particle::Type, double>& typetovalmap);
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/particle/src/algorithm/4C_particle_algorithm_utils.hpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_utils.hpp
@@ -33,7 +33,7 @@ namespace Particle::ParticleUtils
    */
   template <typename Valtype>
   void read_params_types_related_to_values(const Teuchos::ParameterList& params,
-      const std::string& name, std::map<Particle::TypeEnum, Valtype>& typetovalmap);
+      const std::string& name, std::map<Particle::Type, Valtype>& typetovalmap);
 
 }  // namespace Particle::ParticleUtils
 

--- a/src/particle/src/algorithm/4C_particle_algorithm_viscous_damping.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_viscous_damping.cpp
@@ -47,7 +47,8 @@ void Particle::ViscousDampingHandler::apply_viscous_damping()
         particlecontainerbundle->get_specific_container(type, Particle::Status::Owned);
 
     // apply viscous damping contribution
-    container->update_state(1.0, Particle::Acceleration, -viscdampfac_, Particle::Velocity);
+    container->update_state(
+        1.0, Particle::State::Acceleration, -viscdampfac_, Particle::State::Velocity);
   }
 }
 

--- a/src/particle/src/algorithm/4C_particle_algorithm_viscous_damping.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_viscous_damping.cpp
@@ -44,7 +44,7 @@ void Particle::ViscousDampingHandler::apply_viscous_damping()
 
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container =
-        particlecontainerbundle->get_specific_container(type, Particle::Owned);
+        particlecontainerbundle->get_specific_container(type, Particle::Status::Owned);
 
     // apply viscous damping contribution
     container->update_state(1.0, Particle::Acceleration, -viscdampfac_, Particle::Velocity);

--- a/src/particle/src/algorithm/4C_particle_algorithm_viscous_damping.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_viscous_damping.cpp
@@ -40,7 +40,7 @@ void Particle::ViscousDampingHandler::apply_viscous_damping()
   for (const auto& type : particlecontainerbundle->get_particle_types())
   {
     // no viscous damping contribution for boundary or rigid particles
-    if (type == Particle::BoundaryPhase or type == Particle::RigidPhase) continue;
+    if (type == Particle::Type::BoundaryPhase or type == Particle::Type::RigidPhase) continue;
 
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container =

--- a/src/particle/src/engine/4C_particle_engine.cpp
+++ b/src/particle/src/engine/4C_particle_engine.cpp
@@ -197,7 +197,7 @@ void Particle::ParticleEngine::erase_particles_outside_bounding_box(
     const ParticleStates& states = particlestocheck[i]->return_particle_states();
 
     // get position of particle
-    const std::vector<double>& pos = states[Position];
+    const std::vector<double>& pos = states[static_cast<int>(State::Position)];
 
 #ifdef FOUR_C_ENABLE_ASSERTIONS
     // get type of particles
@@ -207,8 +207,9 @@ void Particle::ParticleEngine::erase_particles_outside_bounding_box(
     ParticleContainer* container =
         particlecontainerbundle_->get_specific_container(type, Status::Owned);
 
-    if (static_cast<int>(pos.size()) != container->get_state_dim(Position))
-      FOUR_C_THROW("dimension of particle state '{}' not valid!", enum_to_state_name(Position));
+    if (static_cast<int>(pos.size()) != container->get_state_dim(State::Position))
+      FOUR_C_THROW(
+          "dimension of particle state '{}' not valid!", enum_to_state_name(State::Position));
 #endif
 
     // check particle location with respect to bounding box in each spatial directions
@@ -508,7 +509,7 @@ void Particle::ParticleEngine::build_particle_to_particle_neighbors()
       const int* currglobalid = container->get_ptr_to_global_id(ownedindex);
 
       // get position of particle
-      const double* currpos = container->get_ptr_to_state(Position, ownedindex);
+      const double* currpos = container->get_ptr_to_state(State::Position, ownedindex);
 
       // iterate over neighboring bins (including current bin)
       for (int gidofneighborbin : binning_->halfneighboringbinstobins_[rowlidofbin])
@@ -543,7 +544,8 @@ void Particle::ParticleEngine::build_particle_to_particle_neighbors()
           if (gidofbin == gidofneighborbin and neighborglobalid[0] <= currglobalid[0]) continue;
 
           // get position of neighboring particle
-          const double* neighborpos = neighborcontainer->get_ptr_to_state(Position, neighborindex);
+          const double* neighborpos =
+              neighborcontainer->get_ptr_to_state(State::Position, neighborindex);
 
           // distance vector from owned particle to neighboring particle
           double dist[3];
@@ -779,7 +781,8 @@ void Particle::ParticleEngine::get_particles_within_radius(const double* positio
           particlecontainerbundle_->get_specific_container(neighbortype, neighborstatus);
 
       // get position of neighboring particle
-      const double* neighborpos = neighborcontainer->get_ptr_to_state(Position, neighborindex);
+      const double* neighborpos =
+          neighborcontainer->get_ptr_to_state(State::Position, neighborindex);
 
       // distance vector from position to neighboring particle
       double dist[3];
@@ -1286,7 +1289,7 @@ void Particle::ParticleEngine::check_particles_at_boundaries(
           particlecontainerbundle_->get_specific_container(type, Status::Owned);
 
       // get position of particle
-      const double* currpos = container->get_ptr_to_state(Position, ownedindex);
+      const double* currpos = container->get_ptr_to_state(State::Position, ownedindex);
 
       // get global id of bin
       const int gidofbin = binning_->binstrategy_->convert_pos_to_gid(currpos);
@@ -1316,7 +1319,7 @@ void Particle::ParticleEngine::check_particles_at_boundaries(
 
       // check for periodic boundary in each spatial directions
       {
-        double* currpos = container->get_ptr_to_state_writable(Position, ownedindex);
+        double* currpos = container->get_ptr_to_state_writable(State::Position, ownedindex);
 
         for (int dim = 0; dim < 3; ++dim)
         {
@@ -1366,7 +1369,7 @@ void Particle::ParticleEngine::determine_particles_to_be_distributed(
     const ParticleStates& states = particlestodistribute[i]->return_particle_states();
 
     // get position of particle
-    const std::vector<double>& pos = states[Position];
+    const std::vector<double>& pos = states[static_cast<int>(State::Position)];
 
 #ifdef FOUR_C_ENABLE_ASSERTIONS
     // get type of particles
@@ -1376,8 +1379,9 @@ void Particle::ParticleEngine::determine_particles_to_be_distributed(
     ParticleContainer* container =
         particlecontainerbundle_->get_specific_container(type, Status::Owned);
 
-    if (static_cast<int>(pos.size()) != container->get_state_dim(Position))
-      FOUR_C_THROW("dimension of particle state '{}' not valid!", enum_to_state_name(Position));
+    if (static_cast<int>(pos.size()) != container->get_state_dim(State::Position))
+      FOUR_C_THROW(
+          "dimension of particle state '{}' not valid!", enum_to_state_name(State::Position));
 #endif
 
     // get global id of bin
@@ -1492,7 +1496,7 @@ void Particle::ParticleEngine::determine_particles_to_be_transferred(
           particlecontainerbundle_->get_specific_container(type, Status::Owned);
 
       // get position of particle
-      const double* currpos = container->get_ptr_to_state(Position, ownedindex);
+      const double* currpos = container->get_ptr_to_state(State::Position, ownedindex);
 
       // get global id of bin
       const int gidofbin = binning_->binstrategy_->convert_pos_to_gid(currpos);
@@ -1673,7 +1677,7 @@ Particle::ParticleEngine::pack_specific_states_of_particles_to_be_refreshed(
         const double* state_ptr = container->get_ptr_to_state(state, ownedindex);
 
         // fill particle state
-        states[state].assign(state_ptr, state_ptr + statedim);
+        states[static_cast<int>(state)].assign(state_ptr, state_ptr + statedim);
       }
 
       pack_states_and_append_to_send_buffers(type, indexIt.second, states, sdata);
@@ -1860,7 +1864,7 @@ void Particle::ParticleEngine::insert_owned_particles(
       if (gidofbin < 0)
       {
         // get position of particle
-        const std::vector<double>& pos = states[Position];
+        const std::vector<double>& pos = states[static_cast<int>(State::Position)];
 
         // get type of particles
         ParticleType type = particleobject->return_particle_type();
@@ -1869,8 +1873,9 @@ void Particle::ParticleEngine::insert_owned_particles(
         ParticleContainer* container =
             particlecontainerbundle_->get_specific_container(type, Status::Owned);
 
-        if (static_cast<int>(pos.size()) != container->get_state_dim(Position))
-          FOUR_C_THROW("dimension of particle state '{}' not valid!", enum_to_state_name(Position));
+        if (static_cast<int>(pos.size()) != container->get_state_dim(State::Position))
+          FOUR_C_THROW(
+              "dimension of particle state '{}' not valid!", enum_to_state_name(State::Position));
 
         // get global id of bin
         gidofbin = binning_->binstrategy_->convert_pos_to_gid(pos.data());
@@ -1999,11 +2004,11 @@ void Particle::ParticleEngine::store_positions_after_particle_transfer()
     if (particlestored == 0) continue;
 
     // get pointer to particle states
-    const double* pos = container->get_ptr_to_state(Position, 0);
-    double* lasttransferpos = container->get_ptr_to_state_writable(LastTransferPosition, 0);
+    const double* pos = container->get_ptr_to_state(State::Position, 0);
+    double* lasttransferpos = container->get_ptr_to_state_writable(State::LastTransferPosition, 0);
 
     // get particle state dimension
-    int statedim = container->get_state_dim(Position);
+    int statedim = container->get_state_dim(State::Position);
 
     // copy particle position data
     for (int i = 0; i < (statedim * particlestored); ++i) lasttransferpos[i] = pos[i];
@@ -2033,10 +2038,10 @@ void Particle::ParticleEngine::relate_owned_particles_to_bins()
     if (particlestored <= 0) continue;
 
     // get pointer to position of particle after last transfer
-    const double* lasttransferpos = container->get_ptr_to_state(LastTransferPosition, 0);
+    const double* lasttransferpos = container->get_ptr_to_state(State::LastTransferPosition, 0);
 
     // get particle state dimension
-    int statedim = container->get_state_dim(Position);
+    int statedim = container->get_state_dim(State::Position);
 
     // loop over particles in container
     for (int index = 0; index < particlestored; ++index)

--- a/src/particle/src/engine/4C_particle_engine.cpp
+++ b/src/particle/src/engine/4C_particle_engine.cpp
@@ -1018,7 +1018,7 @@ void Particle::ParticleEngine::setup_data_storage(
     const std::map<ParticleType, std::set<ParticleState>>& particlestatestotypes)
 {
   // determine size of vectors indexed by particle types
-  typevectorsize_ = ((--particlestatestotypes.end())->first) + 1;
+  typevectorsize_ = static_cast<int>((--particlestatestotypes.end())->first) + 1;
 
   // allocate memory to hold particle types
   directghostingtargets_.resize(typevectorsize_);
@@ -1057,7 +1057,8 @@ void Particle::ParticleEngine::setup_type_weights()
       params_, "PHASE_TO_DYNLOADBALFAC", typetodynloadbal);
 
   // insert weight of particle type
-  for (const auto& typeIt : typetodynloadbal) typeweights_[typeIt.first] = typeIt.second;
+  for (const auto& typeIt : typetodynloadbal)
+    typeweights_[static_cast<int>(typeIt.first)] = typeIt.second;
 }
 
 void Particle::ParticleEngine::determine_bin_dis_dependent_maps_and_sets()
@@ -1293,7 +1294,7 @@ void Particle::ParticleEngine::check_particles_at_boundaries(
       // particle left computational domain
       if (gidofbin == -1)
       {
-        (particlestoremove[type]).insert(ownedindex);
+        (particlestoremove[static_cast<int>(type)]).insert(ownedindex);
 
         // get global id of particle
         const int* currglobalid = container->get_ptr_to_global_id(ownedindex);
@@ -1434,7 +1435,8 @@ void Particle::ParticleEngine::determine_particles_to_be_distributed(
     }
     // particle is owned by this processor
     else if (myrank_ == ownerofparticle)
-      particlestokeep[type].push_back(std::make_pair(ownerofparticle, particlestodistribute[i]));
+      particlestokeep[static_cast<int>(type)].push_back(
+          std::make_pair(ownerofparticle, particlestodistribute[i]));
     // particle is owned by another processor
     else
     {
@@ -1499,7 +1501,7 @@ void Particle::ParticleEngine::determine_particles_to_be_transferred(
       if (gidofbin == -1)
       {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-        if (not particlestoremove[type].contains(ownedindex))
+        if (not particlestoremove[static_cast<int>(type)].contains(ownedindex))
           FOUR_C_THROW(
               "on processor {} a particle left the computational domain without being detected!",
               myrank_);
@@ -1525,7 +1527,7 @@ void Particle::ParticleEngine::determine_particles_to_be_transferred(
           std::make_shared<ParticleObject>(type, globalid, states, gidofbin));
 
       // store index of particle to be removed from containers after particle transfer
-      (particlestoremove[type]).insert(ownedindex);
+      (particlestoremove[static_cast<int>(type)]).insert(ownedindex);
 
       // append global id of particle to be send
       communicatedparticletargets_[sendtoproc].emplace_back(globalid);
@@ -1590,14 +1592,14 @@ std::map<int, std::vector<char>> Particle::ParticleEngine::pack_particles_to_be_
   for (const auto& type : particlecontainerbundle_->get_particle_types())
   {
     // check for particles of current type to be sent
-    if (directghostingtargets_[type].empty()) continue;
+    if (directghostingtargets_[static_cast<int>(type)].empty()) continue;
 
     // get container of owned particles of current particle type
     ParticleContainer* container =
         particlecontainerbundle_->get_specific_container(type, Status::Owned);
 
     // iterate over owned particles of current type
-    for (const auto& indexIt : directghostingtargets_[type])
+    for (const auto& indexIt : directghostingtargets_[static_cast<int>(type)])
     {
       int ownedindex = indexIt.first;
 
@@ -1642,17 +1644,18 @@ Particle::ParticleEngine::pack_specific_states_of_particles_to_be_refreshed(
     ParticleType type = typeIt.first;
 
     // check for particles of current type to be sent
-    if (directghostingtargets_[type].empty()) continue;
+    if (directghostingtargets_[static_cast<int>(type)].empty()) continue;
 
     // determine necessary size of vector for states
-    int statesvectorsize = *std::max_element(typeIt.second.begin(), typeIt.second.end()) + 1;
+    int statesvectorsize =
+        static_cast<int>(*std::max_element(typeIt.second.begin(), typeIt.second.end())) + 1;
 
     // get container of owned particles of current particle type
     ParticleContainer* container =
         particlecontainerbundle_->get_specific_container(type, Status::Owned);
 
     // iterate over owned particles of current type
-    for (const auto& indexIt : directghostingtargets_[type])
+    for (const auto& indexIt : directghostingtargets_[static_cast<int>(type)])
     {
       int ownedindex = indexIt.first;
 
@@ -1718,7 +1721,7 @@ void Particle::ParticleEngine::communicate_particles(
       FOUR_C_ASSERT_ALWAYS(particleobject, "received object is not a particle object!");
 
       // store received particle
-      particlestoreceive[particleobject->return_particle_type()].push_back(
+      particlestoreceive[static_cast<int>(particleobject->return_particle_type())].push_back(
           std::make_pair(msgsource, particleobject));
     }
   }
@@ -1755,7 +1758,7 @@ void Particle::ParticleEngine::communicate_direct_ghosting_map(
 {
   // iterate over particle types
   for (const auto& type : particlecontainerbundle_->get_particle_types())
-    directghostingtargets_[type].clear();
+    directghostingtargets_[static_cast<int>(type)].clear();
 
   // invalidate flags denoting validity of direct ghosting
   validdirectghosting_ = false;
@@ -1805,7 +1808,7 @@ void Particle::ParticleEngine::communicate_direct_ghosting_map(
           // get index of owned particle
           int ownedindex = indexIt.first;
 
-          (directghostingtargets_[type])[ownedindex].push_back(indexIt.second);
+          (directghostingtargets_[static_cast<int>(type)])[ownedindex].push_back(indexIt.second);
         }
       }
     }
@@ -1817,7 +1820,7 @@ void Particle::ParticleEngine::communicate_direct_ghosting_map(
   // cache procs to which this proc sends refreshed particle data
   cached_procs_send_ghost_data_to_.clear();
   for (const auto& type : particlecontainerbundle_->get_particle_types())
-    for (const auto& [ownedindex, targets] : directghostingtargets_[type])
+    for (const auto& [ownedindex, targets] : directghostingtargets_[static_cast<int>(type)])
       for (const auto& [proc, ghostedindex] : targets)
         cached_procs_send_ghost_data_to_.insert(proc);
 }
@@ -1829,14 +1832,14 @@ void Particle::ParticleEngine::insert_owned_particles(
   for (const auto& type : particlecontainerbundle_->get_particle_types())
   {
     // check for particles of current type
-    if (particlestoinsert[type].empty()) continue;
+    if (particlestoinsert[static_cast<int>(type)].empty()) continue;
 
     // get container of owned particles of current particle type
     ParticleContainer* container =
         particlecontainerbundle_->get_specific_container(type, Status::Owned);
 
     // iterate over particle objects pairs
-    for (const auto& objectpair : particlestoinsert[type])
+    for (const auto& objectpair : particlestoinsert[static_cast<int>(type)])
     {
       // get particle object
       ParticleObjShrdPtr particleobject = objectpair.second;
@@ -1899,14 +1902,14 @@ void Particle::ParticleEngine::insert_ghosted_particles(
   for (const auto& type : particlecontainerbundle_->get_particle_types())
   {
     // check for particles of current type
-    if (particlestoinsert[type].empty()) continue;
+    if (particlestoinsert[static_cast<int>(type)].empty()) continue;
 
     // get container of ghosted particles of current particle type
     ParticleContainer* container =
         particlecontainerbundle_->get_specific_container(type, Status::Ghosted);
 
     // iterate over particle objects pairs
-    for (const auto& objectpair : particlestoinsert[type])
+    for (const auto& objectpair : particlestoinsert[static_cast<int>(type)])
     {
       // get owner of sending processor
       int sendingproc = objectpair.first;
@@ -1960,7 +1963,7 @@ void Particle::ParticleEngine::remove_particles_from_containers(
   for (const auto& type : particlecontainerbundle_->get_particle_types())
   {
     // check for particles of current type
-    if (particlestoremove[type].empty()) continue;
+    if (particlestoremove[static_cast<int>(type)].empty()) continue;
 
     // get container of owned particles of current particle type
     ParticleContainer* container =
@@ -1968,7 +1971,8 @@ void Particle::ParticleEngine::remove_particles_from_containers(
 
     // iterate in reversed order over particles to be removed
     std::set<int>::reverse_iterator rit;
-    for (rit = particlestoremove[type].rbegin(); rit != particlestoremove[type].rend(); ++rit)
+    for (rit = particlestoremove[static_cast<int>(type)].rbegin();
+        rit != particlestoremove[static_cast<int>(type)].rend(); ++rit)
       container->remove_particle(*rit);
   }
 
@@ -2093,7 +2097,7 @@ void Particle::ParticleEngine::determine_bin_weights()
     {
       // add weight of particle of specific type
       binning_->binweights_->get_vector(0).get_values()[rowlidofbin] +=
-          typeweights_[particleIt.first];
+          typeweights_[static_cast<int>(particleIt.first)];
     }
   }
 }

--- a/src/particle/src/engine/4C_particle_engine.cpp
+++ b/src/particle/src/engine/4C_particle_engine.cpp
@@ -204,7 +204,8 @@ void Particle::ParticleEngine::erase_particles_outside_bounding_box(
     ParticleType type = particlestocheck[i]->return_particle_type();
 
     // get container of owned particles of current particle type
-    ParticleContainer* container = particlecontainerbundle_->get_specific_container(type, Owned);
+    ParticleContainer* container =
+        particlecontainerbundle_->get_specific_container(type, Status::Owned);
 
     if (static_cast<int>(pos.size()) != container->get_state_dim(Position))
       FOUR_C_THROW("dimension of particle state '{}' not valid!", enum_to_state_name(Position));
@@ -321,7 +322,8 @@ void Particle::ParticleEngine::transfer_particles()
   relate_owned_particles_to_bins();
 
   // check and decrease the size of all containers of owned particles
-  particlecontainerbundle_->check_and_decrease_size_all_containers_of_specific_status(Owned);
+  particlecontainerbundle_->check_and_decrease_size_all_containers_of_specific_status(
+      Status::Owned);
 }
 
 void Particle::ParticleEngine::ghost_particles()
@@ -334,7 +336,7 @@ void Particle::ParticleEngine::ghost_particles()
   std::map<int, std::map<ParticleType, std::map<int, std::pair<int, int>>>> directghosting;
 
   // clear all containers of ghosted particles
-  particlecontainerbundle_->clear_all_containers_of_specific_status(Ghosted);
+  particlecontainerbundle_->clear_all_containers_of_specific_status(Status::Ghosted);
 
   // determine particles that need to be ghosted
   determine_particles_to_be_ghosted(particlestosend);
@@ -349,7 +351,8 @@ void Particle::ParticleEngine::ghost_particles()
   communicate_direct_ghosting_map(directghosting);
 
   // check and decrease the size of all containers of ghosted particles
-  particlecontainerbundle_->check_and_decrease_size_all_containers_of_specific_status(Ghosted);
+  particlecontainerbundle_->check_and_decrease_size_all_containers_of_specific_status(
+      Status::Ghosted);
 }
 
 void Particle::ParticleEngine::refresh_particles() const
@@ -407,7 +410,7 @@ void Particle::ParticleEngine::dynamic_load_balancing()
   particlecontainerbundle_->get_vector_of_particle_objects_of_all_containers(particlestodistribute);
 
   // clear all containers of owned particles
-  particlecontainerbundle_->clear_all_containers_of_specific_status(Owned);
+  particlecontainerbundle_->clear_all_containers_of_specific_status(Status::Owned);
 
   // invalidate particle safety flags
   invalidate_particle_safety_flags();
@@ -419,7 +422,8 @@ void Particle::ParticleEngine::dynamic_load_balancing()
   distribute_particles(particlestodistribute);
 
   // check and decrease the size of all containers of owned particles
-  particlecontainerbundle_->check_and_decrease_size_all_containers_of_specific_status(Owned);
+  particlecontainerbundle_->check_and_decrease_size_all_containers_of_specific_status(
+      Status::Owned);
 }
 
 void Particle::ParticleEngine::hand_over_particles_to_be_removed(
@@ -437,7 +441,8 @@ void Particle::ParticleEngine::hand_over_particles_to_be_removed(
     remove_particles_from_containers(particlestoremove);
 
     // check and decrease the size of all containers of owned particles
-    particlecontainerbundle_->check_and_decrease_size_all_containers_of_specific_status(Owned);
+    particlecontainerbundle_->check_and_decrease_size_all_containers_of_specific_status(
+        Status::Owned);
   }
 }
 
@@ -496,7 +501,8 @@ void Particle::ParticleEngine::build_particle_to_particle_neighbors()
       const int ownedindex = particleIt.second;
 
       // get container of owned particles of current particle type
-      ParticleContainer* container = particlecontainerbundle_->get_specific_container(type, Owned);
+      ParticleContainer* container =
+          particlecontainerbundle_->get_specific_container(type, Status::Owned);
 
       // get global id of particle
       const int* currglobalid = container->get_ptr_to_global_id(ownedindex);
@@ -515,7 +521,7 @@ void Particle::ParticleEngine::build_particle_to_particle_neighbors()
 
         // get status of neighboring particles
         ParticleStatus neighborstatus =
-            (binning_->binrowmap_->lid(gidofneighborbin) < 0) ? Ghosted : Owned;
+            (binning_->binrowmap_->lid(gidofneighborbin) < 0) ? Status::Ghosted : Status::Owned;
 
         // iterate over particles in current neighboring bin
         for (const auto& neighborParticleIt : particlestobins_[collidofneighboringbin])
@@ -552,7 +558,7 @@ void Particle::ParticleEngine::build_particle_to_particle_neighbors()
 
           // append potential particle neighbor pair
           potentialparticleneighbors_.push_back(
-              std::make_pair(std::make_tuple(type, Owned, ownedindex),
+              std::make_pair(std::make_tuple(type, Status::Owned, ownedindex),
                   std::make_tuple(neighbortype, neighborstatus, neighborindex)));
         }
       }
@@ -577,7 +583,7 @@ void Particle::ParticleEngine::build_global_id_to_local_index_map()
   for (const auto& type : particlecontainerbundle_->get_particle_types())
   {
     // iterate over particle statuses
-    for (const auto& status : {Owned, Ghosted})
+    for (const auto& status : {Status::Owned, Status::Ghosted})
     {
       // get container of current particle type and current status
       ParticleContainer* container = particlecontainerbundle_->get_specific_container(type, status);
@@ -677,7 +683,8 @@ void Particle::ParticleEngine::relate_all_particles_to_all_procs(
   for (const auto& type : particlecontainerbundle_->get_particle_types())
   {
     // get container of owned particles of current particle type
-    ParticleContainer* container = particlecontainerbundle_->get_specific_container(type, Owned);
+    ParticleContainer* container =
+        particlecontainerbundle_->get_specific_container(type, Status::Owned);
 
     // get number of particles stored in container
     const int particlestored = container->particles_stored();
@@ -756,7 +763,7 @@ void Particle::ParticleEngine::get_particles_within_radius(const double* positio
 
     // get status of neighboring particles
     ParticleStatus neighborstatus =
-        (binning_->binrowmap_->lid(gidofneighborbin) < 0) ? Ghosted : Owned;
+        (binning_->binrowmap_->lid(gidofneighborbin) < 0) ? Status::Ghosted : Status::Owned;
 
     // iterate over particles in current neighboring bin
     for (const auto& neighborParticleIt : particlestobins_[collidofneighboringbin])
@@ -861,7 +868,8 @@ int Particle::ParticleEngine::get_number_of_particles() const
   for (const auto& type : particlecontainerbundle_->get_particle_types())
   {
     // get container of owned particles of current particle type
-    ParticleContainer* container = particlecontainerbundle_->get_specific_container(type, Owned);
+    ParticleContainer* container =
+        particlecontainerbundle_->get_specific_container(type, Status::Owned);
 
     // add number of particles stored in container
     numberofparticles += container->particles_stored();
@@ -876,7 +884,8 @@ int Particle::ParticleEngine::get_number_of_particles_of_specific_type(
   if (not particlecontainerbundle_->get_particle_types().contains(type)) return 0;
 
   // get container of owned particles of specific particle type
-  ParticleContainer* container = particlecontainerbundle_->get_specific_container(type, Owned);
+  ParticleContainer* container =
+      particlecontainerbundle_->get_specific_container(type, Status::Owned);
 
   return container->particles_stored();
 }
@@ -1272,7 +1281,8 @@ void Particle::ParticleEngine::check_particles_at_boundaries(
       const int ownedindex = particleIt.second;
 
       // get container of owned particle of current particle type
-      ParticleContainer* container = particlecontainerbundle_->get_specific_container(type, Owned);
+      ParticleContainer* container =
+          particlecontainerbundle_->get_specific_container(type, Status::Owned);
 
       // get position of particle
       const double* currpos = container->get_ptr_to_state(Position, ownedindex);
@@ -1362,7 +1372,8 @@ void Particle::ParticleEngine::determine_particles_to_be_distributed(
     ParticleType type = particlestodistribute[i]->return_particle_type();
 
     // get container of owned particles of current particle type
-    ParticleContainer* container = particlecontainerbundle_->get_specific_container(type, Owned);
+    ParticleContainer* container =
+        particlecontainerbundle_->get_specific_container(type, Status::Owned);
 
     if (static_cast<int>(pos.size()) != container->get_state_dim(Position))
       FOUR_C_THROW("dimension of particle state '{}' not valid!", enum_to_state_name(Position));
@@ -1475,7 +1486,8 @@ void Particle::ParticleEngine::determine_particles_to_be_transferred(
       const int ownedindex = particleIt.second;
 
       // get container of owned particle of current particle type
-      ParticleContainer* container = particlecontainerbundle_->get_specific_container(type, Owned);
+      ParticleContainer* container =
+          particlecontainerbundle_->get_specific_container(type, Status::Owned);
 
       // get position of particle
       const double* currpos = container->get_ptr_to_state(Position, ownedindex);
@@ -1549,7 +1561,8 @@ void Particle::ParticleEngine::determine_particles_to_be_ghosted(
       const int ownedindex = particleIt.second;
 
       // get container of owned particle of current particle type
-      ParticleContainer* container = particlecontainerbundle_->get_specific_container(type, Owned);
+      ParticleContainer* container =
+          particlecontainerbundle_->get_specific_container(type, Status::Owned);
 
       int globalid(0);
       ParticleStates states;
@@ -1580,7 +1593,8 @@ std::map<int, std::vector<char>> Particle::ParticleEngine::pack_particles_to_be_
     if (directghostingtargets_[type].empty()) continue;
 
     // get container of owned particles of current particle type
-    ParticleContainer* container = particlecontainerbundle_->get_specific_container(type, Owned);
+    ParticleContainer* container =
+        particlecontainerbundle_->get_specific_container(type, Status::Owned);
 
     // iterate over owned particles of current type
     for (const auto& indexIt : directghostingtargets_[type])
@@ -1634,7 +1648,8 @@ Particle::ParticleEngine::pack_specific_states_of_particles_to_be_refreshed(
     int statesvectorsize = *std::max_element(typeIt.second.begin(), typeIt.second.end()) + 1;
 
     // get container of owned particles of current particle type
-    ParticleContainer* container = particlecontainerbundle_->get_specific_container(type, Owned);
+    ParticleContainer* container =
+        particlecontainerbundle_->get_specific_container(type, Status::Owned);
 
     // iterate over owned particles of current type
     for (const auto& indexIt : directghostingtargets_[type])
@@ -1729,7 +1744,7 @@ void Particle::ParticleEngine::communicate_refreshed_particles(
 
       // replace particle directly in container of ghosted particles
       ParticleContainer* container =
-          particlecontainerbundle_->get_specific_container(entry.type, Ghosted);
+          particlecontainerbundle_->get_specific_container(entry.type, Status::Ghosted);
       container->replace_particle(entry.ghostedindex, -1, entry.states);
     }
   }
@@ -1817,7 +1832,8 @@ void Particle::ParticleEngine::insert_owned_particles(
     if (particlestoinsert[type].empty()) continue;
 
     // get container of owned particles of current particle type
-    ParticleContainer* container = particlecontainerbundle_->get_specific_container(type, Owned);
+    ParticleContainer* container =
+        particlecontainerbundle_->get_specific_container(type, Status::Owned);
 
     // iterate over particle objects pairs
     for (const auto& objectpair : particlestoinsert[type])
@@ -1848,7 +1864,7 @@ void Particle::ParticleEngine::insert_owned_particles(
 
         // get container of owned particles of current particle type
         ParticleContainer* container =
-            particlecontainerbundle_->get_specific_container(type, Owned);
+            particlecontainerbundle_->get_specific_container(type, Status::Owned);
 
         if (static_cast<int>(pos.size()) != container->get_state_dim(Position))
           FOUR_C_THROW("dimension of particle state '{}' not valid!", enum_to_state_name(Position));
@@ -1886,7 +1902,8 @@ void Particle::ParticleEngine::insert_ghosted_particles(
     if (particlestoinsert[type].empty()) continue;
 
     // get container of ghosted particles of current particle type
-    ParticleContainer* container = particlecontainerbundle_->get_specific_container(type, Ghosted);
+    ParticleContainer* container =
+        particlecontainerbundle_->get_specific_container(type, Status::Ghosted);
 
     // iterate over particle objects pairs
     for (const auto& objectpair : particlestoinsert[type])
@@ -1946,7 +1963,8 @@ void Particle::ParticleEngine::remove_particles_from_containers(
     if (particlestoremove[type].empty()) continue;
 
     // get container of owned particles of current particle type
-    ParticleContainer* container = particlecontainerbundle_->get_specific_container(type, Owned);
+    ParticleContainer* container =
+        particlecontainerbundle_->get_specific_container(type, Status::Owned);
 
     // iterate in reversed order over particles to be removed
     std::set<int>::reverse_iterator rit;
@@ -1967,7 +1985,8 @@ void Particle::ParticleEngine::store_positions_after_particle_transfer()
   for (const auto& type : particlecontainerbundle_->get_particle_types())
   {
     // get container of owned particles of current particle type
-    ParticleContainer* container = particlecontainerbundle_->get_specific_container(type, Owned);
+    ParticleContainer* container =
+        particlecontainerbundle_->get_specific_container(type, Status::Owned);
 
     // get number of particles stored in container
     const int particlestored = container->particles_stored();
@@ -2000,7 +2019,8 @@ void Particle::ParticleEngine::relate_owned_particles_to_bins()
   for (const auto& type : particlecontainerbundle_->get_particle_types())
   {
     // get container of owned particles of current particle type
-    ParticleContainer* container = particlecontainerbundle_->get_specific_container(type, Owned);
+    ParticleContainer* container =
+        particlecontainerbundle_->get_specific_container(type, Status::Owned);
 
     // get number of particles stored in container
     const int particlestored = container->particles_stored();

--- a/src/particle/src/engine/4C_particle_engine.cpp
+++ b/src/particle/src/engine/4C_particle_engine.cpp
@@ -60,7 +60,7 @@ Particle::ParticleEngine::ParticleEngine(MPI_Comm comm, const Teuchos::Parameter
 Particle::ParticleEngine::~ParticleEngine() = default;
 
 void Particle::ParticleEngine::setup(
-    const std::map<ParticleType, std::set<ParticleState>>& particlestatestotypes)
+    const std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes)
 {
   // setup binning strategy
   setup_binning_strategy();
@@ -201,7 +201,7 @@ void Particle::ParticleEngine::erase_particles_outside_bounding_box(
 
 #ifdef FOUR_C_ENABLE_ASSERTIONS
     // get type of particles
-    ParticleType type = particlestocheck[i]->return_particle_type();
+    Particle::Type type = particlestocheck[i]->return_particle_type();
 
     // get container of owned particles of current particle type
     ParticleContainer* container =
@@ -334,7 +334,7 @@ void Particle::ParticleEngine::ghost_particles()
   std::vector<std::vector<ParticleObjShrdPtr>> particlestosend(
       Core::Communication::num_mpi_ranks(comm_));
   std::vector<std::vector<std::pair<int, ParticleObjShrdPtr>>> particlestoinsert(typevectorsize_);
-  std::map<int, std::map<ParticleType, std::map<int, std::pair<int, int>>>> directghosting;
+  std::map<int, std::map<Particle::Type, std::map<int, std::pair<int, int>>>> directghosting;
 
   // clear all containers of ghosted particles
   particlecontainerbundle_->clear_all_containers_of_specific_status(Status::Ghosted);
@@ -496,7 +496,7 @@ void Particle::ParticleEngine::build_particle_to_particle_neighbors()
     for (const auto& particleIt : particlestobins_[collidofbin])
     {
       // get type of particle
-      ParticleType type = particleIt.first;
+      Particle::Type type = particleIt.first;
 
       // get local index of owned particle
       const int ownedindex = particleIt.second;
@@ -521,14 +521,14 @@ void Particle::ParticleEngine::build_particle_to_particle_neighbors()
         if (particlestobins_[collidofneighboringbin].empty()) continue;
 
         // get status of neighboring particles
-        ParticleStatus neighborstatus =
+        Particle::Status neighborstatus =
             (binning_->binrowmap_->lid(gidofneighborbin) < 0) ? Status::Ghosted : Status::Owned;
 
         // iterate over particles in current neighboring bin
         for (const auto& neighborParticleIt : particlestobins_[collidofneighboringbin])
         {
           // get type of neighboring particle
-          ParticleType neighbortype = neighborParticleIt.first;
+          Particle::Type neighbortype = neighborParticleIt.first;
 
           // get local index of neighboring particle
           const int neighborindex = neighborParticleIt.second;
@@ -764,14 +764,14 @@ void Particle::ParticleEngine::get_particles_within_radius(const double* positio
     if (particlestobins_[collidofneighboringbin].empty()) continue;
 
     // get status of neighboring particles
-    ParticleStatus neighborstatus =
+    Particle::Status neighborstatus =
         (binning_->binrowmap_->lid(gidofneighborbin) < 0) ? Status::Ghosted : Status::Owned;
 
     // iterate over particles in current neighboring bin
     for (const auto& neighborParticleIt : particlestobins_[collidofneighboringbin])
     {
       // get type of neighboring particle
-      ParticleType neighbortype = neighborParticleIt.first;
+      Particle::Type neighbortype = neighborParticleIt.first;
 
       // get local index of neighboring particle
       const int neighborindex = neighborParticleIt.second;
@@ -882,7 +882,7 @@ int Particle::ParticleEngine::get_number_of_particles() const
 }
 
 int Particle::ParticleEngine::get_number_of_particles_of_specific_type(
-    const ParticleType type) const
+    const Particle::Type type) const
 {
   if (not particlecontainerbundle_->get_particle_types().contains(type)) return 0;
 
@@ -1011,14 +1011,14 @@ void Particle::ParticleEngine::setup_bin_ghosting()
 }
 
 void Particle::ParticleEngine::setup_particle_container_bundle(
-    const std::map<ParticleType, std::set<ParticleState>>& particlestatestotypes) const
+    const std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes) const
 {
   // setup particle container bundle
   particlecontainerbundle_->setup(particlestatestotypes);
 }
 
 void Particle::ParticleEngine::setup_data_storage(
-    const std::map<ParticleType, std::set<ParticleState>>& particlestatestotypes)
+    const std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes)
 {
   // determine size of vectors indexed by particle types
   typevectorsize_ = static_cast<int>((--particlestatestotypes.end())->first) + 1;
@@ -1053,7 +1053,7 @@ void Particle::ParticleEngine::setup_type_weights()
   typeweights_.resize(typevectorsize_);
 
   // init map relating particle types to dynamic load balance factor
-  std::map<ParticleType, double> typetodynloadbal;
+  std::map<Particle::Type, double> typetodynloadbal;
 
   // read parameters relating particle types to values
   ParticleUtils::read_params_types_related_to_values(
@@ -1279,7 +1279,7 @@ void Particle::ParticleEngine::check_particles_at_boundaries(
     for (const auto& particleIt : particlestobins_[collidofbin])
     {
       // get type of particle
-      ParticleType type = particleIt.first;
+      Particle::Type type = particleIt.first;
 
       // get local index of owned particle
       const int ownedindex = particleIt.second;
@@ -1373,7 +1373,7 @@ void Particle::ParticleEngine::determine_particles_to_be_distributed(
 
 #ifdef FOUR_C_ENABLE_ASSERTIONS
     // get type of particles
-    ParticleType type = particlestodistribute[i]->return_particle_type();
+    Particle::Type type = particlestodistribute[i]->return_particle_type();
 
     // get container of owned particles of current particle type
     ParticleContainer* container =
@@ -1418,7 +1418,7 @@ void Particle::ParticleEngine::determine_particles_to_be_distributed(
   for (int i = 0; i < numparticles; ++i)
   {
     // get type of particle
-    ParticleType type = particlestodistribute[i]->return_particle_type();
+    Particle::Type type = particlestodistribute[i]->return_particle_type();
 
     // get owner of particle
     int ownerofparticle = pidlist[i];
@@ -1486,7 +1486,7 @@ void Particle::ParticleEngine::determine_particles_to_be_transferred(
     for (const auto& particleIt : particlestobins_[collidofbin])
     {
       // get type of particle
-      ParticleType type = particleIt.first;
+      Particle::Type type = particleIt.first;
 
       // get local index of owned particle
       const int ownedindex = particleIt.second;
@@ -1561,7 +1561,7 @@ void Particle::ParticleEngine::determine_particles_to_be_ghosted(
     for (const auto& particleIt : particlestobins_[collidofbin])
     {
       // get type of particle
-      ParticleType type = particleIt.first;
+      Particle::Type type = particleIt.first;
 
       // get local index of owned particle
       const int ownedindex = particleIt.second;
@@ -1619,7 +1619,7 @@ std::map<int, std::vector<char>> Particle::ParticleEngine::pack_particles_to_be_
   return sdata;
 }
 
-void Particle::ParticleEngine::pack_states_and_append_to_send_buffers(ParticleType type,
+void Particle::ParticleEngine::pack_states_and_append_to_send_buffers(Particle::Type type,
     const std::vector<std::pair<int, int>>& targets, const ParticleStates& states,
     std::map<int, std::vector<char>>& sdata) const
 {
@@ -1645,7 +1645,7 @@ Particle::ParticleEngine::pack_specific_states_of_particles_to_be_refreshed(
   for (const auto& typeIt : particlestatestotypes)
   {
     // get type of particles
-    ParticleType type = typeIt.first;
+    Particle::Type type = typeIt.first;
 
     // check for particles of current type to be sent
     if (directghostingtargets_[static_cast<int>(type)].empty()) continue;
@@ -1758,7 +1758,8 @@ void Particle::ParticleEngine::communicate_refreshed_particles(
 }
 
 void Particle::ParticleEngine::communicate_direct_ghosting_map(
-    const std::map<int, std::map<ParticleType, std::map<int, std::pair<int, int>>>>& directghosting)
+    const std::map<int, std::map<Particle::Type, std::map<int, std::pair<int, int>>>>&
+        directghosting)
 {
   // iterate over particle types
   for (const auto& type : particlecontainerbundle_->get_particle_types())
@@ -1788,7 +1789,7 @@ void Particle::ParticleEngine::communicate_direct_ghosting_map(
       ParticleUtils::immediate_recv_blocking_send(comm_, sdata);
 
   // init receiving map
-  std::map<ParticleType, std::map<int, std::pair<int, int>>> receiveddirectghosting;
+  std::map<Particle::Type, std::map<int, std::pair<int, int>>> receiveddirectghosting;
 
   // unpack and store received data
   for (const auto& [msgsource, rmsg] : rdata)
@@ -1804,7 +1805,7 @@ void Particle::ParticleEngine::communicate_direct_ghosting_map(
       for (const auto& typeIt : receiveddirectghosting)
       {
         // get type of particles
-        ParticleType type = typeIt.first;
+        Particle::Type type = typeIt.first;
 
         // iterate over this processors local indices of owned particles
         for (const auto& indexIt : typeIt.second)
@@ -1867,7 +1868,7 @@ void Particle::ParticleEngine::insert_owned_particles(
         const std::vector<double>& pos = states[static_cast<int>(State::Position)];
 
         // get type of particles
-        ParticleType type = particleobject->return_particle_type();
+        Particle::Type type = particleobject->return_particle_type();
 
         // get container of owned particles of current particle type
         ParticleContainer* container =
@@ -1901,7 +1902,7 @@ void Particle::ParticleEngine::insert_owned_particles(
 
 void Particle::ParticleEngine::insert_ghosted_particles(
     std::vector<std::vector<std::pair<int, ParticleObjShrdPtr>>>& particlestoinsert,
-    std::map<int, std::map<ParticleType, std::map<int, std::pair<int, int>>>>& directghosting)
+    std::map<int, std::map<Particle::Type, std::map<int, std::pair<int, int>>>>& directghosting)
 {
   // iterate over particle types
   for (const auto& type : particlecontainerbundle_->get_particle_types())

--- a/src/particle/src/engine/4C_particle_engine.hpp
+++ b/src/particle/src/engine/4C_particle_engine.hpp
@@ -87,7 +87,7 @@ namespace Particle
      *
      * \param[in] particlestatestotypes particle types and corresponding particle states
      */
-    void setup(const std::map<ParticleType, std::set<ParticleState>>& particlestatestotypes);
+    void setup(const std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes);
 
     /*!
      * \brief write restart of particle engine
@@ -399,7 +399,7 @@ namespace Particle
 
     int get_number_of_particles() const override;
 
-    int get_number_of_particles_of_specific_type(const ParticleType type) const override;
+    int get_number_of_particles_of_specific_type(const Particle::Type type) const override;
 
     /*!
      * \brief write binning discretization output
@@ -442,7 +442,7 @@ namespace Particle
      * \param[in] particlestatestotypes particle types and corresponding particle states
      */
     void setup_particle_container_bundle(
-        const std::map<ParticleType, std::set<ParticleState>>& particlestatestotypes) const;
+        const std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes) const;
 
     /*!
      * \brief setup data storage
@@ -451,7 +451,7 @@ namespace Particle
      * \param[in] particlestatestotypes particle types and corresponding particle states
      */
     void setup_data_storage(
-        const std::map<ParticleType, std::set<ParticleState>>& particlestatestotypes);
+        const std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes);
 
     /*!
      * \brief init particle runtime vtp writer
@@ -605,7 +605,7 @@ namespace Particle
      * \param[in]  states      particle states to send
      * \param[out] sdata       send buffers indexed by target processor rank
      */
-    void pack_states_and_append_to_send_buffers(ParticleType type,
+    void pack_states_and_append_to_send_buffers(Particle::Type type,
         const std::vector<std::pair<int, int>>& targets, const ParticleStates& states,
         std::map<int, std::vector<char>>& sdata) const;
 
@@ -644,7 +644,7 @@ namespace Particle
      * \param[in] directghosting direct ghosting information
      */
     void communicate_direct_ghosting_map(
-        const std::map<int, std::map<ParticleType, std::map<int, std::pair<int, int>>>>&
+        const std::map<int, std::map<Particle::Type, std::map<int, std::pair<int, int>>>>&
             directghosting);
 
     /*!
@@ -665,7 +665,8 @@ namespace Particle
      */
     void insert_ghosted_particles(
         std::vector<std::vector<std::pair<int, ParticleObjShrdPtr>>>& particlestoinsert,
-        std::map<int, std::map<ParticleType, std::map<int, std::pair<int, int>>>>& directghosting);
+        std::map<int, std::map<Particle::Type, std::map<int, std::pair<int, int>>>>&
+            directghosting);
 
     /*!
      * \brief remove particles from containers

--- a/src/particle/src/engine/4C_particle_engine_container.cpp
+++ b/src/particle/src/engine/4C_particle_engine_container.cpp
@@ -20,7 +20,8 @@ Particle::ParticleContainer::ParticleContainer()
   // empty constructor
 }
 
-void Particle::ParticleContainer::setup(int containersize, const std::set<ParticleState>& stateset)
+void Particle::ParticleContainer::setup(
+    int containersize, const std::set<Particle::State>& stateset)
 {
   // set size of particle container (at least one)
   containersize_ = (containersize > 0) ? containersize : 1;
@@ -237,7 +238,7 @@ void Particle::ParticleContainer::remove_particle(int index)
   --particlestored_;
 }
 
-const double* Particle::ParticleContainer::get_ptr_to_state(ParticleState state, int index) const
+const double* Particle::ParticleContainer::get_ptr_to_state(Particle::State state, int index) const
 {
   FOUR_C_ASSERT(storedstates_.contains(state), "particle state '{}' not stored in container!",
       enum_to_state_name(state));
@@ -250,13 +251,13 @@ const double* Particle::ParticleContainer::get_ptr_to_state(ParticleState state,
   return &((states_[state_idx])[index * statedim_[state_idx]]);
 };
 
-double* Particle::ParticleContainer::get_ptr_to_state_writable(ParticleState state, int index)
+double* Particle::ParticleContainer::get_ptr_to_state_writable(Particle::State state, int index)
 {
   return const_cast<double*>(
       const_cast<const ParticleContainer&>(*this).get_ptr_to_state(state, index));
 };
 
-double Particle::ParticleContainer::get_min_value_of_state(ParticleState state) const
+double Particle::ParticleContainer::get_min_value_of_state(Particle::State state) const
 {
   FOUR_C_ASSERT(storedstates_.contains(state), "particle state '{}' not stored in container!",
       enum_to_state_name(state));
@@ -272,7 +273,7 @@ double Particle::ParticleContainer::get_min_value_of_state(ParticleState state) 
   return min;
 }
 
-double Particle::ParticleContainer::get_max_value_of_state(ParticleState state) const
+double Particle::ParticleContainer::get_max_value_of_state(Particle::State state) const
 {
   FOUR_C_ASSERT(storedstates_.contains(state), "particle state '{}' not stored in container!",
       enum_to_state_name(state));

--- a/src/particle/src/engine/4C_particle_engine_container.cpp
+++ b/src/particle/src/engine/4C_particle_engine_container.cpp
@@ -29,7 +29,7 @@ void Particle::ParticleContainer::setup(int containersize, const std::set<Partic
   storedstates_ = stateset;
 
   // determine necessary size of vector for states
-  statesvectorsize_ = *(--storedstates_.end()) + 1;
+  statesvectorsize_ = static_cast<int>(*(--storedstates_.end())) + 1;
 
   // allocate memory for global ids
   globalids_.resize(containersize_, -1);
@@ -41,11 +41,13 @@ void Particle::ParticleContainer::setup(int containersize, const std::set<Partic
   // iterate over states to be stored in container
   for (const auto& state : storedstates_)
   {
+    const int state_idx = static_cast<int>(state);
+
     // set particle state dimension for current state
-    statedim_[state] = enum_to_state_dim(state);
+    statedim_[state_idx] = enum_to_state_dim(state);
 
     // allocate memory for current state in particle container
-    states_[state].resize(containersize_ * statedim_[state]);
+    states_[state_idx].resize(containersize_ * statedim_[state_idx]);
   }
 }
 
@@ -60,8 +62,10 @@ void Particle::ParticleContainer::increase_container_size()
   // iterate over states stored in container
   for (const auto& state : storedstates_)
   {
+    const int state_idx = static_cast<int>(state);
+
     // resize vector of current state
-    states_[state].resize(containersize_ * statedim_[state]);
+    states_[state_idx].resize(containersize_ * statedim_[state_idx]);
   }
 }
 
@@ -83,8 +87,10 @@ void Particle::ParticleContainer::decrease_container_size()
   // iterate over states stored in container
   for (const auto& state : storedstates_)
   {
+    const int state_idx = static_cast<int>(state);
+
     // resize vector of current state
-    states_[state].resize(containersize_ * statedim_[state]);
+    states_[state_idx].resize(containersize_ * statedim_[state_idx]);
   }
 }
 
@@ -95,8 +101,10 @@ void Particle::ParticleContainer::add_particle(
   // check states in container
   for (const auto& state : storedstates_)
   {
-    if (state < static_cast<int>(states.size()) and not states[state].empty() and
-        static_cast<int>(states[state].size()) != statedim_[state])
+    const int state_idx = static_cast<int>(state);
+
+    if (state_idx < static_cast<int>(states.size()) and not states[state_idx].empty() and
+        static_cast<int>(states[state_idx].size()) != statedim_[state_idx])
       FOUR_C_THROW("can not add particle: dimensions of state '{}' do not match!",
           enum_to_state_name(state));
   }
@@ -117,20 +125,22 @@ void Particle::ParticleContainer::add_particle(
   // iterate over states stored in container
   for (const auto& state : storedstates_)
   {
+    const int state_idx = static_cast<int>(state);
+
     // get pointer to particle state
     double* state_ptr = get_ptr_to_state_writable(state, index);
 
     // state not handed over
-    if (states.size() <= state or states[state].empty())
+    if (static_cast<int>(states.size()) <= state_idx or states[state_idx].empty())
     {
       // initialize to zero
-      for (int dim = 0; dim < statedim_[state]; ++dim) state_ptr[dim] = 0.0;
+      for (int dim = 0; dim < statedim_[state_idx]; ++dim) state_ptr[dim] = 0.0;
     }
     // state handed over
     else
     {
       // store state in container
-      for (int dim = 0; dim < statedim_[state]; ++dim) state_ptr[dim] = states[state][dim];
+      for (int dim = 0; dim < statedim_[state_idx]; ++dim) state_ptr[dim] = states[state_idx][dim];
     }
   }
 }
@@ -147,15 +157,17 @@ void Particle::ParticleContainer::replace_particle(
   // iterate over states stored in container
   for (const auto& state : storedstates_)
   {
+    const int state_idx = static_cast<int>(state);
+
     // state not handed over
-    if (states.size() <= state or states[state].empty())
+    if (static_cast<int>(states.size()) <= state_idx or states[state_idx].empty())
     {
       // leave state untouched
     }
     // state handed over
     else
     {
-      FOUR_C_ASSERT(static_cast<int>(states[state].size()) == statedim_[state],
+      FOUR_C_ASSERT(static_cast<int>(states[state_idx].size()) == statedim_[state_idx],
           "can not replace particle: dimensions of state '{}' do not match!",
           enum_to_state_name(state));
 
@@ -163,7 +175,7 @@ void Particle::ParticleContainer::replace_particle(
       double* state_ptr = get_ptr_to_state_writable(state, index);
 
       // replace state in container
-      for (int dim = 0; dim < statedim_[state]; ++dim) state_ptr[dim] = states[state][dim];
+      for (int dim = 0; dim < statedim_[state_idx]; ++dim) state_ptr[dim] = states[state_idx][dim];
     }
   }
 }
@@ -187,7 +199,8 @@ void Particle::ParticleContainer::get_particle(
     const double* state_ptr = get_ptr_to_state(state, index);
 
     // fill particle state
-    states[state].assign(state_ptr, state_ptr + statedim_[state]);
+    const int state_idx = static_cast<int>(state);
+    states[state_idx].assign(state_ptr, state_ptr + statedim_[state_idx]);
   }
 }
 
@@ -216,7 +229,8 @@ void Particle::ParticleContainer::remove_particle(int index)
     double* state_ptr_index = get_ptr_to_state_writable(state, index);
     double* state_ptr_last = get_ptr_to_state_writable(state, last_index);
 
-    for (int dim = 0; dim < statedim_[state]; ++dim) state_ptr_index[dim] = state_ptr_last[dim];
+    for (int dim = 0; dim < statedim_[static_cast<int>(state)]; ++dim)
+      state_ptr_index[dim] = state_ptr_last[dim];
   }
 
   // decrease counter of stored particles
@@ -231,7 +245,9 @@ const double* Particle::ParticleContainer::get_ptr_to_state(ParticleState state,
   FOUR_C_ASSERT(index >= 0 and index < particlestored_,
       "can not return pointer to state of particle as index {} out of bounds!", index);
 
-  return &((states_[state])[index * statedim_[state]]);
+  const int state_idx = static_cast<int>(state);
+
+  return &((states_[state_idx])[index * statedim_[state_idx]]);
 };
 
 double* Particle::ParticleContainer::get_ptr_to_state_writable(ParticleState state, int index)
@@ -250,7 +266,8 @@ double Particle::ParticleContainer::get_min_value_of_state(ParticleState state) 
   const double* state_ptr = get_ptr_to_state(state, 0);
   double min = state_ptr[0];
 
-  for (int i = 1; i < (particlestored_ * statedim_[state]); ++i) min = std::min(min, state_ptr[i]);
+  for (int i = 1; i < (particlestored_ * statedim_[static_cast<int>(state)]); ++i)
+    min = std::min(min, state_ptr[i]);
 
   return min;
 }
@@ -265,7 +282,8 @@ double Particle::ParticleContainer::get_max_value_of_state(ParticleState state) 
   const double* state_ptr = get_ptr_to_state(state, 0);
   double max = state_ptr[0];
 
-  for (int i = 1; i < (particlestored_ * statedim_[state]); ++i) max = std::max(max, state_ptr[i]);
+  for (int i = 1; i < (particlestored_ * statedim_[static_cast<int>(state)]); ++i)
+    max = std::max(max, state_ptr[i]);
 
   return max;
 }

--- a/src/particle/src/engine/4C_particle_engine_container.hpp
+++ b/src/particle/src/engine/4C_particle_engine_container.hpp
@@ -44,7 +44,7 @@ namespace Particle
      * \param[in] containersize size of particle container
      * \param[in] stateset      set of particle states to be stored
      */
-    void setup(int containersize, const std::set<ParticleState>& stateset);
+    void setup(int containersize, const std::set<Particle::State>& stateset);
 
     //! \name manipulate container size
     //! @{
@@ -155,7 +155,7 @@ namespace Particle
      *
      * \return dimension of particle state
      */
-    inline int get_state_dim(ParticleState state)
+    inline int get_state_dim(Particle::State state)
     {
       FOUR_C_ASSERT(storedstates_.contains(state), "particle state '{}' not stored in container!",
           enum_to_state_name(state));
@@ -181,7 +181,7 @@ namespace Particle
      *
      * \return pointer with read-only access to particle state
      */
-    const double* get_ptr_to_state(ParticleState state, int index) const;
+    const double* get_ptr_to_state(Particle::State state, int index) const;
 
     /*!
      * \brief conditionally get read-only pointer to state of a particle at index
@@ -199,7 +199,7 @@ namespace Particle
      *
      * \return pointer with read-only access to particle state or nullptr
      */
-    inline const double* try_get_ptr_to_state(ParticleState state, int index) const
+    inline const double* try_get_ptr_to_state(Particle::State state, int index) const
     {
       FOUR_C_ASSERT(index >= 0 and index < particlestored_,
           "can not return pointer to state of particle as index {} out of bounds!", index);
@@ -224,7 +224,7 @@ namespace Particle
      *
      * \return pointer with writable access to particle state
      */
-    double* get_ptr_to_state_writable(ParticleState state, int index);
+    double* get_ptr_to_state_writable(Particle::State state, int index);
 
     /*!
      * \brief conditionally get writable pointer to state of a particle at index
@@ -242,7 +242,7 @@ namespace Particle
      *
      * \return pointer with writable access to particle state or nullptr
      */
-    inline double* try_get_ptr_to_state_writable(ParticleState state, int index)
+    inline double* try_get_ptr_to_state_writable(Particle::State state, int index)
     {
       FOUR_C_ASSERT(index >= 0 and index < particlestored_,
           "can not return pointer to state of particle as index {} out of bounds!", index);
@@ -280,7 +280,7 @@ namespace Particle
      * \param[in] fac   scale factor
      * \param[in] state particle state
      */
-    inline void scale_state(double fac, ParticleState state)
+    inline void scale_state(double fac, Particle::State state)
     {
       FOUR_C_ASSERT(storedstates_.contains(state), "particle state '{}' not stored in container!",
           enum_to_state_name(state));
@@ -302,7 +302,8 @@ namespace Particle
      * \param[in] facB   second scale factor
      * \param[in] stateB second particle state
      */
-    inline void update_state(double facA, ParticleState stateA, double facB, ParticleState stateB)
+    inline void update_state(
+        double facA, Particle::State stateA, double facB, Particle::State stateB)
     {
       FOUR_C_ASSERT(stateA != stateB,
           "adding scaled particle state '{}' to itself is not allowed. Use "
@@ -334,7 +335,7 @@ namespace Particle
      * \param[in] val   particle state
      * \param[in] state particle state
      */
-    inline void set_state(std::vector<double> val, ParticleState state)
+    inline void set_state(std::vector<double> val, Particle::State state)
     {
       FOUR_C_ASSERT(storedstates_.contains(state), "particle state '{}' not stored in container!",
           enum_to_state_name(state));
@@ -357,7 +358,7 @@ namespace Particle
      *
      * \param[in] state particle state
      */
-    inline void clear_state(ParticleState state)
+    inline void clear_state(Particle::State state)
     {
       FOUR_C_ASSERT(storedstates_.contains(state), "particle state '{}' not stored in container!",
           enum_to_state_name(state));
@@ -378,7 +379,7 @@ namespace Particle
      *
      * \return stored particle states
      */
-    inline const std::set<ParticleState>& get_stored_states() const { return storedstates_; };
+    inline const std::set<Particle::State>& get_stored_states() const { return storedstates_; };
 
     /*!
      * \brief get flag indicating stored state
@@ -390,7 +391,7 @@ namespace Particle
      *
      * \return flag indicating stored state
      */
-    inline bool have_stored_state(ParticleState state) const
+    inline bool have_stored_state(Particle::State state) const
     {
       return storedstates_.contains(state);
     };
@@ -419,7 +420,7 @@ namespace Particle
      *
      * \return minimum stored value of state in container
      */
-    double get_min_value_of_state(ParticleState state) const;
+    double get_min_value_of_state(Particle::State state) const;
 
     /*!
      * \brief get maximum stored value of state in container
@@ -429,7 +430,7 @@ namespace Particle
      *
      * \return maximum stored value of state in container
      */
-    double get_max_value_of_state(ParticleState state) const;
+    double get_max_value_of_state(Particle::State state) const;
 
    private:
     //! size of particles container
@@ -439,7 +440,7 @@ namespace Particle
     int particlestored_;
 
     //! set of stored particle states
-    std::set<ParticleState> storedstates_;
+    std::set<Particle::State> storedstates_;
 
     //! size of vector for states
     int statesvectorsize_;

--- a/src/particle/src/engine/4C_particle_engine_container.hpp
+++ b/src/particle/src/engine/4C_particle_engine_container.hpp
@@ -160,7 +160,7 @@ namespace Particle
       FOUR_C_ASSERT(storedstates_.contains(state), "particle state '{}' not stored in container!",
           enum_to_state_name(state));
 
-      return statedim_[state];
+      return statedim_[static_cast<int>(state)];
     };
 
     //! \name access global id and particle states
@@ -289,7 +289,8 @@ namespace Particle
 
       double* state_ptr = get_ptr_to_state_writable(state, 0);
 
-      for (int i = 0; i < (particlestored_ * statedim_[state]); ++i) state_ptr[i] *= fac;
+      for (int i = 0; i < (particlestored_ * statedim_[static_cast<int>(state)]); ++i)
+        state_ptr[i] *= fac;
     };
 
     /*!
@@ -314,14 +315,15 @@ namespace Particle
       FOUR_C_ASSERT(storedstates_.contains(stateB), "particle state '{}' not stored in container!",
           enum_to_state_name(stateB));
 
-      FOUR_C_ASSERT(statedim_[stateA] == statedim_[stateB], "dimensions of states do not match!");
+      FOUR_C_ASSERT(statedim_[static_cast<int>(stateA)] == statedim_[static_cast<int>(stateB)],
+          "dimensions of states do not match!");
 
       if (particlestored_ <= 0) return;
 
       const double* state_b_ptr = get_ptr_to_state(stateB, 0);
       double* state_a_ptr = get_ptr_to_state_writable(stateA, 0);
 
-      for (int i = 0; i < (particlestored_ * statedim_[stateA]); ++i)
+      for (int i = 0; i < (particlestored_ * statedim_[static_cast<int>(stateA)]); ++i)
         state_a_ptr[i] = facA * state_a_ptr[i] + facB * state_b_ptr[i];
     };
 
@@ -337,16 +339,16 @@ namespace Particle
       FOUR_C_ASSERT(storedstates_.contains(state), "particle state '{}' not stored in container!",
           enum_to_state_name(state));
 
-      FOUR_C_ASSERT(
-          statedim_[state] == static_cast<int>(val.size()), "dimensions of states do not match!");
+      FOUR_C_ASSERT(statedim_[static_cast<int>(state)] == static_cast<int>(val.size()),
+          "dimensions of states do not match!");
 
       if (particlestored_ <= 0) return;
 
       double* state_ptr = get_ptr_to_state_writable(state, 0);
 
       for (int i = 0; i < particlestored_; ++i)
-        for (int dim = 0; dim < statedim_[state]; ++dim)
-          state_ptr[i * statedim_[state] + dim] = val[dim];
+        for (int dim = 0; dim < statedim_[static_cast<int>(state)]; ++dim)
+          state_ptr[i * statedim_[static_cast<int>(state)] + dim] = val[dim];
     };
 
     /*!
@@ -364,7 +366,8 @@ namespace Particle
 
       double* state_ptr = get_ptr_to_state_writable(state, 0);
 
-      for (int i = 0; i < (particlestored_ * statedim_[state]); ++i) state_ptr[i] = 0.0;
+      for (int i = 0; i < (particlestored_ * statedim_[static_cast<int>(state)]); ++i)
+        state_ptr[i] = 0.0;
     };
 
     //! @}

--- a/src/particle/src/engine/4C_particle_engine_container_bundle.cpp
+++ b/src/particle/src/engine/4C_particle_engine_container_bundle.cpp
@@ -52,14 +52,14 @@ void Particle::ParticleContainerBundle::setup(
     container = std::make_shared<ParticleContainer>();
     container->setup(initialsize, stateset);
     // set container of owned particles
-    (containers_[type])[Owned] = container;
+    (containers_[type])[static_cast<int>(Status::Owned)] = container;
 
     // create container of ghosted particles
     container = std::make_shared<ParticleContainer>();
     // setup container of ghosted particles
     container->setup(initialsize, stateset);
     // set container of ghosted particles
-    (containers_[type])[Ghosted] = container;
+    (containers_[type])[static_cast<int>(Status::Ghosted)] = container;
   }
 }
 
@@ -70,7 +70,7 @@ void Particle::ParticleContainerBundle::get_packed_particle_objects_of_all_conta
   for (const auto& type : storedtypes_)
   {
     // get container of owned particles
-    ParticleContainer* container = (containers_[type])[Owned].get();
+    ParticleContainer* container = (containers_[type])[static_cast<int>(Status::Owned)].get();
 
     // loop over particles in container
     for (int index = 0; index < container->particles_stored(); ++index)
@@ -96,7 +96,7 @@ void Particle::ParticleContainerBundle::get_vector_of_particle_objects_of_all_co
   for (const auto& type : storedtypes_)
   {
     // get container of owned particles
-    ParticleContainer* container = (containers_[type])[Owned].get();
+    ParticleContainer* container = (containers_[type])[static_cast<int>(Status::Owned)].get();
 
     // loop over particles in container
     for (int index = 0; index < container->particles_stored(); ++index)

--- a/src/particle/src/engine/4C_particle_engine_container_bundle.cpp
+++ b/src/particle/src/engine/4C_particle_engine_container_bundle.cpp
@@ -25,7 +25,7 @@ void Particle::ParticleContainerBundle::setup(
   std::shared_ptr<ParticleContainer> container;
 
   // determine necessary size of vector for particle types
-  const int typevectorsize = ((--particlestatestotypes.end())->first) + 1;
+  const int typevectorsize = static_cast<int>((--particlestatestotypes.end())->first) + 1;
 
   // allocate memory to hold particle types
   containers_.resize(typevectorsize);
@@ -40,7 +40,7 @@ void Particle::ParticleContainerBundle::setup(
     storedtypes_.insert(type);
 
     // allocate memory for container of owned and ghosted particles
-    (containers_[type]).resize(2);
+    (containers_[static_cast<int>(type)]).resize(2);
 
     // set of particle state enums of current particle type (equal for owned and ghosted particles)
     const std::set<ParticleState>& stateset = typeIt.second;
@@ -52,14 +52,14 @@ void Particle::ParticleContainerBundle::setup(
     container = std::make_shared<ParticleContainer>();
     container->setup(initialsize, stateset);
     // set container of owned particles
-    (containers_[type])[static_cast<int>(Status::Owned)] = container;
+    (containers_[static_cast<int>(type)])[static_cast<int>(Status::Owned)] = container;
 
     // create container of ghosted particles
     container = std::make_shared<ParticleContainer>();
     // setup container of ghosted particles
     container->setup(initialsize, stateset);
     // set container of ghosted particles
-    (containers_[type])[static_cast<int>(Status::Ghosted)] = container;
+    (containers_[static_cast<int>(type)])[static_cast<int>(Status::Ghosted)] = container;
   }
 }
 
@@ -70,7 +70,8 @@ void Particle::ParticleContainerBundle::get_packed_particle_objects_of_all_conta
   for (const auto& type : storedtypes_)
   {
     // get container of owned particles
-    ParticleContainer* container = (containers_[type])[static_cast<int>(Status::Owned)].get();
+    ParticleContainer* container =
+        (containers_[static_cast<int>(type)])[static_cast<int>(Status::Owned)].get();
 
     // loop over particles in container
     for (int index = 0; index < container->particles_stored(); ++index)
@@ -96,7 +97,8 @@ void Particle::ParticleContainerBundle::get_vector_of_particle_objects_of_all_co
   for (const auto& type : storedtypes_)
   {
     // get container of owned particles
-    ParticleContainer* container = (containers_[type])[static_cast<int>(Status::Owned)].get();
+    ParticleContainer* container =
+        (containers_[static_cast<int>(type)])[static_cast<int>(Status::Owned)].get();
 
     // loop over particles in container
     for (int index = 0; index < container->particles_stored(); ++index)

--- a/src/particle/src/engine/4C_particle_engine_container_bundle.cpp
+++ b/src/particle/src/engine/4C_particle_engine_container_bundle.cpp
@@ -20,7 +20,7 @@ Particle::ParticleContainerBundle::ParticleContainerBundle()
 }
 
 void Particle::ParticleContainerBundle::setup(
-    const std::map<ParticleType, std::set<ParticleState>>& particlestatestotypes)
+    const std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes)
 {
   std::shared_ptr<ParticleContainer> container;
 
@@ -34,7 +34,7 @@ void Particle::ParticleContainerBundle::setup(
   for (const auto& typeIt : particlestatestotypes)
   {
     // get particle type
-    ParticleType type = typeIt.first;
+    Particle::Type type = typeIt.first;
 
     // insert particle type into set of stored containers
     storedtypes_.insert(type);
@@ -43,7 +43,7 @@ void Particle::ParticleContainerBundle::setup(
     (containers_[static_cast<int>(type)]).resize(2);
 
     // set of particle state enums of current particle type (equal for owned and ghosted particles)
-    const std::set<ParticleState>& stateset = typeIt.second;
+    const std::set<Particle::State>& stateset = typeIt.second;
 
     // initial size of particle container
     int initialsize = 1;

--- a/src/particle/src/engine/4C_particle_engine_container_bundle.hpp
+++ b/src/particle/src/engine/4C_particle_engine_container_bundle.hpp
@@ -52,7 +52,7 @@ namespace Particle
      *
      * \param[in] particlestatestotypes particle types and corresponding states
      */
-    void setup(const std::map<ParticleType, std::set<ParticleState>>& particlestatestotypes);
+    void setup(const std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes);
 
     /*!
      * \brief get particle types of stored containers
@@ -60,7 +60,7 @@ namespace Particle
      *
      * \return reference to particle types of stored containers
      */
-    inline const std::set<ParticleType>& get_particle_types() const { return storedtypes_; };
+    inline const std::set<Particle::Type>& get_particle_types() const { return storedtypes_; };
 
     /*!
      * \brief get specific particle container
@@ -71,7 +71,8 @@ namespace Particle
      *
      * @return pointer to particle container
      */
-    inline ParticleContainer* get_specific_container(ParticleType type, ParticleStatus status) const
+    inline ParticleContainer* get_specific_container(
+        Particle::Type type, Particle::Status status) const
     {
       FOUR_C_ASSERT(storedtypes_.contains(type), "container for particle type '{}' not stored!",
           enum_to_type_name(type));
@@ -91,7 +92,7 @@ namespace Particle
      * \param[in] type  particle type
      */
     inline void scale_state_specific_container(
-        double fac, ParticleState state, ParticleType type) const
+        double fac, Particle::State state, Particle::Type type) const
     {
       FOUR_C_ASSERT(storedtypes_.contains(type), "container for particle type '{}' not stored!",
           enum_to_type_name(type));
@@ -111,8 +112,8 @@ namespace Particle
      * \param[in] stateB second particle state
      * \param[in] type   particle type
      */
-    inline void update_state_specific_container(double facA, ParticleState stateA, double facB,
-        ParticleState stateB, ParticleType type) const
+    inline void update_state_specific_container(double facA, Particle::State stateA, double facB,
+        Particle::State stateB, Particle::Type type) const
     {
       FOUR_C_ASSERT(storedtypes_.contains(type), "container for particle type '{}' not stored!",
           enum_to_type_name(type));
@@ -130,7 +131,7 @@ namespace Particle
      * \param[in] type  particle type
      */
     inline void set_state_specific_container(
-        std::vector<double> val, ParticleState state, ParticleType type) const
+        std::vector<double> val, Particle::State state, Particle::Type type) const
     {
       FOUR_C_ASSERT(storedtypes_.contains(type), "container for particle type '{}' not stored!",
           enum_to_type_name(type));
@@ -146,7 +147,7 @@ namespace Particle
      * \param[in] state particle state
      * \param[in] type  particle type
      */
-    inline void clear_state_specific_container(ParticleState state, ParticleType type) const
+    inline void clear_state_specific_container(Particle::State state, Particle::Type type) const
     {
       FOUR_C_ASSERT(storedtypes_.contains(type), "container for particle type '{}' not stored!",
           enum_to_type_name(type));
@@ -166,7 +167,7 @@ namespace Particle
      * \param[in] fac   scale factor
      * \param[in] state particle state
      */
-    inline void scale_state_all_containers(double fac, ParticleState state) const
+    inline void scale_state_all_containers(double fac, Particle::State state) const
     {
       for (const auto& type : storedtypes_)
         ((containers_[static_cast<int>(type)])[static_cast<int>(Status::Owned)])
@@ -184,7 +185,7 @@ namespace Particle
      * \param[in] stateB second particle state
      */
     inline void update_state_all_containers(
-        double facA, ParticleState stateA, double facB, ParticleState stateB) const
+        double facA, Particle::State stateA, double facB, Particle::State stateB) const
     {
       for (const auto& type : storedtypes_)
         ((containers_[static_cast<int>(type)])[static_cast<int>(Status::Owned)])
@@ -198,7 +199,7 @@ namespace Particle
      * \param[in] val   particle state value
      * \param[in] state particle state
      */
-    inline void set_state_all_containers(std::vector<double> val, ParticleState state) const
+    inline void set_state_all_containers(std::vector<double> val, Particle::State state) const
     {
       for (const auto& type : storedtypes_)
         ((containers_[static_cast<int>(type)])[static_cast<int>(Status::Owned)])
@@ -211,7 +212,7 @@ namespace Particle
      *
      * \param[in] state particle state
      */
-    inline void clear_state_all_containers(ParticleState state) const
+    inline void clear_state_all_containers(Particle::State state) const
     {
       for (const auto& type : storedtypes_)
         ((containers_[static_cast<int>(type)])[static_cast<int>(Status::Owned)])
@@ -230,7 +231,7 @@ namespace Particle
      * \param[in] status particle status
      */
     inline void check_and_decrease_size_all_containers_of_specific_status(
-        ParticleStatus status) const
+        Particle::Status status) const
     {
       for (const auto& type : storedtypes_)
         ((containers_[static_cast<int>(type)])[static_cast<int>(status)])
@@ -243,7 +244,7 @@ namespace Particle
      *
      * \param[in] status particle status
      */
-    inline void clear_all_containers_of_specific_status(ParticleStatus status) const
+    inline void clear_all_containers_of_specific_status(Particle::Status status) const
     {
       for (const auto& type : storedtypes_)
         ((containers_[static_cast<int>(type)])[static_cast<int>(status)])->clear_container();
@@ -275,7 +276,7 @@ namespace Particle
 
    private:
     //! set of particle types of stored containers
-    std::set<ParticleType> storedtypes_;
+    std::set<Particle::Type> storedtypes_;
 
     //! collection of particle containers indexed by particle type enum and particle status enum
     TypeStatusContainers containers_;

--- a/src/particle/src/engine/4C_particle_engine_container_bundle.hpp
+++ b/src/particle/src/engine/4C_particle_engine_container_bundle.hpp
@@ -76,7 +76,7 @@ namespace Particle
       FOUR_C_ASSERT(storedtypes_.contains(type), "container for particle type '{}' not stored!",
           enum_to_type_name(type));
 
-      return (containers_[type])[static_cast<int>(status)].get();
+      return (containers_[static_cast<int>(type)])[static_cast<int>(status)].get();
     };
 
     //! \name manipulate particle states of owned particles of specific type
@@ -96,7 +96,8 @@ namespace Particle
       FOUR_C_ASSERT(storedtypes_.contains(type), "container for particle type '{}' not stored!",
           enum_to_type_name(type));
 
-      ((containers_[type])[static_cast<int>(Status::Owned)])->scale_state(fac, state);
+      ((containers_[static_cast<int>(type)])[static_cast<int>(Status::Owned)])
+          ->scale_state(fac, state);
     };
 
     /*!
@@ -116,7 +117,7 @@ namespace Particle
       FOUR_C_ASSERT(storedtypes_.contains(type), "container for particle type '{}' not stored!",
           enum_to_type_name(type));
 
-      ((containers_[type])[static_cast<int>(Status::Owned)])
+      ((containers_[static_cast<int>(type)])[static_cast<int>(Status::Owned)])
           ->update_state(facA, stateA, facB, stateB);
     };
 
@@ -134,7 +135,8 @@ namespace Particle
       FOUR_C_ASSERT(storedtypes_.contains(type), "container for particle type '{}' not stored!",
           enum_to_type_name(type));
 
-      ((containers_[type])[static_cast<int>(Status::Owned)])->set_state(val, state);
+      ((containers_[static_cast<int>(type)])[static_cast<int>(Status::Owned)])
+          ->set_state(val, state);
     };
 
     /*!
@@ -149,7 +151,7 @@ namespace Particle
       FOUR_C_ASSERT(storedtypes_.contains(type), "container for particle type '{}' not stored!",
           enum_to_type_name(type));
 
-      ((containers_[type])[static_cast<int>(Status::Owned)])->clear_state(state);
+      ((containers_[static_cast<int>(type)])[static_cast<int>(Status::Owned)])->clear_state(state);
     };
 
     //! @}
@@ -167,7 +169,8 @@ namespace Particle
     inline void scale_state_all_containers(double fac, ParticleState state) const
     {
       for (const auto& type : storedtypes_)
-        ((containers_[type])[static_cast<int>(Status::Owned)])->scale_state(fac, state);
+        ((containers_[static_cast<int>(type)])[static_cast<int>(Status::Owned)])
+            ->scale_state(fac, state);
     };
 
     /*!
@@ -184,7 +187,7 @@ namespace Particle
         double facA, ParticleState stateA, double facB, ParticleState stateB) const
     {
       for (const auto& type : storedtypes_)
-        ((containers_[type])[static_cast<int>(Status::Owned)])
+        ((containers_[static_cast<int>(type)])[static_cast<int>(Status::Owned)])
             ->update_state(facA, stateA, facB, stateB);
     };
 
@@ -198,7 +201,8 @@ namespace Particle
     inline void set_state_all_containers(std::vector<double> val, ParticleState state) const
     {
       for (const auto& type : storedtypes_)
-        ((containers_[type])[static_cast<int>(Status::Owned)])->set_state(val, state);
+        ((containers_[static_cast<int>(type)])[static_cast<int>(Status::Owned)])
+            ->set_state(val, state);
     };
 
     /*!
@@ -210,7 +214,8 @@ namespace Particle
     inline void clear_state_all_containers(ParticleState state) const
     {
       for (const auto& type : storedtypes_)
-        ((containers_[type])[static_cast<int>(Status::Owned)])->clear_state(state);
+        ((containers_[static_cast<int>(type)])[static_cast<int>(Status::Owned)])
+            ->clear_state(state);
     };
 
     //! @}
@@ -228,7 +233,8 @@ namespace Particle
         ParticleStatus status) const
     {
       for (const auto& type : storedtypes_)
-        ((containers_[type])[static_cast<int>(status)])->check_and_decrease_container_size();
+        ((containers_[static_cast<int>(type)])[static_cast<int>(status)])
+            ->check_and_decrease_container_size();
     }
 
     /*!
@@ -240,7 +246,7 @@ namespace Particle
     inline void clear_all_containers_of_specific_status(ParticleStatus status) const
     {
       for (const auto& type : storedtypes_)
-        ((containers_[type])[static_cast<int>(status)])->clear_container();
+        ((containers_[static_cast<int>(type)])[static_cast<int>(status)])->clear_container();
     };
 
     //! @}

--- a/src/particle/src/engine/4C_particle_engine_container_bundle.hpp
+++ b/src/particle/src/engine/4C_particle_engine_container_bundle.hpp
@@ -76,7 +76,7 @@ namespace Particle
       FOUR_C_ASSERT(storedtypes_.contains(type), "container for particle type '{}' not stored!",
           enum_to_type_name(type));
 
-      return (containers_[type])[status].get();
+      return (containers_[type])[static_cast<int>(status)].get();
     };
 
     //! \name manipulate particle states of owned particles of specific type
@@ -96,7 +96,7 @@ namespace Particle
       FOUR_C_ASSERT(storedtypes_.contains(type), "container for particle type '{}' not stored!",
           enum_to_type_name(type));
 
-      ((containers_[type])[Owned])->scale_state(fac, state);
+      ((containers_[type])[static_cast<int>(Status::Owned)])->scale_state(fac, state);
     };
 
     /*!
@@ -116,7 +116,8 @@ namespace Particle
       FOUR_C_ASSERT(storedtypes_.contains(type), "container for particle type '{}' not stored!",
           enum_to_type_name(type));
 
-      ((containers_[type])[Owned])->update_state(facA, stateA, facB, stateB);
+      ((containers_[type])[static_cast<int>(Status::Owned)])
+          ->update_state(facA, stateA, facB, stateB);
     };
 
     /*!
@@ -133,7 +134,7 @@ namespace Particle
       FOUR_C_ASSERT(storedtypes_.contains(type), "container for particle type '{}' not stored!",
           enum_to_type_name(type));
 
-      ((containers_[type])[Owned])->set_state(val, state);
+      ((containers_[type])[static_cast<int>(Status::Owned)])->set_state(val, state);
     };
 
     /*!
@@ -148,7 +149,7 @@ namespace Particle
       FOUR_C_ASSERT(storedtypes_.contains(type), "container for particle type '{}' not stored!",
           enum_to_type_name(type));
 
-      ((containers_[type])[Owned])->clear_state(state);
+      ((containers_[type])[static_cast<int>(Status::Owned)])->clear_state(state);
     };
 
     //! @}
@@ -165,7 +166,8 @@ namespace Particle
      */
     inline void scale_state_all_containers(double fac, ParticleState state) const
     {
-      for (const auto& type : storedtypes_) ((containers_[type])[Owned])->scale_state(fac, state);
+      for (const auto& type : storedtypes_)
+        ((containers_[type])[static_cast<int>(Status::Owned)])->scale_state(fac, state);
     };
 
     /*!
@@ -182,7 +184,8 @@ namespace Particle
         double facA, ParticleState stateA, double facB, ParticleState stateB) const
     {
       for (const auto& type : storedtypes_)
-        ((containers_[type])[Owned])->update_state(facA, stateA, facB, stateB);
+        ((containers_[type])[static_cast<int>(Status::Owned)])
+            ->update_state(facA, stateA, facB, stateB);
     };
 
     /*!
@@ -194,7 +197,8 @@ namespace Particle
      */
     inline void set_state_all_containers(std::vector<double> val, ParticleState state) const
     {
-      for (const auto& type : storedtypes_) ((containers_[type])[Owned])->set_state(val, state);
+      for (const auto& type : storedtypes_)
+        ((containers_[type])[static_cast<int>(Status::Owned)])->set_state(val, state);
     };
 
     /*!
@@ -205,7 +209,8 @@ namespace Particle
      */
     inline void clear_state_all_containers(ParticleState state) const
     {
-      for (const auto& type : storedtypes_) ((containers_[type])[Owned])->clear_state(state);
+      for (const auto& type : storedtypes_)
+        ((containers_[type])[static_cast<int>(Status::Owned)])->clear_state(state);
     };
 
     //! @}
@@ -223,7 +228,7 @@ namespace Particle
         ParticleStatus status) const
     {
       for (const auto& type : storedtypes_)
-        ((containers_[type])[status])->check_and_decrease_container_size();
+        ((containers_[type])[static_cast<int>(status)])->check_and_decrease_container_size();
     }
 
     /*!
@@ -234,7 +239,8 @@ namespace Particle
      */
     inline void clear_all_containers_of_specific_status(ParticleStatus status) const
     {
-      for (const auto& type : storedtypes_) ((containers_[type])[status])->clear_container();
+      for (const auto& type : storedtypes_)
+        ((containers_[type])[static_cast<int>(status)])->clear_container();
     };
 
     //! @}

--- a/src/particle/src/engine/4C_particle_engine_enums.cpp
+++ b/src/particle/src/engine/4C_particle_engine_enums.cpp
@@ -60,7 +60,7 @@ int Particle::enum_to_state_dim(const ParticleState& state)
     case ParticleState::ColorfieldGradient:
     case ParticleState::InterfaceNormal:
     case ParticleState::WallInterfaceNormal:
-    case ParticleState::temperature_gradient:
+    case ParticleState::TemperatureGradient:
     case ParticleState::AngularVelocity:
     case ParticleState::AngularAcceleration:
     case ParticleState::Force:
@@ -180,7 +180,7 @@ std::string Particle::enum_to_state_name(const ParticleState& state)
     case ParticleState::WallInterfaceNormal:
       name = "wall interface normal";
       break;
-    case ParticleState::temperature_gradient:
+    case ParticleState::TemperatureGradient:
       name = "temperature gradient";
       break;
     case ParticleState::LastIterPosition:

--- a/src/particle/src/engine/4C_particle_engine_enums.cpp
+++ b/src/particle/src/engine/4C_particle_engine_enums.cpp
@@ -259,9 +259,11 @@ static std::vector<std::string> particle_type_names = {
 
 std::string Particle::enum_to_type_name(const ParticleType& type)
 {
-  FOUR_C_ASSERT(type >= 0 and type < static_cast<int>(particle_type_names.size()),
+  const int type_idx = static_cast<int>(type);
+
+  FOUR_C_ASSERT(type_idx >= 0 and type_idx < static_cast<int>(particle_type_names.size()),
       "particle type out of range!");
-  return particle_type_names[type];
+  return particle_type_names[type_idx];
 }
 
 Particle::ParticleType Particle::enum_from_type_name(const std::string& name)

--- a/src/particle/src/engine/4C_particle_engine_enums.cpp
+++ b/src/particle/src/engine/4C_particle_engine_enums.cpp
@@ -19,58 +19,58 @@ int Particle::enum_to_state_dim(const ParticleState& state)
   switch (state)
   {
     // scalar states
-    case Radius:
-    case Mass:
-    case Density:
-    case Pressure:
-    case Temperature:
-    case RigidBodyColor:
-    case Inertia:
-    case DensitySum:
-    case DensityDot:
-    case TemperatureDot:
-    case BoundaryPressure:
-    case Colorfield:
-    case Curvature:
-    case WallColorfield:
-    case LastIterDensity:
-    case LastIterTemperature:
-    case Young:
-    case CriticalStretch:
-    case PDBodyId:
-    case InitialConnectedBonds:
-    case CurrentConnectedBonds:
-    case PDDamageVariable:
-    case DirichletFunctionId:
-    case OpenBoundaryId:
+    case ParticleState::Radius:
+    case ParticleState::Mass:
+    case ParticleState::Density:
+    case ParticleState::Pressure:
+    case ParticleState::Temperature:
+    case ParticleState::RigidBodyColor:
+    case ParticleState::Inertia:
+    case ParticleState::DensitySum:
+    case ParticleState::DensityDot:
+    case ParticleState::TemperatureDot:
+    case ParticleState::BoundaryPressure:
+    case ParticleState::Colorfield:
+    case ParticleState::Curvature:
+    case ParticleState::WallColorfield:
+    case ParticleState::LastIterDensity:
+    case ParticleState::LastIterTemperature:
+    case ParticleState::Young:
+    case ParticleState::CriticalStretch:
+    case ParticleState::PDBodyId:
+    case ParticleState::InitialConnectedBonds:
+    case ParticleState::CurrentConnectedBonds:
+    case ParticleState::PDDamageVariable:
+    case ParticleState::DirichletFunctionId:
+    case ParticleState::OpenBoundaryId:
       dim = 1;
       break;
 
     // vectorial states
-    case Position:
-    case Velocity:
-    case Acceleration:
-    case LastTransferPosition:
-    case ModifiedVelocity:
-    case ModifiedAcceleration:
-    case ReferencePosition:
-    case RelativePosition:
-    case RelativePositionBodyFrame:
-    case BoundaryVelocity:
-    case ColorfieldGradient:
-    case InterfaceNormal:
-    case WallInterfaceNormal:
-    case temperature_gradient:
-    case AngularVelocity:
-    case AngularAcceleration:
-    case Force:
-    case Moment:
-    case LastIterPosition:
-    case LastIterVelocity:
-    case LastIterAcceleration:
-    case LastIterAngularVelocity:
-    case LastIterAngularAcceleration:
-    case LastIterModifiedAcceleration:
+    case ParticleState::Position:
+    case ParticleState::Velocity:
+    case ParticleState::Acceleration:
+    case ParticleState::LastTransferPosition:
+    case ParticleState::ModifiedVelocity:
+    case ParticleState::ModifiedAcceleration:
+    case ParticleState::ReferencePosition:
+    case ParticleState::RelativePosition:
+    case ParticleState::RelativePositionBodyFrame:
+    case ParticleState::BoundaryVelocity:
+    case ParticleState::ColorfieldGradient:
+    case ParticleState::InterfaceNormal:
+    case ParticleState::WallInterfaceNormal:
+    case ParticleState::temperature_gradient:
+    case ParticleState::AngularVelocity:
+    case ParticleState::AngularAcceleration:
+    case ParticleState::Force:
+    case ParticleState::Moment:
+    case ParticleState::LastIterPosition:
+    case ParticleState::LastIterVelocity:
+    case ParticleState::LastIterAcceleration:
+    case ParticleState::LastIterAngularVelocity:
+    case ParticleState::LastIterAngularAcceleration:
+    case ParticleState::LastIterModifiedAcceleration:
       dim = 3;
       break;
 
@@ -87,148 +87,148 @@ std::string Particle::enum_to_state_name(const ParticleState& state)
 
   switch (state)
   {
-    case Radius:
+    case ParticleState::Radius:
       name = "radius";
       break;
-    case Mass:
+    case ParticleState::Mass:
       name = "mass";
       break;
-    case Density:
+    case ParticleState::Density:
       name = "density";
       break;
-    case DensitySum:
+    case ParticleState::DensitySum:
       name = "density sum";
       break;
-    case DensityDot:
+    case ParticleState::DensityDot:
       name = "density dot";
       break;
-    case Pressure:
+    case ParticleState::Pressure:
       name = "pressure";
       break;
-    case Temperature:
+    case ParticleState::Temperature:
       name = "temperature";
       break;
-    case RigidBodyColor:
+    case ParticleState::RigidBodyColor:
       name = "rigid body color";
       break;
-    case Inertia:
+    case ParticleState::Inertia:
       name = "inertia";
       break;
-    case TemperatureDot:
+    case ParticleState::TemperatureDot:
       name = "temperature dot";
       break;
-    case Position:
+    case ParticleState::Position:
       name = "position";
       break;
-    case Velocity:
+    case ParticleState::Velocity:
       name = "velocity";
       break;
-    case Acceleration:
+    case ParticleState::Acceleration:
       name = "acceleration";
       break;
-    case AngularVelocity:
+    case ParticleState::AngularVelocity:
       name = "angular velocity";
       break;
-    case AngularAcceleration:
+    case ParticleState::AngularAcceleration:
       name = "angular acceleration";
       break;
-    case Force:
+    case ParticleState::Force:
       name = "force";
       break;
-    case Moment:
+    case ParticleState::Moment:
       name = "moment";
       break;
-    case LastTransferPosition:
+    case ParticleState::LastTransferPosition:
       name = "position last transfer";
       break;
-    case ReferencePosition:
+    case ParticleState::ReferencePosition:
       name = "reference position";
       break;
-    case RelativePosition:
+    case ParticleState::RelativePosition:
       name = "relative position";
       break;
-    case RelativePositionBodyFrame:
+    case ParticleState::RelativePositionBodyFrame:
       name = "body frame relative position";
       break;
-    case ModifiedVelocity:
+    case ParticleState::ModifiedVelocity:
       name = "modified velocity";
       break;
-    case ModifiedAcceleration:
+    case ParticleState::ModifiedAcceleration:
       name = "modified acceleration";
       break;
-    case BoundaryPressure:
+    case ParticleState::BoundaryPressure:
       name = "boundary pressure";
       break;
-    case BoundaryVelocity:
+    case ParticleState::BoundaryVelocity:
       name = "boundary velocity";
       break;
-    case Colorfield:
+    case ParticleState::Colorfield:
       name = "colorfield";
       break;
-    case ColorfieldGradient:
+    case ParticleState::ColorfieldGradient:
       name = "colorfield gradient";
       break;
-    case InterfaceNormal:
+    case ParticleState::InterfaceNormal:
       name = "interface normal";
       break;
-    case Curvature:
+    case ParticleState::Curvature:
       name = "curvature";
       break;
-    case WallColorfield:
+    case ParticleState::WallColorfield:
       name = "wall colorfield";
       break;
-    case WallInterfaceNormal:
+    case ParticleState::WallInterfaceNormal:
       name = "wall interface normal";
       break;
-    case temperature_gradient:
+    case ParticleState::temperature_gradient:
       name = "temperature gradient";
       break;
-    case LastIterPosition:
+    case ParticleState::LastIterPosition:
       name = "position last iteration";
       break;
-    case LastIterVelocity:
+    case ParticleState::LastIterVelocity:
       name = "velocity last iteration";
       break;
-    case LastIterAcceleration:
+    case ParticleState::LastIterAcceleration:
       name = "acceleration last iteration";
       break;
-    case LastIterAngularVelocity:
+    case ParticleState::LastIterAngularVelocity:
       name = "angular velocity last iteration";
       break;
-    case LastIterAngularAcceleration:
+    case ParticleState::LastIterAngularAcceleration:
       name = "angular acceleration last iteration";
       break;
-    case LastIterModifiedAcceleration:
+    case ParticleState::LastIterModifiedAcceleration:
       name = "modified acceleration last iteration";
       break;
-    case LastIterDensity:
+    case ParticleState::LastIterDensity:
       name = "density last iteration";
       break;
-    case LastIterTemperature:
+    case ParticleState::LastIterTemperature:
       name = "temperature last iteration";
       break;
-    case PDBodyId:
+    case ParticleState::PDBodyId:
       name = "peridynamics body id";
       break;
-    case CriticalStretch:
+    case ParticleState::CriticalStretch:
       name = "critical stretch";
       break;
-    case Young:
+    case ParticleState::Young:
       name = "Youngs modulus";
       break;
-    case InitialConnectedBonds:
+    case ParticleState::InitialConnectedBonds:
       name = "initial active bonds";
       break;
-    case CurrentConnectedBonds:
+    case ParticleState::CurrentConnectedBonds:
       name = "remained active bonds";
       break;
-    case PDDamageVariable:
+    case ParticleState::PDDamageVariable:
       name = "pd_damage_phi";
       break;
-    case DirichletFunctionId:
+    case ParticleState::DirichletFunctionId:
       name = "dirichlet_function_id";
       break;
-    case OpenBoundaryId:
+    case ParticleState::OpenBoundaryId:
       name = "open_boundary_id";
       break;
     default:
@@ -243,11 +243,11 @@ Particle::ParticleState Particle::enum_from_state_name(const std::string& name)
   ParticleState state;
 
   if (name == "density")
-    state = Density;
+    state = ParticleState::Density;
   else if (name == "pressure")
-    state = Pressure;
+    state = ParticleState::Pressure;
   else if (name == "temperature")
-    state = Temperature;
+    state = ParticleState::Temperature;
   else
     FOUR_C_THROW("particle state '{}' unknown!", name);
 

--- a/src/particle/src/engine/4C_particle_engine_enums.cpp
+++ b/src/particle/src/engine/4C_particle_engine_enums.cpp
@@ -279,10 +279,10 @@ std::string Particle::enum_to_status_name(const ParticleStatus& status)
 
   switch (status)
   {
-    case Owned:
+    case ParticleStatus::Owned:
       name = "owned";
       break;
-    case Ghosted:
+    case ParticleStatus::Ghosted:
       name = "ghosted";
       break;
     default:

--- a/src/particle/src/engine/4C_particle_engine_enums.hpp
+++ b/src/particle/src/engine/4C_particle_engine_enums.hpp
@@ -153,7 +153,7 @@ namespace Particle
    * Enum for respective particle type used to relate and distinguish particles to different phases.
    *
    */
-  enum ParticleType
+  enum class ParticleType
   {
     /*---------------------------------------------------------------------------*/
     // default particle types
@@ -161,12 +161,12 @@ namespace Particle
     Phase2,  //!< particle type for particles of second phase
     /*---------------------------------------------------------------------------*/
     // particle types for SPH interaction
-    BoundaryPhase,     //!< particle type for boundary phase particles
-    RigidPhase,        //!< particle type for rigid phase particles
-    DirichletPhase,    //!< particle type for dirichlet phase particles (open boundary)
-    NeumannPhase,      //!< particle type for neumann phase particles (open boundary)
-    PDPhase,           //!< particle type for peridynamic phase particles
-    UninitializedType  //!< not yet defined particle type
+    BoundaryPhase,   //!< particle type for boundary phase particles
+    RigidPhase,      //!< particle type for rigid phase particles
+    DirichletPhase,  //!< particle type for dirichlet phase particles (open boundary)
+    NeumannPhase,    //!< particle type for neumann phase particles (open boundary)
+    PDPhase,         //!< particle type for peridynamic phase particles
+    Uninitialized    //!< not yet defined particle type
     /*---------------------------------------------------------------------------*/
   };
 

--- a/src/particle/src/engine/4C_particle_engine_enums.hpp
+++ b/src/particle/src/engine/4C_particle_engine_enums.hpp
@@ -31,7 +31,7 @@ namespace Particle
    * \brief enums of particle states
    *
    */
-  enum ParticleState
+  enum class ParticleState
   {
     /*---------------------------------------------------------------------------*/
     // default particle states

--- a/src/particle/src/engine/4C_particle_engine_enums.hpp
+++ b/src/particle/src/engine/4C_particle_engine_enums.hpp
@@ -61,18 +61,18 @@ namespace Particle
     Inertia,                    //!< mass moment of inertia
     /*---------------------------------------------------------------------------*/
     // particle states for SPH interaction
-    DensitySum,            //!< density from summation of weighted masses
-    DensityDot,            //!< first time derivative of density
-    TemperatureDot,        //!< first time derivative of temperature
-    BoundaryPressure,      //!< boundary pressure
-    BoundaryVelocity,      //!< boundary velocity
-    Colorfield,            //!< colorfield
-    ColorfieldGradient,    //!< colorfield gradient
-    InterfaceNormal,       //!< interface normal
-    Curvature,             //!< curvature
-    WallColorfield,        //!< wall colorfield
-    WallInterfaceNormal,   //!< wall interface normal
-    temperature_gradient,  //!< temperature gradient
+    DensitySum,           //!< density from summation of weighted masses
+    DensityDot,           //!< first time derivative of density
+    TemperatureDot,       //!< first time derivative of temperature
+    BoundaryPressure,     //!< boundary pressure
+    BoundaryVelocity,     //!< boundary velocity
+    Colorfield,           //!< colorfield
+    ColorfieldGradient,   //!< colorfield gradient
+    InterfaceNormal,      //!< interface normal
+    Curvature,            //!< curvature
+    WallColorfield,       //!< wall colorfield
+    WallInterfaceNormal,  //!< wall interface normal
+    TemperatureGradient,  //!< temperature gradient
     /*---------------------------------------------------------------------------*/
     // particle states for DEM interaction
     AngularVelocity,      //!< angular velocity

--- a/src/particle/src/engine/4C_particle_engine_enums.hpp
+++ b/src/particle/src/engine/4C_particle_engine_enums.hpp
@@ -207,11 +207,11 @@ namespace Particle
    * processor.
    *
    */
-  enum ParticleStatus
+  enum class ParticleStatus
   {
-    Owned,               //!< particle status for particles being owned on processors
-    Ghosted,             //!< particle status for particles being ghosted on processors
-    UninitializedStatus  //!< not yet defined particle status
+    Owned,         //!< particle status for particles being owned on processors
+    Ghosted,       //!< particle status for particles being ghosted on processors
+    Uninitialized  //!< not yet defined particle status
   };
 
   /*!

--- a/src/particle/src/engine/4C_particle_engine_interface.hpp
+++ b/src/particle/src/engine/4C_particle_engine_interface.hpp
@@ -243,7 +243,7 @@ namespace Particle
      *
      * \return number of particles on this processors
      */
-    virtual int get_number_of_particles_of_specific_type(const ParticleType type) const = 0;
+    virtual int get_number_of_particles_of_specific_type(const Particle::Type type) const = 0;
   };
 
 }  // namespace Particle

--- a/src/particle/src/engine/4C_particle_engine_object.cpp
+++ b/src/particle/src/engine/4C_particle_engine_object.cpp
@@ -24,7 +24,8 @@ Core::Communication::ParObject* Particle::ParticleObjectType::create(
   return my_particleobject;
 }
 
-Particle::ParticleObject::ParticleObject() : type_(Phase1), globalid_(0), bingid_(-1), index_(-1)
+Particle::ParticleObject::ParticleObject()
+    : type_(ParticleType::Phase1), globalid_(0), bingid_(-1), index_(-1)
 {
   // empty constructor
 }

--- a/src/particle/src/engine/4C_particle_engine_object.cpp
+++ b/src/particle/src/engine/4C_particle_engine_object.cpp
@@ -25,13 +25,13 @@ Core::Communication::ParObject* Particle::ParticleObjectType::create(
 }
 
 Particle::ParticleObject::ParticleObject()
-    : type_(ParticleType::Phase1), globalid_(0), bingid_(-1), index_(-1)
+    : type_(Particle::Type::Phase1), globalid_(0), bingid_(-1), index_(-1)
 {
   // empty constructor
 }
 
 Particle::ParticleObject::ParticleObject(
-    ParticleType type, int globalid, const ParticleStates& states, int bingid, int index)
+    Particle::Type type, int globalid, const ParticleStates& states, int bingid, int index)
     : type_(type), globalid_(globalid), states_(states), bingid_(bingid), index_(index)
 {
   // empty constructor

--- a/src/particle/src/engine/4C_particle_engine_object.hpp
+++ b/src/particle/src/engine/4C_particle_engine_object.hpp
@@ -93,7 +93,7 @@ namespace Particle
      * \param[in] index    index of particle in container
      *                     optional: set to -1 if omnitted
      */
-    ParticleObject(ParticleType type, int globalid, const ParticleStates& states, int bingid = -1,
+    ParticleObject(Particle::Type type, int globalid, const ParticleStates& states, int bingid = -1,
         int index = -1);
 
     int unique_par_object_id() const override
@@ -127,7 +127,7 @@ namespace Particle
      *
      * \return particle type
      */
-    inline ParticleType return_particle_type() const { return type_; };
+    inline Particle::Type return_particle_type() const { return type_; };
 
     /*!
      * \brief get global id of particle
@@ -165,7 +165,7 @@ namespace Particle
 
    private:
     //! particle type
-    ParticleType type_;
+    Particle::Type type_;
 
     //! global id of particle
     int globalid_;

--- a/src/particle/src/engine/4C_particle_engine_particlereader.cpp
+++ b/src/particle/src/engine/4C_particle_engine_particlereader.cpp
@@ -50,22 +50,24 @@ void Particle::read_particles(Core::IO::InputFile& input, const std::string& sec
       particletype = Particle::enum_from_type_name(type);
 
       // allocate memory to hold particle position state
-      particlestates.resize(Particle::Position + 1);
+      particlestates.resize(static_cast<int>(Particle::State::Position) + 1);
 
       // set position state
-      particlestates[Particle::Position] = std::vector<double>(pos.begin(), pos.end());
+      particlestates[static_cast<int>(Particle::State::Position)] =
+          std::vector<double>(pos.begin(), pos.end());
 
       // optional particle states
       {
         std::string statelabel;
-        Particle::StateEnum particlestate;
+        Particle::State particlestate;
         std::vector<double> state;
 
         // optional particle parameters
         const std::unordered_map<std::string, Particle::ParticleState> additional_states = {
-            {"RAD", Particle::Radius}, {"RIGIDCOLOR", Particle::RigidBodyColor},
-            {"PDBODYID", Particle::PDBodyId}, {"DIRICHLET_FUNCT", Particle::DirichletFunctionId},
-            {"BOUNDARYID", Particle::OpenBoundaryId}};
+            {"RAD", Particle::State::Radius}, {"RIGIDCOLOR", Particle::State::RigidBodyColor},
+            {"PDBODYID", Particle::State::PDBodyId},
+            {"DIRICHLET_FUNCT", Particle::State::DirichletFunctionId},
+            {"BOUNDARYID", Particle::State::OpenBoundaryId}};
 
         while (!parser.at_end())
         {
@@ -93,11 +95,13 @@ void Particle::read_particles(Core::IO::InputFile& input, const std::string& sec
             FOUR_C_THROW("Optional particle state with label '{}' unknown!", statelabel);
 
           // allocate memory to hold optional particle state
-          if (static_cast<int>(particlestates.size()) < (particlestate + 1))
-            particlestates.resize(particlestate + 1);
+          const int particlestate_idx = static_cast<int>(particlestate);
+
+          if (static_cast<int>(particlestates.size()) < (particlestate_idx + 1))
+            particlestates.resize(particlestate_idx + 1);
 
           // set optional particle state
-          particlestates[particlestate] = state;
+          particlestates[particlestate_idx] = state;
         }
       }
 

--- a/src/particle/src/engine/4C_particle_engine_particlereader.cpp
+++ b/src/particle/src/engine/4C_particle_engine_particlereader.cpp
@@ -36,7 +36,7 @@ void Particle::read_particles(Core::IO::InputFile& input, const std::string& sec
     any_particles_read = true;
 
     {
-      Particle::TypeEnum particletype;
+      Particle::Type particletype;
       Particle::ParticleStates particlestates;
 
       Core::IO::ValueParser parser{particle_line.get_as_dat_style_string(),

--- a/src/particle/src/engine/4C_particle_engine_particlereader.cpp
+++ b/src/particle/src/engine/4C_particle_engine_particlereader.cpp
@@ -63,7 +63,7 @@ void Particle::read_particles(Core::IO::InputFile& input, const std::string& sec
         std::vector<double> state;
 
         // optional particle parameters
-        const std::unordered_map<std::string, Particle::ParticleState> additional_states = {
+        const std::unordered_map<std::string, Particle::State> additional_states = {
             {"RAD", Particle::State::Radius}, {"RIGIDCOLOR", Particle::State::RigidBodyColor},
             {"PDBODYID", Particle::State::PDBodyId},
             {"DIRICHLET_FUNCT", Particle::State::DirichletFunctionId},

--- a/src/particle/src/engine/4C_particle_engine_refresh_entry.cpp
+++ b/src/particle/src/engine/4C_particle_engine_refresh_entry.cpp
@@ -33,9 +33,10 @@ Particle::ParticleRefreshEntry Particle::ParticleRefreshEntry::unpack(
   ParticleRefreshEntry entry;
 
   // unpack particle type
-  int type_int;
-  extract_from_pack(buffer, type_int);
-  entry.type = static_cast<ParticleType>(type_int);
+  int type_idx;
+
+  extract_from_pack(buffer, type_idx);
+  entry.type = static_cast<ParticleType>(type_idx);
 
   // unpack ghosted index
   extract_from_pack(buffer, entry.ghostedindex);

--- a/src/particle/src/engine/4C_particle_engine_refresh_entry.cpp
+++ b/src/particle/src/engine/4C_particle_engine_refresh_entry.cpp
@@ -14,7 +14,7 @@ FOUR_C_NAMESPACE_OPEN
 /*---------------------------------------------------------------------------*
  | definitions                                                               |
  *---------------------------------------------------------------------------*/
-void Particle::ParticleRefreshEntry::pack(ParticleType type, int ghostedindex,
+void Particle::ParticleRefreshEntry::pack(Particle::Type type, int ghostedindex,
     const Core::Communication::PackBuffer& prepacked_states, std::vector<char>& sendbuffer)
 {
   // pack type and ghosted index header
@@ -36,7 +36,7 @@ Particle::ParticleRefreshEntry Particle::ParticleRefreshEntry::unpack(
   int type_idx;
 
   extract_from_pack(buffer, type_idx);
-  entry.type = static_cast<ParticleType>(type_idx);
+  entry.type = static_cast<Particle::Type>(type_idx);
 
   // unpack ghosted index
   extract_from_pack(buffer, entry.ghostedindex);

--- a/src/particle/src/engine/4C_particle_engine_refresh_entry.hpp
+++ b/src/particle/src/engine/4C_particle_engine_refresh_entry.hpp
@@ -44,7 +44,7 @@ namespace Particle
   struct ParticleRefreshEntry
   {
     //! particle type
-    ParticleType type;
+    Particle::Type type;
 
     //! local index of the particle in the container of ghosted particles on the target processor
     int ghostedindex;
@@ -65,7 +65,7 @@ namespace Particle
      * \param[in]  prepacked_states pre-packed particle states
      * \param[out] sendbuffer       send buffer of the target processor to append to
      */
-    static void pack(ParticleType type, int ghostedindex,
+    static void pack(Particle::Type type, int ghostedindex,
         const Core::Communication::PackBuffer& prepacked_states, std::vector<char>& sendbuffer);
 
     /*!

--- a/src/particle/src/engine/4C_particle_engine_runtime_vtp_writer.cpp
+++ b/src/particle/src/engine/4C_particle_engine_runtime_vtp_writer.cpp
@@ -31,14 +31,16 @@ void Particle::ParticleRuntimeVtpWriter::init(
   particlecontainerbundle_ = particlecontainerbundle;
 
   // insert specific particle states in black list
-  blackliststates_.insert({DensitySum, DensityDot});
-  blackliststates_.insert(TemperatureDot);
-  blackliststates_.insert({LastTransferPosition, ReferencePosition});
-  blackliststates_.insert({ModifiedVelocity, ModifiedAcceleration});
-  blackliststates_.insert({InterfaceNormal, Curvature, WallColorfield, WallInterfaceNormal});
-  blackliststates_.insert({LastIterPosition, LastIterVelocity, LastIterAcceleration,
-      LastIterAngularVelocity, LastIterAngularAcceleration, LastIterModifiedAcceleration,
-      LastIterDensity, LastIterTemperature});
+  blackliststates_.insert({State::DensitySum, State::DensityDot});
+  blackliststates_.insert(State::TemperatureDot);
+  blackliststates_.insert({State::LastTransferPosition, State::ReferencePosition});
+  blackliststates_.insert({State::ModifiedVelocity, State::ModifiedAcceleration});
+  blackliststates_.insert({State::InterfaceNormal, State::Curvature, State::WallColorfield,
+      State::WallInterfaceNormal});
+  blackliststates_.insert(
+      {State::LastIterPosition, State::LastIterVelocity, State::LastIterAcceleration,
+          State::LastIterAngularVelocity, State::LastIterAngularAcceleration,
+          State::LastIterModifiedAcceleration, State::LastIterDensity, State::LastIterTemperature});
 }
 
 void Particle::ParticleRuntimeVtpWriter::setup(bool write_ghosted_particles)
@@ -101,12 +103,12 @@ void Particle::ParticleRuntimeVtpWriter::set_particle_positions_and_states()
       const int particlestored = container->particles_stored();
 
       // get particle states stored in container
-      const std::set<ParticleState>& states = container->get_stored_states();
+      const std::set<State>& states = container->get_stored_states();
 
 #ifdef FOUR_C_ENABLE_ASSERTIONS
       // safety check
-      if (not container->have_stored_state(Position))
-        FOUR_C_THROW("particle state '{}' not found!", enum_to_state_name(Position));
+      if (not container->have_stored_state(State::Position))
+        FOUR_C_THROW("particle state '{}' not found!", enum_to_state_name(State::Position));
 #endif
 
       // iterate over particle states
@@ -122,7 +124,7 @@ void Particle::ParticleRuntimeVtpWriter::set_particle_positions_and_states()
         const double* state_ptr =
             (particlestored > 0) ? container->get_ptr_to_state(state, 0) : nullptr;
 
-        if (state == Position)
+        if (state == State::Position)
         {
           // get and prepare storage for position data
           std::vector<double>& positiondata =

--- a/src/particle/src/engine/4C_particle_engine_runtime_vtp_writer.cpp
+++ b/src/particle/src/engine/4C_particle_engine_runtime_vtp_writer.cpp
@@ -44,7 +44,8 @@ void Particle::ParticleRuntimeVtpWriter::init(
 void Particle::ParticleRuntimeVtpWriter::setup(bool write_ghosted_particles)
 {
   // determine size of vector indexed by particle types
-  const int typevectorsize = *(--particlecontainerbundle_->get_particle_types().end()) + 1;
+  const int typevectorsize =
+      static_cast<int>(*(--particlecontainerbundle_->get_particle_types().end())) + 1;
 
   // allocate memory to hold particle types
   runtime_visualization_managers_.resize(typevectorsize);
@@ -53,7 +54,7 @@ void Particle::ParticleRuntimeVtpWriter::setup(bool write_ghosted_particles)
   for (const auto& type : particlecontainerbundle_->get_particle_types())
   {
     // allocate memory for vtp writer objects of owned and ghosted states
-    (runtime_visualization_managers_[type]).resize(2);
+    (runtime_visualization_managers_[static_cast<int>(type)]).resize(2);
 
     // iterate over particle statuses
     for (const auto& status : {Status::Owned, Status::Ghosted})
@@ -64,7 +65,7 @@ void Particle::ParticleRuntimeVtpWriter::setup(bool write_ghosted_particles)
       fieldname << "particle-" << enum_to_type_name(type) << "-" << enum_to_status_name(status);
 
       // construct visualiation manager object for current particle type and status
-      (runtime_visualization_managers_[type])[static_cast<int>(status)] =
+      (runtime_visualization_managers_[static_cast<int>(type)])[static_cast<int>(status)] =
           std::make_shared<Core::IO::VisualizationManager>(
               Core::IO::visualization_parameters_factory(
                   Global::Problem::instance()->io_params().sublist("RUNTIME VTK OUTPUT"),
@@ -90,7 +91,8 @@ void Particle::ParticleRuntimeVtpWriter::set_particle_positions_and_states()
     for (const auto& status : {Status::Owned, Status::Ghosted})
     {
       // check for runtime vtp writer for current particle type and status
-      if (not(runtime_visualization_managers_[type])[static_cast<int>(status)]) continue;
+      if (not(runtime_visualization_managers_[static_cast<int>(type)])[static_cast<int>(status)])
+        continue;
 
       // get container of current particle type and status
       ParticleContainer* container = particlecontainerbundle_->get_specific_container(type, status);
@@ -124,7 +126,7 @@ void Particle::ParticleRuntimeVtpWriter::set_particle_positions_and_states()
         {
           // get and prepare storage for position data
           std::vector<double>& positiondata =
-              (runtime_visualization_managers_[type])[static_cast<int>(status)]
+              (runtime_visualization_managers_[static_cast<int>(type)])[static_cast<int>(status)]
                   ->get_visualization_data()
                   .get_point_coordinates();
           positiondata.clear();
@@ -151,7 +153,7 @@ void Particle::ParticleRuntimeVtpWriter::set_particle_positions_and_states()
           for (int i = 0; i < (statedim * particlestored); ++i) statedata.push_back(state_ptr[i]);
 
           // append particle state data to vtp writer
-          (runtime_visualization_managers_[type])[static_cast<int>(status)]
+          (runtime_visualization_managers_[static_cast<int>(type)])[static_cast<int>(status)]
               ->get_visualization_data()
               .set_point_data_vector<double>(statename, statedata, statedim);
         }
@@ -168,7 +170,7 @@ void Particle::ParticleRuntimeVtpWriter::set_particle_positions_and_states()
       for (int i = 0; i < particlestored; ++i) globaliddata.push_back(globalids[i]);
 
       // append global id of particles to vtp writer
-      (runtime_visualization_managers_[type])[static_cast<int>(status)]
+      (runtime_visualization_managers_[static_cast<int>(type)])[static_cast<int>(status)]
           ->get_visualization_data()
           .set_point_data_vector<int>("globalid", globaliddata, 1);
 
@@ -176,7 +178,7 @@ void Particle::ParticleRuntimeVtpWriter::set_particle_positions_and_states()
       std::vector<int> ownerdata(particlestored, Core::Communication::my_mpi_rank(comm_));
 
       // append owner of particles to vtp writer
-      (runtime_visualization_managers_[type])[static_cast<int>(status)]
+      (runtime_visualization_managers_[static_cast<int>(type)])[static_cast<int>(status)]
           ->get_visualization_data()
           .set_point_data_vector<int>("owner", ownerdata, 1);
     }
@@ -193,10 +195,11 @@ void Particle::ParticleRuntimeVtpWriter::write_to_disk(
     for (const auto& status : {Status::Owned, Status::Ghosted})
     {
       // check for runtime vtp writer for current particle type and status
-      if (not(runtime_visualization_managers_[type])[static_cast<int>(status)]) continue;
+      if (not(runtime_visualization_managers_[static_cast<int>(type)])[static_cast<int>(status)])
+        continue;
 
-      (runtime_visualization_managers_[type])[static_cast<int>(status)]->write_to_disk(
-          visualization_time, visualization_step);
+      (runtime_visualization_managers_[static_cast<int>(type)])[static_cast<int>(status)]
+          ->write_to_disk(visualization_time, visualization_step);
     }
   }
 }

--- a/src/particle/src/engine/4C_particle_engine_runtime_vtp_writer.cpp
+++ b/src/particle/src/engine/4C_particle_engine_runtime_vtp_writer.cpp
@@ -56,15 +56,15 @@ void Particle::ParticleRuntimeVtpWriter::setup(bool write_ghosted_particles)
     (runtime_visualization_managers_[type]).resize(2);
 
     // iterate over particle statuses
-    for (const auto& status : {Owned, Ghosted})
+    for (const auto& status : {Status::Owned, Status::Ghosted})
     {
-      if (status == Ghosted and write_ghosted_particles == false) continue;
+      if (status == Status::Ghosted and write_ghosted_particles == false) continue;
 
       std::ostringstream fieldname;
       fieldname << "particle-" << enum_to_type_name(type) << "-" << enum_to_status_name(status);
 
       // construct visualiation manager object for current particle type and status
-      (runtime_visualization_managers_[type])[status] =
+      (runtime_visualization_managers_[type])[static_cast<int>(status)] =
           std::make_shared<Core::IO::VisualizationManager>(
               Core::IO::visualization_parameters_factory(
                   Global::Problem::instance()->io_params().sublist("RUNTIME VTK OUTPUT"),
@@ -87,10 +87,10 @@ void Particle::ParticleRuntimeVtpWriter::set_particle_positions_and_states()
   for (const auto& type : particlecontainerbundle_->get_particle_types())
   {
     // iterate over particle statuses
-    for (const auto& status : {Owned, Ghosted})
+    for (const auto& status : {Status::Owned, Status::Ghosted})
     {
       // check for runtime vtp writer for current particle type and status
-      if (not(runtime_visualization_managers_[type])[status]) continue;
+      if (not(runtime_visualization_managers_[type])[static_cast<int>(status)]) continue;
 
       // get container of current particle type and status
       ParticleContainer* container = particlecontainerbundle_->get_specific_container(type, status);
@@ -123,9 +123,10 @@ void Particle::ParticleRuntimeVtpWriter::set_particle_positions_and_states()
         if (state == Position)
         {
           // get and prepare storage for position data
-          std::vector<double>& positiondata = (runtime_visualization_managers_[type])[status]
-                                                  ->get_visualization_data()
-                                                  .get_point_coordinates();
+          std::vector<double>& positiondata =
+              (runtime_visualization_managers_[type])[static_cast<int>(status)]
+                  ->get_visualization_data()
+                  .get_point_coordinates();
           positiondata.clear();
           positiondata.reserve(statedim * particlestored);
 
@@ -150,7 +151,7 @@ void Particle::ParticleRuntimeVtpWriter::set_particle_positions_and_states()
           for (int i = 0; i < (statedim * particlestored); ++i) statedata.push_back(state_ptr[i]);
 
           // append particle state data to vtp writer
-          (runtime_visualization_managers_[type])[status]
+          (runtime_visualization_managers_[type])[static_cast<int>(status)]
               ->get_visualization_data()
               .set_point_data_vector<double>(statename, statedata, statedim);
         }
@@ -167,7 +168,7 @@ void Particle::ParticleRuntimeVtpWriter::set_particle_positions_and_states()
       for (int i = 0; i < particlestored; ++i) globaliddata.push_back(globalids[i]);
 
       // append global id of particles to vtp writer
-      (runtime_visualization_managers_[type])[status]
+      (runtime_visualization_managers_[type])[static_cast<int>(status)]
           ->get_visualization_data()
           .set_point_data_vector<int>("globalid", globaliddata, 1);
 
@@ -175,7 +176,7 @@ void Particle::ParticleRuntimeVtpWriter::set_particle_positions_and_states()
       std::vector<int> ownerdata(particlestored, Core::Communication::my_mpi_rank(comm_));
 
       // append owner of particles to vtp writer
-      (runtime_visualization_managers_[type])[status]
+      (runtime_visualization_managers_[type])[static_cast<int>(status)]
           ->get_visualization_data()
           .set_point_data_vector<int>("owner", ownerdata, 1);
     }
@@ -189,12 +190,12 @@ void Particle::ParticleRuntimeVtpWriter::write_to_disk(
   for (const auto& type : particlecontainerbundle_->get_particle_types())
   {
     // iterate over particle statuses
-    for (const auto& status : {Owned, Ghosted})
+    for (const auto& status : {Status::Owned, Status::Ghosted})
     {
       // check for runtime vtp writer for current particle type and status
-      if (not(runtime_visualization_managers_[type])[status]) continue;
+      if (not(runtime_visualization_managers_[type])[static_cast<int>(status)]) continue;
 
-      (runtime_visualization_managers_[type])[status]->write_to_disk(
+      (runtime_visualization_managers_[type])[static_cast<int>(status)]->write_to_disk(
           visualization_time, visualization_step);
     }
   }

--- a/src/particle/src/engine/4C_particle_engine_runtime_vtp_writer.hpp
+++ b/src/particle/src/engine/4C_particle_engine_runtime_vtp_writer.hpp
@@ -110,7 +110,7 @@ namespace Particle
      *       about defining all particle states for the output via a list in the input file.
      *
      */
-    std::set<ParticleState> blackliststates_;
+    std::set<Particle::State> blackliststates_;
   };
 
 }  // namespace Particle

--- a/src/particle/src/engine/4C_particle_engine_typedefs.hpp
+++ b/src/particle/src/engine/4C_particle_engine_typedefs.hpp
@@ -44,7 +44,7 @@ namespace Core::Elements
 namespace Particle
 {
   //! particle type enum
-  using TypeEnum = ParticleType;
+  using Type = ParticleType;
 
   //! particle status enum
   using Status = ParticleStatus;

--- a/src/particle/src/engine/4C_particle_engine_typedefs.hpp
+++ b/src/particle/src/engine/4C_particle_engine_typedefs.hpp
@@ -50,7 +50,7 @@ namespace Particle
   using Status = ParticleStatus;
 
   //! particle state enum
-  using StateEnum = ParticleState;
+  using State = ParticleState;
 
   //! states of particle indexed by particle state enum
   using ParticleStates = std::vector<std::vector<double>>;

--- a/src/particle/src/engine/4C_particle_engine_typedefs.hpp
+++ b/src/particle/src/engine/4C_particle_engine_typedefs.hpp
@@ -47,7 +47,7 @@ namespace Particle
   using TypeEnum = ParticleType;
 
   //! particle status enum
-  using StatusEnum = ParticleStatus;
+  using Status = ParticleStatus;
 
   //! particle state enum
   using StateEnum = ParticleState;

--- a/src/particle/src/interaction/4C_particle_interaction_base.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_base.cpp
@@ -133,7 +133,7 @@ double Particle::ParticleInteractionBase::max_particle_radius() const
         particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // get maximum stored value of state
-    double currmaxrad = container->get_max_value_of_state(Particle::Radius);
+    double currmaxrad = container->get_max_value_of_state(Particle::State::Radius);
 
     // compare to current maximum
     maxrad = std::max(maxrad, currmaxrad);

--- a/src/particle/src/interaction/4C_particle_interaction_base.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_base.cpp
@@ -130,7 +130,7 @@ double Particle::ParticleInteractionBase::max_particle_radius() const
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container =
-        particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // get maximum stored value of state
     double currmaxrad = container->get_max_value_of_state(Particle::Radius);

--- a/src/particle/src/interaction/4C_particle_interaction_base.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_base.hpp
@@ -69,7 +69,7 @@ namespace Particle
 
     //! insert interaction dependent states of all particle types
     virtual void insert_particle_states_of_particle_types(
-        std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) = 0;
+        std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes) = 0;
 
     //! set initial states
     virtual void set_initial_states() = 0;

--- a/src/particle/src/interaction/4C_particle_interaction_base.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_base.hpp
@@ -69,7 +69,7 @@ namespace Particle
 
     //! insert interaction dependent states of all particle types
     virtual void insert_particle_states_of_particle_types(
-        std::map<Particle::TypeEnum, std::set<Particle::StateEnum>>& particlestatestotypes) = 0;
+        std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) = 0;
 
     //! set initial states
     virtual void set_initial_states() = 0;

--- a/src/particle/src/interaction/4C_particle_interaction_dem.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_dem.cpp
@@ -95,7 +95,7 @@ void Particle::ParticleInteractionDEM::read_restart(
 }
 
 void Particle::ParticleInteractionDEM::insert_particle_states_of_particle_types(
-    std::map<Particle::TypeEnum, std::set<Particle::StateEnum>>& particlestatestotypes)
+    std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes)
 {
   // iterate over particle types
   for (auto& typeIt : particlestatestotypes)

--- a/src/particle/src/interaction/4C_particle_interaction_dem.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_dem.cpp
@@ -238,7 +238,7 @@ void Particle::ParticleInteractionDEM::set_initial_radius()
       {
         // get container of owned particles of current particle type
         Particle::ParticleContainer* container =
-            particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+            particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
         // get number of particles stored in container
         const int particlestored = container->particles_stored();
@@ -277,7 +277,7 @@ void Particle::ParticleInteractionDEM::set_initial_radius()
       {
         // get container of owned particles of current particle type
         Particle::ParticleContainer* container =
-            particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+            particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
         // get number of particles stored in container
         const int particlestored = container->particles_stored();
@@ -321,7 +321,7 @@ void Particle::ParticleInteractionDEM::set_initial_radius()
       {
         // get container of owned particles of current particle type
         Particle::ParticleContainer* container =
-            particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+            particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
         // get number of particles stored in container
         const int particlestored = container->particles_stored();
@@ -379,7 +379,7 @@ void Particle::ParticleInteractionDEM::set_initial_mass()
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container =
-        particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // get number of particles stored in container
     const int particlestored = container->particles_stored();
@@ -408,7 +408,7 @@ void Particle::ParticleInteractionDEM::set_initial_inertia()
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container =
-        particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // get number of particles stored in container
     const int particlestored = container->particles_stored();
@@ -437,7 +437,7 @@ void Particle::ParticleInteractionDEM::clear_force_and_moment_states() const
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container =
-        particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // clear force of all particles
     container->clear_state(Particle::Force);
@@ -456,7 +456,7 @@ void Particle::ParticleInteractionDEM::compute_acceleration() const
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container =
-        particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // get number of particles stored in container
     const int particlestored = container->particles_stored();
@@ -536,7 +536,7 @@ void Particle::ParticleInteractionDEM::evaluate_particle_kinetic_energy(double& 
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container =
-        particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // get number of particles stored in container
     const int particlestored = container->particles_stored();
@@ -580,7 +580,7 @@ void Particle::ParticleInteractionDEM::evaluate_particle_gravitational_potential
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container =
-        particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // get number of particles stored in container
     const int particlestored = container->particles_stored();

--- a/src/particle/src/interaction/4C_particle_interaction_dem.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_dem.cpp
@@ -95,16 +95,16 @@ void Particle::ParticleInteractionDEM::read_restart(
 }
 
 void Particle::ParticleInteractionDEM::insert_particle_states_of_particle_types(
-    std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes)
+    std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes)
 {
   // iterate over particle types
   for (auto& typeIt : particlestatestotypes)
   {
     // set of particle states for current particle type
-    std::set<Particle::StateEnum>& particlestates = typeIt.second;
+    std::set<Particle::State>& particlestates = typeIt.second;
 
     // insert states of regular phase particles
-    particlestates.insert({Particle::Force, Particle::Mass, Particle::Radius});
+    particlestates.insert({Particle::State::Force, Particle::State::Mass, Particle::State::Radius});
   }
 
   // states for contact evaluation scheme
@@ -262,7 +262,7 @@ void Particle::ParticleInteractionDEM::set_initial_radius()
         initradius[0] = material->initRadius_;
 
         // set initial radius for all particles of current type
-        container->set_state(initradius, Particle::Radius);
+        container->set_state(initradius, Particle::State::Radius);
       }
 
       break;
@@ -286,10 +286,10 @@ void Particle::ParticleInteractionDEM::set_initial_radius()
         if (particlestored <= 0) continue;
 
         // safety checks
-        FOUR_C_ASSERT_ALWAYS(container->get_min_value_of_state(Particle::Radius) > 0,
+        FOUR_C_ASSERT_ALWAYS(container->get_min_value_of_state(Particle::State::Radius) > 0,
             "the minimum particle radius is smaller than zero. Fix the particle input.");
 
-        FOUR_C_ASSERT_ALWAYS(container->get_max_value_of_state(Particle::Radius) <= r_max,
+        FOUR_C_ASSERT_ALWAYS(container->get_max_value_of_state(Particle::State::Radius) <= r_max,
             "the maximum particle radius is larger than the maximum allowed particle radius!");
       }
 
@@ -334,7 +334,7 @@ void Particle::ParticleInteractionDEM::set_initial_radius()
             particlematerial_->get_ptr_to_particle_mat_parameter(type_i);
 
         // get pointer to particle state
-        double* radius = container->get_ptr_to_state_writable(Particle::Radius, 0);
+        double* radius = container->get_ptr_to_state_writable(Particle::State::Radius, 0);
 
         // determine mu of random particle radius distribution
         const double mu = (radiusdistributiontype == Particle::NormalRadiusDistribution)
@@ -392,8 +392,8 @@ void Particle::ParticleInteractionDEM::set_initial_mass()
         particlematerial_->get_ptr_to_particle_mat_parameter(type_i);
 
     // get pointer to particle states
-    const double* radius = container->get_ptr_to_state(Particle::Radius, 0);
-    double* mass = container->get_ptr_to_state_writable(Particle::Mass, 0);
+    const double* radius = container->get_ptr_to_state(Particle::State::Radius, 0);
+    double* mass = container->get_ptr_to_state_writable(Particle::State::Mass, 0);
 
     // compute mass via particle volume and initial density
     const double fac = material->initDensity_ * 4.0 / 3.0 * std::numbers::pi;
@@ -417,12 +417,12 @@ void Particle::ParticleInteractionDEM::set_initial_inertia()
     if (particlestored <= 0) continue;
 
     // no inertia state for current particle type
-    if (not container->have_stored_state(Particle::Inertia)) continue;
+    if (not container->have_stored_state(Particle::State::Inertia)) continue;
 
     // get pointer to particle states
-    const double* radius = container->get_ptr_to_state(Particle::Radius, 0);
-    const double* mass = container->get_ptr_to_state(Particle::Mass, 0);
-    double* inertia = container->get_ptr_to_state_writable(Particle::Inertia, 0);
+    const double* radius = container->get_ptr_to_state(Particle::State::Radius, 0);
+    const double* mass = container->get_ptr_to_state(Particle::State::Mass, 0);
+    double* inertia = container->get_ptr_to_state_writable(Particle::State::Inertia, 0);
 
     // compute mass via particle volume and initial density
     for (int i = 0; i < particlestored; ++i)
@@ -440,10 +440,11 @@ void Particle::ParticleInteractionDEM::clear_force_and_moment_states() const
         particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // clear force of all particles
-    container->clear_state(Particle::Force);
+    container->clear_state(Particle::State::Force);
 
     // clear moment of all particles
-    if (container->have_stored_state(Particle::Moment)) container->clear_state(Particle::Moment);
+    if (container->have_stored_state(Particle::State::Moment))
+      container->clear_state(Particle::State::Moment);
   }
 }
 
@@ -465,15 +466,16 @@ void Particle::ParticleInteractionDEM::compute_acceleration() const
     if (particlestored <= 0) continue;
 
     // get particle state dimension
-    const int statedim = container->get_state_dim(Particle::Acceleration);
+    const int statedim = container->get_state_dim(Particle::State::Acceleration);
 
     // get pointer to particle states
-    const double* radius = container->get_ptr_to_state(Particle::Radius, 0);
-    const double* mass = container->get_ptr_to_state(Particle::Mass, 0);
-    const double* force = container->get_ptr_to_state(Particle::Force, 0);
-    const double* moment = container->try_get_ptr_to_state(Particle::Moment, 0);
-    double* acc = container->get_ptr_to_state_writable(Particle::Acceleration, 0);
-    double* angacc = container->try_get_ptr_to_state_writable(Particle::AngularAcceleration, 0);
+    const double* radius = container->get_ptr_to_state(Particle::State::Radius, 0);
+    const double* mass = container->get_ptr_to_state(Particle::State::Mass, 0);
+    const double* force = container->get_ptr_to_state(Particle::State::Force, 0);
+    const double* moment = container->try_get_ptr_to_state(Particle::State::Moment, 0);
+    double* acc = container->get_ptr_to_state_writable(Particle::State::Acceleration, 0);
+    double* angacc =
+        container->try_get_ptr_to_state_writable(Particle::State::AngularAcceleration, 0);
 
     // compute acceleration
     for (int i = 0; i < particlestored; ++i)
@@ -545,13 +547,13 @@ void Particle::ParticleInteractionDEM::evaluate_particle_kinetic_energy(double& 
     if (particlestored <= 0) continue;
 
     // get particle state dimension
-    const int statedim = container->get_state_dim(Particle::Position);
+    const int statedim = container->get_state_dim(Particle::State::Position);
 
     // get pointer to particle states
-    const double* radius = container->get_ptr_to_state(Particle::Radius, 0);
-    const double* mass = container->get_ptr_to_state(Particle::Mass, 0);
-    const double* vel = container->get_ptr_to_state(Particle::Velocity, 0);
-    const double* angvel = container->try_get_ptr_to_state(Particle::AngularVelocity, 0);
+    const double* radius = container->get_ptr_to_state(Particle::State::Radius, 0);
+    const double* mass = container->get_ptr_to_state(Particle::State::Mass, 0);
+    const double* vel = container->get_ptr_to_state(Particle::State::Velocity, 0);
+    const double* angvel = container->try_get_ptr_to_state(Particle::State::AngularVelocity, 0);
 
     // add translational kinetic energy contribution
     for (int i = 0; i < particlestored; ++i)
@@ -589,11 +591,11 @@ void Particle::ParticleInteractionDEM::evaluate_particle_gravitational_potential
     if (particlestored <= 0) continue;
 
     // get particle state dimension
-    const int statedim = container->get_state_dim(Particle::Position);
+    const int statedim = container->get_state_dim(Particle::State::Position);
 
     // get pointer to particle states
-    const double* pos = container->get_ptr_to_state(Particle::Position, 0);
-    const double* mass = container->get_ptr_to_state(Particle::Mass, 0);
+    const double* pos = container->get_ptr_to_state(Particle::State::Position, 0);
+    const double* mass = container->get_ptr_to_state(Particle::State::Mass, 0);
 
     // add gravitational potential energy contribution
     for (int i = 0; i < particlestored; ++i)

--- a/src/particle/src/interaction/4C_particle_interaction_dem.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_dem.hpp
@@ -66,8 +66,7 @@ namespace Particle
 
     //! insert interaction dependent states of all particle types
     void insert_particle_states_of_particle_types(
-        std::map<Particle::TypeEnum, std::set<Particle::StateEnum>>& particlestatestotypes)
-        override;
+        std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) override;
 
     //! set initial states
     void set_initial_states() override;

--- a/src/particle/src/interaction/4C_particle_interaction_dem.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_dem.hpp
@@ -66,7 +66,7 @@ namespace Particle
 
     //! insert interaction dependent states of all particle types
     void insert_particle_states_of_particle_types(
-        std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) override;
+        std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes) override;
 
     //! set initial states
     void set_initial_states() override;

--- a/src/particle/src/interaction/4C_particle_interaction_dem_adhesion.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_dem_adhesion.cpp
@@ -169,15 +169,15 @@ void Particle::DEMAdhesion::evaluate_particle_adhesion()
     const int* globalid_j = container_j->get_ptr_to_global_id(particle_j);
 
     // get pointer to particle states
-    const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
-    const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
-    double* force_i = container_i->get_ptr_to_state_writable(Particle::Force, particle_i);
+    const double* vel_i = container_i->get_ptr_to_state(Particle::State::Velocity, particle_i);
+    const double* rad_i = container_i->get_ptr_to_state(Particle::State::Radius, particle_i);
+    double* force_i = container_i->get_ptr_to_state_writable(Particle::State::Force, particle_i);
 
-    const double* vel_j = container_j->get_ptr_to_state(Particle::Velocity, particle_j);
-    const double* rad_j = container_j->get_ptr_to_state(Particle::Radius, particle_j);
+    const double* vel_j = container_j->get_ptr_to_state(Particle::State::Velocity, particle_j);
+    const double* rad_j = container_j->get_ptr_to_state(Particle::State::Radius, particle_j);
     double* force_j = nullptr;
     if (status_j == Particle::Status::Owned)
-      force_j = container_j->get_ptr_to_state_writable(Particle::Force, particle_j);
+      force_j = container_j->get_ptr_to_state_writable(Particle::State::Force, particle_j);
 
     // relative velocity in contact point c between particle i and j (neglecting angular velocity)
     double vel_rel[3];
@@ -289,11 +289,11 @@ void Particle::DEMAdhesion::evaluate_particle_wall_adhesion()
     const int* globalid_i = container_i->get_ptr_to_global_id(particle_i);
 
     // get pointer to particle states
-    const double* pos_i = container_i->get_ptr_to_state(Particle::Position, particle_i);
-    const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
-    const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
-    const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
-    double* force_i = container_i->get_ptr_to_state_writable(Particle::Force, particle_i);
+    const double* pos_i = container_i->get_ptr_to_state(Particle::State::Position, particle_i);
+    const double* vel_i = container_i->get_ptr_to_state(Particle::State::Velocity, particle_i);
+    const double* rad_i = container_i->get_ptr_to_state(Particle::State::Radius, particle_i);
+    const double* mass_i = container_i->get_ptr_to_state(Particle::State::Mass, particle_i);
+    double* force_i = container_i->get_ptr_to_state_writable(Particle::State::Force, particle_i);
 
     // get pointer to column wall element
     Core::Elements::Element* ele = particlewallpair.ele_;

--- a/src/particle/src/interaction/4C_particle_interaction_dem_adhesion.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_dem_adhesion.cpp
@@ -147,12 +147,12 @@ void Particle::DEMAdhesion::evaluate_particle_adhesion()
   for (const auto& particlepair : neighborpairs_->get_ref_to_particle_pair_adhesion_data())
   {
     // access values of local index tuples of particle i and j
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
-    Particle::TypeEnum type_j;
+    Particle::Type type_j;
     Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
@@ -276,7 +276,7 @@ void Particle::DEMAdhesion::evaluate_particle_wall_adhesion()
   for (const auto& particlewallpair : particlewallpairdata)
   {
     // access values of local index tuple of particle i
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlewallpair.tuple_i_;

--- a/src/particle/src/interaction/4C_particle_interaction_dem_adhesion.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_dem_adhesion.cpp
@@ -148,12 +148,12 @@ void Particle::DEMAdhesion::evaluate_particle_adhesion()
   {
     // access values of local index tuples of particle i and j
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
     Particle::TypeEnum type_j;
-    Particle::StatusEnum status_j;
+    Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
 
@@ -176,7 +176,7 @@ void Particle::DEMAdhesion::evaluate_particle_adhesion()
     const double* vel_j = container_j->get_ptr_to_state(Particle::Velocity, particle_j);
     const double* rad_j = container_j->get_ptr_to_state(Particle::Radius, particle_j);
     double* force_j = nullptr;
-    if (status_j == Particle::Owned)
+    if (status_j == Particle::Status::Owned)
       force_j = container_j->get_ptr_to_state_writable(Particle::Force, particle_j);
 
     // relative velocity in contact point c between particle i and j (neglecting angular velocity)
@@ -210,7 +210,7 @@ void Particle::DEMAdhesion::evaluate_particle_adhesion()
         vel_rel_normal, particlepair.m_eff_, adhesionhistory_ij.adhesion_force_);
 
     // copy history from interaction pair ij to ji
-    if (status_j == Particle::Owned)
+    if (status_j == Particle::Status::Owned)
     {
       // get reference to touched adhesion history
       TouchedDEMHistoryPairAdhesion& touchedadhesionhistory_ji =
@@ -277,7 +277,7 @@ void Particle::DEMAdhesion::evaluate_particle_wall_adhesion()
   {
     // access values of local index tuple of particle i
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlewallpair.tuple_i_;
 

--- a/src/particle/src/interaction/4C_particle_interaction_dem_contact.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_dem_contact.cpp
@@ -122,7 +122,7 @@ void Particle::DEMContact::set_current_step_size(const double currentstepsize)
 }
 
 void Particle::DEMContact::insert_particle_states_of_particle_types(
-    std::map<Particle::TypeEnum, std::set<Particle::StateEnum>>& particlestatestotypes) const
+    std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const
 {
   // iterate over particle types
   for (auto& typeIt : particlestatestotypes)
@@ -365,12 +365,12 @@ void Particle::DEMContact::evaluate_particle_contact()
   for (const auto& particlepair : neighborpairs_->get_ref_to_particle_pair_data())
   {
     // access values of local index tuples of particle i and j
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
-    Particle::TypeEnum type_j;
+    Particle::Type type_j;
     Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
@@ -600,7 +600,7 @@ void Particle::DEMContact::evaluate_particle_wall_contact()
   for (const auto& particlewallpair : particlewallpairdata)
   {
     // access values of local index tuple of particle i
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlewallpair.tuple_i_;
@@ -853,12 +853,12 @@ void Particle::DEMContact::evaluate_particle_elastic_potential_energy(
   for (const auto& particlepair : neighborpairs_->get_ref_to_particle_pair_data())
   {
     // access values of local index tuples of particle i and j
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
-    Particle::TypeEnum type_j;
+    Particle::Type type_j;
     Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
@@ -943,7 +943,7 @@ void Particle::DEMContact::evaluate_particle_wall_elastic_potential_energy(
   for (const auto& particlewallpair : neighborpairs_->get_ref_to_particle_wall_pair_data())
   {
     // access values of local index tuple of particle i
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlewallpair.tuple_i_;

--- a/src/particle/src/interaction/4C_particle_interaction_dem_contact.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_dem_contact.cpp
@@ -122,18 +122,18 @@ void Particle::DEMContact::set_current_step_size(const double currentstepsize)
 }
 
 void Particle::DEMContact::insert_particle_states_of_particle_types(
-    std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const
+    std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes) const
 {
   // iterate over particle types
   for (auto& typeIt : particlestatestotypes)
   {
     // set of particle states for current particle type
-    std::set<Particle::StateEnum>& particlestates = typeIt.second;
+    std::set<Particle::State>& particlestates = typeIt.second;
 
     // states for tangential and rolling contact evaluation scheme
     if (contacttangential_ or contactrolling_)
-      particlestates.insert(
-          {Particle::Moment, Particle::AngularVelocity, Particle::AngularAcceleration});
+      particlestates.insert({Particle::State::Moment, Particle::State::AngularVelocity,
+          Particle::State::AngularAcceleration});
   }
 }
 
@@ -162,7 +162,7 @@ void Particle::DEMContact::check_critical_time_step() const
     if (particlestored <= 0) continue;
 
     // get minimum stored value of state
-    double currminmass = container->get_min_value_of_state(Particle::Mass);
+    double currminmass = container->get_min_value_of_state(Particle::State::Mass);
 
     // update value of minimum mass
     minmass = std::min(minmass, currminmass);
@@ -387,31 +387,31 @@ void Particle::DEMContact::evaluate_particle_contact()
     const int* globalid_j = container_j->get_ptr_to_global_id(particle_j);
 
     // get pointer to particle states
-    const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
-    const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
-    double* force_i = container_i->get_ptr_to_state_writable(Particle::Force, particle_i);
+    const double* vel_i = container_i->get_ptr_to_state(Particle::State::Velocity, particle_i);
+    const double* rad_i = container_i->get_ptr_to_state(Particle::State::Radius, particle_i);
+    double* force_i = container_i->get_ptr_to_state_writable(Particle::State::Force, particle_i);
 
     const double* angvel_i = nullptr;
     double* moment_i = nullptr;
     if (contacttangential_ or contactrolling_)
     {
-      angvel_i = container_i->get_ptr_to_state(Particle::AngularVelocity, particle_i);
-      moment_i = container_i->get_ptr_to_state_writable(Particle::Moment, particle_i);
+      angvel_i = container_i->get_ptr_to_state(Particle::State::AngularVelocity, particle_i);
+      moment_i = container_i->get_ptr_to_state_writable(Particle::State::Moment, particle_i);
     }
 
-    const double* vel_j = container_j->get_ptr_to_state(Particle::Velocity, particle_j);
-    const double* rad_j = container_j->get_ptr_to_state(Particle::Radius, particle_j);
+    const double* vel_j = container_j->get_ptr_to_state(Particle::State::Velocity, particle_j);
+    const double* rad_j = container_j->get_ptr_to_state(Particle::State::Radius, particle_j);
     double* force_j = nullptr;
     if (status_j == Particle::Status::Owned)
-      force_j = container_j->get_ptr_to_state_writable(Particle::Force, particle_j);
+      force_j = container_j->get_ptr_to_state_writable(Particle::State::Force, particle_j);
 
     const double* angvel_j = nullptr;
     double* moment_j = nullptr;
     if (contacttangential_ or contactrolling_)
     {
-      angvel_j = container_j->get_ptr_to_state(Particle::AngularVelocity, particle_j);
+      angvel_j = container_j->get_ptr_to_state(Particle::State::AngularVelocity, particle_j);
       if (status_j == Particle::Status::Owned)
-        moment_j = container_j->get_ptr_to_state_writable(Particle::Moment, particle_j);
+        moment_j = container_j->get_ptr_to_state_writable(Particle::State::Moment, particle_j);
     }
 
     // compute vectors from particle i and j to contact point c
@@ -613,18 +613,18 @@ void Particle::DEMContact::evaluate_particle_wall_contact()
     const int* globalid_i = container_i->get_ptr_to_global_id(particle_i);
 
     // get pointer to particle states
-    const double* pos_i = container_i->get_ptr_to_state(Particle::Position, particle_i);
-    const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
-    const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
-    const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
-    double* force_i = container_i->get_ptr_to_state_writable(Particle::Force, particle_i);
+    const double* pos_i = container_i->get_ptr_to_state(Particle::State::Position, particle_i);
+    const double* vel_i = container_i->get_ptr_to_state(Particle::State::Velocity, particle_i);
+    const double* rad_i = container_i->get_ptr_to_state(Particle::State::Radius, particle_i);
+    const double* mass_i = container_i->get_ptr_to_state(Particle::State::Mass, particle_i);
+    double* force_i = container_i->get_ptr_to_state_writable(Particle::State::Force, particle_i);
 
     const double* angvel_i = nullptr;
     double* moment_i = nullptr;
     if (contacttangential_ or contactrolling_)
     {
-      angvel_i = container_i->get_ptr_to_state(Particle::AngularVelocity, particle_i);
-      moment_i = container_i->get_ptr_to_state_writable(Particle::Moment, particle_i);
+      angvel_i = container_i->get_ptr_to_state(Particle::State::AngularVelocity, particle_i);
+      moment_i = container_i->get_ptr_to_state_writable(Particle::State::Moment, particle_i);
     }
 
     // get pointer to column wall element

--- a/src/particle/src/interaction/4C_particle_interaction_dem_contact.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_dem_contact.cpp
@@ -153,7 +153,7 @@ void Particle::DEMContact::check_critical_time_step() const
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container =
-        particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // get number of particles stored in container
     const int particlestored = container->particles_stored();
@@ -366,12 +366,12 @@ void Particle::DEMContact::evaluate_particle_contact()
   {
     // access values of local index tuples of particle i and j
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
     Particle::TypeEnum type_j;
-    Particle::StatusEnum status_j;
+    Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
 
@@ -402,7 +402,7 @@ void Particle::DEMContact::evaluate_particle_contact()
     const double* vel_j = container_j->get_ptr_to_state(Particle::Velocity, particle_j);
     const double* rad_j = container_j->get_ptr_to_state(Particle::Radius, particle_j);
     double* force_j = nullptr;
-    if (status_j == Particle::Owned)
+    if (status_j == Particle::Status::Owned)
       force_j = container_j->get_ptr_to_state_writable(Particle::Force, particle_j);
 
     const double* angvel_j = nullptr;
@@ -410,7 +410,7 @@ void Particle::DEMContact::evaluate_particle_contact()
     if (contacttangential_ or contactrolling_)
     {
       angvel_j = container_j->get_ptr_to_state(Particle::AngularVelocity, particle_j);
-      if (status_j == Particle::Owned)
+      if (status_j == Particle::Status::Owned)
         moment_j = container_j->get_ptr_to_state_writable(Particle::Moment, particle_j);
     }
 
@@ -477,7 +477,7 @@ void Particle::DEMContact::evaluate_particle_contact()
           mu_tangential, normalcontactforce, tangentialcontactforce);
 
       // copy history from interaction pair ij to ji
-      if (status_j == Particle::Owned)
+      if (status_j == Particle::Status::Owned)
       {
         // get reference to touched tangential history
         TouchedDEMHistoryPairTangential& touchedtangentialhistory_ji =
@@ -533,7 +533,7 @@ void Particle::DEMContact::evaluate_particle_contact()
           normalcontactforce, rollingcontactmoment);
 
       // copy history from interaction pair ij to ji
-      if (status_j == Particle::Owned)
+      if (status_j == Particle::Status::Owned)
       {
         // get reference to touched rolling history
         TouchedDEMHistoryPairRolling& touchedrollinghistory_ji =
@@ -601,7 +601,7 @@ void Particle::DEMContact::evaluate_particle_wall_contact()
   {
     // access values of local index tuple of particle i
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlewallpair.tuple_i_;
 
@@ -854,12 +854,12 @@ void Particle::DEMContact::evaluate_particle_elastic_potential_energy(
   {
     // access values of local index tuples of particle i and j
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
     Particle::TypeEnum type_j;
-    Particle::StatusEnum status_j;
+    Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
 
@@ -880,7 +880,7 @@ void Particle::DEMContact::evaluate_particle_elastic_potential_energy(
 
     // add normal potential energy contribution
     elasticpotentialenergy += 0.5 * normalpotentialenergy;
-    if (status_j == Particle::Owned) elasticpotentialenergy += 0.5 * normalpotentialenergy;
+    if (status_j == Particle::Status::Owned) elasticpotentialenergy += 0.5 * normalpotentialenergy;
 
     // calculation of tangential potential energy
     if (contacttangential_)
@@ -899,7 +899,8 @@ void Particle::DEMContact::evaluate_particle_elastic_potential_energy(
 
       // add tangential potential energy contribution
       elasticpotentialenergy += 0.5 * tangentialpotentialenergy;
-      if (status_j == Particle::Owned) elasticpotentialenergy += 0.5 * tangentialpotentialenergy;
+      if (status_j == Particle::Status::Owned)
+        elasticpotentialenergy += 0.5 * tangentialpotentialenergy;
     }
 
     // calculation of rolling potential energy
@@ -918,7 +919,8 @@ void Particle::DEMContact::evaluate_particle_elastic_potential_energy(
 
       // add rolling potential energy contribution
       elasticpotentialenergy += 0.5 * rollingpotentialenergy;
-      if (status_j == Particle::Owned) elasticpotentialenergy += 0.5 * rollingpotentialenergy;
+      if (status_j == Particle::Status::Owned)
+        elasticpotentialenergy += 0.5 * rollingpotentialenergy;
     }
   }
 }
@@ -942,7 +944,7 @@ void Particle::DEMContact::evaluate_particle_wall_elastic_potential_energy(
   {
     // access values of local index tuple of particle i
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlewallpair.tuple_i_;
 

--- a/src/particle/src/interaction/4C_particle_interaction_dem_contact.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_dem_contact.hpp
@@ -70,7 +70,7 @@ namespace Particle
 
     //! insert contact evaluation dependent states
     void insert_particle_states_of_particle_types(
-        std::map<Particle::TypeEnum, std::set<Particle::StateEnum>>& particlestatestotypes) const;
+        std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const;
 
     //! get normal contact stiffness
     double get_normal_contact_stiffness() const;

--- a/src/particle/src/interaction/4C_particle_interaction_dem_contact.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_dem_contact.hpp
@@ -70,7 +70,7 @@ namespace Particle
 
     //! insert contact evaluation dependent states
     void insert_particle_states_of_particle_types(
-        std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const;
+        std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes) const;
 
     //! get normal contact stiffness
     double get_normal_contact_stiffness() const;

--- a/src/particle/src/interaction/4C_particle_interaction_dem_neighbor_pairs.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_dem_neighbor_pairs.cpp
@@ -73,12 +73,12 @@ void Particle::DEMNeighborPairs::evaluate_particle_pairs()
   {
     // access values of local index tuples of particle i and j
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = potentialneighbors.first;
 
     Particle::TypeEnum type_j;
-    Particle::StatusEnum status_j;
+    Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = potentialneighbors.second;
 
@@ -159,7 +159,7 @@ void Particle::DEMNeighborPairs::evaluate_particle_wall_pairs()
   {
     // access values of local index tuple of particle i
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = potentialneighbors.first;
 
@@ -263,7 +263,7 @@ void Particle::DEMNeighborPairs::evaluate_particle_wall_pairs()
 
     // access values of local index tuple of particle i
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = tuple_i;
 
@@ -362,12 +362,12 @@ void Particle::DEMNeighborPairs::evaluate_particle_pairs_adhesion(const double& 
   {
     // access values of local index tuples of particle i and j
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = potentialneighbors.first;
 
     Particle::TypeEnum type_j;
-    Particle::StatusEnum status_j;
+    Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = potentialneighbors.second;
 
@@ -449,7 +449,7 @@ void Particle::DEMNeighborPairs::evaluate_particle_wall_pairs_adhesion(
   {
     // access values of local index tuple of particle i
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = potentialneighbors.first;
 
@@ -571,7 +571,7 @@ void Particle::DEMNeighborPairs::evaluate_particle_wall_pairs_adhesion(
 
     // access values of local index tuple of particle i
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = tuple_i;
 

--- a/src/particle/src/interaction/4C_particle_interaction_dem_neighbor_pairs.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_dem_neighbor_pairs.cpp
@@ -72,12 +72,12 @@ void Particle::DEMNeighborPairs::evaluate_particle_pairs()
       particleengineinterface_->get_potential_particle_neighbors())
   {
     // access values of local index tuples of particle i and j
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = potentialneighbors.first;
 
-    Particle::TypeEnum type_j;
+    Particle::Type type_j;
     Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = potentialneighbors.second;
@@ -158,7 +158,7 @@ void Particle::DEMNeighborPairs::evaluate_particle_wall_pairs()
   for (const auto& potentialneighbors : particlewallinterface_->get_potential_wall_neighbors())
   {
     // access values of local index tuple of particle i
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = potentialneighbors.first;
@@ -262,7 +262,7 @@ void Particle::DEMNeighborPairs::evaluate_particle_wall_pairs()
         particlewallpairdata_[indexofparticlewallpairs[0].second].tuple_i_;
 
     // access values of local index tuple of particle i
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = tuple_i;
@@ -361,12 +361,12 @@ void Particle::DEMNeighborPairs::evaluate_particle_pairs_adhesion(const double& 
       particleengineinterface_->get_potential_particle_neighbors())
   {
     // access values of local index tuples of particle i and j
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = potentialneighbors.first;
 
-    Particle::TypeEnum type_j;
+    Particle::Type type_j;
     Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = potentialneighbors.second;
@@ -448,7 +448,7 @@ void Particle::DEMNeighborPairs::evaluate_particle_wall_pairs_adhesion(
   for (const auto& potentialneighbors : particlewallinterface_->get_potential_wall_neighbors())
   {
     // access values of local index tuple of particle i
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = potentialneighbors.first;
@@ -570,7 +570,7 @@ void Particle::DEMNeighborPairs::evaluate_particle_wall_pairs_adhesion(
         particlewallpairadhesiondata_[indexofparticlewallpairs[0].second].tuple_i_;
 
     // access values of local index tuple of particle i
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = tuple_i;

--- a/src/particle/src/interaction/4C_particle_interaction_dem_neighbor_pairs.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_dem_neighbor_pairs.cpp
@@ -90,13 +90,13 @@ void Particle::DEMNeighborPairs::evaluate_particle_pairs()
         particlecontainerbundle_->get_specific_container(type_j, status_j);
 
     // get pointer to particle states
-    const double* pos_i = container_i->get_ptr_to_state(Particle::Position, particle_i);
-    const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
-    const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
+    const double* pos_i = container_i->get_ptr_to_state(Particle::State::Position, particle_i);
+    const double* rad_i = container_i->get_ptr_to_state(Particle::State::Radius, particle_i);
+    const double* mass_i = container_i->get_ptr_to_state(Particle::State::Mass, particle_i);
 
-    const double* pos_j = container_j->get_ptr_to_state(Particle::Position, particle_j);
-    const double* rad_j = container_j->get_ptr_to_state(Particle::Radius, particle_j);
-    const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
+    const double* pos_j = container_j->get_ptr_to_state(Particle::State::Position, particle_j);
+    const double* rad_j = container_j->get_ptr_to_state(Particle::State::Radius, particle_j);
+    const double* mass_j = container_j->get_ptr_to_state(Particle::State::Mass, particle_j);
 
     // vector from particle i to j
     double r_ji[3];
@@ -171,11 +171,11 @@ void Particle::DEMNeighborPairs::evaluate_particle_wall_pairs()
     const int* globalid_i = container_i->get_ptr_to_global_id(particle_i);
 
     // get pointer to particle states
-    const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
+    const double* rad_i = container_i->get_ptr_to_state(Particle::State::Radius, particle_i);
 
     // get position of particle i
     const Core::LinAlg::Matrix<3, 1> pos_i(
-        container_i->get_ptr_to_state(Particle::Position, particle_i));
+        container_i->get_ptr_to_state(Particle::State::Position, particle_i));
 
     // get pointer to column wall element
     Core::Elements::Element* ele = potentialneighbors.second;
@@ -272,7 +272,7 @@ void Particle::DEMNeighborPairs::evaluate_particle_wall_pairs()
         particlecontainerbundle_->get_specific_container(type_i, status_i);
 
     // get pointer to particle states
-    const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
+    const double* rad_i = container_i->get_ptr_to_state(Particle::State::Radius, particle_i);
 
     // define tolerance dependent on the particle radius
     const double adaptedtol = 1.0e-7 * rad_i[0];
@@ -379,13 +379,13 @@ void Particle::DEMNeighborPairs::evaluate_particle_pairs_adhesion(const double& 
         particlecontainerbundle_->get_specific_container(type_j, status_j);
 
     // get pointer to particle states
-    const double* pos_i = container_i->get_ptr_to_state(Particle::Position, particle_i);
-    const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
-    const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
+    const double* pos_i = container_i->get_ptr_to_state(Particle::State::Position, particle_i);
+    const double* rad_i = container_i->get_ptr_to_state(Particle::State::Radius, particle_i);
+    const double* mass_i = container_i->get_ptr_to_state(Particle::State::Mass, particle_i);
 
-    const double* pos_j = container_j->get_ptr_to_state(Particle::Position, particle_j);
-    const double* rad_j = container_j->get_ptr_to_state(Particle::Radius, particle_j);
-    const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
+    const double* pos_j = container_j->get_ptr_to_state(Particle::State::Position, particle_j);
+    const double* rad_j = container_j->get_ptr_to_state(Particle::State::Radius, particle_j);
+    const double* mass_j = container_j->get_ptr_to_state(Particle::State::Mass, particle_j);
 
     // vector from particle i to j
     double r_ji[3];
@@ -461,11 +461,11 @@ void Particle::DEMNeighborPairs::evaluate_particle_wall_pairs_adhesion(
     const int* globalid_i = container_i->get_ptr_to_global_id(particle_i);
 
     // get pointer to particle states
-    const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
+    const double* rad_i = container_i->get_ptr_to_state(Particle::State::Radius, particle_i);
 
     // get position of particle i
     const Core::LinAlg::Matrix<3, 1> pos_i(
-        container_i->get_ptr_to_state(Particle::Position, particle_i));
+        container_i->get_ptr_to_state(Particle::State::Position, particle_i));
 
     // get pointer to column wall element
     Core::Elements::Element* ele = potentialneighbors.second;
@@ -580,7 +580,7 @@ void Particle::DEMNeighborPairs::evaluate_particle_wall_pairs_adhesion(
         particlecontainerbundle_->get_specific_container(type_i, status_i);
 
     // get pointer to particle states
-    const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
+    const double* rad_i = container_i->get_ptr_to_state(Particle::State::Radius, particle_i);
 
     // define tolerance dependent on the particle radius
     const double adaptedtol = 1.0e-7 * rad_i[0];

--- a/src/particle/src/interaction/4C_particle_interaction_material_handler.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_material_handler.cpp
@@ -22,14 +22,14 @@ Particle::MaterialHandler::MaterialHandler(const Teuchos::ParameterList& params)
 void Particle::MaterialHandler::initialize_parameters()
 {
   // init map relating particle types to material ids
-  std::map<Particle::TypeEnum, int> typetomatidmap;
+  std::map<Particle::Type, int> typetomatidmap;
 
   // read parameters relating particle types to values
   ParticleUtils::read_params_types_related_to_values(
       params_, "PHASE_TO_MATERIAL_ID", typetomatidmap);
 
   // determine size of vector indexed by particle types
-  const int typevectorsize = ((--typetomatidmap.end())->first) + 1;
+  const int typevectorsize = static_cast<int>((--typetomatidmap.end())->first) + 1;
 
   // allocate memory to hold particle types
   phasetypetoparticlematpar_.resize(typevectorsize);
@@ -38,7 +38,7 @@ void Particle::MaterialHandler::initialize_parameters()
   for (auto& typeIt : typetomatidmap)
   {
     // get type of particle
-    Particle::TypeEnum type_i = typeIt.first;
+    Particle::Type type_i = typeIt.first;
 
     // add to set of particle types of stored particle material parameters
     storedtypes_.insert(type_i);
@@ -53,7 +53,7 @@ void Particle::MaterialHandler::initialize_parameters()
     if (particlematparameter == nullptr) FOUR_C_THROW("cast to specific particle material failed!");
 
     // relate particle types to particle material parameters
-    phasetypetoparticlematpar_[type_i] = particlematparameter;
+    phasetypetoparticlematpar_[static_cast<int>(type_i)] = particlematparameter;
   }
 }
 

--- a/src/particle/src/interaction/4C_particle_interaction_material_handler.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_material_handler.hpp
@@ -36,13 +36,13 @@ namespace Particle
 
     //! return pointer to particle material parameter
     inline const Mat::PAR::ParticleMaterialBase* get_ptr_to_particle_mat_parameter(
-        Particle::TypeEnum type_i) const
+        Particle::Type type_i) const
     {
-      return phasetypetoparticlematpar_[type_i];
+      return phasetypetoparticlematpar_[static_cast<int>(type_i)];
     }
 
     //! get particle types of stored particle material parameters
-    inline std::set<Particle::TypeEnum> get_particle_types() const { return storedtypes_; };
+    inline std::set<Particle::Type> get_particle_types() const { return storedtypes_; };
 
    private:
     void initialize_parameters();
@@ -54,7 +54,7 @@ namespace Particle
     std::vector<const Mat::PAR::ParticleMaterialBase*> phasetypetoparticlematpar_;
 
     //! set of particle types of stored particle material parameters
-    std::set<Particle::TypeEnum> storedtypes_;
+    std::set<Particle::Type> storedtypes_;
   };
 }  // namespace Particle
 

--- a/src/particle/src/interaction/4C_particle_interaction_pd_neighbor_pairs.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_pd_neighbor_pairs.cpp
@@ -52,7 +52,7 @@ namespace
     // unresolved until the particle is found in a local container, and local id = -1 marks that
     // "not yet resolved on this rank" state
     return std::make_tuple(
-        Particle::UninitializedType, Particle::Status::Uninitialized, -1, globalid);
+        Particle::Type::Uninitialized, Particle::Status::Uninitialized, -1, globalid);
   }
 
   std::set<long> build_known_peridynamic_bond_hashes(const std::shared_ptr<std::vector<
@@ -119,22 +119,23 @@ void Particle::PDNeighborPairs::evaluate_particle_pairs()
   for (auto& potentialneighbors : particleengineinterface_->get_potential_particle_neighbors())
   {
     // access values of local index tuples of particle i and j
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = potentialneighbors.first;
-    Particle::TypeEnum type_j;
+    Particle::Type type_j;
     Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = potentialneighbors.second;
 
     // filter rigid phase and boundary phase to find close pairs which interact in peridynamic or
     // DEM way
-    if ((type_i != PDPhase and type_i != BoundaryPhase) or
-        (type_j != PDPhase and type_j != BoundaryPhase))
+    if ((type_i != Particle::Type::PDPhase and type_i != Particle::Type::BoundaryPhase) or
+        (type_j != Particle::Type::PDPhase and type_j != Particle::Type::BoundaryPhase))
       continue;
 
-    if (type_i == BoundaryPhase and type_j == BoundaryPhase) continue;
+    if (type_i == Particle::Type::BoundaryPhase and type_j == Particle::Type::BoundaryPhase)
+      continue;
 
     // get corresponding particle containers
     Particle::ParticleContainer* container_i =
@@ -218,11 +219,11 @@ void Particle::PDNeighborPairs::evaluate_particle_pairs()
   {
     auto& particlepair = (*bondlist_)[iter];
     // access values of local index tuples of particle i and j
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i, globalid_i;
     std::tie(type_i, status_i, particle_i, globalid_i) = particlepair.first;
-    Particle::TypeEnum type_j;
+    Particle::Type type_j;
     Particle::Status status_j;
     int particle_j, globalid_j;
     std::tie(type_j, status_j, particle_j, globalid_j) = particlepair.second;
@@ -295,7 +296,7 @@ void Particle::PDNeighborPairs::evaluate_particle_wall_pairs()
   for (const auto& potentialneighbors : particlewallinterface_->get_potential_wall_neighbors())
   {
     // access values of local index tuple of particle i
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = potentialneighbors.first;
@@ -399,7 +400,7 @@ void Particle::PDNeighborPairs::evaluate_particle_wall_pairs()
         particlewallpairdata_[indexofparticlewallpairs[0].second].tuple_i_;
 
     // access values of local index tuple of particle i
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = tuple_i;

--- a/src/particle/src/interaction/4C_particle_interaction_pd_neighbor_pairs.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_pd_neighbor_pairs.cpp
@@ -52,7 +52,7 @@ namespace
     // unresolved until the particle is found in a local container, and local id = -1 marks that
     // "not yet resolved on this rank" state
     return std::make_tuple(
-        Particle::UninitializedType, Particle::UninitializedStatus, -1, globalid);
+        Particle::UninitializedType, Particle::Status::Uninitialized, -1, globalid);
   }
 
   std::set<long> build_known_peridynamic_bond_hashes(const std::shared_ptr<std::vector<
@@ -120,11 +120,11 @@ void Particle::PDNeighborPairs::evaluate_particle_pairs()
   {
     // access values of local index tuples of particle i and j
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = potentialneighbors.first;
     Particle::TypeEnum type_j;
-    Particle::StatusEnum status_j;
+    Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = potentialneighbors.second;
 
@@ -219,11 +219,11 @@ void Particle::PDNeighborPairs::evaluate_particle_pairs()
     auto& particlepair = (*bondlist_)[iter];
     // access values of local index tuples of particle i and j
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i, globalid_i;
     std::tie(type_i, status_i, particle_i, globalid_i) = particlepair.first;
     Particle::TypeEnum type_j;
-    Particle::StatusEnum status_j;
+    Particle::Status status_j;
     int particle_j, globalid_j;
     std::tie(type_j, status_j, particle_j, globalid_j) = particlepair.second;
 
@@ -296,7 +296,7 @@ void Particle::PDNeighborPairs::evaluate_particle_wall_pairs()
   {
     // access values of local index tuple of particle i
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = potentialneighbors.first;
 
@@ -400,7 +400,7 @@ void Particle::PDNeighborPairs::evaluate_particle_wall_pairs()
 
     // access values of local index tuple of particle i
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = tuple_i;
 

--- a/src/particle/src/interaction/4C_particle_interaction_pd_neighbor_pairs.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_pd_neighbor_pairs.cpp
@@ -171,8 +171,8 @@ void Particle::PDNeighborPairs::evaluate_particle_pairs()
 
     // all close and non-bonded particle pairs are considered as potential colliding partners
     // undergoing short range force interaction
-    const double* pos_i = container_i->get_ptr_to_state(Particle::Position, particle_i);
-    const double* pos_j = container_j->get_ptr_to_state(Particle::Position, particle_j);
+    const double* pos_i = container_i->get_ptr_to_state(Particle::State::Position, particle_i);
+    const double* pos_j = container_j->get_ptr_to_state(Particle::State::Position, particle_j);
 
     // vector from particle i to j
     double r_ji[3];
@@ -184,8 +184,8 @@ void Particle::PDNeighborPairs::evaluate_particle_pairs()
     const double absdist = ParticleUtils::vec_norm_two(r_ji);
 
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-    const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
-    const double* rad_j = container_j->get_ptr_to_state(Particle::Radius, particle_j);
+    const double* rad_i = container_i->get_ptr_to_state(Particle::State::Radius, particle_i);
+    const double* rad_j = container_j->get_ptr_to_state(Particle::State::Radius, particle_j);
 
     if (absdist < (1.0e-10 * rad_i[0]) or absdist < (1.0e-10 * rad_j[0]))
       FOUR_C_THROW("absolute distance %f between particles close to zero!", absdist);
@@ -309,11 +309,11 @@ void Particle::PDNeighborPairs::evaluate_particle_wall_pairs()
     const int* globalid_i = container_i->get_ptr_to_global_id(particle_i);
 
     // get pointer to particle states
-    const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
+    const double* rad_i = container_i->get_ptr_to_state(Particle::State::Radius, particle_i);
 
     // get position of particle i
     const Core::LinAlg::Matrix<3, 1> pos_i(
-        container_i->get_ptr_to_state(Particle::Position, particle_i));
+        container_i->get_ptr_to_state(Particle::State::Position, particle_i));
 
     // get pointer to column wall element
     Core::Elements::Element* ele = potentialneighbors.second;
@@ -410,7 +410,7 @@ void Particle::PDNeighborPairs::evaluate_particle_wall_pairs()
         particlecontainerbundle_->get_specific_container(type_i, status_i);
 
     // get pointer to particle states
-    const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
+    const double* rad_i = container_i->get_ptr_to_state(Particle::State::Radius, particle_i);
 
     // define tolerance dependent on the particle radius
     const double adaptedtol = 1.0e-7 * rad_i[0];

--- a/src/particle/src/interaction/4C_particle_interaction_pd_neighbor_pairs.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_pd_neighbor_pairs.cpp
@@ -188,7 +188,7 @@ void Particle::PDNeighborPairs::evaluate_particle_pairs()
     const double* rad_j = container_j->get_ptr_to_state(Particle::State::Radius, particle_j);
 
     if (absdist < (1.0e-10 * rad_i[0]) or absdist < (1.0e-10 * rad_j[0]))
-      FOUR_C_THROW("absolute distance %f between particles close to zero!", absdist);
+      FOUR_C_THROW("absolute distance {} between particles close to zero!", absdist);
 #endif
 
     // gap calculation based on initial spacing

--- a/src/particle/src/interaction/4C_particle_interaction_sph.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph.cpp
@@ -169,7 +169,7 @@ void Particle::ParticleInteractionSPH::check_open_boundaries() const
 {
   // types of particles to check
   const std::unordered_map<Particle::ParticleType, std::string> types_to_check{
-      {{Particle::DirichletPhase, "Dirichlet"}, {Particle::NeumannPhase, "Neumann"}}};
+      {{Particle::Type::DirichletPhase, "Dirichlet"}, {Particle::Type::NeumannPhase, "Neumann"}}};
 
   // get all available boundary ids
   std::vector<int> available_boundary_ids(openboundaries_.size());
@@ -236,25 +236,25 @@ void Particle::ParticleInteractionSPH::read_restart(
 }
 
 void Particle::ParticleInteractionSPH::insert_particle_states_of_particle_types(
-    std::map<Particle::TypeEnum, std::set<Particle::StateEnum>>& particlestatestotypes)
+    std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes)
 {
   // iterate over particle types
   for (auto& typeIt : particlestatestotypes)
   {
     // get type of particles
-    Particle::TypeEnum type = typeIt.first;
+    Particle::Type type = typeIt.first;
 
     // set of particle states for current particle type
     std::set<Particle::StateEnum>& particlestates = typeIt.second;
 
-    if (type == Particle::BoundaryPhase or type == Particle::RigidPhase or
-        type == Particle::PDPhase)
+    if (type == Particle::Type::BoundaryPhase or type == Particle::Type::RigidPhase or
+        type == Particle::Type::PDPhase)
     {
       // insert states of boundary and rigid particles
       particlestates.insert({Particle::Mass, Particle::Radius, Particle::BoundaryPressure,
           Particle::BoundaryVelocity});
     }
-    else if (type == Particle::DirichletPhase or type == Particle::NeumannPhase)
+    else if (type == Particle::Type::DirichletPhase or type == Particle::Type::NeumannPhase)
     {
       // insert states of open boundary particles
       particlestates.insert({Particle::Mass, Particle::Radius, Particle::Density,
@@ -385,7 +385,7 @@ void Particle::ParticleInteractionSPH::set_initial_states()
     }
 
     // set initial state for peridynamics
-    if (peridynamics_ && type_i == Particle::PDPhase)
+    if (peridynamics_ && type_i == Particle::Type::PDPhase)
     {
       // set particle reference position
       container->update_state(0.0, Particle::ReferencePosition, 1.0, Particle::Position);

--- a/src/particle/src/interaction/4C_particle_interaction_sph.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph.cpp
@@ -197,8 +197,8 @@ void Particle::ParticleInteractionSPH::check_open_boundaries() const
     // iterate over particles in container
     for (int particle_i = 0; particle_i < particlestored; ++particle_i)
     {
-      const auto particle_boundary_id =
-          static_cast<int>(*container_i->get_ptr_to_state(Particle::OpenBoundaryId, particle_i));
+      const auto particle_boundary_id = static_cast<int>(
+          *container_i->get_ptr_to_state(Particle::State::OpenBoundaryId, particle_i));
 
       if (std::find(available_boundary_ids.begin(), available_boundary_ids.end(),
               particle_boundary_id) == available_boundary_ids.end())
@@ -236,7 +236,7 @@ void Particle::ParticleInteractionSPH::read_restart(
 }
 
 void Particle::ParticleInteractionSPH::insert_particle_states_of_particle_types(
-    std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes)
+    std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes)
 {
   // iterate over particle types
   for (auto& typeIt : particlestatestotypes)
@@ -245,26 +245,26 @@ void Particle::ParticleInteractionSPH::insert_particle_states_of_particle_types(
     Particle::Type type = typeIt.first;
 
     // set of particle states for current particle type
-    std::set<Particle::StateEnum>& particlestates = typeIt.second;
+    std::set<Particle::State>& particlestates = typeIt.second;
 
     if (type == Particle::Type::BoundaryPhase or type == Particle::Type::RigidPhase or
         type == Particle::Type::PDPhase)
     {
       // insert states of boundary and rigid particles
-      particlestates.insert({Particle::Mass, Particle::Radius, Particle::BoundaryPressure,
-          Particle::BoundaryVelocity});
+      particlestates.insert({Particle::State::Mass, Particle::State::Radius,
+          Particle::State::BoundaryPressure, Particle::State::BoundaryVelocity});
     }
     else if (type == Particle::Type::DirichletPhase or type == Particle::Type::NeumannPhase)
     {
       // insert states of open boundary particles
-      particlestates.insert({Particle::Mass, Particle::Radius, Particle::Density,
-          Particle::Pressure, Particle::OpenBoundaryId});
+      particlestates.insert({Particle::State::Mass, Particle::State::Radius,
+          Particle::State::Density, Particle::State::Pressure, Particle::State::OpenBoundaryId});
     }
     else
     {
       // insert states of regular phase particles
-      particlestates.insert(
-          {Particle::Mass, Particle::Radius, Particle::Density, Particle::Pressure});
+      particlestates.insert({Particle::State::Mass, Particle::State::Radius,
+          Particle::State::Density, Particle::State::Pressure});
     }
   }
 
@@ -329,15 +329,15 @@ void Particle::ParticleInteractionSPH::set_initial_states()
     initradius[0] = material->initRadius_;
 
     // set initial density for respective particles of current type
-    if (container->have_stored_state(Particle::Density))
-      container->set_state(initdensity, Particle::Density);
+    if (container->have_stored_state(Particle::State::Density))
+      container->set_state(initdensity, Particle::State::Density);
 
     // set initial mass and radius for all particles of current type
-    container->set_state(initmass, Particle::Mass);
-    container->set_state(initradius, Particle::Radius);
+    container->set_state(initmass, Particle::State::Mass);
+    container->set_state(initradius, Particle::State::Radius);
 
     // evaluate initial inertia for respective particles of current type
-    if (container->have_stored_state(Particle::Inertia))
+    if (container->have_stored_state(Particle::State::Inertia))
     {
       // (initial) inertia of current phase
       std::vector<double> initinertia(1);
@@ -365,7 +365,7 @@ void Particle::ParticleInteractionSPH::set_initial_states()
       }
 
       // set initial inertia for respective particles of current type
-      container->set_state(initinertia, Particle::Inertia);
+      container->set_state(initinertia, Particle::State::Inertia);
     }
 
     // initial states for temperature evaluation
@@ -381,14 +381,15 @@ void Particle::ParticleInteractionSPH::set_initial_states()
       inittemperature[0] = material->initTemperature_;
 
       // set initial temperature for all particles of current type
-      container->set_state(inittemperature, Particle::Temperature);
+      container->set_state(inittemperature, Particle::State::Temperature);
     }
 
     // set initial state for peridynamics
     if (peridynamics_ && type_i == Particle::Type::PDPhase)
     {
       // set particle reference position
-      container->update_state(0.0, Particle::ReferencePosition, 1.0, Particle::Position);
+      container->update_state(
+          0.0, Particle::State::ReferencePosition, 1.0, Particle::State::Position);
 
       // get material for current particle type
       const Mat::PAR::ParticleMaterialPD* material =
@@ -398,12 +399,12 @@ void Particle::ParticleInteractionSPH::set_initial_states()
       // set Young's modulus for all peridynamic phase particles
       std::vector<double> young(1);
       young[0] = material->young_;
-      container->set_state(young, Particle::Young);
+      container->set_state(young, Particle::State::Young);
 
       // set critical stretch for all peridynamic phase particles
       std::vector<double> stretch(1);
       stretch[0] = material->critical_stretch_;
-      container->set_state(stretch, Particle::CriticalStretch);
+      container->set_state(stretch, Particle::State::CriticalStretch);
 
       // initialize peridynamic bond list once at the beginning of the simulation
       peridynamics_->init_peridynamic_bondlist();

--- a/src/particle/src/interaction/4C_particle_interaction_sph.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph.cpp
@@ -186,7 +186,7 @@ void Particle::ParticleInteractionSPH::check_open_boundaries() const
 
     // get container of owned particles of open boundary phase
     Particle::ParticleContainer* container_i =
-        particlecontainerbundle_->get_specific_container(type_id, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_id, Particle::Status::Owned);
 
     // get number of particles stored in container
     const int particlestored = container_i->particles_stored();
@@ -304,7 +304,7 @@ void Particle::ParticleInteractionSPH::set_initial_states()
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container =
-        particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // get number of particles stored in container
     const int particlestored = container->particles_stored();

--- a/src/particle/src/interaction/4C_particle_interaction_sph.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph.cpp
@@ -168,7 +168,7 @@ void Particle::ParticleInteractionSPH::setup(
 void Particle::ParticleInteractionSPH::check_open_boundaries() const
 {
   // types of particles to check
-  const std::unordered_map<Particle::ParticleType, std::string> types_to_check{
+  const std::unordered_map<Particle::Type, std::string> types_to_check{
       {{Particle::Type::DirichletPhase, "Dirichlet"}, {Particle::Type::NeumannPhase, "Neumann"}}};
 
   // get all available boundary ids

--- a/src/particle/src/interaction/4C_particle_interaction_sph.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph.hpp
@@ -76,7 +76,7 @@ namespace Particle
 
     //! insert interaction dependent states of all particle types
     void insert_particle_states_of_particle_types(
-        std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) override;
+        std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes) override;
 
     //! set initial states
     void set_initial_states() override;

--- a/src/particle/src/interaction/4C_particle_interaction_sph.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph.hpp
@@ -76,8 +76,7 @@ namespace Particle
 
     //! insert interaction dependent states of all particle types
     void insert_particle_states_of_particle_types(
-        std::map<Particle::TypeEnum, std::set<Particle::StateEnum>>& particlestatestotypes)
-        override;
+        std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) override;
 
     //! set initial states
     void set_initial_states() override;

--- a/src/particle/src/interaction/4C_particle_interaction_sph_boundary_particle.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_boundary_particle.cpp
@@ -19,9 +19,10 @@ FOUR_C_NAMESPACE_OPEN
 
 Particle::SPHBoundaryParticleBase::SPHBoundaryParticleBase(const Teuchos::ParameterList& params)
     : params_sph_(params),
-      fluidtypes_(
-          {Particle::Phase1, Particle::Phase2, Particle::DirichletPhase, Particle::NeumannPhase}),
-      boundarytypes_({Particle::BoundaryPhase, Particle::RigidPhase, Particle::PDPhase})
+      fluidtypes_({Particle::Type::Phase1, Particle::Type::Phase2, Particle::Type::DirichletPhase,
+          Particle::Type::NeumannPhase}),
+      boundarytypes_(
+          {Particle::Type::BoundaryPhase, Particle::Type::RigidPhase, Particle::Type::PDPhase})
 {
   // empty constructor
 }
@@ -79,7 +80,7 @@ void Particle::SPHBoundaryParticleAdami::setup(
   }
 
   // determine size of vectors indexed by particle types
-  const int typevectorsize = *(--boundarytypes_.end()) + 1;
+  const int typevectorsize = static_cast<int>(*(--boundarytypes_.end())) + 1;
 
   // allocate memory to hold contributions of neighboring particles
   sumj_wij_.resize(typevectorsize);
@@ -103,10 +104,11 @@ void Particle::SPHBoundaryParticleAdami::init_boundary_particle_states(std::vect
     const int particlestored = container_i->particles_stored();
 
     // allocate memory
-    sumj_wij_[type_i].assign(particlestored, 0.0);
-    sumj_press_j_wij_[type_i].assign(particlestored, 0.0);
-    sumj_dens_j_r_ij_wij_[type_i].assign(particlestored, std::vector<double>(3, 0.0));
-    sumj_vel_j_wij_[type_i].assign(particlestored, std::vector<double>(3, 0.0));
+    sumj_wij_[static_cast<int>(type_i)].assign(particlestored, 0.0);
+    sumj_press_j_wij_[static_cast<int>(type_i)].assign(particlestored, 0.0);
+    sumj_dens_j_r_ij_wij_[static_cast<int>(type_i)].assign(
+        particlestored, std::vector<double>(3, 0.0));
+    sumj_vel_j_wij_[static_cast<int>(type_i)].assign(particlestored, std::vector<double>(3, 0.0));
   }
 
   // get relevant particle pair indices
@@ -121,12 +123,12 @@ void Particle::SPHBoundaryParticleAdami::init_boundary_particle_states(std::vect
         neighborpairs_->get_ref_to_particle_pair_data()[particlepairindex];
 
     // access values of local index tuples of particle i and j
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
-    Particle::TypeEnum type_j;
+    Particle::Type type_j;
     Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
@@ -144,15 +146,16 @@ void Particle::SPHBoundaryParticleAdami::init_boundary_particle_states(std::vect
       const double* press_j = container_j->get_ptr_to_state(Particle::Pressure, particle_j);
 
       // sum contribution of neighboring particle j
-      sumj_wij_[type_i][particle_i] += particlepair.Wij_;
-      sumj_press_j_wij_[type_i][particle_i] += press_j[0] * particlepair.Wij_;
+      sumj_wij_[static_cast<int>(type_i)][particle_i] += particlepair.Wij_;
+      sumj_press_j_wij_[static_cast<int>(type_i)][particle_i] += press_j[0] * particlepair.Wij_;
 
       const double fac = dens_j[0] * particlepair.absdist_ * particlepair.Wij_;
       ParticleUtils::vec_add_scale(
-          sumj_dens_j_r_ij_wij_[type_i][particle_i].data(), fac, particlepair.e_ij_);
+          sumj_dens_j_r_ij_wij_[static_cast<int>(type_i)][particle_i].data(), fac,
+          particlepair.e_ij_);
 
       ParticleUtils::vec_add_scale(
-          sumj_vel_j_wij_[type_i][particle_i].data(), particlepair.Wij_, vel_j);
+          sumj_vel_j_wij_[static_cast<int>(type_i)][particle_i].data(), particlepair.Wij_, vel_j);
     }
 
     // evaluate contribution of neighboring fluid particle i
@@ -168,15 +171,16 @@ void Particle::SPHBoundaryParticleAdami::init_boundary_particle_states(std::vect
       const double* press_i = container_i->get_ptr_to_state(Particle::Pressure, particle_i);
 
       // sum contribution of neighboring particle i
-      sumj_wij_[type_j][particle_j] += particlepair.Wji_;
-      sumj_press_j_wij_[type_j][particle_j] += press_i[0] * particlepair.Wji_;
+      sumj_wij_[static_cast<int>(type_j)][particle_j] += particlepair.Wji_;
+      sumj_press_j_wij_[static_cast<int>(type_j)][particle_j] += press_i[0] * particlepair.Wji_;
 
       const double fac = -dens_i[0] * particlepair.absdist_ * particlepair.Wji_;
       ParticleUtils::vec_add_scale(
-          sumj_dens_j_r_ij_wij_[type_j][particle_j].data(), fac, particlepair.e_ij_);
+          sumj_dens_j_r_ij_wij_[static_cast<int>(type_j)][particle_j].data(), fac,
+          particlepair.e_ij_);
 
       ParticleUtils::vec_add_scale(
-          sumj_vel_j_wij_[type_j][particle_j].data(), particlepair.Wji_, vel_i);
+          sumj_vel_j_wij_[static_cast<int>(type_j)][particle_j].data(), particlepair.Wji_, vel_i);
     }
   }
 
@@ -195,7 +199,7 @@ void Particle::SPHBoundaryParticleAdami::init_boundary_particle_states(std::vect
     for (int particle_i = 0; particle_i < container_i->particles_stored(); ++particle_i)
     {
       // set modified boundary particle states
-      if (sumj_wij_[type_i][particle_i] > 0.0)
+      if (sumj_wij_[static_cast<int>(type_i)][particle_i] > 0.0)
       {
         // get pointer to particle states
         const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
@@ -210,18 +214,19 @@ void Particle::SPHBoundaryParticleAdami::init_boundary_particle_states(std::vect
         ParticleUtils::vec_set(relacc, gravity.data());
         ParticleUtils::vec_sub(relacc, acc_i);
 
-        const double inv_sumj_Wij = 1.0 / sumj_wij_[type_i][particle_i];
+        const double inv_sumj_Wij = 1.0 / sumj_wij_[static_cast<int>(type_i)][particle_i];
 
         // set modified boundary pressure
         boundarypress_i[0] =
-            (sumj_press_j_wij_[type_i][particle_i] +
-                ParticleUtils::vec_dot(relacc, sumj_dens_j_r_ij_wij_[type_i][particle_i].data())) *
+            (sumj_press_j_wij_[static_cast<int>(type_i)][particle_i] +
+                ParticleUtils::vec_dot(
+                    relacc, sumj_dens_j_r_ij_wij_[static_cast<int>(type_i)][particle_i].data())) *
             inv_sumj_Wij;
 
         // set modified boundary velocity
         ParticleUtils::vec_set_scale(boundaryvel_i, 2.0, vel_i);
-        ParticleUtils::vec_add_scale(
-            boundaryvel_i, -inv_sumj_Wij, sumj_vel_j_wij_[type_i][particle_i].data());
+        ParticleUtils::vec_add_scale(boundaryvel_i, -inv_sumj_Wij,
+            sumj_vel_j_wij_[static_cast<int>(type_i)][particle_i].data());
       }
     }
   }

--- a/src/particle/src/interaction/4C_particle_interaction_sph_boundary_particle.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_boundary_particle.cpp
@@ -73,7 +73,8 @@ void Particle::SPHBoundaryParticleAdami::setup(
 
   // setup modified states of ghosted boundary particles to refresh
   {
-    std::vector<Particle::StateEnum> states{Particle::BoundaryPressure, Particle::BoundaryVelocity};
+    std::vector<Particle::State> states{
+        Particle::State::BoundaryPressure, Particle::State::BoundaryVelocity};
 
     for (const auto& type_i : boundarytypes_)
       boundarystatestorefresh_.push_back(std::make_pair(type_i, states));
@@ -141,9 +142,9 @@ void Particle::SPHBoundaryParticleAdami::init_boundary_particle_states(std::vect
           particlecontainerbundle_->get_specific_container(type_j, status_j);
 
       // get pointer to particle states
-      const double* vel_j = container_j->get_ptr_to_state(Particle::Velocity, particle_j);
-      const double* dens_j = container_j->get_ptr_to_state(Particle::Density, particle_j);
-      const double* press_j = container_j->get_ptr_to_state(Particle::Pressure, particle_j);
+      const double* vel_j = container_j->get_ptr_to_state(Particle::State::Velocity, particle_j);
+      const double* dens_j = container_j->get_ptr_to_state(Particle::State::Density, particle_j);
+      const double* press_j = container_j->get_ptr_to_state(Particle::State::Pressure, particle_j);
 
       // sum contribution of neighboring particle j
       sumj_wij_[static_cast<int>(type_i)][particle_i] += particlepair.Wij_;
@@ -166,9 +167,9 @@ void Particle::SPHBoundaryParticleAdami::init_boundary_particle_states(std::vect
           particlecontainerbundle_->get_specific_container(type_i, status_i);
 
       // get pointer to particle states
-      const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
-      const double* dens_i = container_i->get_ptr_to_state(Particle::Density, particle_i);
-      const double* press_i = container_i->get_ptr_to_state(Particle::Pressure, particle_i);
+      const double* vel_i = container_i->get_ptr_to_state(Particle::State::Velocity, particle_i);
+      const double* dens_i = container_i->get_ptr_to_state(Particle::State::Density, particle_i);
+      const double* press_i = container_i->get_ptr_to_state(Particle::State::Pressure, particle_i);
 
       // sum contribution of neighboring particle i
       sumj_wij_[static_cast<int>(type_j)][particle_j] += particlepair.Wji_;
@@ -192,8 +193,8 @@ void Particle::SPHBoundaryParticleAdami::init_boundary_particle_states(std::vect
         particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // clear modified boundary particle states
-    container_i->clear_state(Particle::BoundaryPressure);
-    container_i->clear_state(Particle::BoundaryVelocity);
+    container_i->clear_state(Particle::State::BoundaryPressure);
+    container_i->clear_state(Particle::State::BoundaryVelocity);
 
     // iterate over particles in container
     for (int particle_i = 0; particle_i < container_i->particles_stored(); ++particle_i)
@@ -202,12 +203,13 @@ void Particle::SPHBoundaryParticleAdami::init_boundary_particle_states(std::vect
       if (sumj_wij_[static_cast<int>(type_i)][particle_i] > 0.0)
       {
         // get pointer to particle states
-        const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
-        const double* acc_i = container_i->get_ptr_to_state(Particle::Acceleration, particle_i);
+        const double* vel_i = container_i->get_ptr_to_state(Particle::State::Velocity, particle_i);
+        const double* acc_i =
+            container_i->get_ptr_to_state(Particle::State::Acceleration, particle_i);
         double* boundarypress_i =
-            container_i->get_ptr_to_state_writable(Particle::BoundaryPressure, particle_i);
+            container_i->get_ptr_to_state_writable(Particle::State::BoundaryPressure, particle_i);
         double* boundaryvel_i =
-            container_i->get_ptr_to_state_writable(Particle::BoundaryVelocity, particle_i);
+            container_i->get_ptr_to_state_writable(Particle::State::BoundaryVelocity, particle_i);
 
         // get relative acceleration of boundary particle
         double relacc[3];

--- a/src/particle/src/interaction/4C_particle_interaction_sph_boundary_particle.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_boundary_particle.cpp
@@ -97,7 +97,7 @@ void Particle::SPHBoundaryParticleAdami::init_boundary_particle_states(std::vect
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container_i =
-        particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // get number of particles stored in container
     const int particlestored = container_i->particles_stored();
@@ -122,12 +122,12 @@ void Particle::SPHBoundaryParticleAdami::init_boundary_particle_states(std::vect
 
     // access values of local index tuples of particle i and j
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
     Particle::TypeEnum type_j;
-    Particle::StatusEnum status_j;
+    Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
 
@@ -156,7 +156,7 @@ void Particle::SPHBoundaryParticleAdami::init_boundary_particle_states(std::vect
     }
 
     // evaluate contribution of neighboring fluid particle i
-    if (boundarytypes_.contains(type_j) and status_j == Particle::Owned)
+    if (boundarytypes_.contains(type_j) and status_j == Particle::Status::Owned)
     {
       // get container of owned particles
       Particle::ParticleContainer* container_i =
@@ -185,7 +185,7 @@ void Particle::SPHBoundaryParticleAdami::init_boundary_particle_states(std::vect
   {
     // get container of owned particles
     Particle::ParticleContainer* container_i =
-        particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // clear modified boundary particle states
     container_i->clear_state(Particle::BoundaryPressure);

--- a/src/particle/src/interaction/4C_particle_interaction_sph_boundary_particle.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_boundary_particle.hpp
@@ -66,10 +66,10 @@ namespace Particle
     std::shared_ptr<Particle::SPHNeighborPairs> neighborpairs_;
 
     //! set of fluid particle types
-    std::set<Particle::TypeEnum> fluidtypes_;
+    std::set<Particle::Type> fluidtypes_;
 
     //! set of boundary particle types
-    std::set<Particle::TypeEnum> boundarytypes_;
+    std::set<Particle::Type> boundarytypes_;
   };
 
   class SPHBoundaryParticleAdami : public SPHBoundaryParticleBase

--- a/src/particle/src/interaction/4C_particle_interaction_sph_density.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_density.cpp
@@ -80,7 +80,7 @@ void Particle::SPHDensityBase::setup(
 
   // setup density of ghosted particles to refresh
   {
-    std::vector<Particle::StateEnum> states{Particle::Density};
+    std::vector<Particle::State> states{Particle::State::Density};
 
     for (const auto& type_i : fluidtypes_)
       densitytorefresh_.push_back(std::make_pair(type_i, states));
@@ -117,7 +117,7 @@ void Particle::SPHDensityBase::clear_density_sum_state() const
         particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // clear density sum state
-    container_i->clear_state(Particle::DensitySum);
+    container_i->clear_state(Particle::State::DensitySum);
   }
 }
 
@@ -136,9 +136,10 @@ void Particle::SPHDensityBase::sum_weighted_mass_self_contribution() const
     for (int particle_i = 0; particle_i < container_i->particles_stored(); ++particle_i)
     {
       // get pointer to particle states
-      const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
-      const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
-      double* denssum_i = container_i->get_ptr_to_state_writable(Particle::DensitySum, particle_i);
+      const double* rad_i = container_i->get_ptr_to_state(Particle::State::Radius, particle_i);
+      const double* mass_i = container_i->get_ptr_to_state(Particle::State::Mass, particle_i);
+      double* denssum_i =
+          container_i->get_ptr_to_state_writable(Particle::State::DensitySum, particle_i);
 
       // evaluate kernel
       const double Wii = kernel_->w0(rad_i[0]);
@@ -175,14 +176,15 @@ void Particle::SPHDensityBase::sum_weighted_mass_particle_contribution() const
         particlecontainerbundle_->get_specific_container(type_j, status_j);
 
     // get pointer to particle states
-    const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
+    const double* mass_i = container_i->get_ptr_to_state(Particle::State::Mass, particle_i);
     double* denssum_i =
-        container_i->try_get_ptr_to_state_writable(Particle::DensitySum, particle_i);
+        container_i->try_get_ptr_to_state_writable(Particle::State::DensitySum, particle_i);
 
-    const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
+    const double* mass_j = container_j->get_ptr_to_state(Particle::State::Mass, particle_j);
     double* denssum_j = nullptr;
     if (status_j == Particle::Status::Owned)
-      denssum_j = container_j->try_get_ptr_to_state_writable(Particle::DensitySum, particle_j);
+      denssum_j =
+          container_j->try_get_ptr_to_state_writable(Particle::State::DensitySum, particle_j);
 
     // sum contribution of neighboring particle j
     if (denssum_i) denssum_i[0] += particlepair.Wij_ * mass_i[0];
@@ -218,9 +220,10 @@ void Particle::SPHDensityBase::sum_weighted_mass_particle_wall_contribution() co
         particlecontainerbundle_->get_specific_container(type_i, status_i);
 
     // get pointer to particle states
-    const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
-    const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
-    double* denssum_i = container_i->get_ptr_to_state_writable(Particle::DensitySum, particle_i);
+    const double* rad_i = container_i->get_ptr_to_state(Particle::State::Radius, particle_i);
+    const double* mass_i = container_i->get_ptr_to_state(Particle::State::Mass, particle_i);
+    double* denssum_i =
+        container_i->get_ptr_to_state_writable(Particle::State::DensitySum, particle_i);
 
     // compute vector from wall contact point j to particle i
     double r_ij[3];
@@ -283,7 +286,7 @@ void Particle::SPHDensityBase::clear_colorfield_state() const
         particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // clear colorfield state
-    container_i->clear_state(Particle::Colorfield);
+    container_i->clear_state(Particle::State::Colorfield);
   }
 }
 
@@ -302,11 +305,11 @@ void Particle::SPHDensityBase::sum_colorfield_self_contribution() const
     for (int particle_i = 0; particle_i < container_i->particles_stored(); ++particle_i)
     {
       // get pointer to particle states
-      const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
-      const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
-      const double* dens_i = container_i->get_ptr_to_state(Particle::Density, particle_i);
+      const double* rad_i = container_i->get_ptr_to_state(Particle::State::Radius, particle_i);
+      const double* mass_i = container_i->get_ptr_to_state(Particle::State::Mass, particle_i);
+      const double* dens_i = container_i->get_ptr_to_state(Particle::State::Density, particle_i);
       double* colorfield_i =
-          container_i->get_ptr_to_state_writable(Particle::Colorfield, particle_i);
+          container_i->get_ptr_to_state_writable(Particle::State::Colorfield, particle_i);
 
       // evaluate kernel
       const double Wii = kernel_->w0(rad_i[0]);
@@ -350,24 +353,25 @@ void Particle::SPHDensityBase::sum_colorfield_particle_contribution() const
         particlematerial_->get_ptr_to_particle_mat_parameter(type_j);
 
     // get pointer to particle states
-    const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
+    const double* mass_i = container_i->get_ptr_to_state(Particle::State::Mass, particle_i);
 
-    const double* dens_i = container_i->have_stored_state(Particle::Density)
-                               ? container_i->get_ptr_to_state(Particle::Density, particle_i)
+    const double* dens_i = container_i->have_stored_state(Particle::State::Density)
+                               ? container_i->get_ptr_to_state(Particle::State::Density, particle_i)
                                : &(material_j->initDensity_);
 
     double* colorfield_i =
-        container_i->try_get_ptr_to_state_writable(Particle::Colorfield, particle_i);
+        container_i->try_get_ptr_to_state_writable(Particle::State::Colorfield, particle_i);
 
-    const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
+    const double* mass_j = container_j->get_ptr_to_state(Particle::State::Mass, particle_j);
 
-    const double* dens_j = container_j->have_stored_state(Particle::Density)
-                               ? container_j->get_ptr_to_state(Particle::Density, particle_j)
+    const double* dens_j = container_j->have_stored_state(Particle::State::Density)
+                               ? container_j->get_ptr_to_state(Particle::State::Density, particle_j)
                                : &(material_i->initDensity_);
 
     double* colorfield_j = nullptr;
     if (status_j == Particle::Status::Owned)
-      colorfield_j = container_j->try_get_ptr_to_state_writable(Particle::Colorfield, particle_j);
+      colorfield_j =
+          container_j->try_get_ptr_to_state_writable(Particle::State::Colorfield, particle_j);
 
     // sum contribution of neighboring particle j
     if (colorfield_i) colorfield_i[0] += (particlepair.Wij_ / dens_j[0]) * mass_j[0];
@@ -406,11 +410,12 @@ void Particle::SPHDensityBase::sum_colorfield_particle_wall_contribution() const
         particlematerial_->get_ptr_to_particle_mat_parameter(type_i);
 
     // get pointer to particle states
-    const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
-    double* colorfield_i = container_i->get_ptr_to_state_writable(Particle::Colorfield, particle_i);
+    const double* rad_i = container_i->get_ptr_to_state(Particle::State::Radius, particle_i);
+    double* colorfield_i =
+        container_i->get_ptr_to_state_writable(Particle::State::Colorfield, particle_i);
 
     // get pointer to virtual particle states
-    const double* mass_k = container_i->get_ptr_to_state(Particle::Mass, particle_i);
+    const double* mass_k = container_i->get_ptr_to_state(Particle::State::Mass, particle_i);
     const double* dens_k = &(material_i->initDensity_);
 
     // (current) volume of virtual particle k
@@ -474,7 +479,7 @@ void Particle::SPHDensityBase::clear_density_dot_state() const
         particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // clear density dot state
-    container_i->clear_state(Particle::DensityDot);
+    container_i->clear_state(Particle::State::DensityDot);
   }
 }
 
@@ -512,33 +517,34 @@ void Particle::SPHDensityBase::continuity_equation_particle_contribution() const
 
     // get pointer to particle states
     const double* vel_i =
-        container_i->have_stored_state(Particle::ModifiedVelocity)
-            ? container_i->get_ptr_to_state(Particle::ModifiedVelocity, particle_i)
-            : container_i->get_ptr_to_state(Particle::Velocity, particle_i);
+        container_i->have_stored_state(Particle::State::ModifiedVelocity)
+            ? container_i->get_ptr_to_state(Particle::State::ModifiedVelocity, particle_i)
+            : container_i->get_ptr_to_state(Particle::State::Velocity, particle_i);
 
-    const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
+    const double* mass_i = container_i->get_ptr_to_state(Particle::State::Mass, particle_i);
 
-    const double* dens_i = container_i->have_stored_state(Particle::Density)
-                               ? container_i->get_ptr_to_state(Particle::Density, particle_i)
+    const double* dens_i = container_i->have_stored_state(Particle::State::Density)
+                               ? container_i->get_ptr_to_state(Particle::State::Density, particle_i)
                                : &(material_j->initDensity_);
 
     double* densdot_i =
-        container_i->try_get_ptr_to_state_writable(Particle::DensityDot, particle_i);
+        container_i->try_get_ptr_to_state_writable(Particle::State::DensityDot, particle_i);
 
     const double* vel_j =
-        container_j->have_stored_state(Particle::ModifiedVelocity)
-            ? container_j->get_ptr_to_state(Particle::ModifiedVelocity, particle_j)
-            : container_j->get_ptr_to_state(Particle::Velocity, particle_j);
+        container_j->have_stored_state(Particle::State::ModifiedVelocity)
+            ? container_j->get_ptr_to_state(Particle::State::ModifiedVelocity, particle_j)
+            : container_j->get_ptr_to_state(Particle::State::Velocity, particle_j);
 
-    const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
+    const double* mass_j = container_j->get_ptr_to_state(Particle::State::Mass, particle_j);
 
-    const double* dens_j = container_j->have_stored_state(Particle::Density)
-                               ? container_j->get_ptr_to_state(Particle::Density, particle_j)
+    const double* dens_j = container_j->have_stored_state(Particle::State::Density)
+                               ? container_j->get_ptr_to_state(Particle::State::Density, particle_j)
                                : &(material_i->initDensity_);
 
     double* densdot_j = nullptr;
     if (status_j == Particle::Status::Owned)
-      densdot_j = container_j->try_get_ptr_to_state_writable(Particle::DensityDot, particle_j);
+      densdot_j =
+          container_j->try_get_ptr_to_state_writable(Particle::State::DensityDot, particle_j);
 
     // relative velocity (use modified velocities in case of transport velocity formulation)
     double vel_ij[3];
@@ -592,13 +598,14 @@ void Particle::SPHDensityBase::continuity_equation_particle_wall_contribution() 
 
     // get pointer to particle states
     const double* vel_i =
-        container_i->have_stored_state(Particle::ModifiedVelocity)
-            ? container_i->get_ptr_to_state(Particle::ModifiedVelocity, particle_i)
-            : container_i->get_ptr_to_state(Particle::Velocity, particle_i);
+        container_i->have_stored_state(Particle::State::ModifiedVelocity)
+            ? container_i->get_ptr_to_state(Particle::State::ModifiedVelocity, particle_i)
+            : container_i->get_ptr_to_state(Particle::State::Velocity, particle_i);
 
-    const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
-    const double* dens_i = container_i->get_ptr_to_state(Particle::Density, particle_i);
-    double* densdot_i = container_i->get_ptr_to_state_writable(Particle::DensityDot, particle_i);
+    const double* rad_i = container_i->get_ptr_to_state(Particle::State::Radius, particle_i);
+    const double* dens_i = container_i->get_ptr_to_state(Particle::State::Density, particle_i);
+    double* densdot_i =
+        container_i->get_ptr_to_state_writable(Particle::State::DensityDot, particle_i);
 
     // get pointer to column wall element
     Core::Elements::Element* ele = particlewallpair.ele_;
@@ -639,7 +646,7 @@ void Particle::SPHDensityBase::continuity_equation_particle_wall_contribution() 
     }
 
     // get pointer to virtual particle states
-    const double* mass_k = container_i->get_ptr_to_state(Particle::Mass, particle_i);
+    const double* mass_k = container_i->get_ptr_to_state(Particle::State::Mass, particle_i);
     const double* dens_k = &(material_i->initDensity_);
     const double* vel_k = vel_j.data();
 
@@ -699,7 +706,7 @@ void Particle::SPHDensityBase::set_density_sum() const
         particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // update density of all particles
-    container_i->update_state(0.0, Particle::Density, 1.0, Particle::DensitySum);
+    container_i->update_state(0.0, Particle::State::Density, 1.0, Particle::State::DensitySum);
   }
 }
 
@@ -713,7 +720,7 @@ void Particle::SPHDensityBase::add_time_step_scaled_density_dot() const
         particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // update density of all particles
-    container_i->update_state(1.0, Particle::Density, dt_, Particle::DensityDot);
+    container_i->update_state(1.0, Particle::State::Density, dt_, Particle::State::DensityDot);
   }
 }
 
@@ -724,7 +731,7 @@ Particle::SPHDensitySummation::SPHDensitySummation(const Teuchos::ParameterList&
 }
 
 void Particle::SPHDensitySummation::insert_particle_states_of_particle_types(
-    std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const
+    std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes) const
 {
   // iterate over particle types
   for (auto& typeIt : particlestatestotypes)
@@ -733,13 +740,13 @@ void Particle::SPHDensitySummation::insert_particle_states_of_particle_types(
     Particle::Type type_i = typeIt.first;
 
     // set of particle states for current particle type
-    std::set<Particle::StateEnum>& particlestates = typeIt.second;
+    std::set<Particle::State>& particlestates = typeIt.second;
 
     // current particle type is not a fluid particle type
     if (not fluidtypes_.contains(type_i)) continue;
 
     // states for density evaluation scheme
-    particlestates.insert(Particle::DensitySum);
+    particlestates.insert(Particle::State::DensitySum);
   }
 }
 
@@ -764,7 +771,7 @@ Particle::SPHDensityIntegration::SPHDensityIntegration(const Teuchos::ParameterL
 }
 
 void Particle::SPHDensityIntegration::insert_particle_states_of_particle_types(
-    std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const
+    std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes) const
 {
   // iterate over particle types
   for (auto& typeIt : particlestatestotypes)
@@ -773,13 +780,13 @@ void Particle::SPHDensityIntegration::insert_particle_states_of_particle_types(
     Particle::Type type_i = typeIt.first;
 
     // set of particle states for current particle type
-    std::set<Particle::StateEnum>& particlestates = typeIt.second;
+    std::set<Particle::State>& particlestates = typeIt.second;
 
     // current particle type is not a fluid particle type
     if (not fluidtypes_.contains(type_i)) continue;
 
     // states for density evaluation scheme
-    particlestates.insert(Particle::DensityDot);
+    particlestates.insert(Particle::State::DensityDot);
   }
 }
 
@@ -820,7 +827,7 @@ void Particle::SPHDensityPredictCorrect::setup(
 }
 
 void Particle::SPHDensityPredictCorrect::insert_particle_states_of_particle_types(
-    std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const
+    std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes) const
 {
   // iterate over particle types
   for (auto& typeIt : particlestatestotypes)
@@ -829,13 +836,14 @@ void Particle::SPHDensityPredictCorrect::insert_particle_states_of_particle_type
     Particle::Type type_i = typeIt.first;
 
     // set of particle states for current particle type
-    std::set<Particle::StateEnum>& particlestates = typeIt.second;
+    std::set<Particle::State>& particlestates = typeIt.second;
 
     // current particle type is not a fluid particle type
     if (not fluidtypes_.contains(type_i)) continue;
 
     // states for density evaluation scheme
-    particlestates.insert({Particle::DensityDot, Particle::DensitySum, Particle::Colorfield});
+    particlestates.insert(
+        {Particle::State::DensityDot, Particle::State::DensitySum, Particle::State::Colorfield});
   }
 }
 
@@ -916,9 +924,9 @@ void Particle::SPHDensityPredictCorrect::correct_density() const
     if (particlestored <= 0) continue;
 
     // get pointer to particle state
-    const double* denssum = container_i->get_ptr_to_state(Particle::DensitySum, 0);
-    const double* colorfield = container_i->get_ptr_to_state(Particle::Colorfield, 0);
-    double* dens = container_i->get_ptr_to_state_writable(Particle::Density, 0);
+    const double* denssum = container_i->get_ptr_to_state(Particle::State::DensitySum, 0);
+    const double* colorfield = container_i->get_ptr_to_state(Particle::State::Colorfield, 0);
+    double* dens = container_i->get_ptr_to_state_writable(Particle::State::Density, 0);
 
     // get material for current particle type
     const Mat::PAR::ParticleMaterialBase* material =

--- a/src/particle/src/interaction/4C_particle_interaction_sph_density.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_density.cpp
@@ -34,7 +34,7 @@ FOUR_C_NAMESPACE_OPEN
  | definitions                                                               |
  *---------------------------------------------------------------------------*/
 Particle::SPHDensityBase::SPHDensityBase(const Teuchos::ParameterList& params)
-    : params_sph_(params), fluidtypes_({Particle::Phase1, Particle::Phase2}), dt_(0.0)
+    : params_sph_(params), fluidtypes_({Particle::Type::Phase1, Particle::Type::Phase2}), dt_(0.0)
 {
   // empty constructor
 }
@@ -157,12 +157,12 @@ void Particle::SPHDensityBase::sum_weighted_mass_particle_contribution() const
   for (auto& particlepair : neighborpairs_->get_ref_to_particle_pair_data())
   {
     // access values of local index tuples of particle i and j
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
-    Particle::TypeEnum type_j;
+    Particle::Type type_j;
     Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
@@ -208,7 +208,7 @@ void Particle::SPHDensityBase::sum_weighted_mass_particle_wall_contribution() co
         neighborpairs_->get_ref_to_particle_wall_pair_data()[particlewallpairindex];
 
     // access values of local index tuple of particle i
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlewallpair.tuple_i_;
@@ -325,12 +325,12 @@ void Particle::SPHDensityBase::sum_colorfield_particle_contribution() const
   for (auto& particlepair : neighborpairs_->get_ref_to_particle_pair_data())
   {
     // access values of local index tuples of particle i and j
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
-    Particle::TypeEnum type_j;
+    Particle::Type type_j;
     Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
@@ -392,7 +392,7 @@ void Particle::SPHDensityBase::sum_colorfield_particle_wall_contribution() const
         neighborpairs_->get_ref_to_particle_wall_pair_data()[particlewallpairindex];
 
     // access values of local index tuple of particle i
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlewallpair.tuple_i_;
@@ -486,12 +486,12 @@ void Particle::SPHDensityBase::continuity_equation_particle_contribution() const
   for (auto& particlepair : neighborpairs_->get_ref_to_particle_pair_data())
   {
     // access values of local index tuples of particle i and j
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
-    Particle::TypeEnum type_j;
+    Particle::Type type_j;
     Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
@@ -577,7 +577,7 @@ void Particle::SPHDensityBase::continuity_equation_particle_wall_contribution() 
         neighborpairs_->get_ref_to_particle_wall_pair_data()[particlewallpairindex];
 
     // access values of local index tuple of particle i
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlewallpair.tuple_i_;
@@ -724,13 +724,13 @@ Particle::SPHDensitySummation::SPHDensitySummation(const Teuchos::ParameterList&
 }
 
 void Particle::SPHDensitySummation::insert_particle_states_of_particle_types(
-    std::map<Particle::TypeEnum, std::set<Particle::StateEnum>>& particlestatestotypes) const
+    std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const
 {
   // iterate over particle types
   for (auto& typeIt : particlestatestotypes)
   {
     // get type of particles
-    Particle::TypeEnum type_i = typeIt.first;
+    Particle::Type type_i = typeIt.first;
 
     // set of particle states for current particle type
     std::set<Particle::StateEnum>& particlestates = typeIt.second;
@@ -764,13 +764,13 @@ Particle::SPHDensityIntegration::SPHDensityIntegration(const Teuchos::ParameterL
 }
 
 void Particle::SPHDensityIntegration::insert_particle_states_of_particle_types(
-    std::map<Particle::TypeEnum, std::set<Particle::StateEnum>>& particlestatestotypes) const
+    std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const
 {
   // iterate over particle types
   for (auto& typeIt : particlestatestotypes)
   {
     // get type of particles
-    Particle::TypeEnum type_i = typeIt.first;
+    Particle::Type type_i = typeIt.first;
 
     // set of particle states for current particle type
     std::set<Particle::StateEnum>& particlestates = typeIt.second;
@@ -820,13 +820,13 @@ void Particle::SPHDensityPredictCorrect::setup(
 }
 
 void Particle::SPHDensityPredictCorrect::insert_particle_states_of_particle_types(
-    std::map<Particle::TypeEnum, std::set<Particle::StateEnum>>& particlestatestotypes) const
+    std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const
 {
   // iterate over particle types
   for (auto& typeIt : particlestatestotypes)
   {
     // get type of particles
-    Particle::TypeEnum type_i = typeIt.first;
+    Particle::Type type_i = typeIt.first;
 
     // set of particle states for current particle type
     std::set<Particle::StateEnum>& particlestates = typeIt.second;

--- a/src/particle/src/interaction/4C_particle_interaction_sph_density.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_density.cpp
@@ -114,7 +114,7 @@ void Particle::SPHDensityBase::clear_density_sum_state() const
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container_i =
-        particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // clear density sum state
     container_i->clear_state(Particle::DensitySum);
@@ -130,7 +130,7 @@ void Particle::SPHDensityBase::sum_weighted_mass_self_contribution() const
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container_i =
-        particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // iterate over particles in container
     for (int particle_i = 0; particle_i < container_i->particles_stored(); ++particle_i)
@@ -158,12 +158,12 @@ void Particle::SPHDensityBase::sum_weighted_mass_particle_contribution() const
   {
     // access values of local index tuples of particle i and j
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
     Particle::TypeEnum type_j;
-    Particle::StatusEnum status_j;
+    Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
 
@@ -181,7 +181,7 @@ void Particle::SPHDensityBase::sum_weighted_mass_particle_contribution() const
 
     const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
     double* denssum_j = nullptr;
-    if (status_j == Particle::Owned)
+    if (status_j == Particle::Status::Owned)
       denssum_j = container_j->try_get_ptr_to_state_writable(Particle::DensitySum, particle_j);
 
     // sum contribution of neighboring particle j
@@ -209,7 +209,7 @@ void Particle::SPHDensityBase::sum_weighted_mass_particle_wall_contribution() co
 
     // access values of local index tuple of particle i
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlewallpair.tuple_i_;
 
@@ -280,7 +280,7 @@ void Particle::SPHDensityBase::clear_colorfield_state() const
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container_i =
-        particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // clear colorfield state
     container_i->clear_state(Particle::Colorfield);
@@ -296,7 +296,7 @@ void Particle::SPHDensityBase::sum_colorfield_self_contribution() const
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container_i =
-        particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // iterate over particles in container
     for (int particle_i = 0; particle_i < container_i->particles_stored(); ++particle_i)
@@ -326,12 +326,12 @@ void Particle::SPHDensityBase::sum_colorfield_particle_contribution() const
   {
     // access values of local index tuples of particle i and j
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
     Particle::TypeEnum type_j;
-    Particle::StatusEnum status_j;
+    Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
 
@@ -366,7 +366,7 @@ void Particle::SPHDensityBase::sum_colorfield_particle_contribution() const
                                : &(material_i->initDensity_);
 
     double* colorfield_j = nullptr;
-    if (status_j == Particle::Owned)
+    if (status_j == Particle::Status::Owned)
       colorfield_j = container_j->try_get_ptr_to_state_writable(Particle::Colorfield, particle_j);
 
     // sum contribution of neighboring particle j
@@ -393,7 +393,7 @@ void Particle::SPHDensityBase::sum_colorfield_particle_wall_contribution() const
 
     // access values of local index tuple of particle i
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlewallpair.tuple_i_;
 
@@ -471,7 +471,7 @@ void Particle::SPHDensityBase::clear_density_dot_state() const
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container_i =
-        particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // clear density dot state
     container_i->clear_state(Particle::DensityDot);
@@ -487,12 +487,12 @@ void Particle::SPHDensityBase::continuity_equation_particle_contribution() const
   {
     // access values of local index tuples of particle i and j
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
     Particle::TypeEnum type_j;
-    Particle::StatusEnum status_j;
+    Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
 
@@ -537,7 +537,7 @@ void Particle::SPHDensityBase::continuity_equation_particle_contribution() const
                                : &(material_i->initDensity_);
 
     double* densdot_j = nullptr;
-    if (status_j == Particle::Owned)
+    if (status_j == Particle::Status::Owned)
       densdot_j = container_j->try_get_ptr_to_state_writable(Particle::DensityDot, particle_j);
 
     // relative velocity (use modified velocities in case of transport velocity formulation)
@@ -578,7 +578,7 @@ void Particle::SPHDensityBase::continuity_equation_particle_wall_contribution() 
 
     // access values of local index tuple of particle i
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlewallpair.tuple_i_;
 
@@ -696,7 +696,7 @@ void Particle::SPHDensityBase::set_density_sum() const
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container_i =
-        particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // update density of all particles
     container_i->update_state(0.0, Particle::Density, 1.0, Particle::DensitySum);
@@ -710,7 +710,7 @@ void Particle::SPHDensityBase::add_time_step_scaled_density_dot() const
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container_i =
-        particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // update density of all particles
     container_i->update_state(1.0, Particle::Density, dt_, Particle::DensityDot);
@@ -907,7 +907,7 @@ void Particle::SPHDensityPredictCorrect::correct_density() const
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container_i =
-        particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // get number of particles stored in container
     const int particlestored = container_i->particles_stored();

--- a/src/particle/src/interaction/4C_particle_interaction_sph_density.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_density.hpp
@@ -65,7 +65,7 @@ namespace Particle
 
     //! insert density evaluation dependent states
     virtual void insert_particle_states_of_particle_types(
-        std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const = 0;
+        std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes) const = 0;
 
     //! compute density field
     virtual void compute_density() const = 0;
@@ -164,8 +164,7 @@ namespace Particle
 
     //! insert density evaluation dependent states
     void insert_particle_states_of_particle_types(
-        std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes)
-        const override;
+        std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes) const override;
 
     //! compute density field
     void compute_density() const override;
@@ -179,8 +178,7 @@ namespace Particle
 
     //! insert density evaluation dependent states
     void insert_particle_states_of_particle_types(
-        std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes)
-        const override;
+        std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes) const override;
 
     //! compute density field
     void compute_density() const override;
@@ -212,8 +210,7 @@ namespace Particle
 
     //! insert density evaluation dependent states
     void insert_particle_states_of_particle_types(
-        std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes)
-        const override;
+        std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes) const override;
 
     //! compute density field
     void compute_density() const override;

--- a/src/particle/src/interaction/4C_particle_interaction_sph_density.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_density.hpp
@@ -65,8 +65,7 @@ namespace Particle
 
     //! insert density evaluation dependent states
     virtual void insert_particle_states_of_particle_types(
-        std::map<Particle::TypeEnum, std::set<Particle::StateEnum>>& particlestatestotypes)
-        const = 0;
+        std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const = 0;
 
     //! compute density field
     virtual void compute_density() const = 0;
@@ -151,7 +150,7 @@ namespace Particle
     Particle::StatesOfTypesToRefresh densitytorefresh_;
 
     //! set of fluid particle types
-    std::set<Particle::TypeEnum> fluidtypes_;
+    std::set<Particle::Type> fluidtypes_;
 
     //! time step size
     double dt_;
@@ -165,7 +164,7 @@ namespace Particle
 
     //! insert density evaluation dependent states
     void insert_particle_states_of_particle_types(
-        std::map<Particle::TypeEnum, std::set<Particle::StateEnum>>& particlestatestotypes)
+        std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes)
         const override;
 
     //! compute density field
@@ -180,7 +179,7 @@ namespace Particle
 
     //! insert density evaluation dependent states
     void insert_particle_states_of_particle_types(
-        std::map<Particle::TypeEnum, std::set<Particle::StateEnum>>& particlestatestotypes)
+        std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes)
         const override;
 
     //! compute density field
@@ -213,7 +212,7 @@ namespace Particle
 
     //! insert density evaluation dependent states
     void insert_particle_states_of_particle_types(
-        std::map<Particle::TypeEnum, std::set<Particle::StateEnum>>& particlestatestotypes)
+        std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes)
         const override;
 
     //! compute density field

--- a/src/particle/src/interaction/4C_particle_interaction_sph_equationofstate_bundle.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_equationofstate_bundle.cpp
@@ -32,7 +32,7 @@ void Particle::SPHEquationOfStateBundle::init(Particle::MaterialHandler& particl
       Teuchos::getIntegralValue<Particle::EquationOfStateType>(params_sph_, "EQUATIONOFSTATE");
 
   // determine size of vector indexed by particle types
-  const int typevectorsize = *(--particlematerial.get_particle_types().end()) + 1;
+  const int typevectorsize = static_cast<int>(*(--particlematerial.get_particle_types().end())) + 1;
 
   // allocate memory to hold particle types
   phasetypetoequationofstate_.resize(typevectorsize);
@@ -41,8 +41,8 @@ void Particle::SPHEquationOfStateBundle::init(Particle::MaterialHandler& particl
   for (const auto& type_i : particlematerial.get_particle_types())
   {
     // no equation of state for boundary or rigid particles
-    if (type_i == Particle::BoundaryPhase or type_i == Particle::RigidPhase or
-        type_i == Particle::PDPhase)
+    if (type_i == Particle::Type::BoundaryPhase or type_i == Particle::Type::RigidPhase or
+        type_i == Particle::Type::PDPhase)
       continue;
 
     // add to set of particle types of stored equation of state handlers
@@ -62,16 +62,18 @@ void Particle::SPHEquationOfStateBundle::init(Particle::MaterialHandler& particl
         const double refdensfac = material->refDensFac_;
         const double exponent = material->exponent_;
 
-        phasetypetoequationofstate_[type_i] = std::unique_ptr<Particle::SPHEquationOfStateGenTait>(
-            new Particle::SPHEquationOfStateGenTait(speedofsound, refdensfac, exponent));
+        phasetypetoequationofstate_[static_cast<int>(type_i)] =
+            std::unique_ptr<Particle::SPHEquationOfStateGenTait>(
+                new Particle::SPHEquationOfStateGenTait(speedofsound, refdensfac, exponent));
         break;
       }
       case Particle::IdealGas:
       {
         const double speedofsound = material->speed_of_sound();
 
-        phasetypetoequationofstate_[type_i] = std::unique_ptr<Particle::SPHEquationOfStateIdealGas>(
-            new Particle::SPHEquationOfStateIdealGas(speedofsound));
+        phasetypetoequationofstate_[static_cast<int>(type_i)] =
+            std::unique_ptr<Particle::SPHEquationOfStateIdealGas>(
+                new Particle::SPHEquationOfStateIdealGas(speedofsound));
         break;
       }
       default:

--- a/src/particle/src/interaction/4C_particle_interaction_sph_equationofstate_bundle.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_equationofstate_bundle.hpp
@@ -44,9 +44,9 @@ namespace Particle
 
     //! return pointer to specific equation of state
     inline const Particle::SPHEquationOfStateBase* get_ptr_to_specific_equation_of_state(
-        Particle::TypeEnum type_i) const
+        Particle::Type type_i) const
     {
-      return phasetypetoequationofstate_[type_i].get();
+      return phasetypetoequationofstate_[static_cast<int>(type_i)].get();
     };
 
    private:
@@ -57,7 +57,7 @@ namespace Particle
     std::vector<std::unique_ptr<Particle::SPHEquationOfStateBase>> phasetypetoequationofstate_;
 
     //! set of particle types of stored equation of state handlers
-    std::set<Particle::TypeEnum> storedtypes_;
+    std::set<Particle::Type> storedtypes_;
   };
 
 }  // namespace Particle

--- a/src/particle/src/interaction/4C_particle_interaction_sph_heatloss_evaporation.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_heatloss_evaporation.cpp
@@ -66,7 +66,7 @@ void Particle::SPHHeatLossEvaporation::evaluate_evaporation_induced_heat_loss() 
 
   // get container of owned particles of evaporating phase
   Particle::ParticleContainer* container_i =
-      particlecontainerbundle_->get_specific_container(evaporatingphase_, Particle::Owned);
+      particlecontainerbundle_->get_specific_container(evaporatingphase_, Particle::Status::Owned);
 
   const Mat::PAR::ParticleMaterialThermo* thermomaterial_i = thermomaterial_[evaporatingphase_];
 

--- a/src/particle/src/interaction/4C_particle_interaction_sph_heatloss_evaporation.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_heatloss_evaporation.cpp
@@ -20,7 +20,7 @@ FOUR_C_NAMESPACE_OPEN
 
 Particle::SPHHeatLossEvaporation::SPHHeatLossEvaporation(const Teuchos::ParameterList& params)
     : params_sph_(params),
-      evaporatingphase_(Particle::Phase1),
+      evaporatingphase_(Particle::Type::Phase1),
       recoilboilingtemp_(params_sph_.get<double>("VAPOR_RECOIL_BOILINGTEMPERATURE")),
       recoil_pfac_(params_sph_.get<double>("VAPOR_RECOIL_PFAC")),
       recoil_tfac_(params_sph_.get<double>("VAPOR_RECOIL_TFAC")),
@@ -48,15 +48,17 @@ void Particle::SPHHeatLossEvaporation::setup(
   particlematerial_ = particlematerial;
 
   // determine size of vectors indexed by particle types
-  const int typevectorsize = *(--particlecontainerbundle_->get_particle_types().end()) + 1;
+  const int typevectorsize =
+      static_cast<int>(*(--particlecontainerbundle_->get_particle_types().end())) + 1;
 
   // allocate memory to hold particle types
   thermomaterial_.resize(typevectorsize);
 
   // iterate over particle types
   for (const auto& type_i : particlecontainerbundle_->get_particle_types())
-    thermomaterial_[type_i] = dynamic_cast<const Mat::PAR::ParticleMaterialThermo*>(
-        particlematerial_->get_ptr_to_particle_mat_parameter(type_i));
+    thermomaterial_[static_cast<int>(type_i)] =
+        dynamic_cast<const Mat::PAR::ParticleMaterialThermo*>(
+            particlematerial_->get_ptr_to_particle_mat_parameter(type_i));
 }
 
 void Particle::SPHHeatLossEvaporation::evaluate_evaporation_induced_heat_loss() const
@@ -68,7 +70,8 @@ void Particle::SPHHeatLossEvaporation::evaluate_evaporation_induced_heat_loss() 
   Particle::ParticleContainer* container_i =
       particlecontainerbundle_->get_specific_container(evaporatingphase_, Particle::Status::Owned);
 
-  const Mat::PAR::ParticleMaterialThermo* thermomaterial_i = thermomaterial_[evaporatingphase_];
+  const Mat::PAR::ParticleMaterialThermo* thermomaterial_i =
+      thermomaterial_[static_cast<int>(evaporatingphase_)];
 
   // iterate over particles in container
   for (int particle_i = 0; particle_i < container_i->particles_stored(); ++particle_i)

--- a/src/particle/src/interaction/4C_particle_interaction_sph_heatloss_evaporation.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_heatloss_evaporation.cpp
@@ -76,12 +76,14 @@ void Particle::SPHHeatLossEvaporation::evaluate_evaporation_induced_heat_loss() 
   // iterate over particles in container
   for (int particle_i = 0; particle_i < container_i->particles_stored(); ++particle_i)
   {
-    const double* dens_i = container_i->get_ptr_to_state(Particle::Density, particle_i);
-    const double* temp_i = container_i->get_ptr_to_state(Particle::Temperature, particle_i);
-    const double* cfg_i = container_i->get_ptr_to_state(Particle::ColorfieldGradient, particle_i);
-    const double* ifn_i = container_i->get_ptr_to_state(Particle::InterfaceNormal, particle_i);
+    const double* dens_i = container_i->get_ptr_to_state(Particle::State::Density, particle_i);
+    const double* temp_i = container_i->get_ptr_to_state(Particle::State::Temperature, particle_i);
+    const double* cfg_i =
+        container_i->get_ptr_to_state(Particle::State::ColorfieldGradient, particle_i);
+    const double* ifn_i =
+        container_i->get_ptr_to_state(Particle::State::InterfaceNormal, particle_i);
     double* tempdot_i =
-        container_i->get_ptr_to_state_writable(Particle::TemperatureDot, particle_i);
+        container_i->get_ptr_to_state_writable(Particle::State::TemperatureDot, particle_i);
 
     // evaluation only for non-zero interface normal
     if (not(ParticleUtils::vec_norm_two(ifn_i) > 0.0)) continue;

--- a/src/particle/src/interaction/4C_particle_interaction_sph_heatloss_evaporation.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_heatloss_evaporation.hpp
@@ -73,7 +73,7 @@ namespace Particle
     std::vector<const Mat::PAR::ParticleMaterialThermo*> thermomaterial_;
 
     //! evaporating phase
-    Particle::TypeEnum evaporatingphase_;
+    Particle::Type evaporatingphase_;
 
     //! boiling temperature in recoil pressure formula
     double recoilboilingtemp_;

--- a/src/particle/src/interaction/4C_particle_interaction_sph_heatsource.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_heatsource.cpp
@@ -125,13 +125,14 @@ void Particle::SPHHeatSourceVolume::evaluate_heat_source(const double& evaltime)
     for (int particle_i = 0; particle_i < container_i->particles_stored(); ++particle_i)
     {
       // get pointer to particle states
-      const double* dens_i = (container_i->have_stored_state(Particle::Density))
-                                 ? container_i->get_ptr_to_state(Particle::Density, particle_i)
-                                 : &(basematerial_i->initDensity_);
+      const double* dens_i =
+          (container_i->have_stored_state(Particle::State::Density))
+              ? container_i->get_ptr_to_state(Particle::State::Density, particle_i)
+              : &(basematerial_i->initDensity_);
 
-      const double* pos_i = container_i->get_ptr_to_state(Particle::Position, particle_i);
+      const double* pos_i = container_i->get_ptr_to_state(Particle::State::Position, particle_i);
       double* tempdot_i =
-          container_i->get_ptr_to_state_writable(Particle::TemperatureDot, particle_i);
+          container_i->get_ptr_to_state_writable(Particle::State::TemperatureDot, particle_i);
 
       // evaluate function defining heat source
       funct = function.evaluate_time_derivative(std::span(pos_i, 3), evaltime, 0, 0);
@@ -233,16 +234,16 @@ void Particle::SPHHeatSourceSurface::evaluate_heat_source(const double& evaltime
         particlematerial_->get_ptr_to_particle_mat_parameter(type_j);
 
     // get pointer to particle states
-    const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
+    const double* mass_i = container_i->get_ptr_to_state(Particle::State::Mass, particle_i);
 
-    const double* dens_i = container_i->have_stored_state(Particle::Density)
-                               ? container_i->get_ptr_to_state(Particle::Density, particle_i)
+    const double* dens_i = container_i->have_stored_state(Particle::State::Density)
+                               ? container_i->get_ptr_to_state(Particle::State::Density, particle_i)
                                : &(material_i->initDensity_);
 
-    const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
+    const double* mass_j = container_j->get_ptr_to_state(Particle::State::Mass, particle_j);
 
-    const double* dens_j = container_j->have_stored_state(Particle::Density)
-                               ? container_j->get_ptr_to_state(Particle::Density, particle_j)
+    const double* dens_j = container_j->have_stored_state(Particle::State::Density)
+                               ? container_j->get_ptr_to_state(Particle::State::Density, particle_j)
                                : &(material_j->initDensity_);
 
     // (current) volume of particle i and j
@@ -315,13 +316,14 @@ void Particle::SPHHeatSourceSurface::evaluate_heat_source(const double& evaltime
       if (f_i_proj < 0.0) continue;
 
       // get pointer to particle states
-      const double* dens_i = (container_i->have_stored_state(Particle::Density))
-                                 ? container_i->get_ptr_to_state(Particle::Density, particle_i)
-                                 : &(basematerial_i->initDensity_);
+      const double* dens_i =
+          (container_i->have_stored_state(Particle::State::Density))
+              ? container_i->get_ptr_to_state(Particle::State::Density, particle_i)
+              : &(basematerial_i->initDensity_);
 
-      const double* pos_i = container_i->get_ptr_to_state(Particle::Position, particle_i);
+      const double* pos_i = container_i->get_ptr_to_state(Particle::State::Position, particle_i);
       double* tempdot_i =
-          container_i->get_ptr_to_state_writable(Particle::TemperatureDot, particle_i);
+          container_i->get_ptr_to_state_writable(Particle::State::TemperatureDot, particle_i);
 
       // evaluate function defining heat source
       funct = function.evaluate_time_derivative(std::span(pos_i, 3), evaltime, 0, 0);

--- a/src/particle/src/interaction/4C_particle_interaction_sph_heatsource.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_heatsource.cpp
@@ -48,25 +48,27 @@ void Particle::SPHHeatSourceBase::setup(
   neighborpairs_ = neighborpairs;
 
   // determine size of vectors indexed by particle types
-  const int typevectorsize = *(--particlecontainerbundle_->get_particle_types().end()) + 1;
+  const int typevectorsize =
+      static_cast<int>(*(--particlecontainerbundle_->get_particle_types().end())) + 1;
 
   // allocate memory to hold particle types
   thermomaterial_.resize(typevectorsize);
 
   // iterate over particle types
   for (const auto& type_i : particlecontainerbundle_->get_particle_types())
-    thermomaterial_[type_i] = dynamic_cast<const Mat::PAR::ParticleMaterialThermo*>(
-        particlematerial_->get_ptr_to_particle_mat_parameter(type_i));
+    thermomaterial_[static_cast<int>(type_i)] =
+        dynamic_cast<const Mat::PAR::ParticleMaterialThermo*>(
+            particlematerial_->get_ptr_to_particle_mat_parameter(type_i));
 
   // set of potential absorbing particle types
-  std::set<Particle::TypeEnum> potentialabsorbingtypes = {
-      Particle::Phase1, Particle::Phase2, Particle::RigidPhase, Particle::PDPhase};
+  std::set<Particle::Type> potentialabsorbingtypes = {Particle::Type::Phase1,
+      Particle::Type::Phase2, Particle::Type::RigidPhase, Particle::Type::PDPhase};
 
   // iterate over particle types
   for (const auto& type_i : particlecontainerbundle_->get_particle_types())
   {
     // determine absorbing particle types
-    if (thermomaterial_[type_i]->thermalAbsorptivity_ > 0.0)
+    if (thermomaterial_[static_cast<int>(type_i)]->thermalAbsorptivity_ > 0.0)
     {
       // safety check
       if (not potentialabsorbingtypes.contains(type_i))
@@ -116,7 +118,8 @@ void Particle::SPHHeatSourceVolume::evaluate_heat_source(const double& evaltime)
     const Mat::PAR::ParticleMaterialBase* basematerial_i =
         particlematerial_->get_ptr_to_particle_mat_parameter(type_i);
 
-    const Mat::PAR::ParticleMaterialThermo* thermomaterial_i = thermomaterial_[type_i];
+    const Mat::PAR::ParticleMaterialThermo* thermomaterial_i =
+        thermomaterial_[static_cast<int>(type_i)];
 
     // iterate over particles in container
     for (int particle_i = 0; particle_i < container_i->particles_stored(); ++particle_i)
@@ -174,7 +177,7 @@ void Particle::SPHHeatSourceSurface::evaluate_heat_source(const double& evaltime
   TEUCHOS_FUNC_TIME_MONITOR("Particle::SPHHeatSourceSurface::EvaluateHeatSource");
 
   // determine size of vectors indexed by particle types
-  const int typevectorsize = *(--absorbingtypes_.end()) + 1;
+  const int typevectorsize = static_cast<int>(*(--absorbingtypes_.end())) + 1;
 
   // colorfield gradient of absorbing interface particles
   std::vector<std::vector<std::vector<double>>> cfg_i(typevectorsize);
@@ -190,7 +193,7 @@ void Particle::SPHHeatSourceSurface::evaluate_heat_source(const double& evaltime
     const int particlestored = container_i->particles_stored();
 
     // allocate memory
-    cfg_i[type_i].assign(particlestored, std::vector<double>(3, 0.0));
+    cfg_i[static_cast<int>(type_i)].assign(particlestored, std::vector<double>(3, 0.0));
   }
 
   // get relevant particle pair indices
@@ -205,12 +208,12 @@ void Particle::SPHHeatSourceSurface::evaluate_heat_source(const double& evaltime
         neighborpairs_->get_ref_to_particle_pair_data()[particlepairindex];
 
     // access values of local index tuples of particle i and j
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
-    Particle::TypeEnum type_j;
+    Particle::Type type_j;
     Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
@@ -253,7 +256,7 @@ void Particle::SPHHeatSourceSurface::evaluate_heat_source(const double& evaltime
     if (absorbingtypes_.contains(type_i))
     {
       // sum contribution of neighboring particle j
-      ParticleUtils::vec_add_scale(cfg_i[type_i][particle_i].data(),
+      ParticleUtils::vec_add_scale(cfg_i[static_cast<int>(type_i)][particle_i].data(),
           dens_i[0] / V_i * fac * particlepair.dWdrij_, particlepair.e_ij_);
     }
 
@@ -261,7 +264,7 @@ void Particle::SPHHeatSourceSurface::evaluate_heat_source(const double& evaltime
     if (absorbingtypes_.contains(type_j) and status_j == Particle::Status::Owned)
     {
       // sum contribution of neighboring particle i
-      ParticleUtils::vec_add_scale(cfg_i[type_j][particle_j].data(),
+      ParticleUtils::vec_add_scale(cfg_i[static_cast<int>(type_j)][particle_j].data(),
           -dens_j[0] / V_j * fac * particlepair.dWdrji_, particlepair.e_ij_);
     }
   }
@@ -289,21 +292,24 @@ void Particle::SPHHeatSourceSurface::evaluate_heat_source(const double& evaltime
     const Mat::PAR::ParticleMaterialBase* basematerial_i =
         particlematerial_->get_ptr_to_particle_mat_parameter(type_i);
 
-    const Mat::PAR::ParticleMaterialThermo* thermomaterial_i = thermomaterial_[type_i];
+    const Mat::PAR::ParticleMaterialThermo* thermomaterial_i =
+        thermomaterial_[static_cast<int>(type_i)];
 
     // iterate over particles in container
     for (int particle_i = 0; particle_i < container_i->particles_stored(); ++particle_i)
     {
       // norm of colorfield gradient of absorbing interface particles
-      const double f_i = ParticleUtils::vec_norm_two(cfg_i[type_i][particle_i].data());
+      const double f_i =
+          ParticleUtils::vec_norm_two(cfg_i[static_cast<int>(type_i)][particle_i].data());
 
       // no heat source contribution to current particle
       if (not(f_i > 0.0)) continue;
 
       // projection of colorfield gradient with heat source direction
-      const double f_i_proj = eval_direction_ ? -ParticleUtils::vec_dot(direction_.data(),
-                                                    cfg_i[type_i][particle_i].data())
-                                              : f_i;
+      const double f_i_proj = eval_direction_
+                                  ? -ParticleUtils::vec_dot(direction_.data(),
+                                        cfg_i[static_cast<int>(type_i)][particle_i].data())
+                                  : f_i;
 
       // heat source contribution only for surface opposing heat source
       if (f_i_proj < 0.0) continue;

--- a/src/particle/src/interaction/4C_particle_interaction_sph_heatsource.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_heatsource.cpp
@@ -110,7 +110,7 @@ void Particle::SPHHeatSourceVolume::evaluate_heat_source(const double& evaltime)
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container_i =
-        particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // get material for current particle type
     const Mat::PAR::ParticleMaterialBase* basematerial_i =
@@ -184,7 +184,7 @@ void Particle::SPHHeatSourceSurface::evaluate_heat_source(const double& evaltime
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container_i =
-        particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // get number of particles stored in container
     const int particlestored = container_i->particles_stored();
@@ -206,12 +206,12 @@ void Particle::SPHHeatSourceSurface::evaluate_heat_source(const double& evaltime
 
     // access values of local index tuples of particle i and j
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
     Particle::TypeEnum type_j;
-    Particle::StatusEnum status_j;
+    Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
 
@@ -258,7 +258,7 @@ void Particle::SPHHeatSourceSurface::evaluate_heat_source(const double& evaltime
     }
 
     // evaluate contribution of neighboring particle i
-    if (absorbingtypes_.contains(type_j) and status_j == Particle::Owned)
+    if (absorbingtypes_.contains(type_j) and status_j == Particle::Status::Owned)
     {
       // sum contribution of neighboring particle i
       ParticleUtils::vec_add_scale(cfg_i[type_j][particle_j].data(),
@@ -283,7 +283,7 @@ void Particle::SPHHeatSourceSurface::evaluate_heat_source(const double& evaltime
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container_i =
-        particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // get material for current particle type
     const Mat::PAR::ParticleMaterialBase* basematerial_i =

--- a/src/particle/src/interaction/4C_particle_interaction_sph_heatsource.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_heatsource.hpp
@@ -85,10 +85,10 @@ namespace Particle
     const int heatsourcefctnumber_;
 
     //! set of absorbing particle types
-    std::set<Particle::TypeEnum> absorbingtypes_;
+    std::set<Particle::Type> absorbingtypes_;
 
     //! set of non-absorbing particle types
-    std::set<Particle::TypeEnum> nonabsorbingtypes_;
+    std::set<Particle::Type> nonabsorbingtypes_;
   };
 
   class SPHHeatSourceVolume : public SPHHeatSourceBase

--- a/src/particle/src/interaction/4C_particle_interaction_sph_momentum.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_momentum.cpp
@@ -141,7 +141,7 @@ void Particle::SPHMomentum::setup(
 }
 
 void Particle::SPHMomentum::insert_particle_states_of_particle_types(
-    std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const
+    std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes) const
 {
   // iterate over particle types
   for (auto& typeIt : particlestatestotypes)
@@ -150,7 +150,7 @@ void Particle::SPHMomentum::insert_particle_states_of_particle_types(
     Particle::Type type_i = typeIt.first;
 
     // set of particle states for current particle type
-    std::set<Particle::StateEnum>& particlestates = typeIt.second;
+    std::set<Particle::State>& particlestates = typeIt.second;
 
     // current particle type is not a pure fluid particle type
     if (not purefluidtypes_.contains(type_i)) continue;
@@ -158,7 +158,8 @@ void Particle::SPHMomentum::insert_particle_states_of_particle_types(
     // additional states for transport velocity formulation
     if (transportvelocityformulation_ !=
         Particle::TransportVelocityFormulation::NoTransportVelocity)
-      particlestates.insert({Particle::ModifiedVelocity, Particle::ModifiedAcceleration});
+      particlestates.insert(
+          {Particle::State::ModifiedVelocity, Particle::State::ModifiedAcceleration});
   }
 }
 
@@ -253,39 +254,39 @@ void Particle::SPHMomentum::momentum_equation_particle_contribution() const
     const Mat::PAR::ParticleMaterialSPHFluid* material_j = fluidmaterial_[static_cast<int>(type_j)];
 
     // get pointer to particle states
-    const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
-    const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
-    const double* dens_i = container_i->get_ptr_to_state(Particle::Density, particle_i);
-    const double* press_i = container_i->get_ptr_to_state(Particle::Pressure, particle_i);
-    const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
+    const double* rad_i = container_i->get_ptr_to_state(Particle::State::Radius, particle_i);
+    const double* mass_i = container_i->get_ptr_to_state(Particle::State::Mass, particle_i);
+    const double* dens_i = container_i->get_ptr_to_state(Particle::State::Density, particle_i);
+    const double* press_i = container_i->get_ptr_to_state(Particle::State::Pressure, particle_i);
+    const double* vel_i = container_i->get_ptr_to_state(Particle::State::Velocity, particle_i);
 
     double* acc_i = nullptr;
     if (intfluidtypes_.contains(type_i))
-      acc_i = container_i->get_ptr_to_state_writable(Particle::Acceleration, particle_i);
+      acc_i = container_i->get_ptr_to_state_writable(Particle::State::Acceleration, particle_i);
 
     const double* mod_vel_i =
-        container_i->try_get_ptr_to_state(Particle::ModifiedVelocity, particle_i);
-    double* mod_acc_i =
-        container_i->try_get_ptr_to_state_writable(Particle::ModifiedAcceleration, particle_i);
+        container_i->try_get_ptr_to_state(Particle::State::ModifiedVelocity, particle_i);
+    double* mod_acc_i = container_i->try_get_ptr_to_state_writable(
+        Particle::State::ModifiedAcceleration, particle_i);
 
     // get pointer to particle states
-    const double* rad_j = container_j->get_ptr_to_state(Particle::Radius, particle_j);
-    const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
-    const double* dens_j = container_j->get_ptr_to_state(Particle::Density, particle_j);
-    const double* press_j = container_j->get_ptr_to_state(Particle::Pressure, particle_j);
-    const double* vel_j = container_j->get_ptr_to_state(Particle::Velocity, particle_j);
+    const double* rad_j = container_j->get_ptr_to_state(Particle::State::Radius, particle_j);
+    const double* mass_j = container_j->get_ptr_to_state(Particle::State::Mass, particle_j);
+    const double* dens_j = container_j->get_ptr_to_state(Particle::State::Density, particle_j);
+    const double* press_j = container_j->get_ptr_to_state(Particle::State::Pressure, particle_j);
+    const double* vel_j = container_j->get_ptr_to_state(Particle::State::Velocity, particle_j);
 
     double* acc_j = nullptr;
     if (intfluidtypes_.contains(type_j) and status_j == Particle::Status::Owned)
-      acc_j = container_j->get_ptr_to_state_writable(Particle::Acceleration, particle_j);
+      acc_j = container_j->get_ptr_to_state_writable(Particle::State::Acceleration, particle_j);
 
     const double* mod_vel_j =
-        container_j->try_get_ptr_to_state(Particle::ModifiedVelocity, particle_j);
+        container_j->try_get_ptr_to_state(Particle::State::ModifiedVelocity, particle_j);
 
     double* mod_acc_j = nullptr;
     if (status_j == Particle::Status::Owned)
-      mod_acc_j =
-          container_j->try_get_ptr_to_state_writable(Particle::ModifiedAcceleration, particle_j);
+      mod_acc_j = container_j->try_get_ptr_to_state_writable(
+          Particle::State::ModifiedAcceleration, particle_j);
 
     // evaluate specific coefficient
     double speccoeff_ij(0.0);
@@ -435,28 +436,30 @@ void Particle::SPHMomentum::momentum_equation_particle_boundary_contribution() c
         equationofstatebundle_->get_ptr_to_specific_equation_of_state(type_i);
 
     // get pointer to particle states
-    const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
-    const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
-    const double* dens_i = container_i->get_ptr_to_state(Particle::Density, particle_i);
-    const double* press_i = container_i->get_ptr_to_state(Particle::Pressure, particle_i);
-    const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
+    const double* rad_i = container_i->get_ptr_to_state(Particle::State::Radius, particle_i);
+    const double* mass_i = container_i->get_ptr_to_state(Particle::State::Mass, particle_i);
+    const double* dens_i = container_i->get_ptr_to_state(Particle::State::Density, particle_i);
+    const double* press_i = container_i->get_ptr_to_state(Particle::State::Pressure, particle_i);
+    const double* vel_i = container_i->get_ptr_to_state(Particle::State::Velocity, particle_i);
 
     double* acc_i = nullptr;
     if (status_i == Particle::Status::Owned)
-      acc_i = container_i->get_ptr_to_state_writable(Particle::Acceleration, particle_i);
+      acc_i = container_i->get_ptr_to_state_writable(Particle::State::Acceleration, particle_i);
 
     const double* mod_vel_i =
-        container_i->try_get_ptr_to_state(Particle::ModifiedVelocity, particle_i);
+        container_i->try_get_ptr_to_state(Particle::State::ModifiedVelocity, particle_i);
 
     double* mod_acc_i = nullptr;
     if (status_i == Particle::Status::Owned)
-      mod_acc_i =
-          container_i->try_get_ptr_to_state_writable(Particle::ModifiedAcceleration, particle_i);
+      mod_acc_i = container_i->try_get_ptr_to_state_writable(
+          Particle::State::ModifiedAcceleration, particle_i);
 
     // get pointer to boundary particle states
-    const double* mass_j = container_i->get_ptr_to_state(Particle::Mass, particle_i);
-    const double* press_j = container_j->get_ptr_to_state(Particle::BoundaryPressure, particle_j);
-    const double* vel_j = container_j->get_ptr_to_state(Particle::BoundaryVelocity, particle_j);
+    const double* mass_j = container_i->get_ptr_to_state(Particle::State::Mass, particle_i);
+    const double* press_j =
+        container_j->get_ptr_to_state(Particle::State::BoundaryPressure, particle_j);
+    const double* vel_j =
+        container_j->get_ptr_to_state(Particle::State::BoundaryVelocity, particle_j);
 
     double temp_dens(0.0);
     temp_dens = equationofstate_i->pressure_to_density(press_j[0], material_i->initDensity_);
@@ -464,7 +467,7 @@ void Particle::SPHMomentum::momentum_equation_particle_boundary_contribution() c
 
     double* force_j = nullptr;
     if (status_j == Particle::Status::Owned)
-      force_j = container_j->try_get_ptr_to_state_writable(Particle::Force, particle_j);
+      force_j = container_j->try_get_ptr_to_state_writable(Particle::State::Force, particle_j);
 
     // contribution from neighboring boundary particle j
     double acc_ij[3] = {0.0, 0.0, 0.0};
@@ -624,18 +627,19 @@ void Particle::SPHMomentum::momentum_equation_particle_wall_contribution() const
         equationofstatebundle_->get_ptr_to_specific_equation_of_state(type_i);
 
     // get pointer to particle states
-    const double* pos_i = container_i->get_ptr_to_state(Particle::Position, particle_i);
-    const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
-    const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
-    const double* dens_i = container_i->get_ptr_to_state(Particle::Density, particle_i);
-    const double* press_i = container_i->get_ptr_to_state(Particle::Pressure, particle_i);
-    const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
-    double* acc_i = container_i->get_ptr_to_state_writable(Particle::Acceleration, particle_i);
+    const double* pos_i = container_i->get_ptr_to_state(Particle::State::Position, particle_i);
+    const double* rad_i = container_i->get_ptr_to_state(Particle::State::Radius, particle_i);
+    const double* mass_i = container_i->get_ptr_to_state(Particle::State::Mass, particle_i);
+    const double* dens_i = container_i->get_ptr_to_state(Particle::State::Density, particle_i);
+    const double* press_i = container_i->get_ptr_to_state(Particle::State::Pressure, particle_i);
+    const double* vel_i = container_i->get_ptr_to_state(Particle::State::Velocity, particle_i);
+    double* acc_i =
+        container_i->get_ptr_to_state_writable(Particle::State::Acceleration, particle_i);
 
     const double* mod_vel_i =
-        container_i->try_get_ptr_to_state(Particle::ModifiedVelocity, particle_i);
-    double* mod_acc_i =
-        container_i->try_get_ptr_to_state_writable(Particle::ModifiedAcceleration, particle_i);
+        container_i->try_get_ptr_to_state(Particle::State::ModifiedVelocity, particle_i);
+    double* mod_acc_i = container_i->try_get_ptr_to_state_writable(
+        Particle::State::ModifiedAcceleration, particle_i);
 
     // get pointer to column wall element
     Core::Elements::Element* ele = particlewallpair.ele_;
@@ -723,7 +727,7 @@ void Particle::SPHMomentum::momentum_equation_particle_wall_contribution() const
         ParticleUtils::vec_sub(r_kl_weighted, r_jk);
 
         // get pointer to virtual particle states
-        const double* mass_k = container_i->get_ptr_to_state(Particle::Mass, particle_i);
+        const double* mass_k = container_i->get_ptr_to_state(Particle::State::Mass, particle_i);
 
         const double temp_press_k = weightedpressure[particlewallpairindex] +
                                     ParticleUtils::vec_dot(r_kl_weighted,

--- a/src/particle/src/interaction/4C_particle_interaction_sph_momentum.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_momentum.cpp
@@ -228,12 +228,12 @@ void Particle::SPHMomentum::momentum_equation_particle_contribution() const
 
     // access values of local index tuples of particle i and j
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
     Particle::TypeEnum type_j;
-    Particle::StatusEnum status_j;
+    Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
 
@@ -272,14 +272,14 @@ void Particle::SPHMomentum::momentum_equation_particle_contribution() const
     const double* vel_j = container_j->get_ptr_to_state(Particle::Velocity, particle_j);
 
     double* acc_j = nullptr;
-    if (intfluidtypes_.contains(type_j) and status_j == Particle::Owned)
+    if (intfluidtypes_.contains(type_j) and status_j == Particle::Status::Owned)
       acc_j = container_j->get_ptr_to_state_writable(Particle::Acceleration, particle_j);
 
     const double* mod_vel_j =
         container_j->try_get_ptr_to_state(Particle::ModifiedVelocity, particle_j);
 
     double* mod_acc_j = nullptr;
-    if (status_j == Particle::Owned)
+    if (status_j == Particle::Status::Owned)
       mod_acc_j =
           container_j->try_get_ptr_to_state_writable(Particle::ModifiedAcceleration, particle_j);
 
@@ -388,12 +388,12 @@ void Particle::SPHMomentum::momentum_equation_particle_boundary_contribution() c
 
     // access values of local index tuples of particle i and j
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
     Particle::TypeEnum type_j;
-    Particle::StatusEnum status_j;
+    Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
 
@@ -438,14 +438,14 @@ void Particle::SPHMomentum::momentum_equation_particle_boundary_contribution() c
     const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
 
     double* acc_i = nullptr;
-    if (status_i == Particle::Owned)
+    if (status_i == Particle::Status::Owned)
       acc_i = container_i->get_ptr_to_state_writable(Particle::Acceleration, particle_i);
 
     const double* mod_vel_i =
         container_i->try_get_ptr_to_state(Particle::ModifiedVelocity, particle_i);
 
     double* mod_acc_i = nullptr;
-    if (status_i == Particle::Owned)
+    if (status_i == Particle::Status::Owned)
       mod_acc_i =
           container_i->try_get_ptr_to_state_writable(Particle::ModifiedAcceleration, particle_i);
 
@@ -459,7 +459,7 @@ void Particle::SPHMomentum::momentum_equation_particle_boundary_contribution() c
     const double* dens_j = &temp_dens;
 
     double* force_j = nullptr;
-    if (status_j == Particle::Owned)
+    if (status_j == Particle::Status::Owned)
       force_j = container_j->try_get_ptr_to_state_writable(Particle::Force, particle_j);
 
     // contribution from neighboring boundary particle j
@@ -604,7 +604,7 @@ void Particle::SPHMomentum::momentum_equation_particle_wall_contribution() const
 
     // access values of local index tuple of particle i
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlewallpair.tuple_i_;
 

--- a/src/particle/src/interaction/4C_particle_interaction_sph_momentum.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_momentum.cpp
@@ -47,11 +47,13 @@ Particle::SPHMomentum::SPHMomentum(const Teuchos::ParameterList& params)
               params_sph_, "TRANSPORTVELOCITYFORMULATION")),
       writeparticlewallinteraction_(params_sph_.get<bool>("WRITE_PARTICLE_WALL_INTERACTION")),
       reduced_dimension_scale_factor_(params_sph_.get<double>("REDUCED_DIMENSION_SCALE_FACTOR")),
-      allfluidtypes_(
-          {Particle::Phase1, Particle::Phase2, Particle::DirichletPhase, Particle::NeumannPhase}),
-      intfluidtypes_({Particle::Phase1, Particle::Phase2, Particle::NeumannPhase}),
-      purefluidtypes_({Particle::Phase1, Particle::Phase2}),
-      boundarytypes_({Particle::BoundaryPhase, Particle::RigidPhase, Particle::PDPhase})
+      allfluidtypes_({Particle::Type::Phase1, Particle::Type::Phase2,
+          Particle::Type::DirichletPhase, Particle::Type::NeumannPhase}),
+      intfluidtypes_(
+          {Particle::Type::Phase1, Particle::Type::Phase2, Particle::Type::NeumannPhase}),
+      purefluidtypes_({Particle::Type::Phase1, Particle::Type::Phase2}),
+      boundarytypes_(
+          {Particle::Type::BoundaryPhase, Particle::Type::RigidPhase, Particle::Type::PDPhase})
 {
   init_momentum_formulation_handler();
 
@@ -123,7 +125,8 @@ void Particle::SPHMomentum::setup(
       boundarytypes_.erase(type_i);
 
   // determine size of vectors indexed by particle types
-  const int typevectorsize = *(--particlecontainerbundle_->get_particle_types().end()) + 1;
+  const int typevectorsize =
+      static_cast<int>(*(--particlecontainerbundle_->get_particle_types().end())) + 1;
 
   // allocate memory to hold particle types
   fluidmaterial_.resize(typevectorsize);
@@ -131,19 +134,20 @@ void Particle::SPHMomentum::setup(
   // iterate over all fluid particle types
   for (const auto& type_i : allfluidtypes_)
   {
-    fluidmaterial_[type_i] = dynamic_cast<const Mat::PAR::ParticleMaterialSPHFluid*>(
-        particlematerial_->get_ptr_to_particle_mat_parameter(type_i));
+    fluidmaterial_[static_cast<int>(type_i)] =
+        dynamic_cast<const Mat::PAR::ParticleMaterialSPHFluid*>(
+            particlematerial_->get_ptr_to_particle_mat_parameter(type_i));
   }
 }
 
 void Particle::SPHMomentum::insert_particle_states_of_particle_types(
-    std::map<Particle::TypeEnum, std::set<Particle::StateEnum>>& particlestatestotypes) const
+    std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const
 {
   // iterate over particle types
   for (auto& typeIt : particlestatestotypes)
   {
     // get type of particles
-    Particle::TypeEnum type_i = typeIt.first;
+    Particle::Type type_i = typeIt.first;
 
     // set of particle states for current particle type
     std::set<Particle::StateEnum>& particlestates = typeIt.second;
@@ -227,12 +231,12 @@ void Particle::SPHMomentum::momentum_equation_particle_contribution() const
         neighborpairs_->get_ref_to_particle_pair_data()[particlepairindex];
 
     // access values of local index tuples of particle i and j
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
-    Particle::TypeEnum type_j;
+    Particle::Type type_j;
     Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
@@ -245,8 +249,8 @@ void Particle::SPHMomentum::momentum_equation_particle_contribution() const
         particlecontainerbundle_->get_specific_container(type_j, status_j);
 
     // get material for particle types
-    const Mat::PAR::ParticleMaterialSPHFluid* material_i = fluidmaterial_[type_i];
-    const Mat::PAR::ParticleMaterialSPHFluid* material_j = fluidmaterial_[type_j];
+    const Mat::PAR::ParticleMaterialSPHFluid* material_i = fluidmaterial_[static_cast<int>(type_i)];
+    const Mat::PAR::ParticleMaterialSPHFluid* material_j = fluidmaterial_[static_cast<int>(type_j)];
 
     // get pointer to particle states
     const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
@@ -387,12 +391,12 @@ void Particle::SPHMomentum::momentum_equation_particle_boundary_contribution() c
         neighborpairs_->get_ref_to_particle_pair_data()[particlepairindex];
 
     // access values of local index tuples of particle i and j
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
-    Particle::TypeEnum type_j;
+    Particle::Type type_j;
     Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
@@ -424,7 +428,7 @@ void Particle::SPHMomentum::momentum_equation_particle_boundary_contribution() c
         particlecontainerbundle_->get_specific_container(type_j, status_j);
 
     // get material for particle types
-    const Mat::PAR::ParticleMaterialSPHFluid* material_i = fluidmaterial_[type_i];
+    const Mat::PAR::ParticleMaterialSPHFluid* material_i = fluidmaterial_[static_cast<int>(type_i)];
 
     // get equation of state for particle types
     const Particle::SPHEquationOfStateBase* equationofstate_i =
@@ -603,7 +607,7 @@ void Particle::SPHMomentum::momentum_equation_particle_wall_contribution() const
     const SPHParticleWallPair& particlewallpair = particlewallpairdata[particlewallpairindex];
 
     // access values of local index tuple of particle i
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlewallpair.tuple_i_;
@@ -613,7 +617,7 @@ void Particle::SPHMomentum::momentum_equation_particle_wall_contribution() const
         particlecontainerbundle_->get_specific_container(type_i, status_i);
 
     // get material for particle types
-    const Mat::PAR::ParticleMaterialSPHFluid* material_i = fluidmaterial_[type_i];
+    const Mat::PAR::ParticleMaterialSPHFluid* material_i = fluidmaterial_[static_cast<int>(type_i)];
 
     // get equation of state for particle types
     const Particle::SPHEquationOfStateBase* equationofstate_i =

--- a/src/particle/src/interaction/4C_particle_interaction_sph_momentum.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_momentum.hpp
@@ -78,7 +78,7 @@ namespace Particle
 
     //! insert momentum evaluation dependent states
     void insert_particle_states_of_particle_types(
-        std::map<Particle::TypeEnum, std::set<Particle::StateEnum>>& particlestatestotypes) const;
+        std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const;
 
     //! add momentum contribution to acceleration field
     void add_acceleration_contribution() const;
@@ -151,16 +151,16 @@ namespace Particle
     const double reduced_dimension_scale_factor_;
 
     //! set of all fluid particle types
-    std::set<Particle::TypeEnum> allfluidtypes_;
+    std::set<Particle::Type> allfluidtypes_;
 
     //! set of integrated fluid particle types
-    std::set<Particle::TypeEnum> intfluidtypes_;
+    std::set<Particle::Type> intfluidtypes_;
 
     //! set of pure fluid particle types
-    std::set<Particle::TypeEnum> purefluidtypes_;
+    std::set<Particle::Type> purefluidtypes_;
 
     //! set of boundary particle types
-    std::set<Particle::TypeEnum> boundarytypes_;
+    std::set<Particle::Type> boundarytypes_;
   };
 
 }  // namespace Particle

--- a/src/particle/src/interaction/4C_particle_interaction_sph_momentum.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_momentum.hpp
@@ -78,7 +78,7 @@ namespace Particle
 
     //! insert momentum evaluation dependent states
     void insert_particle_states_of_particle_types(
-        std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const;
+        std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes) const;
 
     //! add momentum contribution to acceleration field
     void add_acceleration_contribution() const;

--- a/src/particle/src/interaction/4C_particle_interaction_sph_neighbor_pairs.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_neighbor_pairs.cpp
@@ -46,7 +46,8 @@ void Particle::SPHNeighborPairs::setup(
   kernel_ = kernel;
 
   // determine size of vectors indexed by particle types
-  const int typevectorsize = *(--particlecontainerbundle_->get_particle_types().end()) + 1;
+  const int typevectorsize =
+      static_cast<int>(*(--particlecontainerbundle_->get_particle_types().end())) + 1;
 
   // allocate memory to hold index of particle pairs for each type
   indexofparticlepairs_.resize(typevectorsize, std::vector<std::vector<int>>(typevectorsize));
@@ -56,7 +57,7 @@ void Particle::SPHNeighborPairs::setup(
 }
 
 void Particle::SPHNeighborPairs::get_relevant_particle_pair_indices_for_disjoint_combination(
-    const std::set<Particle::TypeEnum>& types_a, const std::set<Particle::TypeEnum>& types_b,
+    const std::set<Particle::Type>& types_a, const std::set<Particle::Type>& types_b,
     std::vector<int>& relindices) const
 {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
@@ -69,15 +70,17 @@ void Particle::SPHNeighborPairs::get_relevant_particle_pair_indices_for_disjoint
   for (const auto& type_i : types_a)
     for (const auto& type_j : types_b)
     {
-      relindices.insert(relindices.end(), indexofparticlepairs_[type_i][type_j].begin(),
-          indexofparticlepairs_[type_i][type_j].end());
-      relindices.insert(relindices.end(), indexofparticlepairs_[type_j][type_i].begin(),
-          indexofparticlepairs_[type_j][type_i].end());
+      relindices.insert(relindices.end(),
+          indexofparticlepairs_[static_cast<int>(type_i)][static_cast<int>(type_j)].begin(),
+          indexofparticlepairs_[static_cast<int>(type_i)][static_cast<int>(type_j)].end());
+      relindices.insert(relindices.end(),
+          indexofparticlepairs_[static_cast<int>(type_j)][static_cast<int>(type_i)].begin(),
+          indexofparticlepairs_[static_cast<int>(type_j)][static_cast<int>(type_i)].end());
     }
 }
 
 void Particle::SPHNeighborPairs::get_relevant_particle_pair_indices_for_equal_combination(
-    const std::set<Particle::TypeEnum>& types_a, std::vector<int>& relindices) const
+    const std::set<Particle::Type>& types_a, std::vector<int>& relindices) const
 {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
   if (relindices.size() != 0) FOUR_C_THROW("vector of relevant particle pair indices not cleared!");
@@ -85,17 +88,18 @@ void Particle::SPHNeighborPairs::get_relevant_particle_pair_indices_for_equal_co
 
   for (const auto& type_i : types_a)
     for (const auto& type_j : types_a)
-      relindices.insert(relindices.end(), indexofparticlepairs_[type_i][type_j].begin(),
-          indexofparticlepairs_[type_i][type_j].end());
+      relindices.insert(relindices.end(),
+          indexofparticlepairs_[static_cast<int>(type_i)][static_cast<int>(type_j)].begin(),
+          indexofparticlepairs_[static_cast<int>(type_i)][static_cast<int>(type_j)].end());
 }
 
 void Particle::SPHNeighborPairs::get_relevant_particle_wall_pair_indices(
-    const std::set<Particle::TypeEnum>& types_a, std::vector<int>& relindices) const
+    const std::set<Particle::Type>& types_a, std::vector<int>& relindices) const
 {
   // iterate over particle types to consider
   for (const auto& type_i : types_a)
-    relindices.insert(relindices.end(), indexofparticlewallpairs_[type_i].begin(),
-        indexofparticlewallpairs_[type_i].end());
+    relindices.insert(relindices.end(), indexofparticlewallpairs_[static_cast<int>(type_i)].begin(),
+        indexofparticlewallpairs_[static_cast<int>(type_i)].end());
 }
 
 void Particle::SPHNeighborPairs::evaluate_neighbor_pairs()
@@ -117,7 +121,7 @@ void Particle::SPHNeighborPairs::evaluate_particle_pairs()
   // clear index of particle pairs for each type
   for (const auto& type_i : particlecontainerbundle_->get_particle_types())
     for (const auto& type_j : particlecontainerbundle_->get_particle_types())
-      indexofparticlepairs_[type_i][type_j].clear();
+      indexofparticlepairs_[static_cast<int>(type_i)][static_cast<int>(type_j)].clear();
 
   // index of particle pairs
   int particlepairindex = 0;
@@ -126,17 +130,18 @@ void Particle::SPHNeighborPairs::evaluate_particle_pairs()
   for (auto& potentialneighbors : particleengineinterface_->get_potential_particle_neighbors())
   {
     // access values of local index tuples of particle i and j
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = potentialneighbors.first;
 
-    Particle::TypeEnum type_j;
+    Particle::Type type_j;
     Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = potentialneighbors.second;
 
-    if (type_i == Particle::BoundaryPhase and type_j == Particle::BoundaryPhase) continue;
+    if (type_i == Particle::Type::BoundaryPhase and type_j == Particle::Type::BoundaryPhase)
+      continue;
 
     // get corresponding particle containers
     Particle::ParticleContainer* container_i =
@@ -176,7 +181,8 @@ void Particle::SPHNeighborPairs::evaluate_particle_pairs()
       SPHParticlePair& particlepair = particlepairdata_[particlepairindex];
 
       // store index of particle pairs for each type
-      indexofparticlepairs_[type_i][type_j].push_back(particlepairindex);
+      indexofparticlepairs_[static_cast<int>(type_i)][static_cast<int>(type_j)].push_back(
+          particlepairindex);
 
       // increase index
       ++particlepairindex;
@@ -235,7 +241,7 @@ void Particle::SPHNeighborPairs::evaluate_particle_wall_pairs()
 
   // clear index of particle wall pairs for each type
   for (const auto& type_i : particlecontainerbundle_->get_particle_types())
-    indexofparticlewallpairs_[type_i].clear();
+    indexofparticlewallpairs_[static_cast<int>(type_i)].clear();
 
   // relate particles to index of particle-wall pairs (considering object type of contact point)
   std::unordered_map<int, std::vector<std::pair<Core::Geo::ObjectType, int>>>
@@ -248,7 +254,7 @@ void Particle::SPHNeighborPairs::evaluate_particle_wall_pairs()
   for (const auto& potentialneighbors : particlewallinterface_->get_potential_wall_neighbors())
   {
     // access values of local index tuple of particle i
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = potentialneighbors.first;
@@ -349,7 +355,7 @@ void Particle::SPHNeighborPairs::evaluate_particle_wall_pairs()
         particlewallpairdata_[indexofparticlewallpairs[0].second].tuple_i_;
 
     // access values of local index tuple of particle i
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = tuple_i;
@@ -437,13 +443,13 @@ void Particle::SPHNeighborPairs::evaluate_particle_wall_pairs()
   for (auto& particlewallpair : particlewallpairdata_)
   {
     // access values of local index tuple of particle i
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlewallpair.tuple_i_;
 
     // store index of particle wall pairs for each type
-    indexofparticlewallpairs_[type_i].push_back(particlewallpairindex);
+    indexofparticlewallpairs_[static_cast<int>(type_i)].push_back(particlewallpairindex);
 
     // increase index
     ++particlewallpairindex;

--- a/src/particle/src/interaction/4C_particle_interaction_sph_neighbor_pairs.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_neighbor_pairs.cpp
@@ -151,11 +151,11 @@ void Particle::SPHNeighborPairs::evaluate_particle_pairs()
         particlecontainerbundle_->get_specific_container(type_j, status_j);
 
     // get pointer to particle states
-    const double* pos_i = container_i->get_ptr_to_state(Particle::Position, particle_i);
-    const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
+    const double* pos_i = container_i->get_ptr_to_state(Particle::State::Position, particle_i);
+    const double* rad_i = container_i->get_ptr_to_state(Particle::State::Radius, particle_i);
 
-    const double* pos_j = container_j->get_ptr_to_state(Particle::Position, particle_j);
-    const double* rad_j = container_j->get_ptr_to_state(Particle::Radius, particle_j);
+    const double* pos_j = container_j->get_ptr_to_state(Particle::State::Position, particle_j);
+    const double* rad_j = container_j->get_ptr_to_state(Particle::State::Radius, particle_j);
 
     // vector from particle i to j
     double r_ji[3];
@@ -267,11 +267,11 @@ void Particle::SPHNeighborPairs::evaluate_particle_wall_pairs()
     const int* globalid_i = container_i->get_ptr_to_global_id(particle_i);
 
     // get pointer to particle states
-    const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
+    const double* rad_i = container_i->get_ptr_to_state(Particle::State::Radius, particle_i);
 
     // get position of particle i
     const Core::LinAlg::Matrix<3, 1> pos_i(
-        container_i->get_ptr_to_state(Particle::Position, particle_i));
+        container_i->get_ptr_to_state(Particle::State::Position, particle_i));
 
     // get pointer to column wall element
     Core::Elements::Element* ele = potentialneighbors.second;
@@ -365,7 +365,7 @@ void Particle::SPHNeighborPairs::evaluate_particle_wall_pairs()
         particlecontainerbundle_->get_specific_container(type_i, status_i);
 
     // get pointer to particle states
-    const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
+    const double* rad_i = container_i->get_ptr_to_state(Particle::State::Radius, particle_i);
 
     // define tolerance dependent on the particle radius
     const double adaptedtol = 1.0e-7 * rad_i[0];

--- a/src/particle/src/interaction/4C_particle_interaction_sph_neighbor_pairs.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_neighbor_pairs.cpp
@@ -127,12 +127,12 @@ void Particle::SPHNeighborPairs::evaluate_particle_pairs()
   {
     // access values of local index tuples of particle i and j
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = potentialneighbors.first;
 
     Particle::TypeEnum type_j;
-    Particle::StatusEnum status_j;
+    Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = potentialneighbors.second;
 
@@ -249,7 +249,7 @@ void Particle::SPHNeighborPairs::evaluate_particle_wall_pairs()
   {
     // access values of local index tuple of particle i
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = potentialneighbors.first;
 
@@ -350,7 +350,7 @@ void Particle::SPHNeighborPairs::evaluate_particle_wall_pairs()
 
     // access values of local index tuple of particle i
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = tuple_i;
 
@@ -438,7 +438,7 @@ void Particle::SPHNeighborPairs::evaluate_particle_wall_pairs()
   {
     // access values of local index tuple of particle i
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlewallpair.tuple_i_;
 

--- a/src/particle/src/interaction/4C_particle_interaction_sph_neighbor_pairs.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_neighbor_pairs.hpp
@@ -71,16 +71,16 @@ namespace Particle
 
     //! get relevant particle pair indices for disjoint combination of particle types
     void get_relevant_particle_pair_indices_for_disjoint_combination(
-        const std::set<Particle::TypeEnum>& types_a, const std::set<Particle::TypeEnum>& types_b,
+        const std::set<Particle::Type>& types_a, const std::set<Particle::Type>& types_b,
         std::vector<int>& relindices) const;
 
     //! get relevant particle pair indices for equal combination of particle types
     void get_relevant_particle_pair_indices_for_equal_combination(
-        const std::set<Particle::TypeEnum>& types_a, std::vector<int>& relindices) const;
+        const std::set<Particle::Type>& types_a, std::vector<int>& relindices) const;
 
     //! get relevant particle wall pair indices for specific particle types
     void get_relevant_particle_wall_pair_indices(
-        const std::set<Particle::TypeEnum>& types_a, std::vector<int>& relindices) const;
+        const std::set<Particle::Type>& types_a, std::vector<int>& relindices) const;
 
     //! evaluate neighbor pairs
     void evaluate_neighbor_pairs();

--- a/src/particle/src/interaction/4C_particle_interaction_sph_open_boundary.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_open_boundary.cpp
@@ -101,11 +101,11 @@ void Particle::SPHOpenBoundaryBase::check_open_boundary_phase_change(
   {
     // get particle boundary id
     const double* boundary_id_i =
-        container_i->get_ptr_to_state(Particle::OpenBoundaryId, particle_i);
+        container_i->get_ptr_to_state(Particle::State::OpenBoundaryId, particle_i);
     if (static_cast<int>(*boundary_id_i) != boundary_id_) continue;
 
     // get pointer to particle states
-    double* pos_i = container_i->get_ptr_to_state_writable(Particle::Position, particle_i);
+    double* pos_i = container_i->get_ptr_to_state_writable(Particle::State::Position, particle_i);
 
     // compute distance of open boundary particle from plane
     std::vector<double> temp(3);
@@ -152,7 +152,7 @@ void Particle::SPHOpenBoundaryBase::check_open_boundary_phase_change(
   for (int particle_j = 0; particle_j < container_j->particles_stored(); ++particle_j)
   {
     // get pointer to particle states
-    double* pos_j = container_j->get_ptr_to_state_writable(Particle::Position, particle_j);
+    double* pos_j = container_j->get_ptr_to_state_writable(Particle::State::Position, particle_j);
 
     // compute distance of fluid particle from plane
     std::vector<double> temp(3);
@@ -242,7 +242,7 @@ void Particle::SPHOpenBoundaryDirichlet::setup(
 
   // setup states of ghosted particles to refresh
   {
-    std::vector<Particle::StateEnum> states{Particle::Density, Particle::Pressure};
+    std::vector<Particle::State> states{Particle::State::Density, Particle::State::Pressure};
 
     statestorefresh_.push_back(std::make_pair(openboundaryphase_, states));
   }
@@ -274,12 +274,12 @@ void Particle::SPHOpenBoundaryDirichlet::prescribe_open_boundary_states(const do
   {
     // get particle boundary id
     const double* boundary_id_i =
-        container_i->get_ptr_to_state(Particle::OpenBoundaryId, particle_i);
+        container_i->get_ptr_to_state(Particle::State::OpenBoundaryId, particle_i);
     if (static_cast<int>(*boundary_id_i) != boundary_id_) continue;
 
     // get pointer to particle states
-    const double* pos_i = container_i->get_ptr_to_state(Particle::Position, particle_i);
-    double* vel_i = container_i->get_ptr_to_state_writable(Particle::Velocity, particle_i);
+    const double* pos_i = container_i->get_ptr_to_state(Particle::State::Position, particle_i);
+    double* vel_i = container_i->get_ptr_to_state_writable(Particle::State::Velocity, particle_i);
 
     // evaluate function to set velocity
     ParticleUtils::vec_set_scale(
@@ -337,14 +337,14 @@ void Particle::SPHOpenBoundaryDirichlet::interpolate_open_boundary_states()
         particlecontainerbundle_->get_specific_container(type_j, status_j);
 
     // get pointer to particle states
-    const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
-    const double* dens_i = container_i->get_ptr_to_state(Particle::Density, particle_i);
-    const double* press_i = container_i->get_ptr_to_state(Particle::Pressure, particle_i);
+    const double* mass_i = container_i->get_ptr_to_state(Particle::State::Mass, particle_i);
+    const double* dens_i = container_i->get_ptr_to_state(Particle::State::Density, particle_i);
+    const double* press_i = container_i->get_ptr_to_state(Particle::State::Pressure, particle_i);
 
     // get pointer to particle states
-    const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
-    const double* dens_j = container_j->get_ptr_to_state(Particle::Density, particle_j);
-    const double* press_j = container_j->get_ptr_to_state(Particle::Pressure, particle_j);
+    const double* mass_j = container_j->get_ptr_to_state(Particle::State::Mass, particle_j);
+    const double* dens_j = container_j->get_ptr_to_state(Particle::State::Density, particle_j);
+    const double* press_j = container_j->get_ptr_to_state(Particle::State::Pressure, particle_j);
 
     // evaluate contribution of neighboring particle j
     if (type_i == openboundaryphase_)
@@ -368,12 +368,12 @@ void Particle::SPHOpenBoundaryDirichlet::interpolate_open_boundary_states()
   {
     // get particle boundary id
     const double* boundary_id_k =
-        container_k->get_ptr_to_state(Particle::OpenBoundaryId, particle_k);
+        container_k->get_ptr_to_state(Particle::State::OpenBoundaryId, particle_k);
     if (static_cast<int>(*boundary_id_k) != boundary_id_) continue;
 
     // get pointer to particle states
-    double* dens_k = container_k->get_ptr_to_state_writable(Particle::Density, particle_k);
-    double* press_k = container_k->get_ptr_to_state_writable(Particle::Pressure, particle_k);
+    double* dens_k = container_k->get_ptr_to_state_writable(Particle::State::Density, particle_k);
+    double* press_k = container_k->get_ptr_to_state_writable(Particle::State::Pressure, particle_k);
 
     // interpolate pressure
     press_k[0] = (sumj_Vj_Wij[particle_k] > 0.0)
@@ -427,7 +427,7 @@ void Particle::SPHOpenBoundaryNeumann::setup(
 
   // setup states of ghosted particles to refresh
   {
-    std::vector<Particle::StateEnum> states{Particle::Velocity};
+    std::vector<Particle::State> states{Particle::State::Velocity};
 
     statestorefresh_.push_back(std::make_pair(openboundaryphase_, states));
   }
@@ -469,12 +469,13 @@ void Particle::SPHOpenBoundaryNeumann::prescribe_open_boundary_states(const doub
     {
       // get particle boundary id
       const double* boundary_id_i =
-          container_i->get_ptr_to_state(Particle::OpenBoundaryId, particle_i);
+          container_i->get_ptr_to_state(Particle::State::OpenBoundaryId, particle_i);
       if (static_cast<int>(*boundary_id_i) != boundary_id_) continue;
 
       // get pointer to particle states
-      const double* pos_i = container_i->get_ptr_to_state(Particle::Position, particle_i);
-      double* press_i = container_i->get_ptr_to_state_writable(Particle::Pressure, particle_i);
+      const double* pos_i = container_i->get_ptr_to_state(Particle::State::Position, particle_i);
+      double* press_i =
+          container_i->get_ptr_to_state_writable(Particle::State::Pressure, particle_i);
 
       // evaluate function to set pressure
       press_i[0] = function.evaluate(std::span(pos_i, 3), evaltime, 0);
@@ -483,7 +484,7 @@ void Particle::SPHOpenBoundaryNeumann::prescribe_open_boundary_states(const doub
   else
   {
     // clear pressure state
-    container_i->clear_state(Particle::Pressure);
+    container_i->clear_state(Particle::State::Pressure);
   }
 
   // iterate over particles in container
@@ -491,12 +492,12 @@ void Particle::SPHOpenBoundaryNeumann::prescribe_open_boundary_states(const doub
   {
     // get particle boundary id
     const double* boundary_id_i =
-        container_i->get_ptr_to_state(Particle::OpenBoundaryId, particle_i);
+        container_i->get_ptr_to_state(Particle::State::OpenBoundaryId, particle_i);
     if (static_cast<int>(*boundary_id_i) != boundary_id_) continue;
 
     // get pointer to particle states
-    const double* press_i = container_i->get_ptr_to_state(Particle::Pressure, particle_i);
-    double* dens_i = container_i->get_ptr_to_state_writable(Particle::Density, particle_i);
+    const double* press_i = container_i->get_ptr_to_state(Particle::State::Pressure, particle_i);
+    double* dens_i = container_i->get_ptr_to_state_writable(Particle::State::Density, particle_i);
 
     // compute density
     dens_i[0] = equationofstate_i->pressure_to_density(press_i[0], material_i->initDensity_);

--- a/src/particle/src/interaction/4C_particle_interaction_sph_open_boundary.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_open_boundary.cpp
@@ -30,8 +30,8 @@ FOUR_C_NAMESPACE_OPEN
 Particle::SPHOpenBoundaryBase::SPHOpenBoundaryBase(double initialparticlespacing, int boundary_id)
     : initialparticlespacing_(initialparticlespacing),
       prescribedstatefunctid_(-1),
-      fluidphase_(Particle::Phase1),
-      openboundaryphase_(Particle::DirichletPhase),
+      fluidphase_(Particle::Type::Phase1),
+      openboundaryphase_(Particle::Type::DirichletPhase),
       boundary_id_(boundary_id)
 {
   // empty constructor
@@ -73,7 +73,8 @@ void Particle::SPHOpenBoundaryBase::check_open_boundary_phase_change(
     const double maxinteractiondistance)
 {
   // determine size of vectors indexed by particle types
-  const int typevectorsize = *(--particlecontainerbundle_->get_particle_types().end()) + 1;
+  const int typevectorsize =
+      static_cast<int>(*(--particlecontainerbundle_->get_particle_types().end())) + 1;
 
   std::vector<std::set<int>> particlestoremove(typevectorsize);
   std::vector<std::vector<std::pair<int, Particle::ParticleObjShrdPtr>>> particlestoinsert(
@@ -139,7 +140,7 @@ void Particle::SPHOpenBoundaryBase::check_open_boundary_phase_change(
       globalidstofree.push_back(globalid_i[0]);
 
       // store index of open boundary particle to be removed from container
-      particlestoremove[openboundaryphase_].insert(particle_i);
+      particlestoremove[static_cast<int>(openboundaryphase_)].insert(particle_i);
     }
   }
 
@@ -171,10 +172,11 @@ void Particle::SPHOpenBoundaryBase::check_open_boundary_phase_change(
           std::make_shared<Particle::ParticleObject>(openboundaryphase_, globalid, particlestates);
 
       // append particle to be insert
-      particlestoinsert[openboundaryphase_].push_back(std::make_pair(-1, particleobject));
+      particlestoinsert[static_cast<int>(openboundaryphase_)].push_back(
+          std::make_pair(-1, particleobject));
 
       // store index of fluid particle to be removed from container
-      particlestoremove[fluidphase_].insert(particle_j);
+      particlestoremove[static_cast<int>(fluidphase_)].insert(particle_j);
     }
   }
 
@@ -189,7 +191,7 @@ void Particle::SPHOpenBoundaryBase::check_open_boundary_phase_change(
 
   // append particle to be insert
   for (auto& particleobject : particlesgenerated)
-    particlestoinsert[particleobject->return_particle_type()].push_back(
+    particlestoinsert[static_cast<int>(particleobject->return_particle_type())].push_back(
         std::make_pair(-1, particleobject));
 
   // hand over particles to be inserted
@@ -223,8 +225,8 @@ Particle::SPHOpenBoundaryDirichlet::SPHOpenBoundaryDirichlet(
       "dimension (dim = {}) of plane point is not equal to 3!", planepoint_.size());
 
   // init fluid phase and open boundary phase
-  fluidphase_ = Phase1;
-  openboundaryphase_ = DirichletPhase;
+  fluidphase_ = Particle::Type::Phase1;
+  openboundaryphase_ = Particle::Type::DirichletPhase;
 }
 
 void Particle::SPHOpenBoundaryDirichlet::setup(
@@ -317,12 +319,12 @@ void Particle::SPHOpenBoundaryDirichlet::interpolate_open_boundary_states()
         neighborpairs_->get_ref_to_particle_pair_data()[particlepairindex];
 
     // access values of local index tuples of particle i and j
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
-    Particle::TypeEnum type_j;
+    Particle::Type type_j;
     Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
@@ -408,8 +410,8 @@ Particle::SPHOpenBoundaryNeumann::SPHOpenBoundaryNeumann(
       "dimension (dim = {}) of plane point is not equal to 3!", planepoint_.size());
 
   // init fluid phase and open boundary phase
-  fluidphase_ = Particle::Phase1;
-  openboundaryphase_ = Particle::NeumannPhase;
+  fluidphase_ = Particle::Type::Phase1;
+  openboundaryphase_ = Particle::Type::NeumannPhase;
 }
 
 void Particle::SPHOpenBoundaryNeumann::setup(

--- a/src/particle/src/interaction/4C_particle_interaction_sph_open_boundary.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_open_boundary.cpp
@@ -93,7 +93,7 @@ void Particle::SPHOpenBoundaryBase::check_open_boundary_phase_change(
 
   // get container of owned particles of open boundary phase
   Particle::ParticleContainer* container_i =
-      particlecontainerbundle_->get_specific_container(openboundaryphase_, Particle::Owned);
+      particlecontainerbundle_->get_specific_container(openboundaryphase_, Particle::Status::Owned);
 
   // iterate over particles in container
   for (int particle_i = 0; particle_i < container_i->particles_stored(); ++particle_i)
@@ -145,7 +145,7 @@ void Particle::SPHOpenBoundaryBase::check_open_boundary_phase_change(
 
   // get container of owned particles of fluid phase
   Particle::ParticleContainer* container_j =
-      particlecontainerbundle_->get_specific_container(fluidphase_, Particle::Owned);
+      particlecontainerbundle_->get_specific_container(fluidphase_, Particle::Status::Owned);
 
   // iterate over particles in container
   for (int particle_j = 0; particle_j < container_j->particles_stored(); ++particle_j)
@@ -250,7 +250,7 @@ void Particle::SPHOpenBoundaryDirichlet::prescribe_open_boundary_states(const do
 {
   // get container of owned particles of open boundary phase
   Particle::ParticleContainer* container_i =
-      particlecontainerbundle_->get_specific_container(openboundaryphase_, Particle::Owned);
+      particlecontainerbundle_->get_specific_container(openboundaryphase_, Particle::Status::Owned);
 
   // get number of particles stored in container
   const int particlestored = container_i->particles_stored();
@@ -289,7 +289,7 @@ void Particle::SPHOpenBoundaryDirichlet::interpolate_open_boundary_states()
 {
   // get container of owned particles of open boundary phase
   Particle::ParticleContainer* container_k =
-      particlecontainerbundle_->get_specific_container(openboundaryphase_, Particle::Owned);
+      particlecontainerbundle_->get_specific_container(openboundaryphase_, Particle::Status::Owned);
 
   // get material for current particle type
   const Mat::PAR::ParticleMaterialBase* material_k =
@@ -318,12 +318,12 @@ void Particle::SPHOpenBoundaryDirichlet::interpolate_open_boundary_states()
 
     // access values of local index tuples of particle i and j
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
     Particle::TypeEnum type_j;
-    Particle::StatusEnum status_j;
+    Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
 
@@ -353,7 +353,7 @@ void Particle::SPHOpenBoundaryDirichlet::interpolate_open_boundary_states()
     }
 
     // evaluate contribution of neighboring particle i
-    if (type_j == openboundaryphase_ and status_j == Particle::Owned)
+    if (type_j == openboundaryphase_ and status_j == Particle::Status::Owned)
     {
       const double fac = mass_i[0] / dens_i[0] * particlepair.Wji_;
       sumj_Vj_Wij[particle_j] += fac;
@@ -435,7 +435,7 @@ void Particle::SPHOpenBoundaryNeumann::prescribe_open_boundary_states(const doub
 {
   // get container of owned particles of open boundary phase
   Particle::ParticleContainer* container_i =
-      particlecontainerbundle_->get_specific_container(openboundaryphase_, Particle::Owned);
+      particlecontainerbundle_->get_specific_container(openboundaryphase_, Particle::Status::Owned);
 
   // get material for current particle type
   const Mat::PAR::ParticleMaterialBase* material_i =

--- a/src/particle/src/interaction/4C_particle_interaction_sph_open_boundary.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_open_boundary.hpp
@@ -102,10 +102,10 @@ namespace Particle
     std::vector<double> planepoint_;
 
     //! fluid phase
-    Particle::TypeEnum fluidphase_;
+    Particle::Type fluidphase_;
 
     //! open boundary phase
-    Particle::TypeEnum openboundaryphase_;
+    Particle::Type openboundaryphase_;
 
     //! boundary id
     int boundary_id_;

--- a/src/particle/src/interaction/4C_particle_interaction_sph_peridynamic.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_peridynamic.cpp
@@ -199,12 +199,12 @@ void Particle::SPHPeridynamic::init_peridynamic_bondlist()
   {
     // access values of local index tuples of particle i and j
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = potentialneighbors.first;
 
     Particle::TypeEnum type_j;
-    Particle::StatusEnum status_j;
+    Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = potentialneighbors.second;
 
@@ -295,7 +295,7 @@ void Particle::SPHPeridynamic::add_acceleration_contribution() const
   // clear force of peridynamic phase particles
   Particle::ParticleContainer* container =
       particleengineinterface_->get_particle_container_bundle()->get_specific_container(
-          Particle::PDPhase, Particle::Owned);
+          Particle::PDPhase, Particle::Status::Owned);
   container->clear_state(Particle::Force);
 }
 
@@ -311,12 +311,12 @@ void Particle::SPHPeridynamic::compute_interaction_forces() const
 
     // access values of local index tuples of particle i and j
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i, globalid_i;
     std::tie(type_i, status_i, particle_i, globalid_i) = particlepair.first;
 
     Particle::TypeEnum type_j;
-    Particle::StatusEnum status_j;
+    Particle::Status status_j;
     int particle_j, globalid_j;
     std::tie(type_j, status_j, particle_j, globalid_j) = particlepair.second;
 
@@ -342,7 +342,7 @@ void Particle::SPHPeridynamic::compute_interaction_forces() const
     const double* pos_j = container_j->get_ptr_to_state(Particle::Position, particle_j);
     const double* young_j = container_j->get_ptr_to_state(Particle::Young, particle_j);
     double* force_j = nullptr;
-    if (status_j == Particle::Owned)
+    if (status_j == Particle::Status::Owned)
       force_j = container_j->get_ptr_to_state_writable(Particle::Force, particle_j);
 
     const double* critical_stretch_j =
@@ -426,12 +426,12 @@ void Particle::SPHPeridynamic::compute_interaction_forces() const
   {
     // access values of local index tuples of particle i and j
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
     Particle::TypeEnum type_j;
-    Particle::StatusEnum status_j;
+    Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
 
@@ -450,7 +450,7 @@ void Particle::SPHPeridynamic::compute_interaction_forces() const
     const double* vel_j = container_j->get_ptr_to_state(Particle::Velocity, particle_j);
 
     double* force_j = nullptr;
-    if (status_j == Particle::Owned)
+    if (status_j == Particle::Status::Owned)
       force_j = container_j->try_get_ptr_to_state_writable(Particle::Force, particle_j);
 
     // compute normal gap and rate of normal gap
@@ -473,7 +473,7 @@ void Particle::SPHPeridynamic::compute_acceleration() const
 
   // get container of owned particles of current particle type
   Particle::ParticleContainer* container =
-      particlecontainerbundle_->get_specific_container(Particle::PDPhase, Particle::Owned);
+      particlecontainerbundle_->get_specific_container(Particle::PDPhase, Particle::Status::Owned);
 
   // get number of particles stored in container
   const int particlestored = container->particles_stored();
@@ -514,7 +514,7 @@ void Particle::SPHPeridynamic::damage_evaluation()
       particleengineinterface_->get_particle_container_bundle();
   // get container of owned particles of peridynamic phase
   Particle::ParticleContainer* container =
-      particlecontainerbundle->get_specific_container(Particle::PDPhase, Particle::Owned);
+      particlecontainerbundle->get_specific_container(Particle::PDPhase, Particle::Status::Owned);
 
   // loop over particles in container
   for (int particle_i = 0; particle_i < container->particles_stored(); ++particle_i)

--- a/src/particle/src/interaction/4C_particle_interaction_sph_peridynamic.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_peridynamic.cpp
@@ -161,12 +161,12 @@ void Particle::SPHPeridynamic::setup(
 }
 
 void Particle::SPHPeridynamic::insert_particle_states_of_particle_types(
-    std::map<Particle::TypeEnum, std::set<Particle::StateEnum>>& particlestatestotypes) const
+    std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const
 {
   // iterate over particle types
   for (auto& typeIt : particlestatestotypes)
   {
-    if (typeIt.first == Particle::PDPhase)
+    if (typeIt.first == Particle::Type::PDPhase)
     {
       // set of particle states for current particle type
       std::set<Particle::StateEnum>& particlestates = typeIt.second;
@@ -184,7 +184,7 @@ void Particle::SPHPeridynamic::init_peridynamic_bondlist()
 #ifdef FOUR_C_ENABLE_ASSERTIONS
   // get material for peridynamic phase
   const Mat::PAR::ParticleMaterialBase* material =
-      particlematerial_->get_ptr_to_particle_mat_parameter(Particle::PDPhase);
+      particlematerial_->get_ptr_to_particle_mat_parameter(Particle::Type::PDPhase);
 
   // (initial) radius of current phase
   const double initradius = material->initRadius_;
@@ -198,18 +198,18 @@ void Particle::SPHPeridynamic::init_peridynamic_bondlist()
       particleengineinterface_->get_potential_particle_neighbors())
   {
     // access values of local index tuples of particle i and j
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = potentialneighbors.first;
 
-    Particle::TypeEnum type_j;
+    Particle::Type type_j;
     Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = potentialneighbors.second;
 
     // only peridynamic phase particles can undergo peridynamic interaction
-    if (type_i != Particle::PDPhase || type_j != Particle::PDPhase) continue;
+    if (type_i != Particle::Type::PDPhase || type_j != Particle::Type::PDPhase) continue;
 
     // get corresponding particle containers
     Particle::ParticleContainer* container_i =
@@ -295,7 +295,7 @@ void Particle::SPHPeridynamic::add_acceleration_contribution() const
   // clear force of peridynamic phase particles
   Particle::ParticleContainer* container =
       particleengineinterface_->get_particle_container_bundle()->get_specific_container(
-          Particle::PDPhase, Particle::Status::Owned);
+          Particle::Type::PDPhase, Particle::Status::Owned);
   container->clear_state(Particle::Force);
 }
 
@@ -310,12 +310,12 @@ void Particle::SPHPeridynamic::compute_interaction_forces() const
     const auto& particlepair = (*bondlist_)[iter];
 
     // access values of local index tuples of particle i and j
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i, globalid_i;
     std::tie(type_i, status_i, particle_i, globalid_i) = particlepair.first;
 
-    Particle::TypeEnum type_j;
+    Particle::Type type_j;
     Particle::Status status_j;
     int particle_j, globalid_j;
     std::tie(type_j, status_j, particle_j, globalid_j) = particlepair.second;
@@ -425,12 +425,12 @@ void Particle::SPHPeridynamic::compute_interaction_forces() const
   for (const auto& particlepair : pd_neighbor_pairs)
   {
     // access values of local index tuples of particle i and j
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
-    Particle::TypeEnum type_j;
+    Particle::Type type_j;
     Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
@@ -472,8 +472,8 @@ void Particle::SPHPeridynamic::compute_acceleration() const
   TEUCHOS_FUNC_TIME_MONITOR("Particle::SPHPeridynamic::compute_acceleration");
 
   // get container of owned particles of current particle type
-  Particle::ParticleContainer* container =
-      particlecontainerbundle_->get_specific_container(Particle::PDPhase, Particle::Status::Owned);
+  Particle::ParticleContainer* container = particlecontainerbundle_->get_specific_container(
+      Particle::Type::PDPhase, Particle::Status::Owned);
 
   // get number of particles stored in container
   const int particlestored = container->particles_stored();
@@ -513,8 +513,8 @@ void Particle::SPHPeridynamic::damage_evaluation()
   Particle::ParticleContainerBundleShrdPtr particlecontainerbundle =
       particleengineinterface_->get_particle_container_bundle();
   // get container of owned particles of peridynamic phase
-  Particle::ParticleContainer* container =
-      particlecontainerbundle->get_specific_container(Particle::PDPhase, Particle::Status::Owned);
+  Particle::ParticleContainer* container = particlecontainerbundle->get_specific_container(
+      Particle::Type::PDPhase, Particle::Status::Owned);
 
   // loop over particles in container
   for (int particle_i = 0; particle_i < container->particles_stored(); ++particle_i)

--- a/src/particle/src/interaction/4C_particle_interaction_sph_peridynamic.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_peridynamic.cpp
@@ -161,7 +161,7 @@ void Particle::SPHPeridynamic::setup(
 }
 
 void Particle::SPHPeridynamic::insert_particle_states_of_particle_types(
-    std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const
+    std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes) const
 {
   // iterate over particle types
   for (auto& typeIt : particlestatestotypes)
@@ -169,12 +169,13 @@ void Particle::SPHPeridynamic::insert_particle_states_of_particle_types(
     if (typeIt.first == Particle::Type::PDPhase)
     {
       // set of particle states for current particle type
-      std::set<Particle::StateEnum>& particlestates = typeIt.second;
+      std::set<Particle::State>& particlestates = typeIt.second;
 
       // set temperature state
-      particlestates.insert({Particle::Force, Particle::PDBodyId, Particle::ReferencePosition,
-          Particle::Young, Particle::CriticalStretch, Particle::InitialConnectedBonds,
-          Particle::CurrentConnectedBonds, Particle::PDDamageVariable});
+      particlestates.insert({Particle::State::Force, Particle::State::PDBodyId,
+          Particle::State::ReferencePosition, Particle::State::Young,
+          Particle::State::CriticalStretch, Particle::State::InitialConnectedBonds,
+          Particle::State::CurrentConnectedBonds, Particle::State::PDDamageVariable});
     }
   }
 }
@@ -218,19 +219,19 @@ void Particle::SPHPeridynamic::init_peridynamic_bondlist()
         particlecontainerbundle->get_specific_container(type_j, status_j);
 
     // get pointer to particle states
-    const double* pos_i = container_i->get_ptr_to_state(Particle::Position, particle_i);
-    const double* pdbodyid_i = container_i->get_ptr_to_state(Particle::PDBodyId, particle_i);
+    const double* pos_i = container_i->get_ptr_to_state(Particle::State::Position, particle_i);
+    const double* pdbodyid_i = container_i->get_ptr_to_state(Particle::State::PDBodyId, particle_i);
     double* initialconnectedbonds_i =
-        container_i->get_ptr_to_state_writable(Particle::InitialConnectedBonds, particle_i);
+        container_i->get_ptr_to_state_writable(Particle::State::InitialConnectedBonds, particle_i);
     double* currentconnectedbonds_i =
-        container_i->get_ptr_to_state_writable(Particle::CurrentConnectedBonds, particle_i);
+        container_i->get_ptr_to_state_writable(Particle::State::CurrentConnectedBonds, particle_i);
 
-    const double* pos_j = container_j->get_ptr_to_state(Particle::Position, particle_j);
-    const double* pdbodyid_j = container_j->get_ptr_to_state(Particle::PDBodyId, particle_j);
+    const double* pos_j = container_j->get_ptr_to_state(Particle::State::Position, particle_j);
+    const double* pdbodyid_j = container_j->get_ptr_to_state(Particle::State::PDBodyId, particle_j);
     double* initialconnectedbonds_j =
-        container_j->get_ptr_to_state_writable(Particle::InitialConnectedBonds, particle_j);
+        container_j->get_ptr_to_state_writable(Particle::State::InitialConnectedBonds, particle_j);
     double* currentconnectedbonds_j =
-        container_j->get_ptr_to_state_writable(Particle::CurrentConnectedBonds, particle_j);
+        container_j->get_ptr_to_state_writable(Particle::State::CurrentConnectedBonds, particle_j);
 
     // vector from particle i to j
     double r_ji[3];
@@ -296,7 +297,7 @@ void Particle::SPHPeridynamic::add_acceleration_contribution() const
   Particle::ParticleContainer* container =
       particleengineinterface_->get_particle_container_bundle()->get_specific_container(
           Particle::Type::PDPhase, Particle::Status::Owned);
-  container->clear_state(Particle::Force);
+  container->clear_state(Particle::State::Force);
 }
 
 void Particle::SPHPeridynamic::compute_interaction_forces() const
@@ -329,24 +330,25 @@ void Particle::SPHPeridynamic::compute_interaction_forces() const
 
     //  get pointer to particle states
     const double* ref_pos_i =
-        container_i->get_ptr_to_state(Particle::ReferencePosition, particle_i);
+        container_i->get_ptr_to_state(Particle::State::ReferencePosition, particle_i);
 
-    const double* pos_i = container_i->get_ptr_to_state(Particle::Position, particle_i);
-    const double* young_i = container_i->get_ptr_to_state(Particle::Young, particle_i);
-    double* force_i = container_i->try_get_ptr_to_state_writable(Particle::Force, particle_i);
+    const double* pos_i = container_i->get_ptr_to_state(Particle::State::Position, particle_i);
+    const double* young_i = container_i->get_ptr_to_state(Particle::State::Young, particle_i);
+    double* force_i =
+        container_i->try_get_ptr_to_state_writable(Particle::State::Force, particle_i);
     const double* critical_stretch_i =
-        container_i->get_ptr_to_state(Particle::CriticalStretch, particle_i);
+        container_i->get_ptr_to_state(Particle::State::CriticalStretch, particle_i);
 
     const double* ref_pos_j =
-        container_j->get_ptr_to_state(Particle::ReferencePosition, particle_j);
-    const double* pos_j = container_j->get_ptr_to_state(Particle::Position, particle_j);
-    const double* young_j = container_j->get_ptr_to_state(Particle::Young, particle_j);
+        container_j->get_ptr_to_state(Particle::State::ReferencePosition, particle_j);
+    const double* pos_j = container_j->get_ptr_to_state(Particle::State::Position, particle_j);
+    const double* young_j = container_j->get_ptr_to_state(Particle::State::Young, particle_j);
     double* force_j = nullptr;
     if (status_j == Particle::Status::Owned)
-      force_j = container_j->get_ptr_to_state_writable(Particle::Force, particle_j);
+      force_j = container_j->get_ptr_to_state_writable(Particle::State::Force, particle_j);
 
     const double* critical_stretch_j =
-        container_j->get_ptr_to_state(Particle::CriticalStretch, particle_j);
+        container_j->get_ptr_to_state(Particle::State::CriticalStretch, particle_j);
     // calculate the bond between two particles
     double xi[3];
     ParticleUtils::vec_set(xi, ref_pos_j);
@@ -405,10 +407,10 @@ void Particle::SPHPeridynamic::compute_interaction_forces() const
     }
     else
     {
-      double* currentconnectedbonds_i =
-          container_i->get_ptr_to_state_writable(Particle::CurrentConnectedBonds, particle_i);
-      double* currentconnectedbonds_j =
-          container_j->get_ptr_to_state_writable(Particle::CurrentConnectedBonds, particle_j);
+      double* currentconnectedbonds_i = container_i->get_ptr_to_state_writable(
+          Particle::State::CurrentConnectedBonds, particle_i);
+      double* currentconnectedbonds_j = container_j->get_ptr_to_state_writable(
+          Particle::State::CurrentConnectedBonds, particle_j);
 
       currentconnectedbonds_i[0] -= 1.0;
       currentconnectedbonds_j[0] -= 1.0;
@@ -443,15 +445,16 @@ void Particle::SPHPeridynamic::compute_interaction_forces() const
         particlecontainerbundle->get_specific_container(type_j, status_j);
 
     // get pointer to particle states
-    const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
-    double* force_i = container_i->try_get_ptr_to_state_writable(Particle::Force, particle_i);
+    const double* vel_i = container_i->get_ptr_to_state(Particle::State::Velocity, particle_i);
+    double* force_i =
+        container_i->try_get_ptr_to_state_writable(Particle::State::Force, particle_i);
 
     // get pointer to particle states
-    const double* vel_j = container_j->get_ptr_to_state(Particle::Velocity, particle_j);
+    const double* vel_j = container_j->get_ptr_to_state(Particle::State::Velocity, particle_j);
 
     double* force_j = nullptr;
     if (status_j == Particle::Status::Owned)
-      force_j = container_j->try_get_ptr_to_state_writable(Particle::Force, particle_j);
+      force_j = container_j->try_get_ptr_to_state_writable(Particle::State::Force, particle_j);
 
     // compute normal gap and rate of normal gap
     const double gap = particlepair.gap_;
@@ -482,15 +485,16 @@ void Particle::SPHPeridynamic::compute_acceleration() const
   if (particlestored <= 0) return;
 
   // get particle state dimension
-  const int statedim = container->get_state_dim(Particle::Acceleration);
+  const int statedim = container->get_state_dim(Particle::State::Acceleration);
 
   // get pointer to particle states
-  const double* radius = container->get_ptr_to_state(Particle::Radius, 0);
-  const double* mass = container->get_ptr_to_state(Particle::Mass, 0);
-  const double* force = container->get_ptr_to_state(Particle::Force, 0);
-  const double* moment = container->try_get_ptr_to_state(Particle::Moment, 0);
-  double* acc = container->get_ptr_to_state_writable(Particle::Acceleration, 0);
-  double* angacc = container->try_get_ptr_to_state_writable(Particle::AngularAcceleration, 0);
+  const double* radius = container->get_ptr_to_state(Particle::State::Radius, 0);
+  const double* mass = container->get_ptr_to_state(Particle::State::Mass, 0);
+  const double* force = container->get_ptr_to_state(Particle::State::Force, 0);
+  const double* moment = container->try_get_ptr_to_state(Particle::State::Moment, 0);
+  double* acc = container->get_ptr_to_state_writable(Particle::State::Acceleration, 0);
+  double* angacc =
+      container->try_get_ptr_to_state_writable(Particle::State::AngularAcceleration, 0);
 
   // compute acceleration
   for (int i = 0; i < particlestored; ++i)
@@ -520,13 +524,13 @@ void Particle::SPHPeridynamic::damage_evaluation()
   for (int particle_i = 0; particle_i < container->particles_stored(); ++particle_i)
   {
     const double* initialconnectedbonds_i =
-        container->get_ptr_to_state(Particle::InitialConnectedBonds, particle_i);
+        container->get_ptr_to_state(Particle::State::InitialConnectedBonds, particle_i);
 
     const double* currentconnectedbonds_i =
-        container->get_ptr_to_state(Particle::CurrentConnectedBonds, particle_i);
+        container->get_ptr_to_state(Particle::State::CurrentConnectedBonds, particle_i);
 
     double* pddamagevariable_i =
-        container->get_ptr_to_state_writable(Particle::PDDamageVariable, particle_i);
+        container->get_ptr_to_state_writable(Particle::State::PDDamageVariable, particle_i);
 
     pddamagevariable_i[0] = 1.0 - currentconnectedbonds_i[0] / initialconnectedbonds_i[0];
   }

--- a/src/particle/src/interaction/4C_particle_interaction_sph_peridynamic.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_peridynamic.hpp
@@ -53,7 +53,7 @@ namespace Particle
 
     //! insert peridynamic evaluation dependent states
     void insert_particle_states_of_particle_types(
-        std::map<Type, std::set<StateEnum>>& particlestatestotypes) const;
+        std::map<Type, std::set<Particle::State>>& particlestatestotypes) const;
 
     //! setup peridynamic bond list
     void init_peridynamic_bondlist();

--- a/src/particle/src/interaction/4C_particle_interaction_sph_peridynamic.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_peridynamic.hpp
@@ -53,7 +53,7 @@ namespace Particle
 
     //! insert peridynamic evaluation dependent states
     void insert_particle_states_of_particle_types(
-        std::map<TypeEnum, std::set<StateEnum>>& particlestatestotypes) const;
+        std::map<Type, std::set<StateEnum>>& particlestatestotypes) const;
 
     //! setup peridynamic bond list
     void init_peridynamic_bondlist();

--- a/src/particle/src/interaction/4C_particle_interaction_sph_phase_change.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_phase_change.cpp
@@ -24,8 +24,8 @@ FOUR_C_NAMESPACE_OPEN
  *---------------------------------------------------------------------------*/
 Particle::SPHPhaseChangeBase::SPHPhaseChangeBase(const Teuchos::ParameterList& params)
     : params_sph_(params),
-      belowphase_(Particle::Phase1),
-      abovephase_(Particle::Phase2),
+      belowphase_(Particle::Type::Phase1),
+      abovephase_(Particle::Type::Phase2),
       transitionstate_(Particle::Density),
       transitionvalue_(0.0),
       hysteresisgap_(0.0)
@@ -134,14 +134,14 @@ void Particle::SPHPhaseChangeBase::evaluate_phase_change_from_below_to_above_pha
     std::vector<std::vector<std::pair<int, Particle::ParticleObjShrdPtr>>>& particlestoinsert) const
 {
   // set source and target type of particles
-  Particle::TypeEnum type_source = belowphase_;
-  Particle::TypeEnum type_target = abovephase_;
+  Particle::Type type_source = belowphase_;
+  Particle::Type type_target = abovephase_;
 
   // check for boundary or rigid particles
   bool isboundaryrigid_source =
-      (type_source == Particle::BoundaryPhase or type_source == Particle::RigidPhase);
+      (type_source == Particle::Type::BoundaryPhase or type_source == Particle::Type::RigidPhase);
   bool isboundaryrigid_target =
-      (type_target == Particle::BoundaryPhase or type_target == Particle::RigidPhase);
+      (type_target == Particle::Type::BoundaryPhase or type_target == Particle::Type::RigidPhase);
 
   // get container of owned particles of source particle type
   Particle::ParticleContainer* container =
@@ -200,10 +200,11 @@ void Particle::SPHPhaseChangeBase::evaluate_phase_change_from_below_to_above_pha
           std::make_shared<Particle::ParticleObject>(type_target, globalid, particlestates);
 
       // append particle to be insert
-      particlestoinsert[type_target].push_back(std::make_pair(-1, particleobject));
+      particlestoinsert[static_cast<int>(type_target)].push_back(
+          std::make_pair(-1, particleobject));
 
       // store index of particle to be removed from containers
-      particlestoremove[type_source].insert(index);
+      particlestoremove[static_cast<int>(type_source)].insert(index);
 
       // append source and target type together with global id of particle
       particlesfromphasetophase.push_back(std::make_tuple(type_source, type_target, globalid));
@@ -217,14 +218,14 @@ void Particle::SPHPhaseChangeBase::evaluate_phase_change_from_above_to_below_pha
     std::vector<std::vector<std::pair<int, Particle::ParticleObjShrdPtr>>>& particlestoinsert) const
 {
   // set source and target type of particles
-  Particle::TypeEnum type_source = abovephase_;
-  Particle::TypeEnum type_target = belowphase_;
+  Particle::Type type_source = abovephase_;
+  Particle::Type type_target = belowphase_;
 
   // check for boundary or rigid particles
   bool isboundaryrigid_source =
-      (type_source == Particle::BoundaryPhase or type_source == Particle::RigidPhase);
+      (type_source == Particle::Type::BoundaryPhase or type_source == Particle::Type::RigidPhase);
   bool isboundaryrigid_target =
-      (type_target == Particle::BoundaryPhase or type_target == Particle::RigidPhase);
+      (type_target == Particle::Type::BoundaryPhase or type_target == Particle::Type::RigidPhase);
 
   // get container of owned particles of source particle type
   Particle::ParticleContainer* container =
@@ -283,10 +284,11 @@ void Particle::SPHPhaseChangeBase::evaluate_phase_change_from_above_to_below_pha
           std::make_shared<Particle::ParticleObject>(type_target, globalid, particlestates);
 
       // append particle to be insert
-      particlestoinsert[type_target].push_back(std::make_pair(-1, particleobject));
+      particlestoinsert[static_cast<int>(type_target)].push_back(
+          std::make_pair(-1, particleobject));
 
       // store index of particle to be removed from containers
-      particlestoremove[type_source].insert(index);
+      particlestoremove[static_cast<int>(type_source)].insert(index);
 
       // append source and target type together with global id of particle
       particlesfromphasetophase.push_back(std::make_tuple(type_source, type_target, globalid));
@@ -305,7 +307,8 @@ void Particle::SPHPhaseChangeOneWayScalarBelowToAbove::evaluate_phase_change(
     std::vector<Particle::ParticleTypeToType>& particlesfromphasetophase) const
 {
   // determine size of vectors indexed by particle types
-  const int typevectorsize = *(--particlecontainerbundle_->get_particle_types().end()) + 1;
+  const int typevectorsize =
+      static_cast<int>(*(--particlecontainerbundle_->get_particle_types().end())) + 1;
 
   std::vector<std::set<int>> particlestoremove(typevectorsize);
   std::vector<std::vector<std::pair<int, Particle::ParticleObjShrdPtr>>> particlestoinsert(
@@ -333,7 +336,8 @@ void Particle::SPHPhaseChangeOneWayScalarAboveToBelow::evaluate_phase_change(
     std::vector<Particle::ParticleTypeToType>& particlesfromphasetophase) const
 {
   // determine size of vectors indexed by particle types
-  const int typevectorsize = *(--particlecontainerbundle_->get_particle_types().end()) + 1;
+  const int typevectorsize =
+      static_cast<int>(*(--particlecontainerbundle_->get_particle_types().end())) + 1;
 
   std::vector<std::set<int>> particlestoremove(typevectorsize);
   std::vector<std::vector<std::pair<int, Particle::ParticleObjShrdPtr>>> particlestoinsert(
@@ -361,7 +365,8 @@ void Particle::SPHPhaseChangeTwoWayScalar::evaluate_phase_change(
     std::vector<Particle::ParticleTypeToType>& particlesfromphasetophase) const
 {
   // determine size of vectors indexed by particle types
-  const int typevectorsize = *(--particlecontainerbundle_->get_particle_types().end()) + 1;
+  const int typevectorsize =
+      static_cast<int>(*(--particlecontainerbundle_->get_particle_types().end())) + 1;
 
   std::vector<std::set<int>> particlestoremove(typevectorsize);
   std::vector<std::vector<std::pair<int, Particle::ParticleObjShrdPtr>>> particlestoinsert(

--- a/src/particle/src/interaction/4C_particle_interaction_sph_phase_change.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_phase_change.cpp
@@ -145,7 +145,7 @@ void Particle::SPHPhaseChangeBase::evaluate_phase_change_from_below_to_above_pha
 
   // get container of owned particles of source particle type
   Particle::ParticleContainer* container =
-      particlecontainerbundle_->get_specific_container(type_source, Particle::Owned);
+      particlecontainerbundle_->get_specific_container(type_source, Particle::Status::Owned);
 
   // get number of particles stored in container
   int particlestored = container->particles_stored();
@@ -228,7 +228,7 @@ void Particle::SPHPhaseChangeBase::evaluate_phase_change_from_above_to_below_pha
 
   // get container of owned particles of source particle type
   Particle::ParticleContainer* container =
-      particlecontainerbundle_->get_specific_container(type_source, Particle::Owned);
+      particlecontainerbundle_->get_specific_container(type_source, Particle::Status::Owned);
 
   // get number of particles stored in container
   int particlestored = container->particles_stored();

--- a/src/particle/src/interaction/4C_particle_interaction_sph_phase_change.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_phase_change.cpp
@@ -26,7 +26,7 @@ Particle::SPHPhaseChangeBase::SPHPhaseChangeBase(const Teuchos::ParameterList& p
     : params_sph_(params),
       belowphase_(Particle::Type::Phase1),
       abovephase_(Particle::Type::Phase2),
-      transitionstate_(Particle::Density),
+      transitionstate_(Particle::State::Density),
       transitionvalue_(0.0),
       hysteresisgap_(0.0)
 {
@@ -181,19 +181,20 @@ void Particle::SPHPhaseChangeBase::evaluate_phase_change_from_below_to_above_pha
       // add density and pressure state for boundary or rigid particles
       if (isboundaryrigid_source and (not isboundaryrigid_target))
       {
-        particlestates[Particle::Density].assign(1, material_source->initDensity_);
+        particlestates[static_cast<int>(Particle::State::Density)].assign(
+            1, material_source->initDensity_);
 
         const double press = equationofstate_target->density_to_pressure(
             material_source->initDensity_, material_target->initDensity_);
 
-        particlestates[Particle::Pressure].assign(1, press);
+        particlestates[static_cast<int>(Particle::State::Pressure)].assign(1, press);
       }
 
       // clear velocity and acceleration state of boundary or rigid particles
       if (isboundaryrigid_target and (not isboundaryrigid_source))
       {
-        particlestates[Particle::Velocity].assign(3, 0.0);
-        particlestates[Particle::Acceleration].assign(3, 0.0);
+        particlestates[static_cast<int>(Particle::State::Velocity)].assign(3, 0.0);
+        particlestates[static_cast<int>(Particle::State::Acceleration)].assign(3, 0.0);
       }
 
       Particle::ParticleObjShrdPtr particleobject =
@@ -265,19 +266,20 @@ void Particle::SPHPhaseChangeBase::evaluate_phase_change_from_above_to_below_pha
       // add density and pressure state for boundary or rigid particles
       if (isboundaryrigid_source and (not isboundaryrigid_target))
       {
-        particlestates[Particle::Density].assign(1, material_source->initDensity_);
+        particlestates[static_cast<int>(Particle::State::Density)].assign(
+            1, material_source->initDensity_);
 
         const double press = equationofstate_target->density_to_pressure(
             material_source->initDensity_, material_target->initDensity_);
 
-        particlestates[Particle::Pressure].assign(1, press);
+        particlestates[static_cast<int>(Particle::State::Pressure)].assign(1, press);
       }
 
       // clear velocity and acceleration state of boundary or rigid particles
       if (isboundaryrigid_target and (not isboundaryrigid_source))
       {
-        particlestates[Particle::Velocity].assign(3, 0.0);
-        particlestates[Particle::Acceleration].assign(3, 0.0);
+        particlestates[static_cast<int>(Particle::State::Velocity)].assign(3, 0.0);
+        particlestates[static_cast<int>(Particle::State::Acceleration)].assign(3, 0.0);
       }
 
       Particle::ParticleObjShrdPtr particleobject =

--- a/src/particle/src/interaction/4C_particle_interaction_sph_phase_change.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_phase_change.hpp
@@ -88,10 +88,10 @@ namespace Particle
     std::shared_ptr<Particle::SPHEquationOfStateBundle> equationofstatebundle_;
 
     //! phase below transition value
-    Particle::TypeEnum belowphase_;
+    Particle::Type belowphase_;
 
     //! phase above transition value
-    Particle::TypeEnum abovephase_;
+    Particle::Type abovephase_;
 
     //! transition state of phase change
     Particle::StateEnum transitionstate_;

--- a/src/particle/src/interaction/4C_particle_interaction_sph_phase_change.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_phase_change.hpp
@@ -94,7 +94,7 @@ namespace Particle
     Particle::Type abovephase_;
 
     //! transition state of phase change
-    Particle::StateEnum transitionstate_;
+    Particle::State transitionstate_;
 
     //! transition value of phase change
     double transitionvalue_;

--- a/src/particle/src/interaction/4C_particle_interaction_sph_pressure.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_pressure.cpp
@@ -18,7 +18,7 @@
 
 FOUR_C_NAMESPACE_OPEN
 
-Particle::SPHPressure::SPHPressure() : fluidtypes_({Particle::Phase1, Particle::Phase2})
+Particle::SPHPressure::SPHPressure() : fluidtypes_({Particle::Type::Phase1, Particle::Type::Phase2})
 {
   // empty constructor
 }

--- a/src/particle/src/interaction/4C_particle_interaction_sph_pressure.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_pressure.cpp
@@ -48,7 +48,7 @@ void Particle::SPHPressure::setup(
 
   // setup pressure of ghosted particles to refresh
   {
-    std::vector<Particle::StateEnum> states{Particle::Pressure};
+    std::vector<Particle::State> states{Particle::State::Pressure};
 
     for (const auto& type_i : fluidtypes_)
       pressuretorefresh_.push_back(std::make_pair(type_i, states));
@@ -73,8 +73,8 @@ void Particle::SPHPressure::compute_pressure() const
     if (particlestored <= 0) continue;
 
     // get pointer to particle state
-    const double* dens = container->get_ptr_to_state(Particle::Density, 0);
-    double* press = container->get_ptr_to_state_writable(Particle::Pressure, 0);
+    const double* dens = container->get_ptr_to_state(Particle::State::Density, 0);
+    double* press = container->get_ptr_to_state_writable(Particle::State::Pressure, 0);
 
     // get material for current particle type
     const Mat::PAR::ParticleMaterialBase* material =

--- a/src/particle/src/interaction/4C_particle_interaction_sph_pressure.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_pressure.cpp
@@ -64,7 +64,7 @@ void Particle::SPHPressure::compute_pressure() const
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container =
-        particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // get number of particles stored in container
     const int particlestored = container->particles_stored();

--- a/src/particle/src/interaction/4C_particle_interaction_sph_pressure.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_pressure.hpp
@@ -65,7 +65,7 @@ namespace Particle
     Particle::StatesOfTypesToRefresh pressuretorefresh_;
 
     //! set of fluid particle types
-    std::set<Particle::TypeEnum> fluidtypes_;
+    std::set<Particle::Type> fluidtypes_;
   };
 
 }  // namespace Particle

--- a/src/particle/src/interaction/4C_particle_interaction_sph_rigid_particle_contact.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_rigid_particle_contact.cpp
@@ -139,12 +139,12 @@ void Particle::SPHRigidParticleContactElastic::elastic_contact_particle_contribu
 
     // access values of local index tuples of particle i and j
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
     Particle::TypeEnum type_j;
-    Particle::StatusEnum status_j;
+    Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
 
@@ -163,7 +163,7 @@ void Particle::SPHRigidParticleContactElastic::elastic_contact_particle_contribu
     const double* vel_j = container_j->get_ptr_to_state(Particle::Velocity, particle_j);
 
     double* force_j = nullptr;
-    if (status_j == Particle::Owned)
+    if (status_j == Particle::Status::Owned)
       force_j = container_j->try_get_ptr_to_state_writable(Particle::Force, particle_j);
 
     // compute normal gap and rate of normal gap
@@ -231,7 +231,7 @@ void Particle::SPHRigidParticleContactElastic::elastic_contact_particle_wall_con
 
     // access values of local index tuple of particle i
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlewallpair.tuple_i_;
 

--- a/src/particle/src/interaction/4C_particle_interaction_sph_rigid_particle_contact.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_rigid_particle_contact.cpp
@@ -156,15 +156,16 @@ void Particle::SPHRigidParticleContactElastic::elastic_contact_particle_contribu
         particlecontainerbundle_->get_specific_container(type_j, status_j);
 
     // get pointer to particle states
-    const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
-    double* force_i = container_i->try_get_ptr_to_state_writable(Particle::Force, particle_i);
+    const double* vel_i = container_i->get_ptr_to_state(Particle::State::Velocity, particle_i);
+    double* force_i =
+        container_i->try_get_ptr_to_state_writable(Particle::State::Force, particle_i);
 
     // get pointer to particle states
-    const double* vel_j = container_j->get_ptr_to_state(Particle::Velocity, particle_j);
+    const double* vel_j = container_j->get_ptr_to_state(Particle::State::Velocity, particle_j);
 
     double* force_j = nullptr;
     if (status_j == Particle::Status::Owned)
-      force_j = container_j->try_get_ptr_to_state_writable(Particle::Force, particle_j);
+      force_j = container_j->try_get_ptr_to_state_writable(Particle::State::Force, particle_j);
 
     // compute normal gap and rate of normal gap
     const double gap = particlepair.absdist_ - initialparticlespacing;
@@ -240,9 +241,10 @@ void Particle::SPHRigidParticleContactElastic::elastic_contact_particle_wall_con
         particlecontainerbundle_->get_specific_container(type_i, status_i);
 
     // get pointer to particle states
-    const double* pos_i = container_i->get_ptr_to_state(Particle::Position, particle_i);
-    const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
-    double* force_i = container_i->try_get_ptr_to_state_writable(Particle::Force, particle_i);
+    const double* pos_i = container_i->get_ptr_to_state(Particle::State::Position, particle_i);
+    const double* vel_i = container_i->get_ptr_to_state(Particle::State::Velocity, particle_i);
+    double* force_i =
+        container_i->try_get_ptr_to_state_writable(Particle::State::Force, particle_i);
 
     // get pointer to column wall element
     Core::Elements::Element* ele = particlewallpair.ele_;

--- a/src/particle/src/interaction/4C_particle_interaction_sph_rigid_particle_contact.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_rigid_particle_contact.cpp
@@ -32,7 +32,7 @@ Particle::SPHRigidParticleContactBase::SPHRigidParticleContactBase(
     const Teuchos::ParameterList& params)
     : params_sph_(params),
       writeparticlewallinteraction_(params_sph_.get<bool>("WRITE_PARTICLE_WALL_INTERACTION")),
-      boundarytypes_({Particle::BoundaryPhase, Particle::RigidPhase})
+      boundarytypes_({Particle::Type::BoundaryPhase, Particle::Type::RigidPhase})
 {
   // empty constructor
 }
@@ -68,7 +68,7 @@ void Particle::SPHRigidParticleContactBase::setup(
       boundarytypes_.erase(type_i);
 
   // safety check
-  if (not boundarytypes_.contains(Particle::RigidPhase))
+  if (not boundarytypes_.contains(Particle::Type::RigidPhase))
     FOUR_C_THROW("no rigid particles defined but a rigid particle contact formulation is set!");
 }
 
@@ -138,12 +138,12 @@ void Particle::SPHRigidParticleContactElastic::elastic_contact_particle_contribu
     if (not(particlepair.absdist_ < initialparticlespacing)) continue;
 
     // access values of local index tuples of particle i and j
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
-    Particle::TypeEnum type_j;
+    Particle::Type type_j;
     Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
@@ -219,7 +219,7 @@ void Particle::SPHRigidParticleContactElastic::elastic_contact_particle_wall_con
 
   // get relevant particle wall pair indices for specific particle types
   std::vector<int> relindices;
-  neighborpairs_->get_relevant_particle_wall_pair_indices({Particle::RigidPhase}, relindices);
+  neighborpairs_->get_relevant_particle_wall_pair_indices({Particle::Type::RigidPhase}, relindices);
 
   // iterate over relevant particle-wall pairs
   for (const int particlewallpairindex : relindices)
@@ -230,7 +230,7 @@ void Particle::SPHRigidParticleContactElastic::elastic_contact_particle_wall_con
     if (not(particlewallpair.absdist_ < 0.5 * initialparticlespacing)) continue;
 
     // access values of local index tuple of particle i
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlewallpair.tuple_i_;

--- a/src/particle/src/interaction/4C_particle_interaction_sph_rigid_particle_contact.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_rigid_particle_contact.hpp
@@ -83,7 +83,7 @@ namespace Particle
     const bool writeparticlewallinteraction_;
 
     //! set of boundary particle types
-    std::set<Particle::TypeEnum> boundarytypes_;
+    std::set<Particle::Type> boundarytypes_;
   };
 
   class SPHRigidParticleContactElastic : public SPHRigidParticleContactBase

--- a/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension.cpp
@@ -140,7 +140,7 @@ void Particle::SPHSurfaceTension::setup(
 
   // setup interface normal of ghosted particles to refresh
   {
-    std::vector<Particle::StateEnum> states{Particle::InterfaceNormal};
+    std::vector<Particle::State> states{Particle::State::InterfaceNormal};
 
     // iterate over fluid particle types
     for (const auto& type_i : fluidtypes_)
@@ -154,7 +154,7 @@ void Particle::SPHSurfaceTension::set_current_time(const double currenttime)
 }
 
 void Particle::SPHSurfaceTension::insert_particle_states_of_particle_types(
-    std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const
+    std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes) const
 {
   bool haveboundarytypes = false;
 
@@ -174,17 +174,18 @@ void Particle::SPHSurfaceTension::insert_particle_states_of_particle_types(
     Particle::Type type = typeIt.first;
 
     // set of particle states for current particle type
-    std::set<Particle::StateEnum>& particlestates = typeIt.second;
+    std::set<Particle::State>& particlestates = typeIt.second;
 
     // current particle type is not a fluid particle type
     if (not fluidtypes_.contains(type)) continue;
 
     // states for surface tension evaluation scheme
-    particlestates.insert(
-        {Particle::ColorfieldGradient, Particle::InterfaceNormal, Particle::Curvature});
+    particlestates.insert({Particle::State::ColorfieldGradient, Particle::State::InterfaceNormal,
+        Particle::State::Curvature});
 
     if (haveboundarytypes)
-      particlestates.insert({Particle::WallColorfield, Particle::WallInterfaceNormal});
+      particlestates.insert(
+          {Particle::State::WallColorfield, Particle::State::WallInterfaceNormal});
   }
 }
 
@@ -245,7 +246,7 @@ void Particle::SPHSurfaceTension::compute_colorfield_gradient() const
         particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // clear colorfield gradient state
-    container_i->clear_state(Particle::ColorfieldGradient);
+    container_i->clear_state(Particle::State::ColorfieldGradient);
   }
 
   // get relevant particle pair indices
@@ -280,16 +281,17 @@ void Particle::SPHSurfaceTension::compute_colorfield_gradient() const
         particlecontainerbundle_->get_specific_container(type_j, status_j);
 
     // get pointer to particle states
-    const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
-    const double* dens_i = container_i->get_ptr_to_state(Particle::Density, particle_i);
+    const double* mass_i = container_i->get_ptr_to_state(Particle::State::Mass, particle_i);
+    const double* dens_i = container_i->get_ptr_to_state(Particle::State::Density, particle_i);
     double* cfg_i =
-        container_i->get_ptr_to_state_writable(Particle::ColorfieldGradient, particle_i);
+        container_i->get_ptr_to_state_writable(Particle::State::ColorfieldGradient, particle_i);
 
-    const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
-    const double* dens_j = container_j->get_ptr_to_state(Particle::Density, particle_j);
+    const double* mass_j = container_j->get_ptr_to_state(Particle::State::Mass, particle_j);
+    const double* dens_j = container_j->get_ptr_to_state(Particle::State::Density, particle_j);
     double* cfg_j = nullptr;
     if (status_j == Particle::Status::Owned)
-      cfg_j = container_j->get_ptr_to_state_writable(Particle::ColorfieldGradient, particle_j);
+      cfg_j =
+          container_j->get_ptr_to_state_writable(Particle::State::ColorfieldGradient, particle_j);
 
     // (current) volume of particle i and j
     const double V_i = mass_i[0] / dens_i[0];
@@ -319,9 +321,9 @@ void Particle::SPHSurfaceTension::compute_colorfield_gradient() const
     for (int particle_i = 0; particle_i < container_i->particles_stored(); ++particle_i)
     {
       // get pointer to particle state
-      const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
+      const double* rad_i = container_i->get_ptr_to_state(Particle::State::Radius, particle_i);
       double* cfg_i =
-          container_i->get_ptr_to_state_writable(Particle::ColorfieldGradient, particle_i);
+          container_i->get_ptr_to_state_writable(Particle::State::ColorfieldGradient, particle_i);
 
       // norm of colorfield gradient
       const double cfg_i_norm = ParticleUtils::vec_norm_two(cfg_i);
@@ -342,15 +344,17 @@ void Particle::SPHSurfaceTension::compute_interface_normal() const
         particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // clear interface normal state
-    container_i->clear_state(Particle::InterfaceNormal);
+    container_i->clear_state(Particle::State::InterfaceNormal);
 
     // iterate over particles in container
     for (int particle_i = 0; particle_i < container_i->particles_stored(); ++particle_i)
     {
       // get pointer to particle states
-      const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
-      const double* cfg_i = container_i->get_ptr_to_state(Particle::ColorfieldGradient, particle_i);
-      double* ifn_i = container_i->get_ptr_to_state_writable(Particle::InterfaceNormal, particle_i);
+      const double* rad_i = container_i->get_ptr_to_state(Particle::State::Radius, particle_i);
+      const double* cfg_i =
+          container_i->get_ptr_to_state(Particle::State::ColorfieldGradient, particle_i);
+      double* ifn_i =
+          container_i->get_ptr_to_state_writable(Particle::State::InterfaceNormal, particle_i);
 
       // norm of colorfield gradient
       const double cfg_i_norm = ParticleUtils::vec_norm_two(cfg_i);
@@ -372,10 +376,10 @@ void Particle::SPHSurfaceTension::compute_wall_colorfield_and_wall_interface_nor
         particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // clear wall colorfield state
-    container_i->clear_state(Particle::WallColorfield);
+    container_i->clear_state(Particle::State::WallColorfield);
 
     // clear wall interface normal state
-    container_i->clear_state(Particle::WallInterfaceNormal);
+    container_i->clear_state(Particle::State::WallInterfaceNormal);
   }
 
   // get relevant particle pair indices
@@ -415,15 +419,16 @@ void Particle::SPHSurfaceTension::compute_wall_colorfield_and_wall_interface_nor
           particlematerial_->get_ptr_to_particle_mat_parameter(type_j);
 
       // get pointer to particle states
-      const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
-      const double* dens_i = container_i->get_ptr_to_state(Particle::Density, particle_i);
+      const double* mass_i = container_i->get_ptr_to_state(Particle::State::Mass, particle_i);
+      const double* dens_i = container_i->get_ptr_to_state(Particle::State::Density, particle_i);
       double* wallcf_i =
-          container_i->get_ptr_to_state_writable(Particle::WallColorfield, particle_i);
+          container_i->get_ptr_to_state_writable(Particle::State::WallColorfield, particle_i);
       double* wallifn_i =
-          container_i->get_ptr_to_state_writable(Particle::WallInterfaceNormal, particle_i);
+          container_i->get_ptr_to_state_writable(Particle::State::WallInterfaceNormal, particle_i);
 
-      const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
-      const double* temp_j = container_j->try_get_ptr_to_state(Particle::Temperature, particle_j);
+      const double* mass_j = container_j->get_ptr_to_state(Particle::State::Mass, particle_j);
+      const double* temp_j =
+          container_j->try_get_ptr_to_state(Particle::State::Temperature, particle_j);
 
       // (current) volume of particle i
       const double V_i = mass_i[0] / dens_i[0];
@@ -455,15 +460,16 @@ void Particle::SPHSurfaceTension::compute_wall_colorfield_and_wall_interface_nor
           particlematerial_->get_ptr_to_particle_mat_parameter(type_i);
 
       // get pointer to particle states
-      const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
-      const double* dens_j = container_j->get_ptr_to_state(Particle::Density, particle_j);
+      const double* mass_j = container_j->get_ptr_to_state(Particle::State::Mass, particle_j);
+      const double* dens_j = container_j->get_ptr_to_state(Particle::State::Density, particle_j);
       double* wallcf_j =
-          container_j->get_ptr_to_state_writable(Particle::WallColorfield, particle_j);
+          container_j->get_ptr_to_state_writable(Particle::State::WallColorfield, particle_j);
       double* wallifn_j =
-          container_j->get_ptr_to_state_writable(Particle::WallInterfaceNormal, particle_j);
+          container_j->get_ptr_to_state_writable(Particle::State::WallInterfaceNormal, particle_j);
 
-      const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
-      const double* temp_i = container_i->try_get_ptr_to_state(Particle::Temperature, particle_i);
+      const double* mass_i = container_i->get_ptr_to_state(Particle::State::Mass, particle_i);
+      const double* temp_i =
+          container_i->try_get_ptr_to_state(Particle::State::Temperature, particle_i);
 
       // (initial) volume of boundary particle i
       const double V_i = mass_i[0] / material_i->initDensity_;
@@ -498,9 +504,9 @@ void Particle::SPHSurfaceTension::compute_wall_colorfield_and_wall_interface_nor
     for (int particle_i = 0; particle_i < container_i->particles_stored(); ++particle_i)
     {
       // get pointer to particle state
-      const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
+      const double* rad_i = container_i->get_ptr_to_state(Particle::State::Radius, particle_i);
       double* wallifn_i =
-          container_i->get_ptr_to_state_writable(Particle::WallInterfaceNormal, particle_i);
+          container_i->get_ptr_to_state_writable(Particle::State::WallInterfaceNormal, particle_i);
 
       // norm of wall interface normal
       const double wallifn_i_norm = ParticleUtils::vec_norm_two(wallifn_i);
@@ -534,11 +540,13 @@ void Particle::SPHSurfaceTension::correct_triple_point_normal() const
     for (int particle_i = 0; particle_i < container_i->particles_stored(); ++particle_i)
     {
       // get pointer to particle states
-      const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
+      const double* rad_i = container_i->get_ptr_to_state(Particle::State::Radius, particle_i);
       const double* wallifn_i =
-          container_i->get_ptr_to_state(Particle::WallInterfaceNormal, particle_i);
-      const double* wallcf_i = container_i->get_ptr_to_state(Particle::WallColorfield, particle_i);
-      double* ifn_i = container_i->get_ptr_to_state_writable(Particle::InterfaceNormal, particle_i);
+          container_i->get_ptr_to_state(Particle::State::WallInterfaceNormal, particle_i);
+      const double* wallcf_i =
+          container_i->get_ptr_to_state(Particle::State::WallColorfield, particle_i);
+      double* ifn_i =
+          container_i->get_ptr_to_state_writable(Particle::State::InterfaceNormal, particle_i);
 
       // evaluation only for non-zero wall interface normal
       if (not(ParticleUtils::vec_norm_two(wallifn_i) > 0.0)) continue;
@@ -602,7 +610,7 @@ void Particle::SPHSurfaceTension::compute_curvature() const
         particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // clear curvature state
-    container_i->clear_state(Particle::Curvature);
+    container_i->clear_state(Particle::State::Curvature);
 
     // get number of particles stored in container
     const int particlestored = container_i->particles_stored();
@@ -615,11 +623,13 @@ void Particle::SPHSurfaceTension::compute_curvature() const
     for (int particle_i = 0; particle_i < container_i->particles_stored(); ++particle_i)
     {
       // get pointer to particle states
-      const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
-      const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
-      const double* dens_i = container_i->get_ptr_to_state(Particle::Density, particle_i);
-      const double* ifn_i = container_i->get_ptr_to_state(Particle::InterfaceNormal, particle_i);
-      const double* temp_i = container_i->try_get_ptr_to_state(Particle::Temperature, particle_i);
+      const double* rad_i = container_i->get_ptr_to_state(Particle::State::Radius, particle_i);
+      const double* mass_i = container_i->get_ptr_to_state(Particle::State::Mass, particle_i);
+      const double* dens_i = container_i->get_ptr_to_state(Particle::State::Density, particle_i);
+      const double* ifn_i =
+          container_i->get_ptr_to_state(Particle::State::InterfaceNormal, particle_i);
+      const double* temp_i =
+          container_i->try_get_ptr_to_state(Particle::State::Temperature, particle_i);
 
       // evaluation only for non-zero interface normal
       if (not(ParticleUtils::vec_norm_two(ifn_i) > 0.0)) continue;
@@ -670,15 +680,19 @@ void Particle::SPHSurfaceTension::compute_curvature() const
         particlecontainerbundle_->get_specific_container(type_j, status_j);
 
     // get pointer to particle states
-    const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
-    const double* dens_i = container_i->get_ptr_to_state(Particle::Density, particle_i);
-    const double* ifn_i = container_i->get_ptr_to_state(Particle::InterfaceNormal, particle_i);
-    const double* temp_i = container_i->try_get_ptr_to_state(Particle::Temperature, particle_i);
+    const double* mass_i = container_i->get_ptr_to_state(Particle::State::Mass, particle_i);
+    const double* dens_i = container_i->get_ptr_to_state(Particle::State::Density, particle_i);
+    const double* ifn_i =
+        container_i->get_ptr_to_state(Particle::State::InterfaceNormal, particle_i);
+    const double* temp_i =
+        container_i->try_get_ptr_to_state(Particle::State::Temperature, particle_i);
 
-    const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
-    const double* dens_j = container_j->get_ptr_to_state(Particle::Density, particle_j);
-    const double* ifn_j = container_j->get_ptr_to_state(Particle::InterfaceNormal, particle_j);
-    const double* temp_j = container_j->try_get_ptr_to_state(Particle::Temperature, particle_j);
+    const double* mass_j = container_j->get_ptr_to_state(Particle::State::Mass, particle_j);
+    const double* dens_j = container_j->get_ptr_to_state(Particle::State::Density, particle_j);
+    const double* ifn_j =
+        container_j->get_ptr_to_state(Particle::State::InterfaceNormal, particle_j);
+    const double* temp_j =
+        container_j->try_get_ptr_to_state(Particle::State::Temperature, particle_j);
 
     // evaluation only for non-zero interface normals
     if (not(ParticleUtils::vec_norm_two(ifn_i) > 0.0) or
@@ -741,9 +755,11 @@ void Particle::SPHSurfaceTension::compute_curvature() const
     for (int particle_i = 0; particle_i < container_i->particles_stored(); ++particle_i)
     {
       // get pointer to particle states
-      const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
-      const double* ifn_i = container_i->get_ptr_to_state(Particle::InterfaceNormal, particle_i);
-      double* curv_i = container_i->get_ptr_to_state_writable(Particle::Curvature, particle_i);
+      const double* rad_i = container_i->get_ptr_to_state(Particle::State::Radius, particle_i);
+      const double* ifn_i =
+          container_i->get_ptr_to_state(Particle::State::InterfaceNormal, particle_i);
+      double* curv_i =
+          container_i->get_ptr_to_state_writable(Particle::State::Curvature, particle_i);
 
       // evaluation only for non-zero interface normal
       if (not(ParticleUtils::vec_norm_two(ifn_i) > 0.0)) continue;
@@ -779,12 +795,16 @@ void Particle::SPHSurfaceTension::compute_surface_tension_contribution() const
     for (int particle_i = 0; particle_i < container_i->particles_stored(); ++particle_i)
     {
       // get pointer to particle states
-      const double* dens_i = container_i->get_ptr_to_state(Particle::Density, particle_i);
-      const double* curv_i = container_i->get_ptr_to_state(Particle::Curvature, particle_i);
-      const double* cfg_i = container_i->get_ptr_to_state(Particle::ColorfieldGradient, particle_i);
-      const double* ifn_i = container_i->get_ptr_to_state(Particle::InterfaceNormal, particle_i);
-      const double* temp_i = container_i->try_get_ptr_to_state(Particle::Temperature, particle_i);
-      double* acc_i = container_i->get_ptr_to_state_writable(Particle::Acceleration, particle_i);
+      const double* dens_i = container_i->get_ptr_to_state(Particle::State::Density, particle_i);
+      const double* curv_i = container_i->get_ptr_to_state(Particle::State::Curvature, particle_i);
+      const double* cfg_i =
+          container_i->get_ptr_to_state(Particle::State::ColorfieldGradient, particle_i);
+      const double* ifn_i =
+          container_i->get_ptr_to_state(Particle::State::InterfaceNormal, particle_i);
+      const double* temp_i =
+          container_i->try_get_ptr_to_state(Particle::State::Temperature, particle_i);
+      double* acc_i =
+          container_i->get_ptr_to_state_writable(Particle::State::Acceleration, particle_i);
 
       // evaluation only for non-zero interface normal
       if (not(ParticleUtils::vec_norm_two(ifn_i) > 0.0)) continue;
@@ -833,13 +853,17 @@ void Particle::SPHSurfaceTension::compute_temp_grad_driven_contribution() const
     for (int particle_i = 0; particle_i < container_i->particles_stored(); ++particle_i)
     {
       // get pointer to particle states
-      const double* dens_i = container_i->get_ptr_to_state(Particle::Density, particle_i);
-      const double* cfg_i = container_i->get_ptr_to_state(Particle::ColorfieldGradient, particle_i);
-      const double* ifn_i = container_i->get_ptr_to_state(Particle::InterfaceNormal, particle_i);
-      const double* temp_i = container_i->get_ptr_to_state(Particle::Temperature, particle_i);
+      const double* dens_i = container_i->get_ptr_to_state(Particle::State::Density, particle_i);
+      const double* cfg_i =
+          container_i->get_ptr_to_state(Particle::State::ColorfieldGradient, particle_i);
+      const double* ifn_i =
+          container_i->get_ptr_to_state(Particle::State::InterfaceNormal, particle_i);
+      const double* temp_i =
+          container_i->get_ptr_to_state(Particle::State::Temperature, particle_i);
       const double* tempgrad_i =
-          container_i->get_ptr_to_state(Particle::temperature_gradient, particle_i);
-      double* acc_i = container_i->get_ptr_to_state_writable(Particle::Acceleration, particle_i);
+          container_i->get_ptr_to_state(Particle::State::temperature_gradient, particle_i);
+      double* acc_i =
+          container_i->get_ptr_to_state_writable(Particle::State::Acceleration, particle_i);
 
       // evaluation only for non-zero interface normal
       if (not(ParticleUtils::vec_norm_two(ifn_i) > 0.0)) continue;

--- a/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension.cpp
@@ -861,7 +861,7 @@ void Particle::SPHSurfaceTension::compute_temp_grad_driven_contribution() const
       const double* temp_i =
           container_i->get_ptr_to_state(Particle::State::Temperature, particle_i);
       const double* tempgrad_i =
-          container_i->get_ptr_to_state(Particle::State::temperature_gradient, particle_i);
+          container_i->get_ptr_to_state(Particle::State::TemperatureGradient, particle_i);
       double* acc_i =
           container_i->get_ptr_to_state_writable(Particle::State::Acceleration, particle_i);
 

--- a/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension.cpp
@@ -34,10 +34,11 @@ FOUR_C_NAMESPACE_OPEN
  *---------------------------------------------------------------------------*/
 Particle::SPHSurfaceTension::SPHSurfaceTension(const Teuchos::ParameterList& params)
     : params_sph_(params),
-      liquidtype_(Particle::Phase1),
-      gastype_(Particle::Phase2),
+      liquidtype_(Particle::Type::Phase1),
+      gastype_(Particle::Type::Phase2),
       fluidtypes_({liquidtype_, gastype_}),
-      boundarytypes_({Particle::BoundaryPhase, Particle::RigidPhase, Particle::PDPhase}),
+      boundarytypes_(
+          {Particle::Type::BoundaryPhase, Particle::Type::RigidPhase, Particle::Type::PDPhase}),
       time_(0.0),
       timerampfct_(params.get<int>("SURFACETENSION_RAMP_FUNCT")),
       alpha0_(params_sph_.get<double>("SURFACETENSIONCOEFFICIENT")),
@@ -153,7 +154,7 @@ void Particle::SPHSurfaceTension::set_current_time(const double currenttime)
 }
 
 void Particle::SPHSurfaceTension::insert_particle_states_of_particle_types(
-    std::map<Particle::TypeEnum, std::set<Particle::StateEnum>>& particlestatestotypes) const
+    std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const
 {
   bool haveboundarytypes = false;
 
@@ -161,7 +162,7 @@ void Particle::SPHSurfaceTension::insert_particle_states_of_particle_types(
   for (auto& typeIt : particlestatestotypes)
   {
     // get type of particles
-    Particle::TypeEnum type = typeIt.first;
+    Particle::Type type = typeIt.first;
 
     if (boundarytypes_.contains(type)) haveboundarytypes = true;
   }
@@ -170,7 +171,7 @@ void Particle::SPHSurfaceTension::insert_particle_states_of_particle_types(
   for (auto& typeIt : particlestatestotypes)
   {
     // get type of particles
-    Particle::TypeEnum type = typeIt.first;
+    Particle::Type type = typeIt.first;
 
     // set of particle states for current particle type
     std::set<Particle::StateEnum>& particlestates = typeIt.second;
@@ -258,12 +259,12 @@ void Particle::SPHSurfaceTension::compute_colorfield_gradient() const
         neighborpairs_->get_ref_to_particle_pair_data()[particlepairindex];
 
     // access values of local index tuples of particle i and j
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
-    Particle::TypeEnum type_j;
+    Particle::Type type_j;
     Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
@@ -389,12 +390,12 @@ void Particle::SPHSurfaceTension::compute_wall_colorfield_and_wall_interface_nor
         neighborpairs_->get_ref_to_particle_pair_data()[particlepairindex];
 
     // access values of local index tuples of particle i and j
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
-    Particle::TypeEnum type_j;
+    Particle::Type type_j;
     Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
@@ -587,7 +588,8 @@ void Particle::SPHSurfaceTension::correct_triple_point_normal() const
 void Particle::SPHSurfaceTension::compute_curvature() const
 {
   // determine size of vectors indexed by particle types
-  const int typevectorsize = *(--particlecontainerbundle_->get_particle_types().end()) + 1;
+  const int typevectorsize =
+      static_cast<int>(*(--particlecontainerbundle_->get_particle_types().end())) + 1;
 
   std::vector<std::vector<double>> sumj_nij_Vj_eij_dWij(typevectorsize);
   std::vector<std::vector<double>> sumj_Vj_Wij(typevectorsize);
@@ -606,8 +608,8 @@ void Particle::SPHSurfaceTension::compute_curvature() const
     const int particlestored = container_i->particles_stored();
 
     // allocate memory
-    sumj_nij_Vj_eij_dWij[type_i].assign(particlestored, 0.0);
-    sumj_Vj_Wij[type_i].assign(particlestored, 0.0);
+    sumj_nij_Vj_eij_dWij[static_cast<int>(type_i)].assign(particlestored, 0.0);
+    sumj_Vj_Wij[static_cast<int>(type_i)].assign(particlestored, 0.0);
 
     // iterate over particles in container
     for (int particle_i = 0; particle_i < container_i->particles_stored(); ++particle_i)
@@ -635,7 +637,7 @@ void Particle::SPHSurfaceTension::compute_curvature() const
             ParticleUtils::lin_trans(temp_i[0], trans_ref_temp_, trans_ref_temp_ + trans_d_t_curv_);
 
       // add self-interaction
-      sumj_Vj_Wij[type_i][particle_i] += tempfac * V_i * Wii;
+      sumj_Vj_Wij[static_cast<int>(type_i)][particle_i] += tempfac * V_i * Wii;
     }
   }
 
@@ -650,12 +652,12 @@ void Particle::SPHSurfaceTension::compute_curvature() const
         neighborpairs_->get_ref_to_particle_pair_data()[particlepairindex];
 
     // access values of local index tuples of particle i and j
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
-    Particle::TypeEnum type_j;
+    Particle::Type type_j;
     Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
@@ -704,8 +706,9 @@ void Particle::SPHSurfaceTension::compute_curvature() const
             ParticleUtils::lin_trans(temp_j[0], trans_ref_temp_, trans_ref_temp_ + trans_d_t_curv_);
 
       // sum contribution of neighboring particle j
-      sumj_nij_Vj_eij_dWij[type_i][particle_i] += tempfac * V_j * nij_eij * particlepair.dWdrij_;
-      sumj_Vj_Wij[type_i][particle_i] += tempfac * V_j * particlepair.Wij_;
+      sumj_nij_Vj_eij_dWij[static_cast<int>(type_i)][particle_i] +=
+          tempfac * V_j * nij_eij * particlepair.dWdrij_;
+      sumj_Vj_Wij[static_cast<int>(type_i)][particle_i] += tempfac * V_j * particlepair.Wij_;
     }
 
     // evaluate contribution of neighboring particle i
@@ -721,9 +724,9 @@ void Particle::SPHSurfaceTension::compute_curvature() const
             ParticleUtils::lin_trans(temp_i[0], trans_ref_temp_, trans_ref_temp_ + trans_d_t_curv_);
 
       // sum contribution of neighboring particle i
-      sumj_nij_Vj_eij_dWij[type_j][particle_j] +=
+      sumj_nij_Vj_eij_dWij[static_cast<int>(type_j)][particle_j] +=
           signfac * tempfac * V_i * nij_eij * particlepair.dWdrji_;
-      sumj_Vj_Wij[type_j][particle_j] += tempfac * V_i * particlepair.Wji_;
+      sumj_Vj_Wij[static_cast<int>(type_j)][particle_j] += tempfac * V_i * particlepair.Wji_;
     }
   }
 
@@ -746,10 +749,12 @@ void Particle::SPHSurfaceTension::compute_curvature() const
       if (not(ParticleUtils::vec_norm_two(ifn_i) > 0.0)) continue;
 
       // evaluation only for meaningful contributions
-      if (not(std::abs(sumj_Vj_Wij[type_i][particle_i]) > (1.0e-10 * rad_i[0]))) continue;
+      if (not(std::abs(sumj_Vj_Wij[static_cast<int>(type_i)][particle_i]) > (1.0e-10 * rad_i[0])))
+        continue;
 
       // compute curvature
-      curv_i[0] = -sumj_nij_Vj_eij_dWij[type_i][particle_i] / sumj_Vj_Wij[type_i][particle_i];
+      curv_i[0] = -sumj_nij_Vj_eij_dWij[static_cast<int>(type_i)][particle_i] /
+                  sumj_Vj_Wij[static_cast<int>(type_i)][particle_i];
     }
   }
 }

--- a/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension.cpp
@@ -241,7 +241,7 @@ void Particle::SPHSurfaceTension::compute_colorfield_gradient() const
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container_i =
-        particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // clear colorfield gradient state
     container_i->clear_state(Particle::ColorfieldGradient);
@@ -259,12 +259,12 @@ void Particle::SPHSurfaceTension::compute_colorfield_gradient() const
 
     // access values of local index tuples of particle i and j
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
     Particle::TypeEnum type_j;
-    Particle::StatusEnum status_j;
+    Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
 
@@ -287,7 +287,7 @@ void Particle::SPHSurfaceTension::compute_colorfield_gradient() const
     const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
     const double* dens_j = container_j->get_ptr_to_state(Particle::Density, particle_j);
     double* cfg_j = nullptr;
-    if (status_j == Particle::Owned)
+    if (status_j == Particle::Status::Owned)
       cfg_j = container_j->get_ptr_to_state_writable(Particle::ColorfieldGradient, particle_j);
 
     // (current) volume of particle i and j
@@ -312,7 +312,7 @@ void Particle::SPHSurfaceTension::compute_colorfield_gradient() const
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container_i =
-        particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // iterate over particles in container
     for (int particle_i = 0; particle_i < container_i->particles_stored(); ++particle_i)
@@ -338,7 +338,7 @@ void Particle::SPHSurfaceTension::compute_interface_normal() const
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container_i =
-        particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // clear interface normal state
     container_i->clear_state(Particle::InterfaceNormal);
@@ -368,7 +368,7 @@ void Particle::SPHSurfaceTension::compute_wall_colorfield_and_wall_interface_nor
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container_i =
-        particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // clear wall colorfield state
     container_i->clear_state(Particle::WallColorfield);
@@ -390,12 +390,12 @@ void Particle::SPHSurfaceTension::compute_wall_colorfield_and_wall_interface_nor
 
     // access values of local index tuples of particle i and j
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
     Particle::TypeEnum type_j;
-    Particle::StatusEnum status_j;
+    Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
 
@@ -447,7 +447,7 @@ void Particle::SPHSurfaceTension::compute_wall_colorfield_and_wall_interface_nor
     }
 
     // evaluate contribution of neighboring boundary particle i
-    if (fluidtypes_.contains(type_j) and status_j == Particle::Owned)
+    if (fluidtypes_.contains(type_j) and status_j == Particle::Status::Owned)
     {
       // get material for current particle type
       const Mat::PAR::ParticleMaterialBase* material_i =
@@ -491,7 +491,7 @@ void Particle::SPHSurfaceTension::compute_wall_colorfield_and_wall_interface_nor
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container_i =
-        particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // iterate over particles in container
     for (int particle_i = 0; particle_i < container_i->particles_stored(); ++particle_i)
@@ -527,7 +527,7 @@ void Particle::SPHSurfaceTension::correct_triple_point_normal() const
 
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container_i =
-        particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // iterate over particles in container
     for (int particle_i = 0; particle_i < container_i->particles_stored(); ++particle_i)
@@ -597,7 +597,7 @@ void Particle::SPHSurfaceTension::compute_curvature() const
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container_i =
-        particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // clear curvature state
     container_i->clear_state(Particle::Curvature);
@@ -651,12 +651,12 @@ void Particle::SPHSurfaceTension::compute_curvature() const
 
     // access values of local index tuples of particle i and j
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
     Particle::TypeEnum type_j;
-    Particle::StatusEnum status_j;
+    Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
 
@@ -709,7 +709,7 @@ void Particle::SPHSurfaceTension::compute_curvature() const
     }
 
     // evaluate contribution of neighboring particle i
-    if (status_j == Particle::Owned)
+    if (status_j == Particle::Status::Owned)
     {
       // (current) volume of particle i
       const double V_i = mass_i[0] / dens_i[0];
@@ -732,7 +732,7 @@ void Particle::SPHSurfaceTension::compute_curvature() const
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container_i =
-        particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // iterate over particles in container
     for (int particle_i = 0; particle_i < container_i->particles_stored(); ++particle_i)
@@ -768,7 +768,7 @@ void Particle::SPHSurfaceTension::compute_surface_tension_contribution() const
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container_i =
-        particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // iterate over particles in container
     for (int particle_i = 0; particle_i < container_i->particles_stored(); ++particle_i)
@@ -822,7 +822,7 @@ void Particle::SPHSurfaceTension::compute_temp_grad_driven_contribution() const
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container_i =
-        particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // iterate over particles in container
     for (int particle_i = 0; particle_i < container_i->particles_stored(); ++particle_i)

--- a/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension.hpp
@@ -68,7 +68,7 @@ namespace Particle
 
     //! insert surface tension evaluation dependent states
     void insert_particle_states_of_particle_types(
-        std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const;
+        std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes) const;
 
     //! compute interface quantities
     void compute_interface_quantities();

--- a/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension.hpp
@@ -68,7 +68,7 @@ namespace Particle
 
     //! insert surface tension evaluation dependent states
     void insert_particle_states_of_particle_types(
-        std::map<Particle::TypeEnum, std::set<Particle::StateEnum>>& particlestatestotypes) const;
+        std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const;
 
     //! compute interface quantities
     void compute_interface_quantities();
@@ -126,16 +126,16 @@ namespace Particle
     std::unique_ptr<Particle::SPHBarrierForce> barrierforce_;
 
     //! liquid particle type
-    Particle::TypeEnum liquidtype_;
+    Particle::Type liquidtype_;
 
     //! gas particle type
-    Particle::TypeEnum gastype_;
+    Particle::Type gastype_;
 
     //! set of fluid particle types
-    std::set<Particle::TypeEnum> fluidtypes_;
+    std::set<Particle::Type> fluidtypes_;
 
     //! set of boundary particle types
-    std::set<Particle::TypeEnum> boundarytypes_;
+    std::set<Particle::Type> boundarytypes_;
 
     //! interface normal of ghosted particles to refresh
     Particle::StatesOfTypesToRefresh intnormtorefresh_;

--- a/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_barrier_force.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_barrier_force.cpp
@@ -100,12 +100,12 @@ void Particle::SPHBarrierForce::compute_barrier_force_particle_contribution() co
 
     // access values of local index tuples of particle i and j
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
     Particle::TypeEnum type_j;
-    Particle::StatusEnum status_j;
+    Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
 
@@ -126,7 +126,7 @@ void Particle::SPHBarrierForce::compute_barrier_force_particle_contribution() co
     const double* vel_j = container_j->get_ptr_to_state(Particle::Velocity, particle_j);
     const double* temp_j = container_j->try_get_ptr_to_state(Particle::Temperature, particle_j);
     double* acc_j = nullptr;
-    if (status_j == Particle::Owned)
+    if (status_j == Particle::Status::Owned)
       acc_j = container_j->get_ptr_to_state_writable(Particle::Acceleration, particle_j);
 
     // evaluate transition factor above reference temperature
@@ -180,12 +180,12 @@ void Particle::SPHBarrierForce::compute_barrier_force_particle_boundary_contribu
 
     // access values of local index tuples of particle i and j
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
     Particle::TypeEnum type_j;
-    Particle::StatusEnum status_j;
+    Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
 
@@ -218,7 +218,7 @@ void Particle::SPHBarrierForce::compute_barrier_force_particle_boundary_contribu
     const double* temp_i = container_i->try_get_ptr_to_state(Particle::Temperature, particle_i);
 
     double* acc_i = nullptr;
-    if (status_i == Particle::Owned)
+    if (status_i == Particle::Status::Owned)
       acc_i = container_i->get_ptr_to_state_writable(Particle::Acceleration, particle_i);
 
     // get pointer to boundary particle states

--- a/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_barrier_force.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_barrier_force.cpp
@@ -118,17 +118,20 @@ void Particle::SPHBarrierForce::compute_barrier_force_particle_contribution() co
         particlecontainerbundle_->get_specific_container(type_j, status_j);
 
     // get pointer to particle states
-    const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
-    const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
-    const double* temp_i = container_i->try_get_ptr_to_state(Particle::Temperature, particle_i);
-    double* acc_i = container_i->get_ptr_to_state_writable(Particle::Acceleration, particle_i);
+    const double* mass_i = container_i->get_ptr_to_state(Particle::State::Mass, particle_i);
+    const double* vel_i = container_i->get_ptr_to_state(Particle::State::Velocity, particle_i);
+    const double* temp_i =
+        container_i->try_get_ptr_to_state(Particle::State::Temperature, particle_i);
+    double* acc_i =
+        container_i->get_ptr_to_state_writable(Particle::State::Acceleration, particle_i);
 
-    const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
-    const double* vel_j = container_j->get_ptr_to_state(Particle::Velocity, particle_j);
-    const double* temp_j = container_j->try_get_ptr_to_state(Particle::Temperature, particle_j);
+    const double* mass_j = container_j->get_ptr_to_state(Particle::State::Mass, particle_j);
+    const double* vel_j = container_j->get_ptr_to_state(Particle::State::Velocity, particle_j);
+    const double* temp_j =
+        container_j->try_get_ptr_to_state(Particle::State::Temperature, particle_j);
     double* acc_j = nullptr;
     if (status_j == Particle::Status::Owned)
-      acc_j = container_j->get_ptr_to_state_writable(Particle::Acceleration, particle_j);
+      acc_j = container_j->get_ptr_to_state_writable(Particle::State::Acceleration, particle_j);
 
     // evaluate transition factor above reference temperature
     double tempfac_i = 0.0;
@@ -214,17 +217,19 @@ void Particle::SPHBarrierForce::compute_barrier_force_particle_boundary_contribu
         particlecontainerbundle_->get_specific_container(type_j, status_j);
 
     // get pointer to particle states
-    const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
-    const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
-    const double* temp_i = container_i->try_get_ptr_to_state(Particle::Temperature, particle_i);
+    const double* mass_i = container_i->get_ptr_to_state(Particle::State::Mass, particle_i);
+    const double* vel_i = container_i->get_ptr_to_state(Particle::State::Velocity, particle_i);
+    const double* temp_i =
+        container_i->try_get_ptr_to_state(Particle::State::Temperature, particle_i);
 
     double* acc_i = nullptr;
     if (status_i == Particle::Status::Owned)
-      acc_i = container_i->get_ptr_to_state_writable(Particle::Acceleration, particle_i);
+      acc_i = container_i->get_ptr_to_state_writable(Particle::State::Acceleration, particle_i);
 
     // get pointer to boundary particle states
-    const double* vel_j = container_j->get_ptr_to_state(Particle::Velocity, particle_j);
-    const double* temp_j = container_j->try_get_ptr_to_state(Particle::Temperature, particle_j);
+    const double* vel_j = container_j->get_ptr_to_state(Particle::State::Velocity, particle_j);
+    const double* temp_j =
+        container_j->try_get_ptr_to_state(Particle::State::Temperature, particle_j);
 
     // evaluate transition factor above reference temperature
     double tempfac_i = 0.0;

--- a/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_barrier_force.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_barrier_force.cpp
@@ -22,10 +22,11 @@ FOUR_C_NAMESPACE_OPEN
  *---------------------------------------------------------------------------*/
 Particle::SPHBarrierForce::SPHBarrierForce(const Teuchos::ParameterList& params)
     : params_sph_(params),
-      liquidtype_(Particle::Phase1),
-      gastype_(Particle::Phase2),
+      liquidtype_(Particle::Type::Phase1),
+      gastype_(Particle::Type::Phase2),
       fluidtypes_({liquidtype_, gastype_}),
-      boundarytypes_({Particle::BoundaryPhase, Particle::RigidPhase, Particle::PDPhase}),
+      boundarytypes_(
+          {Particle::Type::BoundaryPhase, Particle::Type::RigidPhase, Particle::Type::PDPhase}),
       dist_(params_sph_.get<double>("BARRIER_FORCE_DISTANCE")),
       cr_(params_sph_.get<double>("BARRIER_FORCE_TEMPSCALE")),
       trans_ref_temp_(params_sph_.get<double>("TRANS_REF_TEMPERATURE")),
@@ -99,12 +100,12 @@ void Particle::SPHBarrierForce::compute_barrier_force_particle_contribution() co
         neighborpairs_->get_ref_to_particle_pair_data()[particlepairindex];
 
     // access values of local index tuples of particle i and j
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
-    Particle::TypeEnum type_j;
+    Particle::Type type_j;
     Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
@@ -179,12 +180,12 @@ void Particle::SPHBarrierForce::compute_barrier_force_particle_boundary_contribu
         neighborpairs_->get_ref_to_particle_pair_data()[particlepairindex];
 
     // access values of local index tuples of particle i and j
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
-    Particle::TypeEnum type_j;
+    Particle::Type type_j;
     Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;

--- a/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_barrier_force.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_barrier_force.hpp
@@ -68,16 +68,16 @@ namespace Particle
     std::shared_ptr<Particle::SPHNeighborPairs> neighborpairs_;
 
     //! liquid particle type
-    Particle::TypeEnum liquidtype_;
+    Particle::Type liquidtype_;
 
     //! gas particle type
-    Particle::TypeEnum gastype_;
+    Particle::Type gastype_;
 
     //! set of fluid particle types
-    std::set<Particle::TypeEnum> fluidtypes_;
+    std::set<Particle::Type> fluidtypes_;
 
     //! set of boundary particle types
-    std::set<Particle::TypeEnum> boundarytypes_;
+    std::set<Particle::Type> boundarytypes_;
 
     //! barrier force distance
     const double dist_;

--- a/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_interface_viscosity.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_interface_viscosity.cpp
@@ -128,12 +128,12 @@ void Particle::SPHInterfaceViscosity::compute_interface_viscosity_particle_contr
 
     // access values of local index tuples of particle i and j
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
     Particle::TypeEnum type_j;
-    Particle::StatusEnum status_j;
+    Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
 
@@ -226,12 +226,12 @@ void Particle::SPHInterfaceViscosity::compute_interface_viscosity_particle_bound
 
     // access values of local index tuples of particle i and j
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
     Particle::TypeEnum type_j;
-    Particle::StatusEnum status_j;
+    Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
 
@@ -277,7 +277,7 @@ void Particle::SPHInterfaceViscosity::compute_interface_viscosity_particle_bound
     const double* temp_i = container_i->try_get_ptr_to_state(Particle::Temperature, particle_i);
 
     double* acc_i = nullptr;
-    if (status_i == Particle::Owned)
+    if (status_i == Particle::Status::Owned)
       acc_i = container_i->get_ptr_to_state_writable(Particle::Acceleration, particle_i);
 
     // get pointer to boundary particle states

--- a/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_interface_viscosity.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_interface_viscosity.cpp
@@ -30,10 +30,11 @@ FOUR_C_NAMESPACE_OPEN
  *---------------------------------------------------------------------------*/
 Particle::SPHInterfaceViscosity::SPHInterfaceViscosity(const Teuchos::ParameterList& params)
     : params_sph_(params),
-      liquidtype_(Particle::Phase1),
-      gastype_(Particle::Phase2),
+      liquidtype_(Particle::Type::Phase1),
+      gastype_(Particle::Type::Phase2),
       fluidtypes_({liquidtype_, gastype_}),
-      boundarytypes_({Particle::BoundaryPhase, Particle::RigidPhase, Particle::PDPhase}),
+      boundarytypes_(
+          {Particle::Type::BoundaryPhase, Particle::Type::RigidPhase, Particle::Type::PDPhase}),
       artvisc_lg_int_(params_sph_.get<double>("INTERFACE_VISCOSITY_LIQUIDGAS")),
       artvisc_sl_int_(params_sph_.get<double>("INTERFACE_VISCOSITY_SOLIDLIQUID")),
       trans_ref_temp_(params_sph_.get<double>("TRANS_REF_TEMPERATURE")),
@@ -86,7 +87,8 @@ void Particle::SPHInterfaceViscosity::setup(
       boundarytypes_.erase(type_i);
 
   // determine size of vectors indexed by particle types
-  const int typevectorsize = *(--particlecontainerbundle_->get_particle_types().end()) + 1;
+  const int typevectorsize =
+      static_cast<int>(*(--particlecontainerbundle_->get_particle_types().end())) + 1;
 
   // allocate memory to hold particle types
   fluidmaterial_.resize(typevectorsize);
@@ -94,8 +96,9 @@ void Particle::SPHInterfaceViscosity::setup(
   // iterate over all fluid particle types
   for (const auto& type_i : fluidtypes_)
   {
-    fluidmaterial_[type_i] = dynamic_cast<const Mat::PAR::ParticleMaterialSPHFluid*>(
-        particlematerial.get_ptr_to_particle_mat_parameter(type_i));
+    fluidmaterial_[static_cast<int>(type_i)] =
+        dynamic_cast<const Mat::PAR::ParticleMaterialSPHFluid*>(
+            particlematerial.get_ptr_to_particle_mat_parameter(type_i));
   }
 }
 
@@ -127,12 +130,12 @@ void Particle::SPHInterfaceViscosity::compute_interface_viscosity_particle_contr
         neighborpairs_->get_ref_to_particle_pair_data()[particlepairindex];
 
     // access values of local index tuples of particle i and j
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
-    Particle::TypeEnum type_j;
+    Particle::Type type_j;
     Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
@@ -145,8 +148,8 @@ void Particle::SPHInterfaceViscosity::compute_interface_viscosity_particle_contr
         particlecontainerbundle_->get_specific_container(type_j, status_j);
 
     // get material for particle types
-    const Mat::PAR::ParticleMaterialSPHFluid* material_i = fluidmaterial_[type_i];
-    const Mat::PAR::ParticleMaterialSPHFluid* material_j = fluidmaterial_[type_j];
+    const Mat::PAR::ParticleMaterialSPHFluid* material_i = fluidmaterial_[static_cast<int>(type_i)];
+    const Mat::PAR::ParticleMaterialSPHFluid* material_j = fluidmaterial_[static_cast<int>(type_j)];
 
     // get pointer to particle states
     const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
@@ -225,12 +228,12 @@ void Particle::SPHInterfaceViscosity::compute_interface_viscosity_particle_bound
         neighborpairs_->get_ref_to_particle_pair_data()[particlepairindex];
 
     // access values of local index tuples of particle i and j
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
-    Particle::TypeEnum type_j;
+    Particle::Type type_j;
     Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
@@ -262,7 +265,7 @@ void Particle::SPHInterfaceViscosity::compute_interface_viscosity_particle_bound
         particlecontainerbundle_->get_specific_container(type_j, status_j);
 
     // get material for particle types
-    const Mat::PAR::ParticleMaterialSPHFluid* material_i = fluidmaterial_[type_i];
+    const Mat::PAR::ParticleMaterialSPHFluid* material_i = fluidmaterial_[static_cast<int>(type_i)];
 
     // get equation of state for particle types
     const Particle::SPHEquationOfStateBase* equationofstate_i =

--- a/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_interface_viscosity.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_interface_viscosity.cpp
@@ -152,21 +152,27 @@ void Particle::SPHInterfaceViscosity::compute_interface_viscosity_particle_contr
     const Mat::PAR::ParticleMaterialSPHFluid* material_j = fluidmaterial_[static_cast<int>(type_j)];
 
     // get pointer to particle states
-    const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
-    const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
-    const double* dens_i = container_i->get_ptr_to_state(Particle::Density, particle_i);
-    const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
-    const double* cfg_i = container_i->get_ptr_to_state(Particle::ColorfieldGradient, particle_i);
-    const double* temp_i = container_i->try_get_ptr_to_state(Particle::Temperature, particle_i);
-    double* acc_i = container_i->get_ptr_to_state_writable(Particle::Acceleration, particle_i);
+    const double* rad_i = container_i->get_ptr_to_state(Particle::State::Radius, particle_i);
+    const double* mass_i = container_i->get_ptr_to_state(Particle::State::Mass, particle_i);
+    const double* dens_i = container_i->get_ptr_to_state(Particle::State::Density, particle_i);
+    const double* vel_i = container_i->get_ptr_to_state(Particle::State::Velocity, particle_i);
+    const double* cfg_i =
+        container_i->get_ptr_to_state(Particle::State::ColorfieldGradient, particle_i);
+    const double* temp_i =
+        container_i->try_get_ptr_to_state(Particle::State::Temperature, particle_i);
+    double* acc_i =
+        container_i->get_ptr_to_state_writable(Particle::State::Acceleration, particle_i);
 
-    const double* rad_j = container_j->get_ptr_to_state(Particle::Radius, particle_j);
-    const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
-    const double* dens_j = container_j->get_ptr_to_state(Particle::Density, particle_j);
-    const double* vel_j = container_j->get_ptr_to_state(Particle::Velocity, particle_j);
-    const double* cfg_j = container_j->get_ptr_to_state(Particle::ColorfieldGradient, particle_j);
-    const double* temp_j = container_j->try_get_ptr_to_state(Particle::Temperature, particle_j);
-    double* acc_j = container_j->get_ptr_to_state_writable(Particle::Acceleration, particle_j);
+    const double* rad_j = container_j->get_ptr_to_state(Particle::State::Radius, particle_j);
+    const double* mass_j = container_j->get_ptr_to_state(Particle::State::Mass, particle_j);
+    const double* dens_j = container_j->get_ptr_to_state(Particle::State::Density, particle_j);
+    const double* vel_j = container_j->get_ptr_to_state(Particle::State::Velocity, particle_j);
+    const double* cfg_j =
+        container_j->get_ptr_to_state(Particle::State::ColorfieldGradient, particle_j);
+    const double* temp_j =
+        container_j->try_get_ptr_to_state(Particle::State::Temperature, particle_j);
+    double* acc_j =
+        container_j->get_ptr_to_state_writable(Particle::State::Acceleration, particle_j);
 
     // get smoothing length
     const double h_i = kernel_->smoothing_length(rad_i[0]);
@@ -272,21 +278,25 @@ void Particle::SPHInterfaceViscosity::compute_interface_viscosity_particle_bound
         equationofstatebundle_->get_ptr_to_specific_equation_of_state(type_i);
 
     // get pointer to particle states
-    const double* rad_i = container_i->get_ptr_to_state(Particle::Radius, particle_i);
-    const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
-    const double* dens_i = container_i->get_ptr_to_state(Particle::Density, particle_i);
-    const double* vel_i = container_i->get_ptr_to_state(Particle::Velocity, particle_i);
-    const double* cfg_i = container_i->get_ptr_to_state(Particle::ColorfieldGradient, particle_i);
-    const double* temp_i = container_i->try_get_ptr_to_state(Particle::Temperature, particle_i);
+    const double* rad_i = container_i->get_ptr_to_state(Particle::State::Radius, particle_i);
+    const double* mass_i = container_i->get_ptr_to_state(Particle::State::Mass, particle_i);
+    const double* dens_i = container_i->get_ptr_to_state(Particle::State::Density, particle_i);
+    const double* vel_i = container_i->get_ptr_to_state(Particle::State::Velocity, particle_i);
+    const double* cfg_i =
+        container_i->get_ptr_to_state(Particle::State::ColorfieldGradient, particle_i);
+    const double* temp_i =
+        container_i->try_get_ptr_to_state(Particle::State::Temperature, particle_i);
 
     double* acc_i = nullptr;
     if (status_i == Particle::Status::Owned)
-      acc_i = container_i->get_ptr_to_state_writable(Particle::Acceleration, particle_i);
+      acc_i = container_i->get_ptr_to_state_writable(Particle::State::Acceleration, particle_i);
 
     // get pointer to boundary particle states
-    const double* mass_j = container_i->get_ptr_to_state(Particle::Mass, particle_i);
-    const double* press_j = container_j->get_ptr_to_state(Particle::BoundaryPressure, particle_j);
-    const double* vel_j = container_j->get_ptr_to_state(Particle::BoundaryVelocity, particle_j);
+    const double* mass_j = container_i->get_ptr_to_state(Particle::State::Mass, particle_i);
+    const double* press_j =
+        container_j->get_ptr_to_state(Particle::State::BoundaryPressure, particle_j);
+    const double* vel_j =
+        container_j->get_ptr_to_state(Particle::State::BoundaryVelocity, particle_j);
 
     double temp_dens(0.0);
     temp_dens = equationofstate_i->pressure_to_density(press_j[0], material_i->initDensity_);

--- a/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_interface_viscosity.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_interface_viscosity.hpp
@@ -107,16 +107,16 @@ namespace Particle
     std::vector<const Mat::PAR::ParticleMaterialSPHFluid*> fluidmaterial_;
 
     //! liquid particle type
-    Particle::TypeEnum liquidtype_;
+    Particle::Type liquidtype_;
 
     //! gas particle type
-    Particle::TypeEnum gastype_;
+    Particle::Type gastype_;
 
     //! set of fluid particle types
-    std::set<Particle::TypeEnum> fluidtypes_;
+    std::set<Particle::Type> fluidtypes_;
 
     //! set of boundary particle types
-    std::set<Particle::TypeEnum> boundarytypes_;
+    std::set<Particle::Type> boundarytypes_;
 
     //! artificial viscosity on liquid-gas interface
     const double artvisc_lg_int_;

--- a/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_recoilpressure_evaporation.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_recoilpressure_evaporation.cpp
@@ -48,11 +48,14 @@ void Particle::SPHRecoilPressureEvaporation::compute_recoil_pressure_contributio
   // iterate over particles in container
   for (int particle_i = 0; particle_i < container_i->particles_stored(); ++particle_i)
   {
-    const double* dens_i = container_i->get_ptr_to_state(Particle::Density, particle_i);
-    const double* temp_i = container_i->get_ptr_to_state(Particle::Temperature, particle_i);
-    const double* cfg_i = container_i->get_ptr_to_state(Particle::ColorfieldGradient, particle_i);
-    const double* ifn_i = container_i->get_ptr_to_state(Particle::InterfaceNormal, particle_i);
-    double* acc_i = container_i->get_ptr_to_state_writable(Particle::Acceleration, particle_i);
+    const double* dens_i = container_i->get_ptr_to_state(Particle::State::Density, particle_i);
+    const double* temp_i = container_i->get_ptr_to_state(Particle::State::Temperature, particle_i);
+    const double* cfg_i =
+        container_i->get_ptr_to_state(Particle::State::ColorfieldGradient, particle_i);
+    const double* ifn_i =
+        container_i->get_ptr_to_state(Particle::State::InterfaceNormal, particle_i);
+    double* acc_i =
+        container_i->get_ptr_to_state_writable(Particle::State::Acceleration, particle_i);
 
     // evaluation only for non-zero interface normal
     if (not(ParticleUtils::vec_norm_two(ifn_i) > 0.0)) continue;

--- a/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_recoilpressure_evaporation.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_recoilpressure_evaporation.cpp
@@ -21,7 +21,7 @@ FOUR_C_NAMESPACE_OPEN
 Particle::SPHRecoilPressureEvaporation::SPHRecoilPressureEvaporation(
     const Teuchos::ParameterList& params)
     : params_sph_(params),
-      evaporatingphase_(Particle::Phase1),
+      evaporatingphase_(Particle::Type::Phase1),
       recoilboilingtemp_(params_sph_.get<double>("VAPOR_RECOIL_BOILINGTEMPERATURE")),
       recoil_pfac_(params_sph_.get<double>("VAPOR_RECOIL_PFAC")),
       recoil_tfac_(params_sph_.get<double>("VAPOR_RECOIL_TFAC"))

--- a/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_recoilpressure_evaporation.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_recoilpressure_evaporation.cpp
@@ -43,7 +43,7 @@ void Particle::SPHRecoilPressureEvaporation::compute_recoil_pressure_contributio
 {
   // get container of owned particles of evaporating phase
   Particle::ParticleContainer* container_i =
-      particlecontainerbundle_->get_specific_container(evaporatingphase_, Particle::Owned);
+      particlecontainerbundle_->get_specific_container(evaporatingphase_, Particle::Status::Owned);
 
   // iterate over particles in container
   for (int particle_i = 0; particle_i < container_i->particles_stored(); ++particle_i)

--- a/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_recoilpressure_evaporation.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_surface_tension_recoilpressure_evaporation.hpp
@@ -57,7 +57,7 @@ namespace Particle
     Particle::ParticleContainerBundleShrdPtr particlecontainerbundle_;
 
     //! evaporating phase
-    Particle::TypeEnum evaporatingphase_;
+    Particle::Type evaporatingphase_;
 
     //! boiling temperature in recoil pressure formula
     double recoilboilingtemp_;

--- a/src/particle/src/interaction/4C_particle_interaction_sph_temperature.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_temperature.cpp
@@ -32,7 +32,7 @@ Particle::SPHTemperature::SPHTemperature(const Teuchos::ParameterList& params)
       time_(0.0),
       dt_(0.0),
       temperaturegradient_(params_sph_.get<bool>("TEMPERATUREGRADIENT")),
-      intthermotypes_({Particle::Phase1, Particle::Phase2, Particle::RigidPhase})
+      intthermotypes_({Particle::Type::Phase1, Particle::Type::Phase2, Particle::Type::RigidPhase})
 {
   init_heat_source_handler();
 
@@ -74,7 +74,8 @@ void Particle::SPHTemperature::setup(
   }
 
   // determine size of vectors indexed by particle types
-  const int typevectorsize = *(--particlecontainerbundle_->get_particle_types().end()) + 1;
+  const int typevectorsize =
+      static_cast<int>(*(--particlecontainerbundle_->get_particle_types().end())) + 1;
 
   // allocate memory to hold particle types
   thermomaterial_.resize(typevectorsize);
@@ -82,11 +83,12 @@ void Particle::SPHTemperature::setup(
   // iterate over particle types
   for (const auto& type_i : particlecontainerbundle_->get_particle_types())
   {
-    thermomaterial_[type_i] = dynamic_cast<const Mat::PAR::ParticleMaterialThermo*>(
-        particlematerial_->get_ptr_to_particle_mat_parameter(type_i));
+    thermomaterial_[static_cast<int>(type_i)] =
+        dynamic_cast<const Mat::PAR::ParticleMaterialThermo*>(
+            particlematerial_->get_ptr_to_particle_mat_parameter(type_i));
 
     // safety check
-    if (not(thermomaterial_[type_i]->thermalCapacity_ > 0.0))
+    if (not(thermomaterial_[static_cast<int>(type_i)]->thermalCapacity_ > 0.0))
       FOUR_C_THROW("thermal capacity for particles of type '{}' not positive!",
           Particle::enum_to_type_name(type_i));
   }
@@ -106,13 +108,13 @@ void Particle::SPHTemperature::set_current_step_size(const double currentstepsiz
 }
 
 void Particle::SPHTemperature::insert_particle_states_of_particle_types(
-    std::map<Particle::TypeEnum, std::set<Particle::StateEnum>>& particlestatestotypes) const
+    std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const
 {
   // iterate over particle types
   for (auto& typeIt : particlestatestotypes)
   {
     // get type of particles
-    Particle::TypeEnum type = typeIt.first;
+    Particle::Type type = typeIt.first;
 
     // set of particle states for current particle type
     std::set<Particle::StateEnum>& particlestates = typeIt.second;
@@ -213,12 +215,12 @@ void Particle::SPHTemperature::energy_equation() const
   for (auto& particlepair : neighborpairs_->get_ref_to_particle_pair_data())
   {
     // access values of local index tuples of particle i and j
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
-    Particle::TypeEnum type_j;
+    Particle::Type type_j;
     Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
@@ -236,8 +238,10 @@ void Particle::SPHTemperature::energy_equation() const
     const Mat::PAR::ParticleMaterialBase* basematerial_j =
         particlematerial_->get_ptr_to_particle_mat_parameter(type_j);
 
-    const Mat::PAR::ParticleMaterialThermo* thermomaterial_i = thermomaterial_[type_i];
-    const Mat::PAR::ParticleMaterialThermo* thermomaterial_j = thermomaterial_[type_j];
+    const Mat::PAR::ParticleMaterialThermo* thermomaterial_i =
+        thermomaterial_[static_cast<int>(type_i)];
+    const Mat::PAR::ParticleMaterialThermo* thermomaterial_j =
+        thermomaterial_[static_cast<int>(type_j)];
 
     // get pointer to particle states
     const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
@@ -300,12 +304,12 @@ void Particle::SPHTemperature::temperature_gradient() const
   for (auto& particlepair : neighborpairs_->get_ref_to_particle_pair_data())
   {
     // access values of local index tuples of particle i and j
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
-    Particle::TypeEnum type_j;
+    Particle::Type type_j;
     Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;

--- a/src/particle/src/interaction/4C_particle_interaction_sph_temperature.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_temperature.cpp
@@ -149,7 +149,7 @@ void Particle::SPHTemperature::compute_temperature() const
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container_i =
-        particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // update temperature of all particles
     container_i->update_state(1.0, Particle::Temperature, dt_, Particle::TemperatureDot);
@@ -203,7 +203,7 @@ void Particle::SPHTemperature::energy_equation() const
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container_i =
-        particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // clear temperature dot state
     container_i->clear_state(Particle::TemperatureDot);
@@ -214,12 +214,12 @@ void Particle::SPHTemperature::energy_equation() const
   {
     // access values of local index tuples of particle i and j
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
     Particle::TypeEnum type_j;
-    Particle::StatusEnum status_j;
+    Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
 
@@ -258,7 +258,7 @@ void Particle::SPHTemperature::energy_equation() const
 
     const double* temp_j = container_j->get_ptr_to_state(Particle::Temperature, particle_j);
     double* tempdot_j = nullptr;
-    if (status_j == Particle::Owned)
+    if (status_j == Particle::Status::Owned)
       tempdot_j = container_j->try_get_ptr_to_state_writable(Particle::TemperatureDot, particle_j);
 
     // thermal conductivities
@@ -290,7 +290,7 @@ void Particle::SPHTemperature::temperature_gradient() const
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container_i =
-        particlecontainerbundle_->get_specific_container(type_i, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // clear temperature gradient state
     container_i->clear_state(Particle::temperature_gradient);
@@ -301,12 +301,12 @@ void Particle::SPHTemperature::temperature_gradient() const
   {
     // access values of local index tuples of particle i and j
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlepair.tuple_i_;
 
     Particle::TypeEnum type_j;
-    Particle::StatusEnum status_j;
+    Particle::Status status_j;
     int particle_j;
     std::tie(type_j, status_j, particle_j) = particlepair.tuple_j_;
 
@@ -342,7 +342,7 @@ void Particle::SPHTemperature::temperature_gradient() const
 
     const double* temp_j = container_j->get_ptr_to_state(Particle::Temperature, particle_j);
     double* tempgrad_j = nullptr;
-    if (status_j == Particle::Owned)
+    if (status_j == Particle::Status::Owned)
       tempgrad_j =
           container_j->try_get_ptr_to_state_writable(Particle::temperature_gradient, particle_j);
 

--- a/src/particle/src/interaction/4C_particle_interaction_sph_temperature.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_temperature.cpp
@@ -67,7 +67,7 @@ void Particle::SPHTemperature::setup(
 
   // setup temperature of ghosted particles to refresh
   {
-    std::vector<Particle::StateEnum> states{Particle::Temperature};
+    std::vector<Particle::State> states{Particle::State::Temperature};
 
     for (const auto& type_i : intthermotypes_)
       temptorefresh_.push_back(std::make_pair(type_i, states));
@@ -108,7 +108,7 @@ void Particle::SPHTemperature::set_current_step_size(const double currentstepsiz
 }
 
 void Particle::SPHTemperature::insert_particle_states_of_particle_types(
-    std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const
+    std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes) const
 {
   // iterate over particle types
   for (auto& typeIt : particlestatestotypes)
@@ -117,19 +117,19 @@ void Particle::SPHTemperature::insert_particle_states_of_particle_types(
     Particle::Type type = typeIt.first;
 
     // set of particle states for current particle type
-    std::set<Particle::StateEnum>& particlestates = typeIt.second;
+    std::set<Particle::State>& particlestates = typeIt.second;
 
     // set temperature state
-    particlestates.insert(Particle::Temperature);
+    particlestates.insert(Particle::State::Temperature);
 
     // current particle type is not an integrated thermo particle type
     if (not intthermotypes_.contains(type)) continue;
 
     // state for temperature evaluation scheme
-    particlestates.insert(Particle::TemperatureDot);
+    particlestates.insert(Particle::State::TemperatureDot);
 
     // state for temperature gradient evaluation
-    if (temperaturegradient_) particlestates.insert(Particle::temperature_gradient);
+    if (temperaturegradient_) particlestates.insert(Particle::State::temperature_gradient);
   }
 }
 
@@ -154,7 +154,8 @@ void Particle::SPHTemperature::compute_temperature() const
         particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // update temperature of all particles
-    container_i->update_state(1.0, Particle::Temperature, dt_, Particle::TemperatureDot);
+    container_i->update_state(
+        1.0, Particle::State::Temperature, dt_, Particle::State::TemperatureDot);
   }
 
   // refresh temperature of ghosted particles
@@ -208,7 +209,7 @@ void Particle::SPHTemperature::energy_equation() const
         particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // clear temperature dot state
-    container_i->clear_state(Particle::TemperatureDot);
+    container_i->clear_state(Particle::State::TemperatureDot);
   }
 
   // iterate over particle pairs
@@ -244,26 +245,27 @@ void Particle::SPHTemperature::energy_equation() const
         thermomaterial_[static_cast<int>(type_j)];
 
     // get pointer to particle states
-    const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
+    const double* mass_i = container_i->get_ptr_to_state(Particle::State::Mass, particle_i);
 
-    const double* dens_i = (container_i->have_stored_state(Particle::Density))
-                               ? container_i->get_ptr_to_state(Particle::Density, particle_i)
+    const double* dens_i = (container_i->have_stored_state(Particle::State::Density))
+                               ? container_i->get_ptr_to_state(Particle::State::Density, particle_i)
                                : &(basematerial_i->initDensity_);
 
-    const double* temp_i = container_i->get_ptr_to_state(Particle::Temperature, particle_i);
+    const double* temp_i = container_i->get_ptr_to_state(Particle::State::Temperature, particle_i);
     double* tempdot_i =
-        container_i->try_get_ptr_to_state_writable(Particle::TemperatureDot, particle_i);
+        container_i->try_get_ptr_to_state_writable(Particle::State::TemperatureDot, particle_i);
 
-    const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
+    const double* mass_j = container_j->get_ptr_to_state(Particle::State::Mass, particle_j);
 
-    const double* dens_j = (container_j->have_stored_state(Particle::Density))
-                               ? container_j->get_ptr_to_state(Particle::Density, particle_j)
+    const double* dens_j = (container_j->have_stored_state(Particle::State::Density))
+                               ? container_j->get_ptr_to_state(Particle::State::Density, particle_j)
                                : &(basematerial_j->initDensity_);
 
-    const double* temp_j = container_j->get_ptr_to_state(Particle::Temperature, particle_j);
+    const double* temp_j = container_j->get_ptr_to_state(Particle::State::Temperature, particle_j);
     double* tempdot_j = nullptr;
     if (status_j == Particle::Status::Owned)
-      tempdot_j = container_j->try_get_ptr_to_state_writable(Particle::TemperatureDot, particle_j);
+      tempdot_j =
+          container_j->try_get_ptr_to_state_writable(Particle::State::TemperatureDot, particle_j);
 
     // thermal conductivities
     const double& k_i = thermomaterial_i->thermalConductivity_;
@@ -297,7 +299,7 @@ void Particle::SPHTemperature::temperature_gradient() const
         particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // clear temperature gradient state
-    container_i->clear_state(Particle::temperature_gradient);
+    container_i->clear_state(Particle::State::temperature_gradient);
   }
 
   // iterate over particle pairs
@@ -328,27 +330,27 @@ void Particle::SPHTemperature::temperature_gradient() const
         particlematerial_->get_ptr_to_particle_mat_parameter(type_j);
 
     // get pointer to particle states
-    const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
+    const double* mass_i = container_i->get_ptr_to_state(Particle::State::Mass, particle_i);
 
-    const double* dens_i = (container_i->have_stored_state(Particle::Density))
-                               ? container_i->get_ptr_to_state(Particle::Density, particle_i)
+    const double* dens_i = (container_i->have_stored_state(Particle::State::Density))
+                               ? container_i->get_ptr_to_state(Particle::State::Density, particle_i)
                                : &(basematerial_i->initDensity_);
 
-    const double* temp_i = container_i->get_ptr_to_state(Particle::Temperature, particle_i);
-    double* tempgrad_i =
-        container_i->try_get_ptr_to_state_writable(Particle::temperature_gradient, particle_i);
+    const double* temp_i = container_i->get_ptr_to_state(Particle::State::Temperature, particle_i);
+    double* tempgrad_i = container_i->try_get_ptr_to_state_writable(
+        Particle::State::temperature_gradient, particle_i);
 
-    const double* mass_j = container_j->get_ptr_to_state(Particle::Mass, particle_j);
+    const double* mass_j = container_j->get_ptr_to_state(Particle::State::Mass, particle_j);
 
-    const double* dens_j = (container_j->have_stored_state(Particle::Density))
-                               ? container_j->get_ptr_to_state(Particle::Density, particle_j)
+    const double* dens_j = (container_j->have_stored_state(Particle::State::Density))
+                               ? container_j->get_ptr_to_state(Particle::State::Density, particle_j)
                                : &(basematerial_j->initDensity_);
 
-    const double* temp_j = container_j->get_ptr_to_state(Particle::Temperature, particle_j);
+    const double* temp_j = container_j->get_ptr_to_state(Particle::State::Temperature, particle_j);
     double* tempgrad_j = nullptr;
     if (status_j == Particle::Status::Owned)
-      tempgrad_j =
-          container_j->try_get_ptr_to_state_writable(Particle::temperature_gradient, particle_j);
+      tempgrad_j = container_j->try_get_ptr_to_state_writable(
+          Particle::State::temperature_gradient, particle_j);
 
     const double temp_ji = temp_j[0] - temp_i[0];
 

--- a/src/particle/src/interaction/4C_particle_interaction_sph_temperature.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_temperature.cpp
@@ -129,7 +129,7 @@ void Particle::SPHTemperature::insert_particle_states_of_particle_types(
     particlestates.insert(Particle::State::TemperatureDot);
 
     // state for temperature gradient evaluation
-    if (temperaturegradient_) particlestates.insert(Particle::State::temperature_gradient);
+    if (temperaturegradient_) particlestates.insert(Particle::State::TemperatureGradient);
   }
 }
 
@@ -299,7 +299,7 @@ void Particle::SPHTemperature::temperature_gradient() const
         particlecontainerbundle_->get_specific_container(type_i, Particle::Status::Owned);
 
     // clear temperature gradient state
-    container_i->clear_state(Particle::State::temperature_gradient);
+    container_i->clear_state(Particle::State::TemperatureGradient);
   }
 
   // iterate over particle pairs
@@ -338,7 +338,7 @@ void Particle::SPHTemperature::temperature_gradient() const
 
     const double* temp_i = container_i->get_ptr_to_state(Particle::State::Temperature, particle_i);
     double* tempgrad_i = container_i->try_get_ptr_to_state_writable(
-        Particle::State::temperature_gradient, particle_i);
+        Particle::State::TemperatureGradient, particle_i);
 
     const double* mass_j = container_j->get_ptr_to_state(Particle::State::Mass, particle_j);
 
@@ -350,7 +350,7 @@ void Particle::SPHTemperature::temperature_gradient() const
     double* tempgrad_j = nullptr;
     if (status_j == Particle::Status::Owned)
       tempgrad_j = container_j->try_get_ptr_to_state_writable(
-          Particle::State::temperature_gradient, particle_j);
+          Particle::State::TemperatureGradient, particle_j);
 
     const double temp_ji = temp_j[0] - temp_i[0];
 

--- a/src/particle/src/interaction/4C_particle_interaction_sph_temperature.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_temperature.hpp
@@ -74,7 +74,7 @@ namespace Particle
 
     //! insert temperature evaluation dependent states
     void insert_particle_states_of_particle_types(
-        std::map<Particle::TypeEnum, std::set<Particle::StateEnum>>& particlestatestotypes) const;
+        std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const;
 
     //! compute temperature field using energy equation
     void compute_temperature() const;
@@ -126,7 +126,7 @@ namespace Particle
     std::vector<const Mat::PAR::ParticleMaterialThermo*> thermomaterial_;
 
     //! set of integrated thermo particle types
-    std::set<Particle::TypeEnum> intthermotypes_;
+    std::set<Particle::Type> intthermotypes_;
   };
 
 }  // namespace Particle

--- a/src/particle/src/interaction/4C_particle_interaction_sph_temperature.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_temperature.hpp
@@ -74,7 +74,7 @@ namespace Particle
 
     //! insert temperature evaluation dependent states
     void insert_particle_states_of_particle_types(
-        std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const;
+        std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes) const;
 
     //! compute temperature field using energy equation
     void compute_temperature() const;

--- a/src/particle/src/interaction/4C_particle_interaction_sph_virtual_wall_particle.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_virtual_wall_particle.cpp
@@ -155,7 +155,7 @@ void Particle::SPHVirtualWallParticle::init_states_at_wall_contact_points(
 
     // access values of local index tuple of particle i
     Particle::TypeEnum type_i;
-    Particle::StatusEnum status_i;
+    Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlewallpair.tuple_i_;
 
@@ -236,7 +236,7 @@ void Particle::SPHVirtualWallParticle::init_states_at_wall_contact_points(
     {
       // access values of local index tuple of particle k
       Particle::TypeEnum type_k;
-      Particle::StatusEnum status_k;
+      Particle::Status status_k;
       int particle_k;
       std::tie(type_k, status_k, particle_k) = neighboringparticle;
 

--- a/src/particle/src/interaction/4C_particle_interaction_sph_virtual_wall_particle.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_virtual_wall_particle.cpp
@@ -29,9 +29,9 @@ FOUR_C_NAMESPACE_OPEN
  *---------------------------------------------------------------------------*/
 Particle::SPHVirtualWallParticle::SPHVirtualWallParticle(const Teuchos::ParameterList& params)
     : params_sph_(params),
-      allfluidtypes_(
-          {Particle::Phase1, Particle::Phase2, Particle::DirichletPhase, Particle::NeumannPhase}),
-      intfluidtypes_({Particle::Phase1, Particle::Phase2, Particle::NeumannPhase})
+      allfluidtypes_({Particle::Type::Phase1, Particle::Type::Phase2,
+          Particle::Type::DirichletPhase, Particle::Type::NeumannPhase}),
+      intfluidtypes_({Particle::Type::Phase1, Particle::Type::Phase2, Particle::Type::NeumannPhase})
 {
   // empty constructor
 }
@@ -154,7 +154,7 @@ void Particle::SPHVirtualWallParticle::init_states_at_wall_contact_points(
     const SPHParticleWallPair& particlewallpair = particlewallpairdata[particlewallpairindex];
 
     // access values of local index tuple of particle i
-    Particle::TypeEnum type_i;
+    Particle::Type type_i;
     Particle::Status status_i;
     int particle_i;
     std::tie(type_i, status_i, particle_i) = particlewallpair.tuple_i_;
@@ -235,7 +235,7 @@ void Particle::SPHVirtualWallParticle::init_states_at_wall_contact_points(
     for (const auto& neighboringparticle : neighboringparticles)
     {
       // access values of local index tuple of particle k
-      Particle::TypeEnum type_k;
+      Particle::Type type_k;
       Particle::Status status_k;
       int particle_k;
       std::tie(type_k, status_k, particle_k) = neighboringparticle;

--- a/src/particle/src/interaction/4C_particle_interaction_sph_virtual_wall_particle.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_virtual_wall_particle.cpp
@@ -164,10 +164,10 @@ void Particle::SPHVirtualWallParticle::init_states_at_wall_contact_points(
         particlecontainerbundle_->get_specific_container(type_i, status_i);
 
     // get pointer to particle states
-    const double* pos_i = container_i->get_ptr_to_state(Particle::Position, particle_i);
+    const double* pos_i = container_i->get_ptr_to_state(Particle::State::Position, particle_i);
 
     // get pointer to wall contact point states
-    const double* rad_j = container_i->get_ptr_to_state(Particle::Radius, particle_i);
+    const double* rad_j = container_i->get_ptr_to_state(Particle::State::Radius, particle_i);
 
     // get pointer to column wall element
     Core::Elements::Element* ele = particlewallpair.ele_;
@@ -248,10 +248,10 @@ void Particle::SPHVirtualWallParticle::init_states_at_wall_contact_points(
           particlecontainerbundle_->get_specific_container(type_k, status_k);
 
       // get pointer to particle states
-      const double* pos_k = container_k->get_ptr_to_state(Particle::Position, particle_k);
-      const double* vel_k = container_k->get_ptr_to_state(Particle::Velocity, particle_k);
-      const double* dens_k = container_k->get_ptr_to_state(Particle::Density, particle_k);
-      const double* press_k = container_k->get_ptr_to_state(Particle::Pressure, particle_k);
+      const double* pos_k = container_k->get_ptr_to_state(Particle::State::Position, particle_k);
+      const double* vel_k = container_k->get_ptr_to_state(Particle::State::Velocity, particle_k);
+      const double* dens_k = container_k->get_ptr_to_state(Particle::State::Density, particle_k);
+      const double* press_k = container_k->get_ptr_to_state(Particle::State::Pressure, particle_k);
 
       // vector from particle k to wall contact point j
       double r_jk[3];

--- a/src/particle/src/interaction/4C_particle_interaction_sph_virtual_wall_particle.hpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_virtual_wall_particle.hpp
@@ -118,10 +118,10 @@ namespace Particle
     std::vector<std::vector<double>> weightedvelocity_;
 
     //! set of all fluid particle types
-    std::set<Particle::TypeEnum> allfluidtypes_;
+    std::set<Particle::Type> allfluidtypes_;
 
     //! set of integrated fluid particle types
-    std::set<Particle::TypeEnum> intfluidtypes_;
+    std::set<Particle::Type> intfluidtypes_;
   };
 
 }  // namespace Particle

--- a/src/particle/src/rigidbody/4C_particle_rigidbody.cpp
+++ b/src/particle/src/rigidbody/4C_particle_rigidbody.cpp
@@ -114,7 +114,7 @@ void Particle::RigidBodyHandler::read_restart(
 }
 
 void Particle::RigidBodyHandler::insert_particle_states_of_particle_types(
-    std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const
+    std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes) const
 {
   // iterate over particle types
   for (auto& typeIt : particlestatestotypes)
@@ -123,13 +123,14 @@ void Particle::RigidBodyHandler::insert_particle_states_of_particle_types(
     Particle::Type type = typeIt.first;
 
     // set of particle states for current particle type
-    std::set<Particle::StateEnum>& particlestates = typeIt.second;
+    std::set<Particle::State>& particlestates = typeIt.second;
 
     if (type == Particle::Type::RigidPhase)
     {
       // insert states of rigid particles
-      particlestates.insert({Particle::RigidBodyColor, Particle::RelativePositionBodyFrame,
-          Particle::RelativePosition, Particle::Inertia, Particle::Force});
+      particlestates.insert(
+          {Particle::State::RigidBodyColor, Particle::State::RelativePositionBodyFrame,
+              Particle::State::RelativePosition, Particle::State::Inertia, Particle::State::Force});
     }
   }
 }
@@ -163,7 +164,7 @@ void Particle::RigidBodyHandler::set_initial_affiliation_pair_data()
 
     // get pointer to particle states
     const double* rigidbodycolor_i =
-        container_i->get_ptr_to_state(Particle::RigidBodyColor, particle_i);
+        container_i->get_ptr_to_state(Particle::State::RigidBodyColor, particle_i);
 
     // get global id of affiliated rigid body k
     const int rigidbody_k = std::round(rigidbodycolor_i[0]);
@@ -784,8 +785,8 @@ void Particle::RigidBodyHandler::compute_partial_mass_quantities()
     double* pos_k = rigidbodydatastate_->get_ref_position()[rigidbody_k].data();
 
     // get pointer to particle states
-    const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
-    const double* pos_i = container_i->get_ptr_to_state(Particle::Position, particle_i);
+    const double* mass_i = container_i->get_ptr_to_state(Particle::State::Mass, particle_i);
+    const double* pos_i = container_i->get_ptr_to_state(Particle::State::Position, particle_i);
 
     // sum contribution of particle i
     mass_k[0] += mass_i[0];
@@ -829,9 +830,9 @@ void Particle::RigidBodyHandler::compute_partial_mass_quantities()
     double* inertia_k = rigidbodydatastate_->get_ref_inertia()[rigidbody_k].data();
 
     // get pointer to particle states
-    const double* mass_i = container_i->get_ptr_to_state(Particle::Mass, particle_i);
-    const double* pos_i = container_i->get_ptr_to_state(Particle::Position, particle_i);
-    const double* inertia_i = container_i->get_ptr_to_state(Particle::Inertia, particle_i);
+    const double* mass_i = container_i->get_ptr_to_state(Particle::State::Mass, particle_i);
+    const double* pos_i = container_i->get_ptr_to_state(Particle::State::Position, particle_i);
+    const double* inertia_i = container_i->get_ptr_to_state(Particle::State::Inertia, particle_i);
 
     double r_ki[3];
     ParticleUtils::vec_set(r_ki, pos_k);
@@ -1031,7 +1032,7 @@ void Particle::RigidBodyHandler::clear_rigid_particle_force()
       Particle::Type::RigidPhase, Particle::Status::Owned);
 
   // clear force of all particles
-  container_i->clear_state(Particle::Force);
+  container_i->clear_state(Particle::State::Force);
 }
 
 void Particle::RigidBodyHandler::compute_partial_force_and_torque()
@@ -1075,8 +1076,9 @@ void Particle::RigidBodyHandler::compute_partial_force_and_torque()
     double* torque_k = rigidbodydatastate_->get_ref_torque()[rigidbody_k].data();
 
     // get pointer to particle states
-    const double* relpos_i = container_i->get_ptr_to_state(Particle::RelativePosition, particle_i);
-    const double* force_i = container_i->get_ptr_to_state(Particle::Force, particle_i);
+    const double* relpos_i =
+        container_i->get_ptr_to_state(Particle::State::RelativePosition, particle_i);
+    const double* force_i = container_i->get_ptr_to_state(Particle::State::Force, particle_i);
 
     // sum contribution of particle i
     ParticleUtils::vec_add(force_k, force_i);
@@ -1477,9 +1479,9 @@ void Particle::RigidBodyHandler::set_rigid_particle_relative_position_in_body_fr
     const double* pos_k = rigidbodydatastate_->get_ref_position()[rigidbody_k].data();
 
     // get pointer to particle states
-    const double* pos_i = container_i->get_ptr_to_state(Particle::Position, particle_i);
-    double* relposbody_i =
-        container_i->get_ptr_to_state_writable(Particle::RelativePositionBodyFrame, particle_i);
+    const double* pos_i = container_i->get_ptr_to_state(Particle::State::Position, particle_i);
+    double* relposbody_i = container_i->get_ptr_to_state_writable(
+        Particle::State::RelativePositionBodyFrame, particle_i);
 
     ParticleUtils::vec_set(relposbody_i, pos_i);
     ParticleUtils::vec_sub(relposbody_i, pos_k);
@@ -1527,9 +1529,9 @@ void Particle::RigidBodyHandler::update_rigid_particle_relative_position()
 
     // get pointer to particle states
     const double* relposbody_i =
-        container_i->get_ptr_to_state(Particle::RelativePositionBodyFrame, particle_i);
+        container_i->get_ptr_to_state(Particle::State::RelativePositionBodyFrame, particle_i);
     double* relpos_i =
-        container_i->get_ptr_to_state_writable(Particle::RelativePosition, particle_i);
+        container_i->get_ptr_to_state_writable(Particle::State::RelativePosition, particle_i);
 
     // update relative position of particle i
     ParticleUtils::quaternion_rotate_vector(relpos_i, rot_k, relposbody_i);
@@ -1576,8 +1578,9 @@ void Particle::RigidBodyHandler::set_rigid_particle_position()
     const double* pos_k = rigidbodydatastate_->get_ref_position()[rigidbody_k].data();
 
     // get pointer to particle states
-    const double* relpos_i = container_i->get_ptr_to_state(Particle::RelativePosition, particle_i);
-    double* pos_i = container_i->get_ptr_to_state_writable(Particle::Position, particle_i);
+    const double* relpos_i =
+        container_i->get_ptr_to_state(Particle::State::RelativePosition, particle_i);
+    double* pos_i = container_i->get_ptr_to_state_writable(Particle::State::Position, particle_i);
 
     // set position of particle i
     ParticleUtils::vec_set(pos_i, pos_k);
@@ -1626,10 +1629,11 @@ void Particle::RigidBodyHandler::set_rigid_particle_velocities()
     const double* angvel_k = rigidbodydatastate_->get_ref_angular_velocity()[rigidbody_k].data();
 
     // get pointer to particle states
-    const double* relpos_i = container_i->get_ptr_to_state(Particle::RelativePosition, particle_i);
-    double* vel_i = container_i->get_ptr_to_state_writable(Particle::Velocity, particle_i);
+    const double* relpos_i =
+        container_i->get_ptr_to_state(Particle::State::RelativePosition, particle_i);
+    double* vel_i = container_i->get_ptr_to_state_writable(Particle::State::Velocity, particle_i);
     double* angvel_i =
-        container_i->try_get_ptr_to_state_writable(Particle::AngularVelocity, particle_i);
+        container_i->try_get_ptr_to_state_writable(Particle::State::AngularVelocity, particle_i);
 
     // set velocities of particle i
     ParticleUtils::vec_set(vel_i, vel_k);
@@ -1681,10 +1685,12 @@ void Particle::RigidBodyHandler::set_rigid_particle_accelerations()
         rigidbodydatastate_->get_ref_angular_acceleration()[rigidbody_k].data();
 
     // get pointer to particle states
-    const double* relpos_i = container_i->get_ptr_to_state(Particle::RelativePosition, particle_i);
-    double* acc_i = container_i->get_ptr_to_state_writable(Particle::Acceleration, particle_i);
-    double* angacc_i =
-        container_i->try_get_ptr_to_state_writable(Particle::AngularAcceleration, particle_i);
+    const double* relpos_i =
+        container_i->get_ptr_to_state(Particle::State::RelativePosition, particle_i);
+    double* acc_i =
+        container_i->get_ptr_to_state_writable(Particle::State::Acceleration, particle_i);
+    double* angacc_i = container_i->try_get_ptr_to_state_writable(
+        Particle::State::AngularAcceleration, particle_i);
 
     // evaluate relative velocity of particle i
     double relvel_i[3];
@@ -1782,9 +1788,9 @@ void Particle::RigidBodyHandler::evaluate_rigid_body_solidification(
       std::tie(std::ignore, std::ignore, particle_i) = *localindextuple;
 
       // get pointer to particle states
-      const double* pos_i = container_i->get_ptr_to_state(Particle::Position, particle_i);
+      const double* pos_i = container_i->get_ptr_to_state(Particle::State::Position, particle_i);
       double* rigidbodycolor_i =
-          container_i->get_ptr_to_state_writable(Particle::RigidBodyColor, particle_i);
+          container_i->get_ptr_to_state_writable(Particle::State::RigidBodyColor, particle_i);
 
       // get particles within radius
       std::vector<Particle::LocalIndexTuple> neighboringparticles;
@@ -1811,9 +1817,9 @@ void Particle::RigidBodyHandler::evaluate_rigid_body_solidification(
             particlecontainerbundle->get_specific_container(type_j, status_j);
 
         // get pointer to particle states
-        const double* pos_j = container_j->get_ptr_to_state(Particle::Position, particle_j);
+        const double* pos_j = container_j->get_ptr_to_state(Particle::State::Position, particle_j);
         const double* rigidbodycolor_j =
-            container_j->get_ptr_to_state(Particle::RigidBodyColor, particle_j);
+            container_j->get_ptr_to_state(Particle::State::RigidBodyColor, particle_j);
 
         // vector from particle i to j
         double r_ji[3];

--- a/src/particle/src/rigidbody/4C_particle_rigidbody.cpp
+++ b/src/particle/src/rigidbody/4C_particle_rigidbody.cpp
@@ -59,9 +59,9 @@ void Particle::RigidBodyHandler::setup(
     Particle::ParticleContainerBundleShrdPtr particlecontainerbundle =
         particleengineinterface_->get_particle_container_bundle();
 
-    if (not particlecontainerbundle->get_particle_types().contains(Particle::RigidPhase))
+    if (not particlecontainerbundle->get_particle_types().contains(Particle::Type::RigidPhase))
       FOUR_C_THROW("no particle container for particle type '{}' found!",
-          Particle::enum_to_type_name(Particle::RigidPhase));
+          Particle::enum_to_type_name(Particle::Type::RigidPhase));
   }
 
   // short screen output
@@ -114,18 +114,18 @@ void Particle::RigidBodyHandler::read_restart(
 }
 
 void Particle::RigidBodyHandler::insert_particle_states_of_particle_types(
-    std::map<Particle::TypeEnum, std::set<Particle::StateEnum>>& particlestatestotypes) const
+    std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const
 {
   // iterate over particle types
   for (auto& typeIt : particlestatestotypes)
   {
     // get type of particles
-    Particle::TypeEnum type = typeIt.first;
+    Particle::Type type = typeIt.first;
 
     // set of particle states for current particle type
     std::set<Particle::StateEnum>& particlestates = typeIt.second;
 
-    if (type == Particle::RigidPhase)
+    if (type == Particle::Type::RigidPhase)
     {
       // insert states of rigid particles
       particlestates.insert({Particle::RigidBodyColor, Particle::RelativePositionBodyFrame,
@@ -153,7 +153,7 @@ void Particle::RigidBodyHandler::set_initial_affiliation_pair_data()
 
   // get container of owned particles of rigid phase
   Particle::ParticleContainer* container_i = particlecontainerbundle->get_specific_container(
-      Particle::RigidPhase, Particle::Status::Owned);
+      Particle::Type::RigidPhase, Particle::Status::Owned);
 
   // loop over particles in container
   for (int particle_i = 0; particle_i < container_i->particles_stored(); ++particle_i)
@@ -379,11 +379,11 @@ bool Particle::RigidBodyHandler::have_rigid_body_phase_change(
   // iterate over particle phase change tuples
   for (const auto& particletypetotype : particlesfromphasetophase)
   {
-    Particle::TypeEnum type_source;
-    Particle::TypeEnum type_target;
+    Particle::Type type_source;
+    Particle::Type type_target;
     std::tie(type_source, type_target, std::ignore) = particletypetotype;
 
-    if (type_source == Particle::RigidPhase or type_target == Particle::RigidPhase)
+    if (type_source == Particle::Type::RigidPhase or type_target == Particle::Type::RigidPhase)
     {
       localhavephasechange = 1;
       break;
@@ -755,7 +755,7 @@ void Particle::RigidBodyHandler::compute_partial_mass_quantities()
 
   // get container of owned particles of rigid phase
   Particle::ParticleContainer* container_i = particlecontainerbundle->get_specific_container(
-      Particle::RigidPhase, Particle::Status::Owned);
+      Particle::Type::RigidPhase, Particle::Status::Owned);
 
 #ifdef FOUR_C_ENABLE_ASSERTIONS
   if (static_cast<int>(affiliationpairdata.size()) != container_i->particles_stored())
@@ -1028,7 +1028,7 @@ void Particle::RigidBodyHandler::clear_rigid_particle_force()
 
   // get container of owned particles of rigid phase
   Particle::ParticleContainer* container_i = particlecontainerbundle->get_specific_container(
-      Particle::RigidPhase, Particle::Status::Owned);
+      Particle::Type::RigidPhase, Particle::Status::Owned);
 
   // clear force of all particles
   container_i->clear_state(Particle::Force);
@@ -1046,7 +1046,7 @@ void Particle::RigidBodyHandler::compute_partial_force_and_torque()
 
   // get container of owned particles of rigid phase
   Particle::ParticleContainer* container_i = particlecontainerbundle->get_specific_container(
-      Particle::RigidPhase, Particle::Status::Owned);
+      Particle::Type::RigidPhase, Particle::Status::Owned);
 
 #ifdef FOUR_C_ENABLE_ASSERTIONS
   if (static_cast<int>(affiliationpairdata.size()) != container_i->particles_stored())
@@ -1449,7 +1449,7 @@ void Particle::RigidBodyHandler::set_rigid_particle_relative_position_in_body_fr
 
   // get container of owned particles of rigid phase
   Particle::ParticleContainer* container_i = particlecontainerbundle->get_specific_container(
-      Particle::RigidPhase, Particle::Status::Owned);
+      Particle::Type::RigidPhase, Particle::Status::Owned);
 
 #ifdef FOUR_C_ENABLE_ASSERTIONS
   if (static_cast<int>(affiliationpairdata.size()) != container_i->particles_stored())
@@ -1498,7 +1498,7 @@ void Particle::RigidBodyHandler::update_rigid_particle_relative_position()
 
   // get container of owned particles of rigid phase
   Particle::ParticleContainer* container_i = particlecontainerbundle->get_specific_container(
-      Particle::RigidPhase, Particle::Status::Owned);
+      Particle::Type::RigidPhase, Particle::Status::Owned);
 
 #ifdef FOUR_C_ENABLE_ASSERTIONS
   if (static_cast<int>(affiliationpairdata.size()) != container_i->particles_stored())
@@ -1548,7 +1548,7 @@ void Particle::RigidBodyHandler::set_rigid_particle_position()
 
   // get container of owned particles of rigid phase
   Particle::ParticleContainer* container_i = particlecontainerbundle->get_specific_container(
-      Particle::RigidPhase, Particle::Status::Owned);
+      Particle::Type::RigidPhase, Particle::Status::Owned);
 
 #ifdef FOUR_C_ENABLE_ASSERTIONS
   if (static_cast<int>(affiliationpairdata.size()) != container_i->particles_stored())
@@ -1597,7 +1597,7 @@ void Particle::RigidBodyHandler::set_rigid_particle_velocities()
 
   // get container of owned particles of rigid phase
   Particle::ParticleContainer* container_i = particlecontainerbundle->get_specific_container(
-      Particle::RigidPhase, Particle::Status::Owned);
+      Particle::Type::RigidPhase, Particle::Status::Owned);
 
 #ifdef FOUR_C_ENABLE_ASSERTIONS
   if (static_cast<int>(affiliationpairdata.size()) != container_i->particles_stored())
@@ -1650,7 +1650,7 @@ void Particle::RigidBodyHandler::set_rigid_particle_accelerations()
 
   // get container of owned particles of rigid phase
   Particle::ParticleContainer* container_i = particlecontainerbundle->get_specific_container(
-      Particle::RigidPhase, Particle::Status::Owned);
+      Particle::Type::RigidPhase, Particle::Status::Owned);
 
 #ifdef FOUR_C_ENABLE_ASSERTIONS
   if (static_cast<int>(affiliationpairdata.size()) != container_i->particles_stored())
@@ -1708,11 +1708,11 @@ void Particle::RigidBodyHandler::evaluate_rigid_body_melting(
   // iterate over particle phase change tuples
   for (const auto& particletypetotype : particlesfromphasetophase)
   {
-    Particle::TypeEnum type_source;
+    Particle::Type type_source;
     int globalid_i;
     std::tie(type_source, std::ignore, globalid_i) = particletypetotype;
 
-    if (type_source == Particle::RigidPhase)
+    if (type_source == Particle::Type::RigidPhase)
     {
       auto it = affiliationpairdata.find(globalid_i);
 
@@ -1745,16 +1745,16 @@ void Particle::RigidBodyHandler::evaluate_rigid_body_solidification(
 
   // get container of owned particles of rigid phase
   Particle::ParticleContainer* container_i = particlecontainerbundle->get_specific_container(
-      Particle::RigidPhase, Particle::Status::Owned);
+      Particle::Type::RigidPhase, Particle::Status::Owned);
 
   // iterate over particle phase change tuples
   for (const auto& particletypetotype : particlesfromphasetophase)
   {
-    Particle::TypeEnum type_target;
+    Particle::Type type_target;
     int globalid_i;
     std::tie(std::ignore, type_target, globalid_i) = particletypetotype;
 
-    if (type_target == Particle::RigidPhase)
+    if (type_target == Particle::Type::RigidPhase)
     {
       // get local index in specific particle container
       Particle::LocalIndexTupleShrdPtr localindextuple =
@@ -1765,13 +1765,13 @@ void Particle::RigidBodyHandler::evaluate_rigid_body_solidification(
         FOUR_C_THROW("particle with global id {} not found on this processor!", globalid_i);
 
       // access values of local index tuples of particle i
-      Particle::TypeEnum type_i;
+      Particle::Type type_i;
       Particle::Status status_i;
       std::tie(type_i, status_i, std::ignore) = *localindextuple;
 
-      if (type_i != Particle::RigidPhase)
+      if (type_i != Particle::Type::RigidPhase)
         FOUR_C_THROW("particle with global id {} not of particle type '{}'!", globalid_i,
-            Particle::enum_to_type_name(Particle::RigidPhase));
+            Particle::enum_to_type_name(Particle::Type::RigidPhase));
 
       if (status_i == Particle::Status::Ghosted)
         FOUR_C_THROW("particle with global id {} not owned on this processor!", globalid_i);
@@ -1798,13 +1798,13 @@ void Particle::RigidBodyHandler::evaluate_rigid_body_solidification(
       for (const auto& neighboringparticle : neighboringparticles)
       {
         // access values of local index tuple of particle j
-        Particle::TypeEnum type_j;
+        Particle::Type type_j;
         Particle::Status status_j;
         int particle_j;
         std::tie(type_j, status_j, particle_j) = neighboringparticle;
 
         // evaluation only for rigid particles
-        if (type_j != Particle::RigidPhase) continue;
+        if (type_j != Particle::Type::RigidPhase) continue;
 
         // get container of particles of current particle type
         Particle::ParticleContainer* container_j =

--- a/src/particle/src/rigidbody/4C_particle_rigidbody.cpp
+++ b/src/particle/src/rigidbody/4C_particle_rigidbody.cpp
@@ -152,8 +152,8 @@ void Particle::RigidBodyHandler::set_initial_affiliation_pair_data()
       particleengineinterface_->get_particle_container_bundle();
 
   // get container of owned particles of rigid phase
-  Particle::ParticleContainer* container_i =
-      particlecontainerbundle->get_specific_container(Particle::RigidPhase, Particle::Owned);
+  Particle::ParticleContainer* container_i = particlecontainerbundle->get_specific_container(
+      Particle::RigidPhase, Particle::Status::Owned);
 
   // loop over particles in container
   for (int particle_i = 0; particle_i < container_i->particles_stored(); ++particle_i)
@@ -754,8 +754,8 @@ void Particle::RigidBodyHandler::compute_partial_mass_quantities()
       particleengineinterface_->get_particle_container_bundle();
 
   // get container of owned particles of rigid phase
-  Particle::ParticleContainer* container_i =
-      particlecontainerbundle->get_specific_container(Particle::RigidPhase, Particle::Owned);
+  Particle::ParticleContainer* container_i = particlecontainerbundle->get_specific_container(
+      Particle::RigidPhase, Particle::Status::Owned);
 
 #ifdef FOUR_C_ENABLE_ASSERTIONS
   if (static_cast<int>(affiliationpairdata.size()) != container_i->particles_stored())
@@ -1027,8 +1027,8 @@ void Particle::RigidBodyHandler::clear_rigid_particle_force()
       particleengineinterface_->get_particle_container_bundle();
 
   // get container of owned particles of rigid phase
-  Particle::ParticleContainer* container_i =
-      particlecontainerbundle->get_specific_container(Particle::RigidPhase, Particle::Owned);
+  Particle::ParticleContainer* container_i = particlecontainerbundle->get_specific_container(
+      Particle::RigidPhase, Particle::Status::Owned);
 
   // clear force of all particles
   container_i->clear_state(Particle::Force);
@@ -1045,8 +1045,8 @@ void Particle::RigidBodyHandler::compute_partial_force_and_torque()
       particleengineinterface_->get_particle_container_bundle();
 
   // get container of owned particles of rigid phase
-  Particle::ParticleContainer* container_i =
-      particlecontainerbundle->get_specific_container(Particle::RigidPhase, Particle::Owned);
+  Particle::ParticleContainer* container_i = particlecontainerbundle->get_specific_container(
+      Particle::RigidPhase, Particle::Status::Owned);
 
 #ifdef FOUR_C_ENABLE_ASSERTIONS
   if (static_cast<int>(affiliationpairdata.size()) != container_i->particles_stored())
@@ -1448,8 +1448,8 @@ void Particle::RigidBodyHandler::set_rigid_particle_relative_position_in_body_fr
       particleengineinterface_->get_particle_container_bundle();
 
   // get container of owned particles of rigid phase
-  Particle::ParticleContainer* container_i =
-      particlecontainerbundle->get_specific_container(Particle::RigidPhase, Particle::Owned);
+  Particle::ParticleContainer* container_i = particlecontainerbundle->get_specific_container(
+      Particle::RigidPhase, Particle::Status::Owned);
 
 #ifdef FOUR_C_ENABLE_ASSERTIONS
   if (static_cast<int>(affiliationpairdata.size()) != container_i->particles_stored())
@@ -1497,8 +1497,8 @@ void Particle::RigidBodyHandler::update_rigid_particle_relative_position()
       particleengineinterface_->get_particle_container_bundle();
 
   // get container of owned particles of rigid phase
-  Particle::ParticleContainer* container_i =
-      particlecontainerbundle->get_specific_container(Particle::RigidPhase, Particle::Owned);
+  Particle::ParticleContainer* container_i = particlecontainerbundle->get_specific_container(
+      Particle::RigidPhase, Particle::Status::Owned);
 
 #ifdef FOUR_C_ENABLE_ASSERTIONS
   if (static_cast<int>(affiliationpairdata.size()) != container_i->particles_stored())
@@ -1547,8 +1547,8 @@ void Particle::RigidBodyHandler::set_rigid_particle_position()
       particleengineinterface_->get_particle_container_bundle();
 
   // get container of owned particles of rigid phase
-  Particle::ParticleContainer* container_i =
-      particlecontainerbundle->get_specific_container(Particle::RigidPhase, Particle::Owned);
+  Particle::ParticleContainer* container_i = particlecontainerbundle->get_specific_container(
+      Particle::RigidPhase, Particle::Status::Owned);
 
 #ifdef FOUR_C_ENABLE_ASSERTIONS
   if (static_cast<int>(affiliationpairdata.size()) != container_i->particles_stored())
@@ -1596,8 +1596,8 @@ void Particle::RigidBodyHandler::set_rigid_particle_velocities()
       particleengineinterface_->get_particle_container_bundle();
 
   // get container of owned particles of rigid phase
-  Particle::ParticleContainer* container_i =
-      particlecontainerbundle->get_specific_container(Particle::RigidPhase, Particle::Owned);
+  Particle::ParticleContainer* container_i = particlecontainerbundle->get_specific_container(
+      Particle::RigidPhase, Particle::Status::Owned);
 
 #ifdef FOUR_C_ENABLE_ASSERTIONS
   if (static_cast<int>(affiliationpairdata.size()) != container_i->particles_stored())
@@ -1649,8 +1649,8 @@ void Particle::RigidBodyHandler::set_rigid_particle_accelerations()
       particleengineinterface_->get_particle_container_bundle();
 
   // get container of owned particles of rigid phase
-  Particle::ParticleContainer* container_i =
-      particlecontainerbundle->get_specific_container(Particle::RigidPhase, Particle::Owned);
+  Particle::ParticleContainer* container_i = particlecontainerbundle->get_specific_container(
+      Particle::RigidPhase, Particle::Status::Owned);
 
 #ifdef FOUR_C_ENABLE_ASSERTIONS
   if (static_cast<int>(affiliationpairdata.size()) != container_i->particles_stored())
@@ -1744,8 +1744,8 @@ void Particle::RigidBodyHandler::evaluate_rigid_body_solidification(
       particleengineinterface_->get_particle_container_bundle();
 
   // get container of owned particles of rigid phase
-  Particle::ParticleContainer* container_i =
-      particlecontainerbundle->get_specific_container(Particle::RigidPhase, Particle::Owned);
+  Particle::ParticleContainer* container_i = particlecontainerbundle->get_specific_container(
+      Particle::RigidPhase, Particle::Status::Owned);
 
   // iterate over particle phase change tuples
   for (const auto& particletypetotype : particlesfromphasetophase)
@@ -1766,14 +1766,14 @@ void Particle::RigidBodyHandler::evaluate_rigid_body_solidification(
 
       // access values of local index tuples of particle i
       Particle::TypeEnum type_i;
-      Particle::StatusEnum status_i;
+      Particle::Status status_i;
       std::tie(type_i, status_i, std::ignore) = *localindextuple;
 
       if (type_i != Particle::RigidPhase)
         FOUR_C_THROW("particle with global id {} not of particle type '{}'!", globalid_i,
             Particle::enum_to_type_name(Particle::RigidPhase));
 
-      if (status_i == Particle::Ghosted)
+      if (status_i == Particle::Status::Ghosted)
         FOUR_C_THROW("particle with global id {} not owned on this processor!", globalid_i);
 #endif
 
@@ -1799,7 +1799,7 @@ void Particle::RigidBodyHandler::evaluate_rigid_body_solidification(
       {
         // access values of local index tuple of particle j
         Particle::TypeEnum type_j;
-        Particle::StatusEnum status_j;
+        Particle::Status status_j;
         int particle_j;
         std::tie(type_j, status_j, particle_j) = neighboringparticle;
 

--- a/src/particle/src/rigidbody/4C_particle_rigidbody.hpp
+++ b/src/particle/src/rigidbody/4C_particle_rigidbody.hpp
@@ -97,7 +97,7 @@ namespace Particle
      * \param[out] particlestatestotypes map of particle types and corresponding states
      */
     void insert_particle_states_of_particle_types(
-        std::map<Particle::TypeEnum, std::set<Particle::StateEnum>>& particlestatestotypes) const;
+        std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const;
 
     /*!
      * \brief write rigid body runtime output

--- a/src/particle/src/rigidbody/4C_particle_rigidbody.hpp
+++ b/src/particle/src/rigidbody/4C_particle_rigidbody.hpp
@@ -97,7 +97,7 @@ namespace Particle
      * \param[out] particlestatestotypes map of particle types and corresponding states
      */
     void insert_particle_states_of_particle_types(
-        std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const;
+        std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes) const;
 
     /*!
      * \brief write rigid body runtime output

--- a/src/particle/src/rigidbody/4C_particle_rigidbody_initial_field.cpp
+++ b/src/particle/src/rigidbody/4C_particle_rigidbody_initial_field.cpp
@@ -17,7 +17,7 @@ FOUR_C_NAMESPACE_OPEN
 
 namespace
 {
-  std::map<Particle::StateEnum, std::map<Particle::TypeEnum, int>>
+  std::map<Particle::StateEnum, std::map<Particle::Type, int>>
   extract_particle_types_to_function_ids(const Teuchos::ParameterList& params);
 
   std::vector<std::vector<double>>& get_rigid_body_state(
@@ -28,12 +28,12 @@ void Particle::set_initial_fields(const Teuchos::ParameterList& params,
     const std::vector<int>& ownedrigidbodies, Particle::RigidBodyDataState& rigidbodydatastates)
 {
   // relating particle types to function ids
-  std::map<Particle::StateEnum, std::map<Particle::TypeEnum, int>> statetotypetofunctidmap =
+  std::map<Particle::StateEnum, std::map<Particle::Type, int>> statetotypetofunctidmap =
       extract_particle_types_to_function_ids(params);
 
   for (auto& stateIt : statetotypetofunctidmap)
   {
-    if (not stateIt.second.contains(Particle::RigidPhase)) continue;
+    if (not stateIt.second.contains(Particle::Type::RigidPhase)) continue;
 
     // state vector
     Particle::StateEnum particleState = stateIt.first;
@@ -43,7 +43,7 @@ void Particle::set_initial_fields(const Teuchos::ParameterList& params,
         get_rigid_body_state(particleState, rigidbodydatastates);
 
     // get id of function
-    const int functid = stateIt.second[Particle::RigidPhase];
+    const int functid = stateIt.second[Particle::Type::RigidPhase];
 
     // get reference to function
     const auto& function =
@@ -78,10 +78,10 @@ void Particle::set_initial_fields(const Teuchos::ParameterList& params,
 
 namespace
 {
-  std::map<Particle::StateEnum, std::map<Particle::TypeEnum, int>>
+  std::map<Particle::StateEnum, std::map<Particle::Type, int>>
   extract_particle_types_to_function_ids(const Teuchos::ParameterList& params)
   {
-    std::map<Particle::StateEnum, std::map<Particle::TypeEnum, int>> statetotypetofunctidmap;
+    std::map<Particle::StateEnum, std::map<Particle::Type, int>> statetotypetofunctidmap;
 
     // get control parameters for initial/boundary conditions
     const Teuchos::ParameterList& params_conditions =
@@ -98,7 +98,7 @@ namespace
     for (const auto& stateIt : initialfieldtostateenum)
     {
       // get reference to sub-map
-      std::map<Particle::TypeEnum, int>& currentstatetypetofunctidmap =
+      std::map<Particle::Type, int>& currentstatetypetofunctidmap =
           statetotypetofunctidmap[stateIt.second];
 
       // read parameters relating particle types to values

--- a/src/particle/src/rigidbody/4C_particle_rigidbody_initial_field.cpp
+++ b/src/particle/src/rigidbody/4C_particle_rigidbody_initial_field.cpp
@@ -17,18 +17,18 @@ FOUR_C_NAMESPACE_OPEN
 
 namespace
 {
-  std::map<Particle::StateEnum, std::map<Particle::Type, int>>
-  extract_particle_types_to_function_ids(const Teuchos::ParameterList& params);
+  std::map<Particle::State, std::map<Particle::Type, int>> extract_particle_types_to_function_ids(
+      const Teuchos::ParameterList& params);
 
   std::vector<std::vector<double>>& get_rigid_body_state(
-      Particle::StateEnum particleState, Particle::RigidBodyDataState& rigidbodydatastates);
+      Particle::State particleState, Particle::RigidBodyDataState& rigidbodydatastates);
 }  // namespace
 
 void Particle::set_initial_fields(const Teuchos::ParameterList& params,
     const std::vector<int>& ownedrigidbodies, Particle::RigidBodyDataState& rigidbodydatastates)
 {
   // relating particle types to function ids
-  std::map<Particle::StateEnum, std::map<Particle::Type, int>> statetotypetofunctidmap =
+  std::map<Particle::State, std::map<Particle::Type, int>> statetotypetofunctidmap =
       extract_particle_types_to_function_ids(params);
 
   for (auto& stateIt : statetotypetofunctidmap)
@@ -36,7 +36,7 @@ void Particle::set_initial_fields(const Teuchos::ParameterList& params,
     if (not stateIt.second.contains(Particle::Type::RigidPhase)) continue;
 
     // state vector
-    Particle::StateEnum particleState = stateIt.first;
+    Particle::State particleState = stateIt.first;
 
     // get pointer to rigid body state
     std::vector<std::vector<double>>& state =
@@ -78,21 +78,21 @@ void Particle::set_initial_fields(const Teuchos::ParameterList& params,
 
 namespace
 {
-  std::map<Particle::StateEnum, std::map<Particle::Type, int>>
-  extract_particle_types_to_function_ids(const Teuchos::ParameterList& params)
+  std::map<Particle::State, std::map<Particle::Type, int>> extract_particle_types_to_function_ids(
+      const Teuchos::ParameterList& params)
   {
-    std::map<Particle::StateEnum, std::map<Particle::Type, int>> statetotypetofunctidmap;
+    std::map<Particle::State, std::map<Particle::Type, int>> statetotypetofunctidmap;
 
     // get control parameters for initial/boundary conditions
     const Teuchos::ParameterList& params_conditions =
         params.sublist("INITIAL AND BOUNDARY CONDITIONS");
 
     // relate particle state to input name
-    std::map<std::string, Particle::StateEnum> initialfieldtostateenum = {
-        std::make_pair("INITIAL_VELOCITY_FIELD", Particle::Velocity),
-        std::make_pair("INITIAL_ANGULAR_VELOCITY_FIELD", Particle::AngularVelocity),
-        std::make_pair("INITIAL_ACCELERATION_FIELD", Particle::Acceleration),
-        std::make_pair("INITIAL_ANGULAR_ACCELERATION_FIELD", Particle::AngularAcceleration)};
+    std::map<std::string, Particle::State> initialfieldtostateenum = {
+        std::make_pair("INITIAL_VELOCITY_FIELD", Particle::State::Velocity),
+        std::make_pair("INITIAL_ANGULAR_VELOCITY_FIELD", Particle::State::AngularVelocity),
+        std::make_pair("INITIAL_ACCELERATION_FIELD", Particle::State::Acceleration),
+        std::make_pair("INITIAL_ANGULAR_ACCELERATION_FIELD", Particle::State::AngularAcceleration)};
 
     // iterate over particle states
     for (const auto& stateIt : initialfieldtostateenum)
@@ -110,7 +110,7 @@ namespace
     // safety check
     for (const auto& iter : statetotypetofunctidmap)
     {
-      if (iter.first == Particle::Temperature and not iter.second.empty())
+      if (iter.first == Particle::State::Temperature and not iter.second.empty())
         FOUR_C_THROW("initial temperature cannot be specified for rigid bodies '{}' !",
             Particle::enum_to_state_name(iter.first));
     }
@@ -120,17 +120,17 @@ namespace
   }
 
   std::vector<std::vector<double>>& get_rigid_body_state(
-      Particle::StateEnum particleState, Particle::RigidBodyDataState& rigidbodydatastates)
+      Particle::State particleState, Particle::RigidBodyDataState& rigidbodydatastates)
   {
     switch (particleState)
     {
-      case Particle::Velocity:
+      case Particle::State::Velocity:
         return rigidbodydatastates.get_ref_velocity();
-      case Particle::AngularVelocity:
+      case Particle::State::AngularVelocity:
         return rigidbodydatastates.get_ref_angular_velocity();
-      case Particle::Acceleration:
+      case Particle::State::Acceleration:
         return rigidbodydatastates.get_ref_acceleration();
-      case Particle::AngularAcceleration:
+      case Particle::State::AngularAcceleration:
         return rigidbodydatastates.get_ref_angular_acceleration();
 
       default:

--- a/src/particle/src/wall/4C_particle_wall.cpp
+++ b/src/particle/src/wall/4C_particle_wall.cpp
@@ -333,7 +333,8 @@ void Particle::WallHandlerBase::build_particle_to_wall_neighbors(
 
         // get container of neighboring particle of current particle type
         Particle::ParticleContainer* neighborcontainer =
-            particlecontainerbundle->get_specific_container(neighborTypeEnum, Particle::Owned);
+            particlecontainerbundle->get_specific_container(
+                neighborTypeEnum, Particle::Status::Owned);
 
         // get position of neighboring particle
         const Core::LinAlg::Matrix<3, 1> currpos(
@@ -352,8 +353,8 @@ void Particle::WallHandlerBase::build_particle_to_wall_neighbors(
           continue;
 
         // append potential wall neighbor pair
-        potentialwallneighbors_.push_back(
-            std::make_pair(std::make_tuple(neighborTypeEnum, Particle::Owned, neighborindex), ele));
+        potentialwallneighbors_.push_back(std::make_pair(
+            std::make_tuple(neighborTypeEnum, Particle::Status::Owned, neighborindex), ele));
       }
     }
   }

--- a/src/particle/src/wall/4C_particle_wall.cpp
+++ b/src/particle/src/wall/4C_particle_wall.cpp
@@ -89,7 +89,7 @@ void Particle::WallHandlerBase::write_restart(const int step, const double time)
 void Particle::WallHandlerBase::read_restart(const int restartstep) {}
 
 void Particle::WallHandlerBase::insert_particle_states_of_particle_types(
-    std::map<Particle::TypeEnum, std::set<Particle::StateEnum>>& particlestatestotypes) const
+    std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const
 {
   // get flags defining considered states of particle wall
   const bool ismoving = params_.get<bool>("PARTICLE_WALL_MOVING");
@@ -326,15 +326,14 @@ void Particle::WallHandlerBase::build_particle_to_wall_neighbors(
       for (auto& neighborParticleIt : particlestobins[collidofneighboringbin])
       {
         // get type of neighboring particle
-        Particle::TypeEnum neighborTypeEnum = neighborParticleIt.first;
+        Particle::Type neighborType = neighborParticleIt.first;
 
         // get local index of neighboring particle
         const int neighborindex = neighborParticleIt.second;
 
         // get container of neighboring particle of current particle type
         Particle::ParticleContainer* neighborcontainer =
-            particlecontainerbundle->get_specific_container(
-                neighborTypeEnum, Particle::Status::Owned);
+            particlecontainerbundle->get_specific_container(neighborType, Particle::Status::Owned);
 
         // get position of neighboring particle
         const Core::LinAlg::Matrix<3, 1> currpos(
@@ -354,7 +353,7 @@ void Particle::WallHandlerBase::build_particle_to_wall_neighbors(
 
         // append potential wall neighbor pair
         potentialwallneighbors_.push_back(std::make_pair(
-            std::make_tuple(neighborTypeEnum, Particle::Status::Owned, neighborindex), ele));
+            std::make_tuple(neighborType, Particle::Status::Owned, neighborindex), ele));
       }
     }
   }

--- a/src/particle/src/wall/4C_particle_wall.cpp
+++ b/src/particle/src/wall/4C_particle_wall.cpp
@@ -89,7 +89,7 @@ void Particle::WallHandlerBase::write_restart(const int step, const double time)
 void Particle::WallHandlerBase::read_restart(const int restartstep) {}
 
 void Particle::WallHandlerBase::insert_particle_states_of_particle_types(
-    std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const
+    std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes) const
 {
   // get flags defining considered states of particle wall
   const bool ismoving = params_.get<bool>("PARTICLE_WALL_MOVING");
@@ -101,29 +101,29 @@ void Particle::WallHandlerBase::insert_particle_states_of_particle_types(
   for (auto& typeIt : particlestatestotypes)
   {
     // set of particle states for current particle type
-    std::set<Particle::StateEnum>& particlestates = typeIt.second;
+    std::set<Particle::State>& particlestates = typeIt.second;
 
     // insert states needed for iteration in particle structure interaction
     particlestates.insert({
-        Particle::LastIterPosition,
-        Particle::LastIterVelocity,
-        Particle::LastIterAcceleration,
+        Particle::State::LastIterPosition,
+        Particle::State::LastIterVelocity,
+        Particle::State::LastIterAcceleration,
     });
 
-    if (particlestates.contains(Particle::AngularVelocity))
-      particlestates.insert(Particle::LastIterAngularVelocity);
+    if (particlestates.contains(Particle::State::AngularVelocity))
+      particlestates.insert(Particle::State::LastIterAngularVelocity);
 
-    if (particlestates.contains(Particle::AngularAcceleration))
-      particlestates.insert(Particle::LastIterAngularAcceleration);
+    if (particlestates.contains(Particle::State::AngularAcceleration))
+      particlestates.insert(Particle::State::LastIterAngularAcceleration);
 
-    if (particlestates.contains(Particle::ModifiedAcceleration))
-      particlestates.insert(Particle::LastIterModifiedAcceleration);
+    if (particlestates.contains(Particle::State::ModifiedAcceleration))
+      particlestates.insert(Particle::State::LastIterModifiedAcceleration);
 
-    if (particlestates.contains(Particle::DensityDot))
-      particlestates.insert(Particle::LastIterDensity);
+    if (particlestates.contains(Particle::State::DensityDot))
+      particlestates.insert(Particle::State::LastIterDensity);
 
-    if (particlestates.contains(Particle::TemperatureDot))
-      particlestates.insert(Particle::LastIterTemperature);
+    if (particlestates.contains(Particle::State::TemperatureDot))
+      particlestates.insert(Particle::State::LastIterTemperature);
   }
 }
 
@@ -337,7 +337,7 @@ void Particle::WallHandlerBase::build_particle_to_wall_neighbors(
 
         // get position of neighboring particle
         const Core::LinAlg::Matrix<3, 1> currpos(
-            neighborcontainer->get_ptr_to_state(Particle::Position, neighborindex));
+            neighborcontainer->get_ptr_to_state(Particle::State::Position, neighborindex));
 
         // get coordinates of closest point on current column wall element to particle
         Core::LinAlg::Matrix<3, 1> closestpos;

--- a/src/particle/src/wall/4C_particle_wall.hpp
+++ b/src/particle/src/wall/4C_particle_wall.hpp
@@ -122,8 +122,7 @@ namespace Particle
      * \param[out] particlestatestotypes map of particle types and corresponding states
      */
     virtual void insert_particle_states_of_particle_types(
-        std::map<Particle::TypeEnum, std::set<Particle::StateEnum>>& particlestatestotypes)
-        const final;
+        std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const final;
 
     /*!
      * \brief write wall runtime output

--- a/src/particle/src/wall/4C_particle_wall.hpp
+++ b/src/particle/src/wall/4C_particle_wall.hpp
@@ -122,7 +122,7 @@ namespace Particle
      * \param[out] particlestatestotypes map of particle types and corresponding states
      */
     virtual void insert_particle_states_of_particle_types(
-        std::map<Particle::Type, std::set<Particle::StateEnum>>& particlestatestotypes) const final;
+        std::map<Particle::Type, std::set<Particle::State>>& particlestatestotypes) const final;
 
     /*!
      * \brief write wall runtime output

--- a/src/particle/tests/4C_particle_container_bundle_test.cpp
+++ b/src/particle/tests/4C_particle_container_bundle_test.cpp
@@ -49,8 +49,8 @@ namespace
 
       // owned particles for phase 1
       {
-        Particle::ParticleContainer* container =
-            particlecontainerbundle_->get_specific_container(Particle::Phase1, Particle::Owned);
+        Particle::ParticleContainer* container = particlecontainerbundle_->get_specific_container(
+            Particle::Phase1, Particle::Status::Owned);
 
         // first particle
         globalid = 1;
@@ -70,8 +70,8 @@ namespace
 
       // ghosted particles for phase 1
       {
-        Particle::ParticleContainer* container =
-            particlecontainerbundle_->get_specific_container(Particle::Phase1, Particle::Ghosted);
+        Particle::ParticleContainer* container = particlecontainerbundle_->get_specific_container(
+            Particle::Phase1, Particle::Status::Ghosted);
 
         // first particle
         globalid = 4;
@@ -86,8 +86,8 @@ namespace
 
       // owned particles for phase 2
       {
-        Particle::ParticleContainer* container =
-            particlecontainerbundle_->get_specific_container(Particle::Phase2, Particle::Owned);
+        Particle::ParticleContainer* container = particlecontainerbundle_->get_specific_container(
+            Particle::Phase2, Particle::Status::Owned);
 
         // first particle
         globalid = 6;
@@ -149,7 +149,7 @@ namespace
         2.0, Particle::Radius, Particle::Phase1);
 
     Particle::ParticleContainer* container =
-        particlecontainerbundle_->get_specific_container(Particle::Phase1, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(Particle::Phase1, Particle::Status::Owned);
 
     ASSERT_EQ(container->particles_stored(), 3);
 
@@ -188,7 +188,7 @@ namespace
         2.0, Particle::Radius, 1.0, Particle::Mass, Particle::Phase1);
 
     Particle::ParticleContainer* container =
-        particlecontainerbundle_->get_specific_container(Particle::Phase1, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(Particle::Phase1, Particle::Status::Owned);
 
     ASSERT_EQ(container->particles_stored(), 3);
 
@@ -228,7 +228,7 @@ namespace
     particlecontainerbundle_->set_state_specific_container(mass, Particle::Mass, Particle::Phase2);
 
     Particle::ParticleContainer* container =
-        particlecontainerbundle_->get_specific_container(Particle::Phase2, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(Particle::Phase2, Particle::Status::Owned);
 
     ASSERT_EQ(container->particles_stored(), 3);
 
@@ -268,7 +268,7 @@ namespace
     particlecontainerbundle_->clear_state_specific_container(Particle::Mass, Particle::Phase2);
 
     Particle::ParticleContainer* container =
-        particlecontainerbundle_->get_specific_container(Particle::Phase2, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(Particle::Phase2, Particle::Status::Owned);
 
     ASSERT_EQ(container->particles_stored(), 3);
 
@@ -313,7 +313,8 @@ namespace
     Particle::ParticleStates particle_reference;
     particle_reference.assign(statesvectorsize_, std::vector<double>{});
 
-    container = particlecontainerbundle_->get_specific_container(Particle::Phase1, Particle::Owned);
+    container =
+        particlecontainerbundle_->get_specific_container(Particle::Phase1, Particle::Status::Owned);
 
     ASSERT_EQ(container->particles_stored(), 3);
 
@@ -338,7 +339,8 @@ namespace
       compare_particle_states(particle_reference, particle);
     }
 
-    container = particlecontainerbundle_->get_specific_container(Particle::Phase2, Particle::Owned);
+    container =
+        particlecontainerbundle_->get_specific_container(Particle::Phase2, Particle::Status::Owned);
 
     ASSERT_EQ(container->particles_stored(), 3);
 
@@ -377,7 +379,8 @@ namespace
     Particle::ParticleStates particle_reference;
     particle_reference.assign(statesvectorsize_, std::vector<double>{});
 
-    container = particlecontainerbundle_->get_specific_container(Particle::Phase1, Particle::Owned);
+    container =
+        particlecontainerbundle_->get_specific_container(Particle::Phase1, Particle::Status::Owned);
 
     ASSERT_EQ(container->particles_stored(), 3);
 
@@ -402,7 +405,8 @@ namespace
       compare_particle_states(particle_reference, particle);
     }
 
-    container = particlecontainerbundle_->get_specific_container(Particle::Phase2, Particle::Owned);
+    container =
+        particlecontainerbundle_->get_specific_container(Particle::Phase2, Particle::Status::Owned);
 
     ASSERT_EQ(container->particles_stored(), 3);
 
@@ -442,7 +446,8 @@ namespace
     Particle::ParticleStates particle_reference;
     particle_reference.assign(statesvectorsize_, std::vector<double>{});
 
-    container = particlecontainerbundle_->get_specific_container(Particle::Phase1, Particle::Owned);
+    container =
+        particlecontainerbundle_->get_specific_container(Particle::Phase1, Particle::Status::Owned);
 
     ASSERT_EQ(container->particles_stored(), 3);
 
@@ -467,7 +472,8 @@ namespace
       compare_particle_states(particle_reference, particle);
     }
 
-    container = particlecontainerbundle_->get_specific_container(Particle::Phase2, Particle::Owned);
+    container =
+        particlecontainerbundle_->get_specific_container(Particle::Phase2, Particle::Status::Owned);
 
     ASSERT_EQ(container->particles_stored(), 3);
 
@@ -507,7 +513,8 @@ namespace
     Particle::ParticleStates particle_reference;
     particle_reference.assign(statesvectorsize_, std::vector<double>{});
 
-    container = particlecontainerbundle_->get_specific_container(Particle::Phase1, Particle::Owned);
+    container =
+        particlecontainerbundle_->get_specific_container(Particle::Phase1, Particle::Status::Owned);
 
     ASSERT_EQ(container->particles_stored(), 3);
 
@@ -532,7 +539,8 @@ namespace
       compare_particle_states(particle_reference, particle);
     }
 
-    container = particlecontainerbundle_->get_specific_container(Particle::Phase2, Particle::Owned);
+    container =
+        particlecontainerbundle_->get_specific_container(Particle::Phase2, Particle::Status::Owned);
 
     ASSERT_EQ(container->particles_stored(), 3);
 
@@ -561,7 +569,7 @@ namespace
   TEST_F(ParticleContainerBundleTest, check_and_decrease_size_all_containers_of_specific_status)
   {
     Particle::ParticleContainer* container =
-        particlecontainerbundle_->get_specific_container(Particle::Phase1, Particle::Owned);
+        particlecontainerbundle_->get_specific_container(Particle::Phase1, Particle::Status::Owned);
 
     ASSERT_EQ(container->particles_stored(), 3);
     ASSERT_EQ(container->container_size(), 4);
@@ -570,7 +578,7 @@ namespace
     container->remove_particle(0);
 
     particlecontainerbundle_->check_and_decrease_size_all_containers_of_specific_status(
-        Particle::Owned);
+        Particle::Status::Owned);
 
     EXPECT_EQ(container->particles_stored(), 1);
     EXPECT_EQ(container->container_size(), 2);
@@ -578,10 +586,10 @@ namespace
 
   TEST_F(ParticleContainerBundleTest, clear_all_containers_of_specific_status)
   {
-    particlecontainerbundle_->clear_all_containers_of_specific_status(Particle::Ghosted);
+    particlecontainerbundle_->clear_all_containers_of_specific_status(Particle::Status::Ghosted);
 
-    Particle::ParticleContainer* container =
-        particlecontainerbundle_->get_specific_container(Particle::Phase1, Particle::Ghosted);
+    Particle::ParticleContainer* container = particlecontainerbundle_->get_specific_container(
+        Particle::Phase1, Particle::Status::Ghosted);
 
     EXPECT_EQ(container->particles_stored(), 0);
   }

--- a/src/particle/tests/4C_particle_container_bundle_test.cpp
+++ b/src/particle/tests/4C_particle_container_bundle_test.cpp
@@ -27,11 +27,11 @@ namespace
       particlecontainerbundle_ = std::make_unique<Particle::ParticleContainerBundle>();
 
       // init two phases with different particle states
-      std::map<Particle::TypeEnum, std::set<Particle::StateEnum>> particlestatestotypes;
+      std::map<Particle::Type, std::set<Particle::StateEnum>> particlestatestotypes;
       std::set<Particle::StateEnum> stateEnumSet = {
           Particle::Position, Particle::Mass, Particle::Radius};
-      particlestatestotypes.insert(std::make_pair(Particle::Phase1, stateEnumSet));
-      particlestatestotypes.insert(std::make_pair(Particle::Phase2, stateEnumSet));
+      particlestatestotypes.insert(std::make_pair(Particle::Type::Phase1, stateEnumSet));
+      particlestatestotypes.insert(std::make_pair(Particle::Type::Phase2, stateEnumSet));
 
       // setup particle container bundle
       particlecontainerbundle_->setup(particlestatestotypes);
@@ -50,7 +50,7 @@ namespace
       // owned particles for phase 1
       {
         Particle::ParticleContainer* container = particlecontainerbundle_->get_specific_container(
-            Particle::Phase1, Particle::Status::Owned);
+            Particle::Type::Phase1, Particle::Status::Owned);
 
         // first particle
         globalid = 1;
@@ -71,7 +71,7 @@ namespace
       // ghosted particles for phase 1
       {
         Particle::ParticleContainer* container = particlecontainerbundle_->get_specific_container(
-            Particle::Phase1, Particle::Status::Ghosted);
+            Particle::Type::Phase1, Particle::Status::Ghosted);
 
         // first particle
         globalid = 4;
@@ -87,7 +87,7 @@ namespace
       // owned particles for phase 2
       {
         Particle::ParticleContainer* container = particlecontainerbundle_->get_specific_container(
-            Particle::Phase2, Particle::Status::Owned);
+            Particle::Type::Phase2, Particle::Status::Owned);
 
         // first particle
         globalid = 6;
@@ -146,10 +146,10 @@ namespace
   TEST_F(ParticleContainerBundleTest, scale_state_specific_container)
   {
     particlecontainerbundle_->scale_state_specific_container(
-        2.0, Particle::Radius, Particle::Phase1);
+        2.0, Particle::Radius, Particle::Type::Phase1);
 
-    Particle::ParticleContainer* container =
-        particlecontainerbundle_->get_specific_container(Particle::Phase1, Particle::Status::Owned);
+    Particle::ParticleContainer* container = particlecontainerbundle_->get_specific_container(
+        Particle::Type::Phase1, Particle::Status::Owned);
 
     ASSERT_EQ(container->particles_stored(), 3);
 
@@ -185,10 +185,10 @@ namespace
   TEST_F(ParticleContainerBundleTest, update_state_specific_container)
   {
     particlecontainerbundle_->update_state_specific_container(
-        2.0, Particle::Radius, 1.0, Particle::Mass, Particle::Phase1);
+        2.0, Particle::Radius, 1.0, Particle::Mass, Particle::Type::Phase1);
 
-    Particle::ParticleContainer* container =
-        particlecontainerbundle_->get_specific_container(Particle::Phase1, Particle::Status::Owned);
+    Particle::ParticleContainer* container = particlecontainerbundle_->get_specific_container(
+        Particle::Type::Phase1, Particle::Status::Owned);
 
     ASSERT_EQ(container->particles_stored(), 3);
 
@@ -225,10 +225,11 @@ namespace
   {
     std::vector<double> mass{1.1};
 
-    particlecontainerbundle_->set_state_specific_container(mass, Particle::Mass, Particle::Phase2);
+    particlecontainerbundle_->set_state_specific_container(
+        mass, Particle::Mass, Particle::Type::Phase2);
 
-    Particle::ParticleContainer* container =
-        particlecontainerbundle_->get_specific_container(Particle::Phase2, Particle::Status::Owned);
+    Particle::ParticleContainer* container = particlecontainerbundle_->get_specific_container(
+        Particle::Type::Phase2, Particle::Status::Owned);
 
     ASSERT_EQ(container->particles_stored(), 3);
 
@@ -265,10 +266,11 @@ namespace
   {
     std::vector<double> mass{0.0};
 
-    particlecontainerbundle_->clear_state_specific_container(Particle::Mass, Particle::Phase2);
+    particlecontainerbundle_->clear_state_specific_container(
+        Particle::Mass, Particle::Type::Phase2);
 
-    Particle::ParticleContainer* container =
-        particlecontainerbundle_->get_specific_container(Particle::Phase2, Particle::Status::Owned);
+    Particle::ParticleContainer* container = particlecontainerbundle_->get_specific_container(
+        Particle::Type::Phase2, Particle::Status::Owned);
 
     ASSERT_EQ(container->particles_stored(), 3);
 
@@ -313,8 +315,8 @@ namespace
     Particle::ParticleStates particle_reference;
     particle_reference.assign(statesvectorsize_, std::vector<double>{});
 
-    container =
-        particlecontainerbundle_->get_specific_container(Particle::Phase1, Particle::Status::Owned);
+    container = particlecontainerbundle_->get_specific_container(
+        Particle::Type::Phase1, Particle::Status::Owned);
 
     ASSERT_EQ(container->particles_stored(), 3);
 
@@ -339,8 +341,8 @@ namespace
       compare_particle_states(particle_reference, particle);
     }
 
-    container =
-        particlecontainerbundle_->get_specific_container(Particle::Phase2, Particle::Status::Owned);
+    container = particlecontainerbundle_->get_specific_container(
+        Particle::Type::Phase2, Particle::Status::Owned);
 
     ASSERT_EQ(container->particles_stored(), 3);
 
@@ -379,8 +381,8 @@ namespace
     Particle::ParticleStates particle_reference;
     particle_reference.assign(statesvectorsize_, std::vector<double>{});
 
-    container =
-        particlecontainerbundle_->get_specific_container(Particle::Phase1, Particle::Status::Owned);
+    container = particlecontainerbundle_->get_specific_container(
+        Particle::Type::Phase1, Particle::Status::Owned);
 
     ASSERT_EQ(container->particles_stored(), 3);
 
@@ -405,8 +407,8 @@ namespace
       compare_particle_states(particle_reference, particle);
     }
 
-    container =
-        particlecontainerbundle_->get_specific_container(Particle::Phase2, Particle::Status::Owned);
+    container = particlecontainerbundle_->get_specific_container(
+        Particle::Type::Phase2, Particle::Status::Owned);
 
     ASSERT_EQ(container->particles_stored(), 3);
 
@@ -446,8 +448,8 @@ namespace
     Particle::ParticleStates particle_reference;
     particle_reference.assign(statesvectorsize_, std::vector<double>{});
 
-    container =
-        particlecontainerbundle_->get_specific_container(Particle::Phase1, Particle::Status::Owned);
+    container = particlecontainerbundle_->get_specific_container(
+        Particle::Type::Phase1, Particle::Status::Owned);
 
     ASSERT_EQ(container->particles_stored(), 3);
 
@@ -472,8 +474,8 @@ namespace
       compare_particle_states(particle_reference, particle);
     }
 
-    container =
-        particlecontainerbundle_->get_specific_container(Particle::Phase2, Particle::Status::Owned);
+    container = particlecontainerbundle_->get_specific_container(
+        Particle::Type::Phase2, Particle::Status::Owned);
 
     ASSERT_EQ(container->particles_stored(), 3);
 
@@ -513,8 +515,8 @@ namespace
     Particle::ParticleStates particle_reference;
     particle_reference.assign(statesvectorsize_, std::vector<double>{});
 
-    container =
-        particlecontainerbundle_->get_specific_container(Particle::Phase1, Particle::Status::Owned);
+    container = particlecontainerbundle_->get_specific_container(
+        Particle::Type::Phase1, Particle::Status::Owned);
 
     ASSERT_EQ(container->particles_stored(), 3);
 
@@ -539,8 +541,8 @@ namespace
       compare_particle_states(particle_reference, particle);
     }
 
-    container =
-        particlecontainerbundle_->get_specific_container(Particle::Phase2, Particle::Status::Owned);
+    container = particlecontainerbundle_->get_specific_container(
+        Particle::Type::Phase2, Particle::Status::Owned);
 
     ASSERT_EQ(container->particles_stored(), 3);
 
@@ -568,8 +570,8 @@ namespace
 
   TEST_F(ParticleContainerBundleTest, check_and_decrease_size_all_containers_of_specific_status)
   {
-    Particle::ParticleContainer* container =
-        particlecontainerbundle_->get_specific_container(Particle::Phase1, Particle::Status::Owned);
+    Particle::ParticleContainer* container = particlecontainerbundle_->get_specific_container(
+        Particle::Type::Phase1, Particle::Status::Owned);
 
     ASSERT_EQ(container->particles_stored(), 3);
     ASSERT_EQ(container->container_size(), 4);
@@ -589,7 +591,7 @@ namespace
     particlecontainerbundle_->clear_all_containers_of_specific_status(Particle::Status::Ghosted);
 
     Particle::ParticleContainer* container = particlecontainerbundle_->get_specific_container(
-        Particle::Phase1, Particle::Status::Ghosted);
+        Particle::Type::Phase1, Particle::Status::Ghosted);
 
     EXPECT_EQ(container->particles_stored(), 0);
   }

--- a/src/particle/tests/4C_particle_container_bundle_test.cpp
+++ b/src/particle/tests/4C_particle_container_bundle_test.cpp
@@ -27,9 +27,9 @@ namespace
       particlecontainerbundle_ = std::make_unique<Particle::ParticleContainerBundle>();
 
       // init two phases with different particle states
-      std::map<Particle::Type, std::set<Particle::StateEnum>> particlestatestotypes;
-      std::set<Particle::StateEnum> stateEnumSet = {
-          Particle::Position, Particle::Mass, Particle::Radius};
+      std::map<Particle::Type, std::set<Particle::State>> particlestatestotypes;
+      std::set<Particle::State> stateEnumSet = {
+          Particle::State::Position, Particle::State::Mass, Particle::State::Radius};
       particlestatestotypes.insert(std::make_pair(Particle::Type::Phase1, stateEnumSet));
       particlestatestotypes.insert(std::make_pair(Particle::Type::Phase2, stateEnumSet));
 
@@ -37,8 +37,8 @@ namespace
       particlecontainerbundle_->setup(particlestatestotypes);
 
       const auto GetMaximumStoredStateEnumSetValue = [&stateEnumSet]()
-      { return *(--stateEnumSet.end()); };
-      statesvectorsize_ = GetMaximumStoredStateEnumSetValue() + 1;
+      { return static_cast<int>(*(--stateEnumSet.end())); };
+      statesvectorsize_ = static_cast<int>(GetMaximumStoredStateEnumSetValue()) + 1;
 
       // init some particles
       int index(0);
@@ -112,9 +112,9 @@ namespace
       Particle::ParticleStates particle;
       particle.assign(statesvectorsize_, std::vector<double>{});
 
-      particle[Particle::Position] = pos;
-      particle[Particle::Mass] = mass;
-      particle[Particle::Radius] = rad;
+      particle[static_cast<int>(Particle::State::Position)] = pos;
+      particle[static_cast<int>(Particle::State::Mass)] = mass;
+      particle[static_cast<int>(Particle::State::Radius)] = rad;
 
       return particle;
     }
@@ -146,7 +146,7 @@ namespace
   TEST_F(ParticleContainerBundleTest, scale_state_specific_container)
   {
     particlecontainerbundle_->scale_state_specific_container(
-        2.0, Particle::Radius, Particle::Type::Phase1);
+        2.0, Particle::State::Radius, Particle::Type::Phase1);
 
     Particle::ParticleContainer* container = particlecontainerbundle_->get_specific_container(
         Particle::Type::Phase1, Particle::Status::Owned);
@@ -185,7 +185,7 @@ namespace
   TEST_F(ParticleContainerBundleTest, update_state_specific_container)
   {
     particlecontainerbundle_->update_state_specific_container(
-        2.0, Particle::Radius, 1.0, Particle::Mass, Particle::Type::Phase1);
+        2.0, Particle::State::Radius, 1.0, Particle::State::Mass, Particle::Type::Phase1);
 
     Particle::ParticleContainer* container = particlecontainerbundle_->get_specific_container(
         Particle::Type::Phase1, Particle::Status::Owned);
@@ -226,7 +226,7 @@ namespace
     std::vector<double> mass{1.1};
 
     particlecontainerbundle_->set_state_specific_container(
-        mass, Particle::Mass, Particle::Type::Phase2);
+        mass, Particle::State::Mass, Particle::Type::Phase2);
 
     Particle::ParticleContainer* container = particlecontainerbundle_->get_specific_container(
         Particle::Type::Phase2, Particle::Status::Owned);
@@ -267,7 +267,7 @@ namespace
     std::vector<double> mass{0.0};
 
     particlecontainerbundle_->clear_state_specific_container(
-        Particle::Mass, Particle::Type::Phase2);
+        Particle::State::Mass, Particle::Type::Phase2);
 
     Particle::ParticleContainer* container = particlecontainerbundle_->get_specific_container(
         Particle::Type::Phase2, Particle::Status::Owned);
@@ -305,7 +305,7 @@ namespace
 
   TEST_F(ParticleContainerBundleTest, scale_state_all_containers)
   {
-    particlecontainerbundle_->scale_state_all_containers(2.0, Particle::Mass);
+    particlecontainerbundle_->scale_state_all_containers(2.0, Particle::State::Mass);
 
     Particle::ParticleContainer* container = nullptr;
     int globalid(0);
@@ -371,7 +371,7 @@ namespace
   TEST_F(ParticleContainerBundleTest, update_state_all_containers)
   {
     particlecontainerbundle_->update_state_all_containers(
-        2.0, Particle::Mass, 1.0, Particle::Radius);
+        2.0, Particle::State::Mass, 1.0, Particle::State::Radius);
 
     Particle::ParticleContainer* container = nullptr;
     int globalid(0);
@@ -438,7 +438,7 @@ namespace
   {
     std::vector<double> mass{1.1};
 
-    particlecontainerbundle_->set_state_all_containers(mass, Particle::Mass);
+    particlecontainerbundle_->set_state_all_containers(mass, Particle::State::Mass);
 
     Particle::ParticleContainer* container = nullptr;
     int globalid(0);
@@ -505,7 +505,7 @@ namespace
   {
     std::vector<double> mass{0.0};
 
-    particlecontainerbundle_->clear_state_all_containers(Particle::Mass);
+    particlecontainerbundle_->clear_state_all_containers(Particle::State::Mass);
 
     Particle::ParticleContainer* container = nullptr;
     int globalid(0);

--- a/src/particle/tests/4C_particle_container_test.cpp
+++ b/src/particle/tests/4C_particle_container_test.cpp
@@ -25,14 +25,14 @@ namespace
     ParticleContainerTest()
     {
       const int size = 7;
-      std::set<Particle::StateEnum> stateEnumSet = {
-          Particle::Position, Particle::Velocity, Particle::Mass};
+      std::set<Particle::State> stateEnumSet = {
+          Particle::State::Position, Particle::State::Velocity, Particle::State::Mass};
 
       // create, init and setup container
       container_ = std::make_unique<Particle::ParticleContainer>();
       container_->setup(size, stateEnumSet);
 
-      const int maximum_stored_state_enum_set_value{*(--stateEnumSet.end())};
+      const int maximum_stored_state_enum_set_value{static_cast<int>(*(--stateEnumSet.end()))};
       statesvectorsize_ = maximum_stored_state_enum_set_value + 1;
 
       // init some particles
@@ -70,9 +70,9 @@ namespace
       Particle::ParticleStates particle;
       particle.assign(statesvectorsize_, std::vector<double>{});
 
-      particle[Particle::Position] = pos;
-      particle[Particle::Velocity] = vel;
-      particle[Particle::Mass] = mass;
+      particle[static_cast<int>(Particle::State::Position)] = pos;
+      particle[static_cast<int>(Particle::State::Velocity)] = vel;
+      particle[static_cast<int>(Particle::State::Mass)] = mass;
 
       return particle;
     }
@@ -245,9 +245,9 @@ namespace
 
   TEST_F(ParticleContainerTest, GetStateDim)
   {
-    EXPECT_EQ(container_->get_state_dim(Particle::Position), 3);
-    EXPECT_EQ(container_->get_state_dim(Particle::Velocity), 3);
-    EXPECT_EQ(container_->get_state_dim(Particle::Mass), 1);
+    EXPECT_EQ(container_->get_state_dim(Particle::State::Position), 3);
+    EXPECT_EQ(container_->get_state_dim(Particle::State::Velocity), 3);
+    EXPECT_EQ(container_->get_state_dim(Particle::State::Mass), 1);
   }
 
   TEST_F(ParticleContainerTest, GetPtrToState)
@@ -289,21 +289,21 @@ namespace
         mass[0] = 0.5;
       }
 
-      const double* currpos = container_->get_ptr_to_state(Particle::Position, index);
+      const double* currpos = container_->get_ptr_to_state(Particle::State::Position, index);
       FOUR_C_EXPECT_ITERABLE_NEAR(currpos, pos.begin(), 3, 1e-14);
 
-      const double* currvel = container_->get_ptr_to_state(Particle::Velocity, index);
+      const double* currvel = container_->get_ptr_to_state(Particle::State::Velocity, index);
       FOUR_C_EXPECT_ITERABLE_NEAR(currvel, vel.begin(), 3, 1e-14);
 
-      const double* currmass = container_->get_ptr_to_state(Particle::Mass, index);
+      const double* currmass = container_->get_ptr_to_state(Particle::State::Mass, index);
       EXPECT_NEAR(currmass[0], mass[0], 1e-14);
 
       {
-        double* newmass = container_->get_ptr_to_state_writable(Particle::Mass, index);
+        double* newmass = container_->get_ptr_to_state_writable(Particle::State::Mass, index);
         newmass[0] = newmass[0] * 3.14;
       }
       {
-        const double* currmass = container_->get_ptr_to_state(Particle::Mass, index);
+        const double* currmass = container_->get_ptr_to_state(Particle::State::Mass, index);
         EXPECT_NEAR(currmass[0], mass[0] * 3.14, 1e-14);
       }
     }
@@ -348,21 +348,21 @@ namespace
         mass[0] = 0.5;
       }
 
-      const double* currpos = container_->try_get_ptr_to_state(Particle::Position, index);
+      const double* currpos = container_->try_get_ptr_to_state(Particle::State::Position, index);
       FOUR_C_EXPECT_ITERABLE_NEAR(currpos, pos.begin(), 3, 1.0e-14);
 
-      const double* currvel = container_->try_get_ptr_to_state(Particle::Velocity, index);
+      const double* currvel = container_->try_get_ptr_to_state(Particle::State::Velocity, index);
       FOUR_C_EXPECT_ITERABLE_NEAR(currvel, vel.begin(), 3, 1.0e-14);
 
-      const double* currmass = container_->try_get_ptr_to_state(Particle::Mass, index);
+      const double* currmass = container_->try_get_ptr_to_state(Particle::State::Mass, index);
       EXPECT_NEAR(currmass[0], mass[0], 1e-14);
 
       {
-        double* newmass = container_->try_get_ptr_to_state_writable(Particle::Mass, index);
+        double* newmass = container_->try_get_ptr_to_state_writable(Particle::State::Mass, index);
         newmass[0] = newmass[0] * 3.14;
       }
       {
-        const double* currmass = container_->try_get_ptr_to_state(Particle::Mass, index);
+        const double* currmass = container_->try_get_ptr_to_state(Particle::State::Mass, index);
         EXPECT_NEAR(currmass[0], mass[0] * 3.14, 1e-14);
       }
     }
@@ -370,10 +370,11 @@ namespace
 
   TEST_F(ParticleContainerTest, TryGetPtrToStateNotStored)
   {
-    const double* acc = container_->try_get_ptr_to_state(Particle::Acceleration, 0);
+    const double* acc = container_->try_get_ptr_to_state(Particle::State::Acceleration, 0);
     EXPECT_EQ(acc, nullptr);
 
-    double* angacc = container_->try_get_ptr_to_state_writable(Particle::AngularAcceleration, 0);
+    double* angacc =
+        container_->try_get_ptr_to_state_writable(Particle::State::AngularAcceleration, 0);
     EXPECT_EQ(angacc, nullptr);
   }
 
@@ -404,9 +405,9 @@ namespace
     Particle::ParticleStates particle_reference;
     particle_reference.assign(statesvectorsize_, std::vector<double>{});
 
-    container_->scale_state(1.5, Particle::Position);
-    container_->scale_state(3.25, Particle::Velocity);
-    container_->scale_state(0.95, Particle::Mass);
+    container_->scale_state(1.5, Particle::State::Position);
+    container_->scale_state(3.25, Particle::State::Velocity);
+    container_->scale_state(0.95, Particle::State::Mass);
 
     for (int index = 0; index < 3; ++index)
     {
@@ -442,7 +443,7 @@ namespace
     Particle::ParticleStates particle_reference;
     particle_reference.assign(statesvectorsize_, std::vector<double>{});
 
-    container_->update_state(1.0, Particle::Position, 0.5, Particle::Velocity);
+    container_->update_state(1.0, Particle::State::Position, 0.5, Particle::State::Velocity);
 
     for (int index = 0; index < 3; ++index)
     {
@@ -491,9 +492,9 @@ namespace
 
     particle_reference = create_test_particle(pos, vel, mass);
 
-    container_->set_state(pos, Particle::Position);
-    container_->set_state(vel, Particle::Velocity);
-    container_->set_state(mass, Particle::Mass);
+    container_->set_state(pos, Particle::State::Position);
+    container_->set_state(vel, Particle::State::Velocity);
+    container_->set_state(mass, Particle::State::Mass);
 
     for (int index = 0; index < 3; ++index)
     {
@@ -513,9 +514,9 @@ namespace
 
     particle_reference = create_test_particle({0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0});
 
-    container_->clear_state(Particle::Position);
-    container_->clear_state(Particle::Velocity);
-    container_->clear_state(Particle::Mass);
+    container_->clear_state(Particle::State::Position);
+    container_->clear_state(Particle::State::Velocity);
+    container_->clear_state(Particle::State::Mass);
 
     for (int index = 0; index < 3; ++index)
     {
@@ -526,33 +527,33 @@ namespace
 
   TEST_F(ParticleContainerTest, GetMinValueOfState)
   {
-    EXPECT_NEAR(container_->get_min_value_of_state(Particle::Mass), 0.12, 1e-14);
-    EXPECT_NEAR(container_->get_min_value_of_state(Particle::Position), -8.54, 1e-14);
+    EXPECT_NEAR(container_->get_min_value_of_state(Particle::State::Mass), 0.12, 1e-14);
+    EXPECT_NEAR(container_->get_min_value_of_state(Particle::State::Position), -8.54, 1e-14);
   }
 
   TEST_F(ParticleContainerTest, GetMaxValueOfState)
   {
-    EXPECT_NEAR(container_->get_max_value_of_state(Particle::Mass), 12.34, 1e-14);
-    EXPECT_NEAR(container_->get_max_value_of_state(Particle::Position), 61.0, 1e-14);
+    EXPECT_NEAR(container_->get_max_value_of_state(Particle::State::Mass), 12.34, 1e-14);
+    EXPECT_NEAR(container_->get_max_value_of_state(Particle::State::Position), 61.0, 1e-14);
   }
 
   TEST_F(ParticleContainerTest, GetStoredStates)
   {
-    const std::set<Particle::StateEnum>& particleStates = container_->get_stored_states();
+    const std::set<Particle::State>& particleStates = container_->get_stored_states();
     EXPECT_EQ(particleStates.size(), 3);
-    EXPECT_TRUE(particleStates.find(Particle::Position) != particleStates.end());
-    EXPECT_TRUE(particleStates.find(Particle::Velocity) != particleStates.end());
-    EXPECT_TRUE(particleStates.find(Particle::Mass) != particleStates.end());
+    EXPECT_TRUE(particleStates.find(Particle::State::Position) != particleStates.end());
+    EXPECT_TRUE(particleStates.find(Particle::State::Velocity) != particleStates.end());
+    EXPECT_TRUE(particleStates.find(Particle::State::Mass) != particleStates.end());
   }
 
   TEST_F(ParticleContainerTest, HaveStoredState)
   {
-    EXPECT_TRUE(container_->have_stored_state(Particle::Position));
-    EXPECT_TRUE(container_->have_stored_state(Particle::Velocity));
-    EXPECT_TRUE(container_->have_stored_state(Particle::Mass));
+    EXPECT_TRUE(container_->have_stored_state(Particle::State::Position));
+    EXPECT_TRUE(container_->have_stored_state(Particle::State::Velocity));
+    EXPECT_TRUE(container_->have_stored_state(Particle::State::Mass));
 
-    EXPECT_FALSE(container_->have_stored_state(Particle::Acceleration));
-    EXPECT_FALSE(container_->have_stored_state(Particle::Density));
+    EXPECT_FALSE(container_->have_stored_state(Particle::State::Acceleration));
+    EXPECT_FALSE(container_->have_stored_state(Particle::State::Density));
   }
 
   TEST_F(ParticleContainerTest, ContainerSize) { EXPECT_EQ(container_->container_size(), 7); }

--- a/src/particle/tests/4C_particle_container_test.cpp
+++ b/src/particle/tests/4C_particle_container_test.cpp
@@ -95,7 +95,7 @@ namespace
 
       for (std::size_t j = 0; j < state_reference.size(); ++j)
         EXPECT_NEAR(state_reference[j], state[j], 1e-14)
-            << "state '" << Particle::enum_to_state_name(static_cast<Particle::ParticleState>(i))
+            << "state '" << Particle::enum_to_state_name(static_cast<Particle::State>(i))
             << "' j = " << j;
     }
   }

--- a/src/pasi/4C_pasi_partitioned_twowaycoup.cpp
+++ b/src/pasi/4C_pasi_partitioned_twowaycoup.cpp
@@ -240,7 +240,7 @@ void PaSI::PasiPartTwoWayCoup::reset_particle_states()
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container =
-        particlecontainerbundle->get_specific_container(type, Particle::Owned);
+        particlecontainerbundle->get_specific_container(type, Particle::Status::Owned);
 
     // reset position, velocity and acceleration states of all particles
     container->update_state(0.0, Particle::Position, 1.0, Particle::LastIterPosition);
@@ -440,7 +440,7 @@ void PaSI::PasiPartTwoWayCoup::save_particle_states()
   {
     // get container of owned particles of current particle type
     Particle::ParticleContainer* container =
-        particlecontainerbundle->get_specific_container(type, Particle::Owned);
+        particlecontainerbundle->get_specific_container(type, Particle::Status::Owned);
 
     // save position, velocity and acceleration states of all particles
     container->update_state(0.0, Particle::LastIterPosition, 1.0, Particle::Position);

--- a/src/pasi/4C_pasi_partitioned_twowaycoup.cpp
+++ b/src/pasi/4C_pasi_partitioned_twowaycoup.cpp
@@ -243,32 +243,34 @@ void PaSI::PasiPartTwoWayCoup::reset_particle_states()
         particlecontainerbundle->get_specific_container(type, Particle::Status::Owned);
 
     // reset position, velocity and acceleration states of all particles
-    container->update_state(0.0, Particle::Position, 1.0, Particle::LastIterPosition);
-    container->update_state(0.0, Particle::Velocity, 1.0, Particle::LastIterVelocity);
-    container->update_state(0.0, Particle::Acceleration, 1.0, Particle::LastIterAcceleration);
+    container->update_state(0.0, Particle::State::Position, 1.0, Particle::State::LastIterPosition);
+    container->update_state(0.0, Particle::State::Velocity, 1.0, Particle::State::LastIterVelocity);
+    container->update_state(
+        0.0, Particle::State::Acceleration, 1.0, Particle::State::LastIterAcceleration);
 
     // reset angular velocity state of all particles
-    if (container->have_stored_state(Particle::AngularVelocity))
+    if (container->have_stored_state(Particle::State::AngularVelocity))
       container->update_state(
-          0.0, Particle::AngularVelocity, 1.0, Particle::LastIterAngularVelocity);
+          0.0, Particle::State::AngularVelocity, 1.0, Particle::State::LastIterAngularVelocity);
 
     // reset angular acceleration state of all particles
-    if (container->have_stored_state(Particle::AngularAcceleration))
-      container->update_state(
-          0.0, Particle::AngularAcceleration, 1.0, Particle::LastIterAngularAcceleration);
+    if (container->have_stored_state(Particle::State::AngularAcceleration))
+      container->update_state(0.0, Particle::State::AngularAcceleration, 1.0,
+          Particle::State::LastIterAngularAcceleration);
 
     // reset modified acceleration state of all particles
-    if (container->have_stored_state(Particle::ModifiedAcceleration))
-      container->update_state(
-          0.0, Particle::ModifiedAcceleration, 1.0, Particle::LastIterModifiedAcceleration);
+    if (container->have_stored_state(Particle::State::ModifiedAcceleration))
+      container->update_state(0.0, Particle::State::ModifiedAcceleration, 1.0,
+          Particle::State::LastIterModifiedAcceleration);
 
     // reset density state of all particles
-    if (container->have_stored_state(Particle::DensityDot))
-      container->update_state(0.0, Particle::Density, 1.0, Particle::LastIterDensity);
+    if (container->have_stored_state(Particle::State::DensityDot))
+      container->update_state(0.0, Particle::State::Density, 1.0, Particle::State::LastIterDensity);
 
     // reset temperature state of all particles
-    if (container->have_stored_state(Particle::TemperatureDot))
-      container->update_state(0.0, Particle::Temperature, 1.0, Particle::LastIterTemperature);
+    if (container->have_stored_state(Particle::State::TemperatureDot))
+      container->update_state(
+          0.0, Particle::State::Temperature, 1.0, Particle::State::LastIterTemperature);
   }
 }
 
@@ -443,32 +445,34 @@ void PaSI::PasiPartTwoWayCoup::save_particle_states()
         particlecontainerbundle->get_specific_container(type, Particle::Status::Owned);
 
     // save position, velocity and acceleration states of all particles
-    container->update_state(0.0, Particle::LastIterPosition, 1.0, Particle::Position);
-    container->update_state(0.0, Particle::LastIterVelocity, 1.0, Particle::Velocity);
-    container->update_state(0.0, Particle::LastIterAcceleration, 1.0, Particle::Acceleration);
+    container->update_state(0.0, Particle::State::LastIterPosition, 1.0, Particle::State::Position);
+    container->update_state(0.0, Particle::State::LastIterVelocity, 1.0, Particle::State::Velocity);
+    container->update_state(
+        0.0, Particle::State::LastIterAcceleration, 1.0, Particle::State::Acceleration);
 
     // save angular velocity state of all particles
-    if (container->have_stored_state(Particle::AngularVelocity))
+    if (container->have_stored_state(Particle::State::AngularVelocity))
       container->update_state(
-          0.0, Particle::LastIterAngularVelocity, 1.0, Particle::AngularVelocity);
+          0.0, Particle::State::LastIterAngularVelocity, 1.0, Particle::State::AngularVelocity);
 
     // save angular acceleration state of all particles
-    if (container->have_stored_state(Particle::AngularAcceleration))
-      container->update_state(
-          0.0, Particle::LastIterAngularAcceleration, 1.0, Particle::AngularAcceleration);
+    if (container->have_stored_state(Particle::State::AngularAcceleration))
+      container->update_state(0.0, Particle::State::LastIterAngularAcceleration, 1.0,
+          Particle::State::AngularAcceleration);
 
     // save modified acceleration state of all particles
-    if (container->have_stored_state(Particle::ModifiedAcceleration))
-      container->update_state(
-          0.0, Particle::LastIterModifiedAcceleration, 1.0, Particle::ModifiedAcceleration);
+    if (container->have_stored_state(Particle::State::ModifiedAcceleration))
+      container->update_state(0.0, Particle::State::LastIterModifiedAcceleration, 1.0,
+          Particle::State::ModifiedAcceleration);
 
     // save density state of all particles
-    if (container->have_stored_state(Particle::DensityDot))
-      container->update_state(0.0, Particle::LastIterDensity, 1.0, Particle::Density);
+    if (container->have_stored_state(Particle::State::DensityDot))
+      container->update_state(0.0, Particle::State::LastIterDensity, 1.0, Particle::State::Density);
 
     // save temperature state of all particles
-    if (container->have_stored_state(Particle::TemperatureDot))
-      container->update_state(0.0, Particle::LastIterTemperature, 1.0, Particle::Temperature);
+    if (container->have_stored_state(Particle::State::TemperatureDot))
+      container->update_state(
+          0.0, Particle::State::LastIterTemperature, 1.0, Particle::State::Temperature);
   }
 }
 


### PR DESCRIPTION
The Dual View PR is rather big and difficult to review. I have pulled out some of the changes that can be easily reviewed and merged without anything to do about device access.

This PR includes swapping the `enum`s over to `enum class`es specifically

After this #2136 will only have the Dual View changes.

## Related Issues and Pull Requests
Subset of #2136, downstream of #2171

## Disclosure of AI assistance

Some local AI review prompting after I wrote the code