### PR TITLE
Make NUMMAT param in material parameter input optional

### DIFF
--- a/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
+++ b/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
@@ -39,12 +39,6 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
   using namespace Core::IO::InputSpecBuilders;
   std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> known_materials;
 
-  const auto size_from_optional_count = [](const std::string& count_parameter_name)
-  {
-    return [count_parameter_name](const Core::IO::InputParameterContainer& container)
-    { return container.get<std::optional<int>>(count_parameter_name).value_or(0); };
-  };
-
   /*----------------------------------------------------------------------*/
   // Newtonian fluid
   {
@@ -1015,9 +1009,11 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
             parameter<bool>("LOCAL",
                 {.description =
                         "individual materials allocated per element or only at global scope"}),
-            parameter<int>("NUMMAT", {.description = "number of materials in list"}),
-            parameter<std::vector<int>>("MATIDS",
-                {.description = "the list material IDs", .size = from_parameter<int>("NUMMAT")}),
+            parameter<int>("NUMMAT",
+                {.description = "number of materials in list (deprecated and ignored: the number "
+                                "is always determined from the length of 'MATIDS')",
+                    .default_value = -1}),
+            parameter<std::vector<int>>("MATIDS", {.description = "the list material IDs"}),
         },
         {.description = "list/collection of materials, i.e. material IDs"});
   }
@@ -1030,13 +1026,17 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
             parameter<bool>("LOCAL",
                 {.description =
                         "individual materials allocated per element or only at global scope"}),
-            parameter<int>("NUMMAT", {.description = "number of materials in list"}),
-            parameter<std::vector<int>>("MATIDS",
-                {.description = "the list material IDs", .size = from_parameter<int>("NUMMAT")}),
-            parameter<int>("NUMREAC", {.description = "number of reactions for these elements"}),
-            parameter<std::vector<int>>("REACIDS", {.description = "advanced reaction list",
-                                                       .default_value = std::vector{0},
-                                                       .size = from_parameter<int>("NUMREAC")}),
+            parameter<int>("NUMMAT",
+                {.description = "number of materials in list (deprecated and ignored: the number "
+                                "is always determined from the length of 'MATIDS')",
+                    .default_value = -1}),
+            parameter<std::vector<int>>("MATIDS", {.description = "the list material IDs"}),
+            parameter<int>("NUMREAC",
+                {.description = "number of reactions for these elements (deprecated and ignored: "
+                                "the number is always determined from the length of 'REACIDS')",
+                    .default_value = -1}),
+            parameter<std::vector<int>>("REACIDS",
+                {.description = "advanced reaction list", .default_value = std::vector{0}}),
         },
         {.description = "list/collection of materials, i.e. material IDs and list of reactions"});
   }
@@ -1049,13 +1049,17 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
             parameter<bool>("LOCAL",
                 {.description =
                         "individual materials allocated per element or only at global scope"}),
-            parameter<int>("NUMMAT", {.description = "number of materials in list"}),
-            parameter<std::vector<int>>("MATIDS",
-                {.description = "the list material IDs", .size = from_parameter<int>("NUMMAT")}),
-            parameter<int>("NUMPAIR", {.description = "number of pairs for these elements"}),
-            parameter<std::vector<int>>("PAIRIDS", {.description = "chemotaxis pairs list",
-                                                       .default_value = std::vector{0},
-                                                       .size = from_parameter<int>("NUMPAIR")}),
+            parameter<int>("NUMMAT",
+                {.description = "number of materials in list (deprecated and ignored: the number "
+                                "is always determined from the length of 'MATIDS')",
+                    .default_value = -1}),
+            parameter<std::vector<int>>("MATIDS", {.description = "the list material IDs"}),
+            parameter<int>("NUMPAIR",
+                {.description = "number of pairs for these elements (deprecated and ignored: the "
+                                "number is always determined from the length of 'PAIRIDS')",
+                    .default_value = -1}),
+            parameter<std::vector<int>>("PAIRIDS",
+                {.description = "chemotaxis pairs list", .default_value = std::vector{0}}),
         },
         {.description =
                 "list/collection of materials, i.e. material IDs and list of chemotactic pairs"});
@@ -1069,17 +1073,23 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
             parameter<bool>("LOCAL",
                 {.description =
                         "individual materials allocated per element or only at global scope"}),
-            parameter<int>("NUMMAT", {.description = "number of materials in list"}),
-            parameter<std::vector<int>>("MATIDS",
-                {.description = "the list material IDs", .size = from_parameter<int>("NUMMAT")}),
-            parameter<int>("NUMPAIR", {.description = "number of pairs for these elements"}),
-            parameter<std::vector<int>>("PAIRIDS", {.description = "chemotaxis pairs list",
-                                                       .default_value = std::vector{0},
-                                                       .size = from_parameter<int>("NUMPAIR")}),
-            parameter<int>("NUMREAC", {.description = "number of reactions for these elements"}),
-            parameter<std::vector<int>>("REACIDS", {.description = "advanced reaction list",
-                                                       .default_value = std::vector{0},
-                                                       .size = from_parameter<int>("NUMREAC")}),
+            parameter<int>("NUMMAT",
+                {.description = "number of materials in list (deprecated and ignored: the number "
+                                "is always determined from the length of 'MATIDS')",
+                    .default_value = -1}),
+            parameter<std::vector<int>>("MATIDS", {.description = "the list material IDs"}),
+            parameter<int>("NUMPAIR",
+                {.description = "number of pairs for these elements (deprecated and ignored: the "
+                                "number is always determined from the length of 'PAIRIDS')",
+                    .default_value = -1}),
+            parameter<std::vector<int>>("PAIRIDS",
+                {.description = "chemotaxis pairs list", .default_value = std::vector{0}}),
+            parameter<int>("NUMREAC",
+                {.description = "number of reactions for these elements (deprecated and ignored: "
+                                "the number is always determined from the length of 'REACIDS')",
+                    .default_value = -1}),
+            parameter<std::vector<int>>("REACIDS",
+                {.description = "advanced reaction list", .default_value = std::vector{0}}),
         },
         {.description = "list/collection of materials, i.e. material IDs and list of "
                         "reactive/chemotactic pairs"});
@@ -1114,9 +1124,11 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
                     .default_value = false}),
             parameter<double>("EPSILON", {.description = "phase porosity"}),
             parameter<double>("TORTUOSITY", {.description = "inverse (!) of phase tortuosity"}),
-            parameter<int>("NUMMAT", {.description = "number of materials in electrolyte"}),
-            parameter<std::vector<int>>("MATIDS",
-                {.description = "the list phasel IDs", .size = from_parameter<int>("NUMMAT")}),
+            parameter<int>("NUMMAT",
+                {.description = "number of materials in electrolyte (deprecated and ignored: the "
+                                "number is always determined from the length of 'MATIDS')",
+                    .default_value = -1}),
+            parameter<std::vector<int>>("MATIDS", {.description = "the list phasel IDs"}),
         },
         {.description = "material parameters for ion species in electrolyte solution"});
   }
