### PR TITLE
Add brew versions to the key hash for caching of macOS workflow

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,23 +1,27 @@
 name: macOS built test
-
 on:
   schedule:
     - cron: 3 4 * * 0
       timezone: "Europe/Berlin"
   workflow_dispatch:
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
 jobs:
   build:
     name: Build 4C on macOS
     runs-on: macos-26
+    outputs:
+      brew-version-hash: ${{ steps.brew-versions.outputs.hash }}
     steps:
       - uses: actions/checkout@v7
       - name: System preparation
         run: ./dependencies/darwin/prepare_system.sh
+      - name: Get Homebrew versions
+        id: brew-versions
+        run: |
+          # Generate a key of all brew libraries
+          echo "hash=$(brew list --versions | sha256sum | awk '{print $1}')" >> $GITHUB_OUTPUT
       - name: Restore dependencies cache
         id: cache-deps
         uses: actions/cache/restore@v6
@@ -37,13 +41,13 @@ jobs:
         with:
           path: ${{ env.HOME }}/opt
           key: ${{ runner.os }}-deps-${{ hashFiles('./dependencies/darwin/compile_dependencies.sh', 'dependencies/darwin/**/install.sh',
-            'dependencies/current/**/install.sh') }}
+            'dependencies/current/**/install.sh') }}-brew-${{ steps.brew-versions.outputs.hash }}
       - name: Restore build cache
         id: cache-build
         uses: actions/cache/restore@v6
         with:
           path: build/
-          key: ${{ runner.os }}-build-${{ github.sha }}
+          key: ${{ runner.os }}-build-${{ github.sha }}-brew-${{ steps.brew-versions.outputs.hash }}
       - name: Build 4C
         if: steps.cache-build.outputs.cache-hit != 'true'
         run: |
@@ -56,8 +60,7 @@ jobs:
         uses: actions/cache/save@v6
         with:
           path: build/
-          key: ${{ runner.os }}-build-${{ github.sha }}
-
+          key: ${{ runner.os }}-build-${{ github.sha }}-brew-${{ steps.brew-versions.outputs.hash }}
   test:
     name: Test 4C on macOS
     needs: build
@@ -66,19 +69,36 @@ jobs:
       - uses: actions/checkout@v7
       - name: System preparation
         run: ./dependencies/darwin/prepare_system.sh
+      - name: Get Homebrew versions
+        id: brew-versions
+        run: |
+          # Generate a key of all brew libraries
+          echo "hash=$(brew list --versions | sha256sum | awk '{print $1}')" >> $GITHUB_OUTPUT
+      - name: Check if the hash differs from the hash in the build job
+        if: steps.brew-versions.outputs.hash != needs.build.outputs.brew-version-hash
+        run: |
+          {
+            echo "### Changed system libraries!"
+            echo ""
+            echo "The test job aborted because the brew system libraries changed after the build job completed."
+            echo "The system libraries installed in the test job have a different version than the ones used in the build job to build the dependencies and 4C."
+            echo ""
+            echo "This should rarely happen. A re-run of the workflow should solve this problem."
+          } >> $GITHUB_STEP_SUMMARY
+          exit 1
       - name: Restore dependencies cache
         id: cache-deps
         uses: actions/cache/restore@v6
         with:
           path: ${{ env.HOME }}/opt
           key: ${{ runner.os }}-deps-${{ hashFiles('./dependencies/darwin/compile_dependencies.sh', 'dependencies/darwin/**/install.sh',
-            'dependencies/current/**/install.sh') }}
+            'dependencies/current/**/install.sh') }}-brew-${{ steps.brew-versions.outputs.hash }}
       - name: Restore build cache
         id: cache-build
         uses: actions/cache/restore@v6
         with:
           path: build/
-          key: ${{ runner.os }}-build-${{ github.sha }}
+          key: ${{ runner.os }}-build-${{ github.sha }}-brew-${{ steps.brew-versions.outputs.hash }}
       - name: Run tests
         run: |
           echo "tests"


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

Add the version of all libraries installed with brew to the hash code of dependency and build step. This is necessary since any upstream update from brew can invalidate the build cache.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->

#1795 

## Disclosure of AI assistance
<!--
If AI tools were used in this contribution, we strongly recommend disclosing their use. This may include:

* A brief description of how AI contributed (e.g., code generation, refactoring, documentation, testing)
* The AI agent(s) and/or tool(s) used
* Any notable successes, limitations, or lessons learned

Any AI-assisted code must be reviewed, understood, and validated by the contributing author, who takes full responsibility for the contribution.
-->

The hash script is written based on suggestion of Gemini.