### PR TITLE
[Actions] Temporarily disable kokkoscuda_build workflow due to ccache issue

### DIFF
--- a/.github/workflows/buildtest_kokkosparallel.yml
+++ b/.github/workflows/buildtest_kokkosparallel.yml
@@ -74,6 +74,8 @@ jobs:
           OMP_DYNAMIC: "FALSE"
 
   kokkoscuda_build:
+    # Temporarily disabled while fixing ccache; see #2183.
+    if: ${{ false }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/4c-multiphysics/4c-dependencies-trilinos-kokkosparallel:0bcb6660
@@ -111,4 +113,6 @@ jobs:
       - name: Check for successful builds and tests
         uses: re-actors/alls-green@release/v1
         with:
+          # Temporarily disabled while fixing ccache; see #2183.
+          allowed-skips: kokkoscuda_build
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
See #2183 . I am making progress towards fixing the ccache for clangcuda (it is related to the overwrite of the CXX_COMPILER_LAUNCHER, which I will amend), but it is still safest to temporarily disable this and prevent this action from being a bottleneck. It will be turned back on in the PR which fixes ccache for clangcuda.