@@ -1166,9 +1178,10 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
         {
             parameter<int>("YOUNGNUM",
                 {.description = "number of Young's modulus in list (if 1 Young is const, "
-                                "if >1 Young is temperature) dependent"}),
-            parameter<std::vector<double>>("YOUNG",
-                {.description = "Young's modulus", .size = from_parameter<int>("YOUNGNUM")}),
+                                "if >1 Young is temperature) dependent (deprecated and ignored: "
+                                "the number is always determined from the length of 'YOUNG')",
+                    .default_value = -1}),
+            parameter<std::vector<double>>("YOUNG", {.description = "Young's modulus"}),
             parameter<double>("NUE", {.description = "Poisson's ratio"}),
             parameter<double>("DENS", {.description = "mass density"}),
             parameter<double>(
@@ -1233,15 +1246,15 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
             parameter<double>("ISOHARD", {.description = "isotropic hardening modulus"}),
             parameter<double>("KINHARD", {.description = "kinematic hardening modulus"}),
             parameter<int>("SAMPLENUM",
-                {.description =
-                        "number of stress-strain pairs for multi-linear isotropic hardening"}),
+                {.description = "number of stress-strain pairs for multi-linear isotropic "
+                                "hardening (deprecated and ignored: the number is always "
+                                "determined from the length of 'SIGMA_Y')",
+                    .default_value = -1}),
             parameter<std::vector<double>>(
                 "SIGMA_Y", {.description = "yield stress values at specific plastic strains. The "
-                                           "value at zero plastic strain is still given in YIELD",
-                               .size = from_parameter<int>("SAMPLENUM")}),
+                                           "value at zero plastic strain is still given in YIELD"}),
             parameter<std::vector<double>>(
-                "EPSBAR_P", {.description = "accumulated plastic strain corresponding to SIGMA_Y",
-                                .size = from_parameter<int>("SAMPLENUM")}),
+                "EPSBAR_P", {.description = "accumulated plastic strain corresponding to SIGMA_Y"}),
             parameter<double>("TOL", {.description = "tolerance for local Newton iteration"}),
         },
         {.description = "Thermo-elastic St.Venant Kirchhoff / plastic von Mises material with "
@@ -1472,9 +1485,11 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
             parameter<std::string>(
                 "KIND", {.description = "kind of Robinson material: Butler, Arya, "
                                         "Arya_NarloyZ (default), Arya_CrMoSteel"}),
-            parameter<int>("YOUNGNUM", {.description = "number of Young's modulus in list"}),
-            parameter<std::vector<double>>("YOUNG",
-                {.description = "Young's modulus", .size = from_parameter<int>("YOUNGNUM")}),
+            parameter<int>("YOUNGNUM",
+                {.description = "number of Young's modulus in list (deprecated and ignored: the "
+                                "number is always determined from the length of 'YOUNG')",
+                    .default_value = -1}),
+            parameter<std::vector<double>>("YOUNG", {.description = "Young's modulus"}),
             parameter<double>("NUE", {.description = "Poisson's ratio"}),
             parameter<double>("DENS", {.description = "mass density"}),
             parameter<double>(
@@ -1508,12 +1523,13 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
             parameter<double>("YOUNG", {.description = "Young's modulus"}),
             parameter<double>("NUE", {.description = "Poisson's ratio"}),
             parameter<double>("DENS", {.description = "mass density"}),
-            parameter<int>("SAMPLENUM", {.description = "number of stress-strain pairs in list"}),
-            parameter<std::vector<double>>("SIGMA_Y",
-                {.description = "yield stress", .size = from_parameter<int>("SAMPLENUM")}),
+            parameter<int>("SAMPLENUM",
+                {.description = "number of stress-strain pairs in list (deprecated and ignored: "
+                                "the number is always determined from the length of 'SIGMA_Y')",
+                    .default_value = -1}),
+            parameter<std::vector<double>>("SIGMA_Y", {.description = "yield stress"}),
             parameter<std::vector<double>>(
-                "EPSBAR_P", {.description = "accumulated plastic strain corresponding to SIGMA_Y",
-                                .size = from_parameter<int>("SAMPLENUM")}),
+                "EPSBAR_P", {.description = "accumulated plastic strain corresponding to SIGMA_Y"}),
             parameter<double>("DAMDEN", {.description = "denominator of damage evaluations law"}),
             parameter<double>("DAMEXP", {.description = "exponent of damage evaluations law"}),
             parameter<double>("DAMTHRESHOLD", {.description = "damage threshold"}),
@@ -1606,9 +1622,12 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
   {
     known_materials[Core::Materials::m_elasthyper] = group("MAT_ElastHyper",
         {
-            parameter<int>("NUMMAT", {.description = "number of materials/potentials in list"}),
-            parameter<std::vector<int>>("MATIDS", {.description = "the list material/potential IDs",
-                                                      .size = from_parameter<int>("NUMMAT")}),
+            parameter<int>("NUMMAT",
+                {.description = "number of materials/potentials in list (deprecated and ignored: "
+                                "the number is always determined from the length of 'MATIDS')",
+                    .default_value = -1}),
+            parameter<std::vector<int>>(
+                "MATIDS", {.description = "the list material/potential IDs"}),
             parameter<double>("DENS", {.description = "material mass density"}),
             parameter<int>("POLYCONVEX",
                 {.description = "1.0 if polyconvexity of system is checked", .default_value = 0}),
@@ -1621,26 +1640,32 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
   {
     known_materials[Core::Materials::m_viscoelasthyper] = group("MAT_ViscoElastHyper",
         {
-            parameter<int>("NUMMAT", {.description = "number of materials/potentials in list"}),
-            parameter<std::vector<int>>("MATIDS", {.description = "the list material/potential IDs",
-                                                      .size = from_parameter<int>("NUMMAT")}),
-            parameter<std::optional<int>>(
-                "NUMELAST", {.description = "explicit number of purely elastic summands"}),
+            parameter<int>("NUMMAT",
+                {.description = "number of materials/potentials in list (deprecated and ignored: "
+                                "the number is always determined from the length of 'MATIDS')",
+                    .default_value = -1}),
+            parameter<std::vector<int>>(
+                "MATIDS", {.description = "the list material/potential IDs"}),
+            parameter<int>("NUMELAST",
+                {.description = "explicit number of purely elastic summands (deprecated and "
+                                "ignored: the number is always determined from the length of "
+                                "'ELAST_MATIDS')",
+                    .default_value = -1}),
             parameter<std::optional<std::vector<int>>>(
-                "ELAST_MATIDS", {.description = "explicit purely elastic summand IDs",
-                                    .size = size_from_optional_count("NUMELAST")}),
-            parameter<std::optional<int>>(
-                "NUMVISCO", {.description = "explicit number of visco summands"}),
+                "ELAST_MATIDS", {.description = "explicit purely elastic summand IDs"}),
+            parameter<int>("NUMVISCO",
+                {.description = "explicit number of visco summands (deprecated and ignored: the "
+                                "number is always determined from the length of 'VISCO_MATIDS')",
+                    .default_value = -1}),
             parameter<std::optional<std::vector<int>>>(
-                "VISCO_MATIDS", {.description = "explicit visco summand IDs",
-                                    .size = size_from_optional_count("NUMVISCO")}),
+                "VISCO_MATIDS", {.description = "explicit visco summand IDs"}),
             parameter<double>("DENS", {.description = "material mass density"}),
             parameter<int>("POLYCONVEX",
                 {.description = "1.0 if polyconvexity of system is checked", .default_value = 0}),
         },
-        {.description = "Viscohyperelastic material. Uses NUMMAT/MATIDS as the complete summand "
-                        "list and supports explicit elastic/visco splits with NUMELAST/"
-                        "ELAST_MATIDS and NUMVISCO/VISCO_MATIDS."});
+        {.description = "Viscohyperelastic material. Uses MATIDS as the complete summand "
+                        "list and supports explicit elastic/visco splits with "
+                        "ELAST_MATIDS and VISCO_MATIDS."});
   }
 
   /*----------------------------------------------------------------------*/
@@ -1648,9 +1673,12 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
   {
     known_materials[Core::Materials::m_plelasthyper] = group("MAT_PlasticElastHyper",
         {
-            parameter<int>("NUMMAT", {.description = "number of materials/potentials in list"}),
-            parameter<std::vector<int>>("MATIDS", {.description = "the list material/potential IDs",
-                                                      .size = from_parameter<int>("NUMMAT")}),
+            parameter<int>("NUMMAT",
+                {.description = "number of materials/potentials in list (deprecated and ignored: "
+                                "the number is always determined from the length of 'MATIDS')",
+                    .default_value = -1}),
+            parameter<std::vector<int>>(
+                "MATIDS", {.description = "the list material/potential IDs"}),
             parameter<double>("DENS", {.description = "material mass density"}),
             parameter<double>("INITYIELD", {.description = "initial yield stress"}),
             parameter<int>("POLYCONVEX",
@@ -1723,9 +1751,12 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
   {
     known_materials[Core::Materials::m_plelasthyperVCU] = group("MAT_PlasticElastHyperVCU",
         {
-            parameter<int>("NUMMAT", {.description = "number of materials/potentials in list"}),
-            parameter<std::vector<int>>("MATIDS", {.description = "the list material/potential IDs",
-                                                      .size = from_parameter<int>("NUMMAT")}),
+            parameter<int>("NUMMAT",
+                {.description = "number of materials/potentials in list (deprecated and ignored: "
+                                "the number is always determined from the length of 'MATIDS')",
+                    .default_value = -1}),
+            parameter<std::vector<int>>(
+                "MATIDS", {.description = "the list material/potential IDs"}),
             parameter<double>("DENS", {.description = "material mass density"}),
             parameter<double>("INITYIELD", {.description = "initial yield stress"}),
             parameter<double>("ISOHARD",
@@ -2067,18 +2098,25 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
   {
     known_materials[Core::Materials::mes_remodelfiber] = group("ELAST_RemodelFiber",
         {
-            parameter<int>("NUMMAT", {.description = "number of materials/potentials in list"}),
-            parameter<std::vector<int>>("MATIDS", {.description = "the list material/potential IDs",
-                                                      .size = from_parameter<int>("NUMMAT")}),
+            parameter<int>("NUMMAT",
+                {.description = "number of materials/potentials in list (deprecated and ignored: "
+                                "the number is always determined from the length of 'MATIDS')",
+                    .default_value = -1}),
+            parameter<std::vector<int>>(
+                "MATIDS", {.description = "the list material/potential IDs"}),
             parameter<double>(
                 "TDECAY", {.description = "decay time of Poisson (degradation) process"}),
             parameter<double>("GROWTHFAC",
                 {.description = "time constant for collagen growth", .default_value = 0.0}),
-            parameter<std::vector<double>>(
-                "COLMASSFRAC", {.description = "initial mass fraction of first collagen fiber "
-                                               "family in constraint mixture",
-                                   .default_value = std::vector{0.0},
-                                   .size = from_parameter<int>("NUMMAT")}),
+            parameter<std::vector<double>>("COLMASSFRAC",
+                {.description = "initial mass fraction of first collagen fiber "
+                                "family in constraint mixture",
+                    .default_value = std::vector{0.0},
+                    .size =
+                        [](const Core::IO::InputParameterContainer& container)
+                    {
+                      return static_cast<int>(container.get<std::vector<int>>("MATIDS").size());
+                    }}),
             parameter<double>("DEPOSITIONSTRETCH", {.description = "deposition stretch"}),
         },
         {.description = "General fiber material for remodeling"});
@@ -2461,9 +2499,11 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
   {
     known_materials[Core::Materials::mes_generalizedmaxwell] = group("VISCO_GeneralizedMaxwell",
         {
-            parameter<int>("NUMBRANCH", {.description = "number of viscoelastic branches"}),
-            parameter<std::vector<int>>("MATIDS",
-                {.description = "the list material IDs", .size = from_parameter<int>("NUMBRANCH")}),
+            parameter<int>("NUMBRANCH",
+                {.description = "number of viscoelastic branches (deprecated and ignored: the "
+                                "number is always determined from the length of 'MATIDS')",
+                    .default_value = -1}),
+            parameter<std::vector<int>>("MATIDS", {.description = "the list material IDs"}),
             parameter<std::string>("SOLVE",
                 {.description = "Solution for evolution equation: OneStepTheta (default) or "
                                 "ExponentialTimeDiscretization (convolution integral)",
@@ -2586,9 +2626,12 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
   {
     known_materials[Core::Materials::m_membrane_elasthyper] = group("MAT_Membrane_ElastHyper",
         {
-            parameter<int>("NUMMAT", {.description = "number of materials/potentials in list"}),
-            parameter<std::vector<int>>("MATIDS", {.description = "the list material/potential IDs",
-                                                      .size = from_parameter<int>("NUMMAT")}),
+            parameter<int>("NUMMAT",
+                {.description = "number of materials/potentials in list (deprecated and ignored: "
+                                "the number is always determined from the length of 'MATIDS')",
+                    .default_value = -1}),
+            parameter<std::vector<int>>(
+                "MATIDS", {.description = "the list material/potential IDs"}),
             parameter<double>("DENS", {.description = "material mass density"}),
             parameter<int>("POLYCONVEX",
                 {.description = "1.0 if polyconvexity of system is checked", .default_value = 0}),
@@ -2623,24 +2666,29 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
     known_materials[Core::Materials::m_growthremodel_elasthyper] = group(
         "MAT_GrowthRemodel_ElastHyper",
         {
-            parameter<int>("NUMMATRF", {.description = "number of remodelfiber materials in list"}),
+            parameter<int>("NUMMATRF",
+                {.description = "number of remodelfiber materials in list (deprecated and ignored: "
+                                "the number is always determined from the length of 'MATIDSRF')",
+                    .default_value = -1}),
             parameter<int>("NUMMATEL3D",
-                {.description = "number of 3d elastin matrix materials/potentials in list",
-                    .default_value = 0}),
+                {.description = "number of 3d elastin matrix materials/potentials in list "
+                                "(deprecated and ignored: the number is always determined from the "
+                                "length of 'MATIDSEL3D')",
+                    .default_value = -1}),
             parameter<int>("NUMMATEL2D",
-                {.description = "number of 2d elastin matrix materials/potentials in list"}),
+                {.description = "number of 2d elastin matrix materials/potentials in list "
+                                "(deprecated and ignored: the number is always determined from the "
+                                "length of 'MATIDSEL2D')",
+                    .default_value = -1}),
             parameter<std::vector<int>>(
                 "MATIDSRF", {.description = "the list remodelfiber material IDs",
-                                .default_value = std::vector{0},
-                                .size = from_parameter<int>("NUMMATRF")}),
+                                .default_value = std::vector<int>{}}),
             parameter<std::vector<int>>(
                 "MATIDSEL3D", {.description = "the list 3d elastin matrix material/potential IDs",
-                                  .default_value = std::vector{-1},
-                                  .size = from_parameter<int>("NUMMATEL3D")}),
+                                  .default_value = std::vector<int>{}}),
             parameter<std::vector<int>>(
                 "MATIDSEL2D", {.description = "the list 2d elastin matrix material/potential IDs",
-                                  .default_value = std::vector{0},
-                                  .size = from_parameter<int>("NUMMATEL2D")}),
+                                  .default_value = std::vector<int>{}}),
             parameter<int>(
                 "MATIDELPENALTY", {.description = "penalty material ID", .default_value = -1}),
             parameter<double>("ELMASSFRAC",
@@ -2684,18 +2732,22 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
     known_materials[Core::Materials::m_multiplicative_split_defgrad_elasthyper] =
         group("MAT_MultiplicativeSplitDefgradElastHyper",
             {
-                parameter<int>(
-                    "NUMMATEL", {.description = "number of elastic materials/potentials in list"}),
+                parameter<int>("NUMMATEL",
+                    {.description = "number of elastic materials/potentials in list (deprecated "
+                                    "and ignored: the number is always determined from the length "
+                                    "of 'MATIDSEL')",
+                        .default_value = -1}),
                 parameter<std::vector<int>>(
                     "MATIDSEL", {.description = "the list of elastic material/potential IDs",
-                                    .default_value = std::vector{-1},
-                                    .size = from_parameter<int>("NUMMATEL")}),
+                                    .default_value = std::vector<int>{}}),
                 parameter<int>("NUMFACINEL",
-                    {.description = "number of factors of inelastic deformation gradient"}),
+                    {.description = "number of factors of inelastic deformation gradient "
+                                    "(deprecated and ignored: the number is always determined from "
+                                    "the length of 'INELDEFGRADFACIDS')",
+                        .default_value = -1}),
                 parameter<std::vector<int>>("INELDEFGRADFACIDS",
                     {.description = "the list of inelastic deformation gradient factor IDs",
-                        .default_value = std::vector{0},
-                        .size = from_parameter<int>("NUMFACINEL")}),
+                        .default_value = std::vector<int>{}}),
                 parameter<double>("DENS", {.description = "material mass density"}),
                 parameter<double>("REF_TEMPERATURE",
                     {.description = "reference temperature for thermoelastic expansion.",
@@ -3376,9 +3428,11 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
                 {.description =
                         "individual materials allocated per element or only at global scope"}),
             parameter<double>("PERMEABILITY", {.description = "permeability of medium"}),
-            parameter<int>("NUMMAT", {.description = "number of materials in list"}),
-            parameter<std::vector<int>>("MATIDS",
-                {.description = "the list material IDs", .size = from_parameter<int>("NUMMAT")}),
+            parameter<int>("NUMMAT",
+                {.description = "number of materials in list (deprecated and ignored: the number "
+                                "is always determined from the length of 'MATIDS')",
+                    .default_value = -1}),
+            parameter<std::vector<int>>("MATIDS", {.description = "the list material IDs"}),
             parameter<int>(
                 "NUMFLUIDPHASES_IN_MULTIPHASEPORESPACE", {.description = "number of fluid phases"}),
         },
@@ -3395,15 +3449,19 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
                 {.description =
                         "individual materials allocated per element or only at global scope"}),
             parameter<double>("PERMEABILITY", {.description = "permeability of medium"}),
-            parameter<int>("NUMMAT", {.description = "number of materials in list"}),
-            parameter<std::vector<int>>("MATIDS",
-                {.description = "the list material IDs", .size = from_parameter<int>("NUMMAT")}),
+            parameter<int>("NUMMAT",
+                {.description = "number of materials in list (deprecated and ignored: the number "
+                                "is always determined from the length of 'MATIDS')",
+                    .default_value = -1}),
+            parameter<std::vector<int>>("MATIDS", {.description = "the list material IDs"}),
             parameter<int>(
                 "NUMFLUIDPHASES_IN_MULTIPHASEPORESPACE", {.description = "number of fluid phases"}),
-            parameter<int>("NUMREAC", {.description = "number of reactions for these elements"}),
-            parameter<std::vector<int>>("REACIDS", {.description = "advanced reaction list",
-                                                       .default_value = std::vector{0},
-                                                       .size = from_parameter<int>("NUMREAC")}),
+            parameter<int>("NUMREAC",
+                {.description = "number of reactions for these elements (deprecated and ignored: "
+                                "the number is always determined from the length of 'REACIDS')",
+                    .default_value = -1}),
+            parameter<std::vector<int>>("REACIDS",
+                {.description = "advanced reaction list", .default_value = std::vector{0}}),
         },
         {.description = "multi phase flow in deformable porous media and list of reactions"});
   }
@@ -4221,10 +4279,12 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
     known_materials[Core::Materials::mix_elasthyper_damage] =
         group("MIX_Constituent_ElastHyper_Damage",
             {
-                parameter<int>("NUMMAT", {.description = "number of summands"}),
+                parameter<int>("NUMMAT",
+                    {.description = "number of summands (deprecated and ignored: the number is "
+                                    "always determined from the length of 'MATIDS')",
+                        .default_value = -1}),
                 parameter<std::vector<int>>(
-                    "MATIDS", {.description = "list material IDs of the membrane summands",
-                                  .size = from_parameter<int>("NUMMAT")}),
+                    "MATIDS", {.description = "list material IDs of the membrane summands"}),
                 parameter<int>(
                     "PRESTRESS_STRATEGY", {.description = "Material id of the prestress strategy "
                                                           "(optional, by default no prestretch)",
@@ -4246,14 +4306,18 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
                 "MEMBRANE_NORMAL",
                 {.description =
                         "A unit vector field pointing in the direction of the membrane normal."}),
-            parameter<int>("NUMMAT", {.description = "number of summands"}),
+            parameter<int>(
+                "NUMMAT", {.description = "number of summands (deprecated and ignored: the number "
+                                          "is always determined from the length of 'MATIDS')",
+                              .default_value = -1}),
             parameter<std::vector<int>>(
-                "MATIDS", {.description = "list material IDs of the membrane summands",
-                              .size = from_parameter<int>("NUMMAT")}),
-            parameter<int>("MEMBRANENUMMAT", {.description = "number of summands"}),
+                "MATIDS", {.description = "list material IDs of the membrane summands"}),
+            parameter<int>("MEMBRANENUMMAT",
+                {.description = "number of summands (deprecated and ignored: the number is always "
+                                "determined from the length of 'MEMBRANEMATIDS')",
+                    .default_value = -1}),
             parameter<std::vector<int>>(
-                "MEMBRANEMATIDS", {.description = "list material IDs of the membrane summands",
-                                      .size = from_parameter<int>("MEMBRANENUMMAT")}),
+                "MEMBRANEMATIDS", {.description = "list material IDs of the membrane summands"}),
             parameter<int>(
                 "PRESTRESS_STRATEGY", {.description = "Material id of the prestress strategy "
                                                       "(optional, by default no prestretch)",
@@ -4320,7 +4384,7 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
                                           "using a restart of the simulation."}),
         },
         {.description =
-                "General material wrapper enabling iterative pretressing for any material"});
+                "General material wrapper enabling iterative prestressing for any material"});
   }
 
   /*----------------------------------------------------------------------*/

--- a/src/mat/4C_mat_elasthyper.cpp
+++ b/src/mat/4C_mat_elasthyper.cpp
@@ -24,17 +24,12 @@ FOUR_C_NAMESPACE_OPEN
 /*----------------------------------------------------------------------*/
 Mat::PAR::ElastHyper::ElastHyper(const Core::Mat::PAR::Parameter::Data& matdata)
     : Parameter(matdata),
-      nummat_(matdata.parameters.get<int>("NUMMAT")),
+      nummat_(static_cast<int>(matdata.parameters.get<std::vector<int>>("MATIDS").size())),
       matids_(matdata.parameters.get<std::vector<int>>("MATIDS")),
       density_(matdata.parameters.get<double>("DENS")),
       polyconvex_(matdata.parameters.get<int>("POLYCONVEX"))
 
 {
-  // check if sizes fit
-  if (nummat_ != (int)matids_.size())
-    FOUR_C_THROW("number of materials {} does not fit to size of material vector {}", nummat_,
-        matids_.size());
-
   // output, that polyconvexity is checked
   if (polyconvex_ != 0) std::cout << "Polyconvexity of your simulation is checked." << std::endl;
 }

--- a/src/mat/4C_mat_elchphase.cpp
+++ b/src/mat/4C_mat_elchphase.cpp
@@ -23,14 +23,10 @@ Mat::PAR::ElchPhase::ElchPhase(const Core::Mat::PAR::Parameter::Data& matdata)
     : Parameter(matdata),
       epsilon_(matdata.parameters.get<double>("EPSILON")),
       tortuosity_(matdata.parameters.get<double>("TORTUOSITY")),
-      nummat_(matdata.parameters.get<int>("NUMMAT")),
+      nummat_(static_cast<int>(matdata.parameters.get<std::vector<int>>("MATIDS").size())),
       matids_(matdata.parameters.get<std::vector<int>>("MATIDS")),
       local_(matdata.parameters.get<bool>("LOCAL"))
 {
-  if (nummat_ != (int)matids_.size())
-    FOUR_C_THROW(
-        "number of phases {} does not fit to size of phase vector {}", nummat_, matids_.size());
-
   if (not local_)
   {
     // make sure the referenced materials in material list have quick access parameters

--- a/src/mat/4C_mat_fluidporo_multiphase_reactions.cpp
+++ b/src/mat/4C_mat_fluidporo_multiphase_reactions.cpp
@@ -23,14 +23,9 @@ FOUR_C_NAMESPACE_OPEN
 Mat::PAR::FluidPoroMultiPhaseReactions::FluidPoroMultiPhaseReactions(
     const Core::Mat::PAR::Parameter::Data& matdata)
     : FluidPoroMultiPhase(matdata),
-      numreac_((matdata.parameters.get<int>("NUMREAC"))),
+      numreac_(static_cast<int>(matdata.parameters.get<std::vector<int>>("REACIDS").size())),
       reacids_((matdata.parameters.get<std::vector<int>>("REACIDS")))
 {
-  // check if sizes fit
-  if (numreac_ != (int)reacids_.size())
-    FOUR_C_THROW("number of materials {} does not fit to size of material vector {}", nummat_,
-        reacids_.size());
-
   if (numreac_ < 1)
     FOUR_C_THROW("if you don't have reactions, use MAT_matlist instead of MAT_matlist_reactions!");
 

--- a/src/mat/4C_mat_growthremodel_elasthyper.cpp
+++ b/src/mat/4C_mat_growthremodel_elasthyper.cpp
@@ -37,9 +37,6 @@ FOUR_C_NAMESPACE_OPEN
 Mat::PAR::GrowthRemodelElastHyper::GrowthRemodelElastHyper(
     const Core::Mat::PAR::Parameter::Data& matdata)
     : Parameter(matdata),
-      nummat_remodelfiber_(matdata.parameters.get<int>("NUMMATRF")),
-      nummat_elastiniso_(matdata.parameters.get<int>("NUMMATEL3D")),
-      nummat_elastinmem_(matdata.parameters.get<int>("NUMMATEL2D")),
       matids_remodelfiber_(matdata.parameters.get<std::vector<int>>("MATIDSRF")),
       matids_elastiniso_(matdata.parameters.get<std::vector<int>>("MATIDSEL3D")),
       matids_elastinmem_(matdata.parameters.get<std::vector<int>>("MATIDSEL2D")),
@@ -57,18 +54,6 @@ Mat::PAR::GrowthRemodelElastHyper::GrowthRemodelElastHyper(
       membrane_(matdata.parameters.get<int>("MEMBRANE")),
       cylinder_(matdata.parameters.get<int>("CYLINDER"))
 {
-  // check if sizes fit
-  if (nummat_remodelfiber_ != (int)matids_remodelfiber_.size())
-    FOUR_C_THROW(
-        "number of remodelfiber materials {} does not fit to size of remodelfiber material vector "
-        "{}",
-        nummat_remodelfiber_, matids_remodelfiber_.size());
-
-  if (nummat_elastinmem_ != (int)matids_elastinmem_.size())
-    FOUR_C_THROW(
-        "number of elastin materials {} does not fit to size of elastin material vector {}",
-        nummat_elastinmem_, matids_elastinmem_.size());
-
   if (membrane_ == 1)
   {
     if ((growthtype_ != 1) || (loctimeint_ != 0))
@@ -78,11 +63,7 @@ Mat::PAR::GrowthRemodelElastHyper::GrowthRemodelElastHyper(
   }
   else
   {
-    if (nummat_elastiniso_ != (int)matids_elastiniso_.size())
-      FOUR_C_THROW(
-          "number of elastin materials {} does not fit to size of elastin material vector {}",
-          nummat_elastiniso_, matids_elastiniso_.size());
-    if (nummat_elastiniso_ == 0) FOUR_C_THROW("you have to set a 3D elastin material");
+    if (matids_elastiniso_.empty()) FOUR_C_THROW("you have to set a 3D elastin material");
     if (matid_penalty_ == -1) FOUR_C_THROW("you have to set a volumetric penalty material");
     if ((p_mean_ == -1) || (ri_ == -1) || (t_ref_ == -1))
       FOUR_C_THROW(

--- a/src/mat/4C_mat_growthremodel_elasthyper.hpp
+++ b/src/mat/4C_mat_growthremodel_elasthyper.hpp
@@ -50,15 +50,6 @@ namespace Mat
       /// @name material parameters
       //@{
 
-      /// length of remodelfiber material list
-      const int nummat_remodelfiber_;
-
-      /// length of 3d elastin matrix material list
-      const int nummat_elastiniso_;
-
-      /// length of membrane elastin matrix material list
-      const int nummat_elastinmem_;
-
       /// the list of remodelfiber material IDs
       const std::vector<int> matids_remodelfiber_;
 

--- a/src/mat/4C_mat_list.cpp
+++ b/src/mat/4C_mat_list.cpp
@@ -20,15 +20,10 @@ FOUR_C_NAMESPACE_OPEN
 /*----------------------------------------------------------------------*/
 Mat::PAR::MatList::MatList(const Core::Mat::PAR::Parameter::Data& matdata)
     : Parameter(matdata),
-      nummat_(matdata.parameters.get<int>("NUMMAT")),
+      nummat_(static_cast<int>(matdata.parameters.get<std::vector<int>>("MATIDS").size())),
       matids_(matdata.parameters.get<std::vector<int>>("MATIDS")),
       local_((matdata.parameters.get<bool>("LOCAL")))
 {
-  // check if sizes fit
-  if (nummat_ != (int)matids_.size())
-    FOUR_C_THROW("number of materials {} does not fit to size of material vector {}", nummat_,
-        matids_.size());
-
   if (not local_)
   {
     // make sure the referenced materials in material list have quick access parameters

--- a/src/mat/4C_mat_list_chemotaxis.cpp
+++ b/src/mat/4C_mat_list_chemotaxis.cpp
@@ -22,14 +22,9 @@ FOUR_C_NAMESPACE_OPEN
  *----------------------------------------------------------------------*/
 Mat::PAR::MatListChemotaxis::MatListChemotaxis(const Core::Mat::PAR::Parameter::Data& matdata)
     : MatList(matdata),
-      numpair_((matdata.parameters.get<int>("NUMPAIR"))),
+      numpair_(static_cast<int>(matdata.parameters.get<std::vector<int>>("PAIRIDS").size())),
       pairids_((matdata.parameters.get<std::vector<int>>("PAIRIDS")))
 {
-  // check if sizes fit
-  if (numpair_ != (int)pairids_.size())
-    FOUR_C_THROW("number of materials {} does not fit to size of material vector {}", nummat_,
-        pairids_.size());
-
   if (numpair_ < 1)
     FOUR_C_THROW(
         "If you don't have chemotactic pairs, use MAT_matlist instead of MAT_matlist_chemotaxis!");

--- a/src/mat/4C_mat_list_reactions.cpp
+++ b/src/mat/4C_mat_list_reactions.cpp
@@ -22,14 +22,9 @@ FOUR_C_NAMESPACE_OPEN
  *----------------------------------------------------------------------*/
 Mat::PAR::MatListReactions::MatListReactions(const Core::Mat::PAR::Parameter::Data& matdata)
     : MatList(matdata),
-      numreac_((matdata.parameters.get<int>("NUMREAC"))),
+      numreac_(static_cast<int>(matdata.parameters.get<std::vector<int>>("REACIDS").size())),
       reacids_((matdata.parameters.get<std::vector<int>>("REACIDS")))
 {
-  // check if sizes fit
-  if (numreac_ != (int)reacids_.size())
-    FOUR_C_THROW("number of materials {} does not fit to size of material vector {}", nummat_,
-        reacids_.size());
-
   if (numreac_ < 1)
     FOUR_C_THROW("if you don't have reactions, use MAT_matlist instead of MAT_matlist_reactions!");
 

--- a/src/mat/4C_mat_multiplicative_split_defgrad_elasthyper.cpp
+++ b/src/mat/4C_mat_multiplicative_split_defgrad_elasthyper.cpp
@@ -43,28 +43,13 @@ FOUR_C_NAMESPACE_OPEN
 Mat::PAR::MultiplicativeSplitDefgradElastHyper::MultiplicativeSplitDefgradElastHyper(
     const Core::Mat::PAR::Parameter::Data& matdata)
     : Parameter(matdata),
-      nummat_elast_(matdata.parameters.get<int>("NUMMATEL")),
       matids_elast_(matdata.parameters.get<std::vector<int>>("MATIDSEL")),
-      numfac_inel_(matdata.parameters.get<int>("NUMFACINEL")),
       inel_defgradfacids_(matdata.parameters.get<std::vector<int>>("INELDEFGRADFACIDS")),
       density_(matdata.parameters.get<double>("DENS")),
       ref_temperature_(matdata.parameters.get<double>("REF_TEMPERATURE")),
       thermal_expansion_coefficient_(
           matdata.parameters.get<double>("THERMAL_EXPANSION_COEFFICIENT"))
 {
-  // check if sizes fit
-  if (nummat_elast_ != static_cast<int>(matids_elast_.size()))
-    FOUR_C_THROW(
-        "number of elastic materials {} does not fit to size of elastic material ID vector {}",
-        nummat_elast_, matids_elast_.size());
-
-  if (numfac_inel_ != static_cast<int>(inel_defgradfacids_.size()))
-  {
-    FOUR_C_THROW(
-        "number of inelastic deformation gradient factors {} does not fit to size of inelastic "
-        "deformation gradient ID vector {}",
-        numfac_inel_, inel_defgradfacids_.size());
-  }
 }
 
 std::shared_ptr<Core::Mat::Material>

--- a/src/mat/4C_mat_multiplicative_split_defgrad_elasthyper.hpp
+++ b/src/mat/4C_mat_multiplicative_split_defgrad_elasthyper.hpp
@@ -56,15 +56,8 @@ namespace Mat
 
       std::shared_ptr<Core::Mat::Material> create_material() override;
 
-      /// length of elastic material list
-      const int nummat_elast_;
-
       /// the list of elastic material IDs
       const std::vector<int> matids_elast_;
-
-      /// number of factors of inelastic deformation gradient F_{in} = F_{in,1} . F_{in,2}. ... .
-      /// F_{in,n} (n factors)
-      const int numfac_inel_;
 
       /// IDs of inelastic deformation gradient factors (i-th ID specifies calculation of F_{in,i})
       const std::vector<int> inel_defgradfacids_;

--- a/src/mat/4C_mat_thermoplasticlinelast.cpp
+++ b/src/mat/4C_mat_thermoplasticlinelast.cpp
@@ -35,6 +35,10 @@ Mat::PAR::ThermoPlasticLinElast::ThermoPlasticLinElast(
       strainbar_p_ref_((matdata.parameters.get<std::vector<double>>("EPSBAR_P"))),
       abstol_(matdata.parameters.get<double>("TOL"))
 {
+  FOUR_C_ASSERT_ALWAYS(sigma_y_.size() == strainbar_p_ref_.size(),
+      "Invalid MAT_Struct_ThermoPlasticLinElast setup (MAT {}): SIGMA_Y has {} entries but "
+      "EPSBAR_P has {} entries. Both have to provide the same number of samples.",
+      matdata.id, sigma_y_.size(), strainbar_p_ref_.size());
 }
 
 

--- a/src/mat/elast/4C_mat_elast_remodelfiber.cpp
+++ b/src/mat/elast/4C_mat_elast_remodelfiber.cpp
@@ -20,18 +20,13 @@ FOUR_C_NAMESPACE_OPEN
 
 Mat::Elastic::PAR::RemodelFiber::RemodelFiber(const Core::Mat::PAR::Parameter::Data& matdata)
     : Parameter(matdata),
-      nummat_(matdata.parameters.get<int>("NUMMAT")),
+      nummat_(static_cast<int>(matdata.parameters.get<std::vector<int>>("MATIDS").size())),
       matids_(matdata.parameters.get<std::vector<int>>("MATIDS")),
       t_decay_(matdata.parameters.get<double>("TDECAY")),
       k_growth_(matdata.parameters.get<double>("GROWTHFAC")),
       init_w_col_(matdata.parameters.get<std::vector<double>>("COLMASSFRAC")),
       G_(matdata.parameters.get<double>("DEPOSITIONSTRETCH"))
 {
-  // check if sizes fit
-  if (nummat_ != (int)matids_.size())
-    FOUR_C_THROW("number of materials {} does not fit to size of material vector {}", nummat_,
-        matids_.size());
-
   // check decay time validity
   if (t_decay_ <= 0.) FOUR_C_THROW("decay time must be positive");
 }

--- a/src/mat/viscoelast/4C_mat_viscoelast_generalizedmaxwell.cpp
+++ b/src/mat/viscoelast/4C_mat_viscoelast_generalizedmaxwell.cpp
@@ -29,19 +29,13 @@ namespace Mat::ViscoElast
 
   PAR::GeneralizedMaxwell::GeneralizedMaxwell(const Core::Mat::PAR::Parameter::Data& matdata)
       : Parameter(matdata),
-        numbranch_(matdata.parameters.get<int>("NUMBRANCH")),
+        numbranch_(static_cast<int>(matdata.parameters.get<std::vector<int>>("MATIDS").size())),
         matids_(matdata.parameters.get<std::vector<int>>("MATIDS")),
         solve_(matdata.parameters.get<std::string>("SOLVE"))
   {
     FOUR_C_ASSERT_ALWAYS(numbranch_ > 0,
-        "Invalid NUMBRANCH={} in VISCO_GeneralizedMaxwell (MAT {}). NUMBRANCH has to be "
-        "positive.",
-        numbranch_, matdata.id);
-
-    FOUR_C_ASSERT_ALWAYS(static_cast<int>(matids_.size()) == numbranch_,
-        "Invalid VISCO_GeneralizedMaxwell branch declaration in MAT {}: NUMBRANCH={} but "
-        "MATIDS has size {}.",
-        matdata.id, numbranch_, matids_.size());
+        "Invalid VISCO_GeneralizedMaxwell branch declaration in MAT {}: MATIDS must not be empty.",
+        matdata.id);
 
     for (int branch_index = 0; branch_index < numbranch_; ++branch_index)
     {
@@ -61,15 +55,6 @@ namespace Mat::ViscoElast
   GeneralizedMaxwell::GeneralizedMaxwell(PAR::GeneralizedMaxwell* params)
       : params_(params), branchespotsum_(0), branchtau_(0), internalpotsum_(0)
   {
-    FOUR_C_ASSERT_ALWAYS(params_->numbranch_ > 0,
-        "Invalid VISCO_GeneralizedMaxwell setup for MAT {}: NUMBRANCH={} is not positive.",
-        params_->id(), params_->numbranch_);
-
-    FOUR_C_ASSERT_ALWAYS(static_cast<int>(params_->matids_.size()) == params_->numbranch_,
-        "Invalid VISCO_GeneralizedMaxwell setup for MAT {}: NUMBRANCH={} but MATIDS has size "
-        "{}.",
-        params_->id(), params_->numbranch_, params_->matids_.size());
-
     // Integration-boundary access: branch material validation currently depends on the global
     // material bundle and remains outside constitutive evaluate/update hot paths.
     FOUR_C_ASSERT_ALWAYS(Global::Problem::instance()->materials() != nullptr,
@@ -401,20 +386,13 @@ namespace Mat::ViscoElast
         point.visco_mat_id);
 
     FOUR_C_ASSERT_ALWAYS(generalized_maxwell_numbranch_value > 0,
-        "Invalid VISCO_GeneralizedMaxwell setup in MAT_ViscoElastHyper (MAT {}): NUMBRANCH={} "
-        "is not positive.",
+        "Invalid VISCO_GeneralizedMaxwell setup in MAT_ViscoElastHyper (MAT {}): number of "
+        "branches {} is not positive.",
         point.visco_mat_id, generalized_maxwell_numbranch_value);
 
     FOUR_C_ASSERT_ALWAYS(generalized_maxwell_matids != nullptr,
         "Failed to read MATIDS for VISCO_GeneralizedMaxwell in MAT_ViscoElastHyper (MAT {}).",
         point.visco_mat_id);
-
-    FOUR_C_ASSERT_ALWAYS(generalized_maxwell_matids->size() ==
-                             static_cast<unsigned int>(generalized_maxwell_numbranch_value),
-        "Invalid VISCO_GeneralizedMaxwell setup in MAT_ViscoElastHyper (MAT {}): NUMBRANCH={} "
-        "but MATIDS has size {}.",
-        point.visco_mat_id, generalized_maxwell_numbranch_value,
-        generalized_maxwell_matids->size());
 
     const auto& branchespotsum = generalized_maxwell->get_branchespotsum();
     const auto& branchtau = generalized_maxwell->get_branchtaus();

--- a/src/mat/viscoelast/4C_mat_viscoelasthyper.cpp
+++ b/src/mat/viscoelast/4C_mat_viscoelasthyper.cpp
@@ -61,38 +61,23 @@ Mat::PAR::ViscoElastHyper::ViscoElastHyper(const Core::Mat::PAR::Parameter::Data
 Mat::PAR::ViscoElastHyper::SummandSplit Mat::PAR::ViscoElastHyper::parse_summand_split(
     const Core::Mat::PAR::Parameter::Data& matdata)
 {
-  const auto& numelast = matdata.parameters.get<std::optional<int>>("NUMELAST");
   const auto& elast_matids =
       matdata.parameters.get<std::optional<std::vector<int>>>("ELAST_MATIDS");
-  const auto& numvisco = matdata.parameters.get<std::optional<int>>("NUMVISCO");
   const auto& visco_matids =
       matdata.parameters.get<std::optional<std::vector<int>>>("VISCO_MATIDS");
 
-  const bool has_split_field = numelast.has_value() || elast_matids.has_value() ||
-                               numvisco.has_value() || visco_matids.has_value();
-  const bool has_complete_split = numelast.has_value() && elast_matids.has_value() &&
-                                  numvisco.has_value() && visco_matids.has_value();
+  const bool has_split_field = elast_matids.has_value() || visco_matids.has_value();
+  const bool has_complete_split = elast_matids.has_value() && visco_matids.has_value();
 
   FOUR_C_ASSERT_ALWAYS(!has_split_field || has_complete_split,
-      "Split MAT_ViscoElastHyper input requires NUMELAST, ELAST_MATIDS, NUMVISCO and "
-      "VISCO_MATIDS together (MAT {}).",
+      "Split MAT_ViscoElastHyper input requires ELAST_MATIDS and VISCO_MATIDS together (MAT {}).",
       matdata.id);
 
   if (has_complete_split)
   {
-    FOUR_C_ASSERT_ALWAYS(*numelast >= 0,
-        "Invalid MAT_ViscoElastHyper setup (MAT {}): NUMELAST={} must be non-negative.", matdata.id,
-        *numelast);
-    FOUR_C_ASSERT_ALWAYS(*numvisco >= 0,
-        "Invalid MAT_ViscoElastHyper setup (MAT {}): NUMVISCO={} must be non-negative.", matdata.id,
-        *numvisco);
-
     SummandSplit split;
-    split.numelast = *numelast;
     split.elast_matids = *elast_matids;
-    split.numvisco = *numvisco;
     split.visco_matids = *visco_matids;
-    split.uses_legacy_matids = false;
     return split;
   }
 
@@ -107,7 +92,6 @@ Mat::PAR::ViscoElastHyper::SummandSplit Mat::PAR::ViscoElastHyper::parse_summand
       matdata.id);
 
   SummandSplit split;
-  split.uses_legacy_matids = true;
 
   const std::vector<int>& matids = matdata.parameters.get<std::vector<int>>("MATIDS");
   const int probinst = Global::Problem::instance()->materials()->get_read_from_problem();
@@ -121,8 +105,6 @@ Mat::PAR::ViscoElastHyper::SummandSplit Mat::PAR::ViscoElastHyper::parse_summand
       split.elast_matids.push_back(summand_mat_id);
   }
 
-  split.numelast = static_cast<int>(split.elast_matids.size());
-  split.numvisco = static_cast<int>(split.visco_matids.size());
   return split;
 }
 
@@ -130,26 +112,9 @@ Mat::PAR::ViscoElastHyper::SummandSplit Mat::PAR::ViscoElastHyper::parse_summand
 Mat::PAR::ViscoElastHyper::ViscoElastHyper(
     const Core::Mat::PAR::Parameter::Data& matdata, const SummandSplit& summand_split)
     : Mat::PAR::ElastHyper(matdata),
-      numelast_(summand_split.numelast),
       elast_matids_(summand_split.elast_matids),
-      numvisco_(summand_split.numvisco),
-      visco_matids_(summand_split.visco_matids),
-      uses_legacy_matids_(summand_split.uses_legacy_matids)
+      visco_matids_(summand_split.visco_matids)
 {
-  FOUR_C_ASSERT_ALWAYS(numelast_ == static_cast<int>(elast_matids_.size()),
-      "Invalid MAT_ViscoElastHyper setup (MAT {}): NUMELAST={} but ELAST_MATIDS has size {}.", id(),
-      numelast_, elast_matids_.size());
-
-  FOUR_C_ASSERT_ALWAYS(numvisco_ == static_cast<int>(visco_matids_.size()),
-      "Invalid MAT_ViscoElastHyper setup (MAT {}): NUMVISCO={} but VISCO_MATIDS has size {}.", id(),
-      numvisco_, visco_matids_.size());
-
-  FOUR_C_ASSERT_ALWAYS(!uses_legacy_matids_ ||
-                           static_cast<int>(elast_matids_.size() + visco_matids_.size()) == nummat_,
-      "Invalid MAT_ViscoElastHyper automatic partitioning (MAT {}): NUMMAT={} but partitioned "
-      "ELAST_MATIDS({}) + VISCO_MATIDS({}) do not match.",
-      id(), nummat_, elast_matids_.size(), visco_matids_.size());
-
   // polyconvexity check is just implemented for isotropic hyperlastic materials
   if (polyconvex_)
     FOUR_C_THROW(

--- a/src/mat/viscoelast/4C_mat_viscoelasthyper.hpp
+++ b/src/mat/viscoelast/4C_mat_viscoelasthyper.hpp
@@ -52,9 +52,9 @@ namespace Mat
      * \brief Parameter object for Mat::ViscoElastHyper.
      *
      * The material is assembled from two ordered summand sets: purely elastic summands and
-     * viscoelastic summands. The explicit split fields `NUMELAST`/`ELAST_MATIDS` and
-     * `NUMVISCO`/`VISCO_MATIDS` define these sets directly. If those fields are omitted, the
-     * material list from `NUMMAT`/`MATIDS` is partitioned by material type during parameter
+     * viscoelastic summands. The explicit split fields `ELAST_MATIDS` and
+     * `VISCO_MATIDS` define these sets directly. If those fields are omitted, the
+     * material list from `MATIDS` is partitioned by material type during parameter
      * construction.
      *
      * The split is stored as immutable parameter data because the material object uses it to build
@@ -68,16 +68,10 @@ namespace Mat
       /// Result of parsing the current material input into elastic and visco summand sets.
       struct SummandSplit
       {
-        /// Number of elastic summands declared by the input split.
-        int numelast = 0;
         /// Material IDs of elastic summands, evaluated before visco contributions.
         std::vector<int> elast_matids;
-        /// Number of visco summands declared by the input split.
-        int numvisco = 0;
         /// Material IDs of visco summands that activate model contributions.
         std::vector<int> visco_matids;
-        /// True if the split was derived from the complete `MATIDS` list by material type.
-        bool uses_legacy_matids = true;
       };
 
       /// Parse the input parameters into explicit elastic and visco summand sets.
@@ -86,26 +80,17 @@ namespace Mat
           const Core::Mat::PAR::Parameter::Data& matdata, const SummandSplit& summand_split);
 
      public:
-      /// Construct and validate the split between elastic and visco summands.
+      /// Construct the split between elastic and visco summands.
       ViscoElastHyper(const Core::Mat::PAR::Parameter::Data& matdata);
 
       /// create material instance of matching type with my parameters
       std::shared_ptr<Core::Mat::Material> create_material() override;
 
-      /// Number of elastic summands used by this material.
-      const int numelast_;
-
       /// Material IDs of elastic summands used by this material.
       const std::vector<int> elast_matids_;
 
-      /// Number of visco summands used by this material.
-      const int numvisco_;
-
       /// Material IDs of visco summands used by this material.
       const std::vector<int> visco_matids_;
-
-      /// True if the summand split was derived from the complete `MATIDS` list by material type.
-      const bool uses_legacy_matids_;
 
       //@}
 


### PR DESCRIPTION
## Description and Context

With the new input format it is not necessary to define the vector length before the values of a vector are given in a parameter field such as `NUMMAT` in a material list. Some materials like `MAT_Solid_Superposition` or `MAT_mixture` omit this length parameter already, but many older materials have it.

I now made all instances of NUMMAT and similar length parameters in the material parameter definitions optional. Note that the parameter has not been removed but is just not read. This is for backward compatibility reason. I know that this will be a point of discussion, but I thought, the optional parameter does not hurt. If desired I can code a warning that this deprecated parameter is contained in the input file.

In this commit I did not change any input file, so they still have the NUMMAT parameter  (and the like). I would like to remove the parameter there as well, but this touches 886 input files (44%):

Parameter | Files | Lines
-- | -- | --
NUMMAT | 795 | 1051
NUMMATEL | 68 | 132
NUMFACINEL | 68 | 132
NUMREAC | 64 | 100
NUMBRANCH | 8 | 8
NUMMATRF | 6 | 6
NUMMATEL2D | 6 | 6
NUMMATEL3D | 4 | 4
NUMELAST | 2 | 6
NUMVISCO | 2 | 6
NUMPAIR | 2 | 2
MEMBRANENUMMAT | 1 | 1
SAMPLENUM | 6 | 6
YOUNGNUM | 47 | 47
total | 886 | 1507

Some more length parameters exist: `NUMSCAL, NUMDOF, NUMVOLFRAC, NUMSLIPSYS, TOTALNUMDOF`, but with most of them I am not sure whether they denote a physically meaningful parameter that is worth to be mentioned.

## Disclosure of AI assistance

I made the first change in 4C_global_legacy_module_validmaterials.cpp` for the ElastHyper material (and the corresponding `4C_mat_elasthyper.cpp`), then let Claude Opus 5 do it for the other occurrences. Several times I mentioned distinct material parameter definitions (see the table above), where the LLM should remove the fixed vector size as well. 

After reviewing the code by me, the LLM did the compiling and testing as well. The table above was also generated by LLM.