### PR TITLE
Particle: Clean up THROW vs ASSERT

### DIFF
--- a/src/particle/src/engine/4C_particle_engine_container.cpp
+++ b/src/particle/src/engine/4C_particle_engine_container.cpp
@@ -73,12 +73,9 @@ void Particle::ParticleContainer::decrease_container_size()
   // set size of particle container (at least one)
   containersize_ = (newsize > 0) ? newsize : 1;
 
-#ifdef FOUR_C_ENABLE_ASSERTIONS
-  if (particlestored_ > containersize_)
-    FOUR_C_THROW(
-        "decreasing size of container not possible: particles stored {} > new container size {}!",
-        particlestored_, containersize_);
-#endif
+  FOUR_C_ASSERT(particlestored_ <= containersize_,
+      "decreasing size of container not possible: particles stored {} > new container size {}!",
+      particlestored_, containersize_);
 
   // resize vector of global ids
   globalids_.resize(containersize_);
@@ -141,10 +138,8 @@ void Particle::ParticleContainer::add_particle(
 void Particle::ParticleContainer::replace_particle(
     int index, int globalid, const ParticleStates& states)
 {
-#ifdef FOUR_C_ENABLE_ASSERTIONS
-  if (index < 0 or index > (particlestored_ - 1))
-    FOUR_C_THROW("can not replace particle as index {} out of bounds!", index);
-#endif
+  FOUR_C_ASSERT(index >= 0 and index < particlestored_,
+      "can not replace particle as index {} out of bounds!", index);
 
   // replace global id in container
   if (globalid >= 0) globalids_[index] = globalid;
@@ -160,11 +155,9 @@ void Particle::ParticleContainer::replace_particle(
     // state handed over
     else
     {
-#ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (static_cast<int>(states[state].size()) != statedim_[state])
-        FOUR_C_THROW("can not replace particle: dimensions of state '{}' do not match!",
-            enum_to_state_name(state));
-#endif
+      FOUR_C_ASSERT(static_cast<int>(states[state].size()) == statedim_[state],
+          "can not replace particle: dimensions of state '{}' do not match!",
+          enum_to_state_name(state));
 
       // get pointer to particle state
       double* state_ptr = get_ptr_to_state_writable(state, index);
@@ -178,10 +171,8 @@ void Particle::ParticleContainer::replace_particle(
 void Particle::ParticleContainer::get_particle(
     int index, int& globalid, ParticleStates& states) const
 {
-#ifdef FOUR_C_ENABLE_ASSERTIONS
-  if (index < 0 or index > (particlestored_ - 1))
-    FOUR_C_THROW("can not return particle as index {} out of bounds!", index);
-#endif
+  FOUR_C_ASSERT(index >= 0 and index < particlestored_,
+      "can not return particle as index {} out of bounds!", index);
 
   // get global id from container
   globalid = globalids_[index];
@@ -202,10 +193,8 @@ void Particle::ParticleContainer::get_particle(
 
 void Particle::ParticleContainer::remove_particle(int index)
 {
-#ifdef FOUR_C_ENABLE_ASSERTIONS
-  if (index < 0 or index > (particlestored_ - 1))
-    FOUR_C_THROW("can not remove particle as index {} out of bounds!", index);
-#endif
+  FOUR_C_ASSERT(index >= 0 and index < particlestored_,
+      "can not remove particle as index {} out of bounds!", index);
 
   // index of last particle
   auto last_index = particlestored_ - 1;
@@ -236,13 +225,11 @@ void Particle::ParticleContainer::remove_particle(int index)
 
 const double* Particle::ParticleContainer::get_ptr_to_state(ParticleState state, int index) const
 {
-#ifdef FOUR_C_ENABLE_ASSERTIONS
-  if (not storedstates_.contains(state))
-    FOUR_C_THROW("particle state '{}' not stored in container!", enum_to_state_name(state));
+  FOUR_C_ASSERT(storedstates_.contains(state), "particle state '{}' not stored in container!",
+      enum_to_state_name(state));
 
-  if (index < 0 or index > (particlestored_ - 1))
-    FOUR_C_THROW("can not return pointer to state of particle as index {} out of bounds!", index);
-#endif
+  FOUR_C_ASSERT(index >= 0 and index < particlestored_,
+      "can not return pointer to state of particle as index {} out of bounds!", index);
 
   return &((states_[state])[index * statedim_[state]]);
 };
@@ -255,10 +242,8 @@ double* Particle::ParticleContainer::get_ptr_to_state_writable(ParticleState sta
 
 double Particle::ParticleContainer::get_min_value_of_state(ParticleState state) const
 {
-#ifdef FOUR_C_ENABLE_ASSERTIONS
-  if (not storedstates_.contains(state))
-    FOUR_C_THROW("particle state '{}' not stored in container!", enum_to_state_name(state));
-#endif
+  FOUR_C_ASSERT(storedstates_.contains(state), "particle state '{}' not stored in container!",
+      enum_to_state_name(state));
 
   if (particlestored_ <= 0) return 0.0;
 
@@ -272,10 +257,8 @@ double Particle::ParticleContainer::get_min_value_of_state(ParticleState state) 
 
 double Particle::ParticleContainer::get_max_value_of_state(ParticleState state) const
 {
-#ifdef FOUR_C_ENABLE_ASSERTIONS
-  if (not storedstates_.contains(state))
-    FOUR_C_THROW("particle state '{}' not stored in container!", enum_to_state_name(state));
-#endif
+  FOUR_C_ASSERT(storedstates_.contains(state), "particle state '{}' not stored in container!",
+      enum_to_state_name(state));
 
   if (particlestored_ <= 0) return 0.0;
 

--- a/src/particle/src/engine/4C_particle_engine_container.hpp
+++ b/src/particle/src/engine/4C_particle_engine_container.hpp
@@ -71,12 +71,10 @@ namespace Particle
      */
     inline void check_and_decrease_container_size()
     {
-#ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (particlestored_ > containersize_)
-        FOUR_C_THROW(
-            "checking size of container not possible: particles stored {} > new container size {}!",
-            particlestored_, containersize_);
-#endif
+      FOUR_C_ASSERT(particlestored_ <= containersize_,
+          "checking size of container not possible: particles stored {} > new "
+          "container size {}!",
+          particlestored_, containersize_);
 
       if (particlestored_ < 0.45 * containersize_) decrease_container_size();
     };
@@ -159,10 +157,8 @@ namespace Particle
      */
     inline int get_state_dim(ParticleState state)
     {
-#ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (not storedstates_.contains(state))
-        FOUR_C_THROW("particle state '{}' not stored in container!", enum_to_state_name(state));
-#endif
+      FOUR_C_ASSERT(storedstates_.contains(state), "particle state '{}' not stored in container!",
+          enum_to_state_name(state));
 
       return statedim_[state];
     };
@@ -205,11 +201,8 @@ namespace Particle
      */
     inline const double* try_get_ptr_to_state(ParticleState state, int index) const
     {
-#ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (index < 0 or index > (particlestored_ - 1))
-        FOUR_C_THROW(
-            "can not return pointer to state of particle as index {} out of bounds!", index);
-#endif
+      FOUR_C_ASSERT(index >= 0 and index < particlestored_,
+          "can not return pointer to state of particle as index {} out of bounds!", index);
 
       if (storedstates_.contains(state)) return get_ptr_to_state(state, index);
 
@@ -251,11 +244,8 @@ namespace Particle
      */
     inline double* try_get_ptr_to_state_writable(ParticleState state, int index)
     {
-#ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (index < 0 or index > (particlestored_ - 1))
-        FOUR_C_THROW(
-            "can not return pointer to state of particle as index {} out of bounds!", index);
-#endif
+      FOUR_C_ASSERT(index >= 0 and index < particlestored_,
+          "can not return pointer to state of particle as index {} out of bounds!", index);
 
       if (storedstates_.contains(state)) return get_ptr_to_state_writable(state, index);
 
@@ -272,11 +262,8 @@ namespace Particle
      */
     inline int* get_ptr_to_global_id(int index)
     {
-#ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (index < 0 or index > (particlestored_ - 1))
-        FOUR_C_THROW(
-            "can not return pointer to global id of particle as index {} out of bounds!", index);
-#endif
+      FOUR_C_ASSERT(index >= 0 and index < particlestored_,
+          "can not return pointer to global id of particle as index {} out of bounds!", index);
 
       return &(globalids_[index]);
     };
@@ -295,10 +282,8 @@ namespace Particle
      */
     inline void scale_state(double fac, ParticleState state)
     {
-#ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (not storedstates_.contains(state))
-        FOUR_C_THROW("particle state '{}' not stored in container!", enum_to_state_name(state));
-#endif
+      FOUR_C_ASSERT(storedstates_.contains(state), "particle state '{}' not stored in container!",
+          enum_to_state_name(state));
 
       if (particlestored_ <= 0) return;
 
@@ -318,21 +303,18 @@ namespace Particle
      */
     inline void update_state(double facA, ParticleState stateA, double facB, ParticleState stateB)
     {
-#ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (stateA == stateB)
-        FOUR_C_THROW(
-            "adding scaled particle state '{}' to itself is not allowed. Use scale_state instead!",
-            enum_to_state_name(stateA));
+      FOUR_C_ASSERT(stateA != stateB,
+          "adding scaled particle state '{}' to itself is not allowed. Use "
+          "scale_state instead!",
+          enum_to_state_name(stateA));
 
-      if (not storedstates_.contains(stateA))
-        FOUR_C_THROW("particle state '{}' not stored in container!", enum_to_state_name(stateA));
+      FOUR_C_ASSERT(storedstates_.contains(stateA), "particle state '{}' not stored in container!",
+          enum_to_state_name(stateA));
 
-      if (not storedstates_.contains(stateB))
-        FOUR_C_THROW("particle state '{}' not stored in container!", enum_to_state_name(stateB));
+      FOUR_C_ASSERT(storedstates_.contains(stateB), "particle state '{}' not stored in container!",
+          enum_to_state_name(stateB));
 
-      if (statedim_[stateA] != statedim_[stateB])
-        FOUR_C_THROW("dimensions of states do not match!");
-#endif
+      FOUR_C_ASSERT(statedim_[stateA] == statedim_[stateB], "dimensions of states do not match!");
 
       if (particlestored_ <= 0) return;
 
@@ -352,13 +334,11 @@ namespace Particle
      */
     inline void set_state(std::vector<double> val, ParticleState state)
     {
-#ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (not storedstates_.contains(state))
-        FOUR_C_THROW("particle state '{}' not stored in container!", enum_to_state_name(state));
+      FOUR_C_ASSERT(storedstates_.contains(state), "particle state '{}' not stored in container!",
+          enum_to_state_name(state));
 
-      if (statedim_[state] != static_cast<int>(val.size()))
-        FOUR_C_THROW("dimensions of states do not match!");
-#endif
+      FOUR_C_ASSERT(
+          statedim_[state] == static_cast<int>(val.size()), "dimensions of states do not match!");
 
       if (particlestored_ <= 0) return;
 
@@ -377,10 +357,8 @@ namespace Particle
      */
     inline void clear_state(ParticleState state)
     {
-#ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (not storedstates_.contains(state))
-        FOUR_C_THROW("particle state '{}' not stored in container!", enum_to_state_name(state));
-#endif
+      FOUR_C_ASSERT(storedstates_.contains(state), "particle state '{}' not stored in container!",
+          enum_to_state_name(state));
 
       if (particlestored_ <= 0) return;
 

--- a/src/particle/src/engine/4C_particle_engine_container_bundle.hpp
+++ b/src/particle/src/engine/4C_particle_engine_container_bundle.hpp
@@ -73,10 +73,8 @@ namespace Particle
      */
     inline ParticleContainer* get_specific_container(ParticleType type, ParticleStatus status) const
     {
-#ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (not storedtypes_.contains(type))
-        FOUR_C_THROW("container for particle type '{}' not stored!", enum_to_type_name(type));
-#endif
+      FOUR_C_ASSERT(storedtypes_.contains(type), "container for particle type '{}' not stored!",
+          enum_to_type_name(type));
 
       return (containers_[type])[status].get();
     };
@@ -95,10 +93,8 @@ namespace Particle
     inline void scale_state_specific_container(
         double fac, ParticleState state, ParticleType type) const
     {
-#ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (not storedtypes_.contains(type))
-        FOUR_C_THROW("container for particle type '{}' not stored!", enum_to_type_name(type));
-#endif
+      FOUR_C_ASSERT(storedtypes_.contains(type), "container for particle type '{}' not stored!",
+          enum_to_type_name(type));
 
       ((containers_[type])[Owned])->scale_state(fac, state);
     };
@@ -117,10 +113,8 @@ namespace Particle
     inline void update_state_specific_container(double facA, ParticleState stateA, double facB,
         ParticleState stateB, ParticleType type) const
     {
-#ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (not storedtypes_.contains(type))
-        FOUR_C_THROW("container for particle type '{}' not stored!", enum_to_type_name(type));
-#endif
+      FOUR_C_ASSERT(storedtypes_.contains(type), "container for particle type '{}' not stored!",
+          enum_to_type_name(type));
 
       ((containers_[type])[Owned])->update_state(facA, stateA, facB, stateB);
     };
@@ -136,10 +130,8 @@ namespace Particle
     inline void set_state_specific_container(
         std::vector<double> val, ParticleState state, ParticleType type) const
     {
-#ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (not storedtypes_.contains(type))
-        FOUR_C_THROW("container for particle type '{}' not stored!", enum_to_type_name(type));
-#endif
+      FOUR_C_ASSERT(storedtypes_.contains(type), "container for particle type '{}' not stored!",
+          enum_to_type_name(type));
 
       ((containers_[type])[Owned])->set_state(val, state);
     };
@@ -153,10 +145,8 @@ namespace Particle
      */
     inline void clear_state_specific_container(ParticleState state, ParticleType type) const
     {
-#ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (not storedtypes_.contains(type))
-        FOUR_C_THROW("container for particle type '{}' not stored!", enum_to_type_name(type));
-#endif
+      FOUR_C_ASSERT(storedtypes_.contains(type), "container for particle type '{}' not stored!",
+          enum_to_type_name(type));
 
       ((containers_[type])[Owned])->clear_state(state);
     };


### PR DESCRIPTION
## Description and Context

This PR tidies up the particle engine container code to use `FOUR_C_ASSERT` where appropriate.

## Related Issues and Pull Requests
Noticed in #2171

## Disclosure of AI assistance
None
