### PR TITLE
Fix cell_block id access in reduced lung

### DIFF
--- a/src/reduced_lung/src/4C_reduced_lung_helpers.cpp
+++ b/src/reduced_lung/src/4C_reduced_lung_helpers.cpp
@@ -281,7 +281,7 @@ namespace ReducedLung
       // read_vtu_file() already asserts that the mesh has points and non-empty cell blocks.
       for (const auto& coordinate : lung_mesh.mesh.points()) node_coordinates.push_back(coordinate);
 
-      // Element ids are handed out consecutively across all cell blocks in ascending block id
+      // Element ids are handed out consecutively across all cell blocks in mesh.cell_blocks()
       // order. This matches the numbering that Core::IO::MeshInput::read_value_from_cell_data()
       // uses, so that cell data of the mesh can be indexed by the global element id.
       for (const auto& cell_block : lung_mesh.mesh.cell_blocks())
@@ -291,11 +291,12 @@ namespace ReducedLung
           FOUR_C_THROW(
               "The reduced lung tree only supports line2 cells, but cell block {} of mesh file "
               "'{}' has cell type '{}'.",
-              cell_block.id(), geometry.file.string(),
+              cell_block.label(), geometry.file.string(),
               Core::FE::cell_type_to_string(cell_block.cell_type()));
         }
 
-        lung_mesh.blocks.ids.push_back(static_cast<int>(cell_block.id()));
+        // group_id is already unique among accepted cell blocks with cell_type==line2.
+        lung_mesh.blocks.ids.push_back(static_cast<int>(cell_block.group_id()));
         lung_mesh.blocks.sizes.push_back(static_cast<int>(cell_block.size()));
 
         for (const auto& cell : cell_block.cells())

--- a/src/reduced_lung/src/4C_reduced_lung_helpers.hpp
+++ b/src/reduced_lung/src/4C_reduced_lung_helpers.hpp
@@ -210,13 +210,13 @@ namespace ReducedLung
   /*!
    * @brief The cell blocks of the lung mesh.
    *
-   * Element ids are handed out consecutively across the cell blocks in ascending block id order,
+   * Element ids are handed out consecutively across the cell blocks in mesh.cell_blocks() order,
    * so every block covers a contiguous range of global element ids. This information is small and
    * replicated on all ranks, unlike the mesh itself.
    */
   struct LungMeshBlocks
   {
-    //! Ids of the cell blocks, in ascending order.
+    //! Ids of the cell blocks, in mesh.cell_blocks() iteration order.
     std::vector<int> ids;
     //! Number of elements in each cell block.
     std::vector<int> sizes;


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

See #2179 .

The reason was that cell blocks no longer have a unique `id()` function.

I also corrected some comments about the cell blocks iteration order.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
Closes #2179 

## Disclosure of AI assistance
<!--
If AI tools were used in this contribution, we strongly recommend disclosing their use. This may include:

* A brief description of how AI contributed (e.g., code generation, refactoring, documentation, testing)
* The AI agent(s) and/or tool(s) used
* Any notable successes, limitations, or lessons learned

Any AI-assisted code must be reviewed, understood, and validated by the contributing author, who takes full responsibility for the contribution.
-->
