### PR TITLE
Reduced lung: Volume dependent pleural pressure bc 

### DIFF
--- a/src/reduced_lung/src/4C_reduced_lung_boundary_conditions.cpp
+++ b/src/reduced_lung/src/4C_reduced_lung_boundary_conditions.cpp
@@ -16,6 +16,7 @@
 #include "4C_utils_function_manager.hpp"
 #include "4C_utils_function_of_time.hpp"
 
+#include <cstdint>
 #include <map>
 #include <ranges>
 #include <tuple>
@@ -53,21 +54,66 @@ namespace ReducedLung
         return "unknown";
       }
 
-      void evaluate_function_value(const BoundaryConditionModel& model,
-          Core::LinAlg::Vector<double>& rhs, const Core::LinAlg::Vector<double>& dofs, double time)
+      /**
+       * The solution variable a boundary condition constrains. Several boundary condition types
+       * may constrain the same variable, and at most one of them may act on a given node.
+       */
+      enum class ConstrainedVariable : std::uint8_t
       {
-        if (model.function == nullptr)
+        Pressure,
+        Flow,
+      };
+
+      [[nodiscard]] ConstrainedVariable constrained_variable(Type type)
+      {
+        switch (type)
         {
-          FOUR_C_THROW(
-              "Boundary condition function not set for bc_function_id {}.", model.function_id);
+          case Type::Pressure:
+            return ConstrainedVariable::Pressure;
+          case Type::Flow:
+            return ConstrainedVariable::Flow;
         }
-        const double bc_value = model.function->evaluate(time);
+        FOUR_C_THROW(
+            "Boundary condition type '{}' constrains no known variable.", bc_type_label(type));
+      }
+
+      [[nodiscard]] const char* constrained_variable_label(ConstrainedVariable variable)
+      {
+        switch (variable)
+        {
+          case ConstrainedVariable::Pressure:
+            return "pressure";
+          case ConstrainedVariable::Flow:
+            return "flow";
+        }
+        return "unknown";
+      }
+
+      /**
+       * Constrain the boundary dof of every entry of @p model to @p bc_value.
+       */
+      void apply_dirichlet_residual(const BoundaryConditionModel& model,
+          Core::LinAlg::Vector<double>& rhs, const Core::LinAlg::Vector<double>& dofs,
+          double bc_value)
+      {
         for (size_t i = 0; i < model.data.size(); ++i)
         {
           const int local_dof_id = model.data.local_dof_id[i];
           const double res = dofs.local_values_as_span()[local_dof_id] - bc_value;
           rhs.replace_local_value(model.data.local_equation_id[i], res);
         }
+      }
+
+      void evaluate_function_value(const BoundaryConditionModel& model,
+          Core::LinAlg::Vector<double>& rhs, const Core::LinAlg::Vector<double>& dofs,
+          const AssemblyContext& assembly_context)
+      {
+        if (model.function == nullptr)
+        {
+          FOUR_C_THROW(
+              "Boundary condition function not set for bc_function_id {}.", model.function_id);
+        }
+        apply_dirichlet_residual(model, rhs, dofs, model.function->evaluate(assembly_context.time));
       }
 
       /**
@@ -137,8 +183,13 @@ namespace ReducedLung
         return definitions;
       }
 
-      void assemble_diagonal_jacobian(
-          const BoundaryConditionModel& model, Core::LinAlg::SparseMatrix& sysmat)
+      /**
+       * A value that does not depend on the solution contributes a single unit entry on the
+       * diagonal. Uses insert_my_values(), which needs an unfilled matrix.
+       */
+      void assemble_unit_diagonal_jacobian(const BoundaryConditionModel& model,
+          Core::LinAlg::SparseMatrix& sysmat, const Core::LinAlg::Vector<double>& /*dofs*/,
+          const AssemblyContext& /*assembly_context*/)
       {
         const double val = 1.0;
         for (size_t i = 0; i < model.data.size(); ++i)
@@ -207,7 +258,7 @@ namespace ReducedLung
       const auto definitions = index_boundary_condition_definitions(bc_parameters, bc_nodes);
 
       std::map<ModelKey, size_t> model_indices;
-      std::map<std::pair<int, Type>, int> bc_per_node_and_type;
+      std::map<std::pair<int, ConstrainedVariable>, int> bc_per_node_and_variable;
       int local_bc_id = 0;
 
       // Walk the constrained nodes grouped by the definition they refer to. Since a node carries
@@ -255,44 +306,45 @@ namespace ReducedLung
                 node_id, bc_id, element_id);
           }
 
-          // Enforce at most one boundary condition per (node, type). For a `bc_nodes` derived from
-          // the mesh this can never trigger, since a node carries exactly one `bc_id` and therefore
-          // appears in exactly one group. It guards callers that assemble `bc_nodes` themselves,
-          // which the unit tests do.
-          const auto duplicate_key = std::make_pair(node_id, bc_type);
-          auto duplicate_it = bc_per_node_and_type.find(duplicate_key);
-          if (duplicate_it != bc_per_node_and_type.end())
+          // Enforce at most one boundary condition per (node, constrained variable). For a
+          // `bc_nodes` derived from the mesh this can never trigger, since a node carries exactly
+          // one `bc_id` and therefore appears in exactly one group. It guards callers that
+          // assemble `bc_nodes` themselves, which the unit tests do.
+          const auto variable = constrained_variable(bc_type);
+          const auto duplicate_key = std::make_pair(node_id, variable);
+          auto duplicate_it = bc_per_node_and_variable.find(duplicate_key);
+          if (duplicate_it != bc_per_node_and_variable.end())
           {
             FOUR_C_THROW(
                 "Multiple {} boundary conditions assigned to node {} (definitions {} and {}).",
-                bc_type_label(bc_type), node_id, duplicate_it->second, bc_id);
+                constrained_variable_label(variable), node_id, duplicate_it->second, bc_id);
           }
-          bc_per_node_and_type.emplace(duplicate_key, bc_id);
+          bc_per_node_and_variable.emplace(duplicate_key, bc_id);
+
+          // The dof a condition acts on follows from the variable it constrains, not from its
+          // type.
           int dof_offset = 0;
-          if (bc_type == Type::Pressure)
+          switch (variable)
           {
-            // Pressure uses inlet/outlet pressure dofs on the attached element.
-            dof_offset = is_inlet ? 0 : 1;
-          }
-          else if (bc_type == Type::Flow)
-          {
-            if (is_inlet)
-            {
-              // Inlet flow dof is stored at the fixed offset 2.
-              dof_offset = 2;
-            }
-            else
-            {
-              // Outlet flow dof is always the last dof of the element.
-              const auto dof_it = global_dof_per_ele.find(element_id);
-              FOUR_C_ASSERT_ALWAYS(dof_it != global_dof_per_ele.end(),
-                  "Missing dof count for element {}.", element_id + 1);
-              dof_offset = dof_it->second - 1;
-            }
-          }
-          else
-          {
-            FOUR_C_THROW("Boundary condition type not implemented.");
+            case ConstrainedVariable::Pressure:
+              // Pressure uses inlet/outlet pressure dofs on the attached element.
+              dof_offset = is_inlet ? 0 : 1;
+              break;
+            case ConstrainedVariable::Flow:
+              if (is_inlet)
+              {
+                // Inlet flow dof is stored at the fixed offset 2.
+                dof_offset = 2;
+              }
+              else
+              {
+                // Outlet flow dof is always the last dof of the element.
+                const auto dof_it = global_dof_per_ele.find(element_id);
+                FOUR_C_ASSERT_ALWAYS(dof_it != global_dof_per_ele.end(),
+                    "Missing dof count for element {}.", element_id + 1);
+                dof_offset = dof_it->second - 1;
+              }
+              break;
           }
 
           const auto first_dof_it = first_global_dof_of_ele.find(element_id);
@@ -374,7 +426,8 @@ namespace ReducedLung
       for (auto& model : boundary_conditions.models)
       {
         model.residual_evaluator = evaluate_function_value;
-        model.jacobian_evaluator = assemble_diagonal_jacobian;
+        model.jacobian_evaluator = assemble_unit_diagonal_jacobian;
+        model.has_constant_jacobian = true;
       }
     }
 
@@ -382,23 +435,28 @@ namespace ReducedLung
         const BoundaryConditionContainer& boundary_conditions,
         const Core::LinAlg::Vector<double>& locally_relevant_dofs, double time)
     {
+      const AssemblyContext assembly_context{.time = time};
+
       for (const auto& model : boundary_conditions.models)
       {
-        model.residual_evaluator(model, rhs, locally_relevant_dofs, time);
+        model.residual_evaluator(model, rhs, locally_relevant_dofs, assembly_context);
       }
     }
 
-    void update_jacobian(
-        Core::LinAlg::SparseMatrix& sysmat, const BoundaryConditionContainer& boundary_conditions)
+    void update_jacobian(Core::LinAlg::SparseMatrix& sysmat,
+        const BoundaryConditionContainer& boundary_conditions,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs, double time)
     {
-      if (sysmat.filled())
-      {
-        return;
-      }
+      const AssemblyContext assembly_context{.time = time};
 
       for (const auto& model : boundary_conditions.models)
       {
-        model.jacobian_evaluator(model, sysmat);
+        // A constant row only needs to be inserted while the matrix graph is still being built.
+        if (model.has_constant_jacobian && sysmat.filled())
+        {
+          continue;
+        }
+        model.jacobian_evaluator(model, sysmat, locally_relevant_dofs, assembly_context);
       }
     }
   }  // namespace BoundaryConditions

--- a/src/reduced_lung/src/4C_reduced_lung_boundary_conditions.cpp
+++ b/src/reduced_lung/src/4C_reduced_lung_boundary_conditions.cpp
@@ -7,20 +7,23 @@
 
 #include "4C_reduced_lung_boundary_conditions.hpp"
 
+#include "4C_comm_mpi_utils.hpp"
 #include "4C_fem_discretization.hpp"
 #include "4C_fem_general_element.hpp"
 #include "4C_linalg_map.hpp"
 #include "4C_linalg_sparsematrix.hpp"
 #include "4C_linalg_vector.hpp"
+#include "4C_reduced_lung_terminal_unit.hpp"
 #include "4C_utils_exceptions.hpp"
 #include "4C_utils_function_manager.hpp"
 #include "4C_utils_function_of_time.hpp"
 
-#include <cstdint>
+#include <cmath>
 #include <map>
 #include <ranges>
-#include <tuple>
+#include <set>
 #include <utility>
+#include <variant>
 #include <vector>
 
 FOUR_C_NAMESPACE_OPEN
@@ -31,52 +34,11 @@ namespace ReducedLung
   {
     namespace
     {
-      struct ModelKey
-      {
-        Type type;
-        int function_id;
-
-        bool operator<(const ModelKey& other) const
-        {
-          return std::tie(type, function_id) < std::tie(other.type, other.function_id);
-        }
-      };
-
-      const char* bc_type_label(Type type)
-      {
-        switch (type)
-        {
-          case Type::Pressure:
-            return "pressure";
-          case Type::Flow:
-            return "flow";
-        }
-        return "unknown";
-      }
+      using InputFromFunction = ReducedLungParameters::BoundaryConditions::FromFunctionDefinition;
 
       /**
-       * The solution variable a boundary condition constrains. Several boundary condition types
-       * may constrain the same variable, and at most one of them may act on a given node.
+       * Human-readable name of a constrained variable, for error messages.
        */
-      enum class ConstrainedVariable : std::uint8_t
-      {
-        Pressure,
-        Flow,
-      };
-
-      [[nodiscard]] ConstrainedVariable constrained_variable(Type type)
-      {
-        switch (type)
-        {
-          case Type::Pressure:
-            return ConstrainedVariable::Pressure;
-          case Type::Flow:
-            return ConstrainedVariable::Flow;
-        }
-        FOUR_C_THROW(
-            "Boundary condition type '{}' constrains no known variable.", bc_type_label(type));
-      }
-
       [[nodiscard]] const char* constrained_variable_label(ConstrainedVariable variable)
       {
         switch (variable)
@@ -104,83 +66,65 @@ namespace ReducedLung
         }
       }
 
-      void evaluate_function_value(const BoundaryConditionModel& model,
-          Core::LinAlg::Vector<double>& rhs, const Core::LinAlg::Vector<double>& dofs,
-          const AssemblyContext& assembly_context)
+      /**
+       * Pleural pressure over the normalized terminal unit volume
+       * xi = (V - residual_volume) / (total_lung_capacity - residual_volume).
+       */
+      [[nodiscard]] double evaluate_volume_dependent_pleural_pressure(
+          const VolumeDependentPleuralPressure& pleural_pressure, double total_terminal_unit_volume)
       {
-        if (model.function == nullptr)
-        {
-          FOUR_C_THROW(
-              "Boundary condition function not set for bc_function_id {}.", model.function_id);
-        }
-        apply_dirichlet_residual(model, rhs, dofs, model.function->evaluate(assembly_context.time));
+        const auto& curve = pleural_pressure.normalized_linear_exponential;
+        const double xi = (total_terminal_unit_volume - pleural_pressure.residual_volume) /
+                          (pleural_pressure.total_lung_capacity - pleural_pressure.residual_volume);
+        return curve.pressure_offset + curve.linear_coefficient * xi +
+               curve.exponential_coefficient * (std::exp(curve.exponential_rate * xi) - 1.0);
       }
 
       /**
-       * The definitions of the input file and the `bc_id`s of the mesh must describe the same set
-       * of boundary conditions: every id used by the mesh needs a definition, and every definition
-       * needs at least one node. Definition ids must be unique and positive across all condition
-       * types combined, since 0 is reserved for unconstrained nodes.
-       *
-       * @return The definitions, indexed by their id.
+       * The value a boundary condition prescribes in the state of @p assembly_context. One
+       * overload per alternative of ValueModel.
        */
-      std::map<int, std::pair<Type, const ReducedLungParameters::BoundaryConditions::Definition*>>
-      index_boundary_condition_definitions(
-          const ReducedLungParameters::BoundaryConditions& bc_parameters,
-          const std::map<int, std::vector<int>>& bc_nodes)
+      [[nodiscard]] double prescribed_value(
+          const TimeFunction& time_function, const AssemblyContext& assembly_context)
       {
-        std::map<int, std::pair<Type, const ReducedLungParameters::BoundaryConditions::Definition*>>
-            definitions;
+        FOUR_C_ASSERT(time_function.function != nullptr,
+            "Implementation error: function {} of a boundary condition was not resolved.",
+            time_function.function_id);
+        return time_function.function->evaluate(assembly_context.time);
+      }
 
-        const auto index_definitions_of_type =
-            [&](Type type, const std::vector<ReducedLungParameters::BoundaryConditions::Definition>&
-                               type_definitions)
+      [[nodiscard]] double prescribed_value(const VolumeDependentPleuralPressure& pleural_pressure,
+          const AssemblyContext& assembly_context)
+      {
+        switch (pleural_pressure.coupling)
         {
-          for (const auto& definition : type_definitions)
-          {
-            if (definition.id <= 0)
-            {
-              FOUR_C_THROW(
-                  "Boundary condition definition ids must be positive, got {}. The id 0 marks "
-                  "nodes without a boundary condition and cannot be defined.",
-                  definition.id);
-            }
-            if (!definitions.emplace(definition.id, std::pair{type, &definition}).second)
-            {
-              FOUR_C_THROW(
-                  "Boundary condition definition id {} is defined more than once.", definition.id);
-            }
-            if (definition.function_id <= 0)
-            {
-              FOUR_C_THROW(
-                  "The function_id of boundary condition definition {} must be positive, got {}.",
-                  definition.id, definition.function_id);
-            }
-            if (!bc_nodes.contains(definition.id))
-            {
-              FOUR_C_THROW(
-                  "Boundary condition definition {} is not used by any node of the mesh. Assign "
-                  "it by setting 'bc_id' to {} on the respective nodes.",
-                  definition.id, definition.id);
-            }
-          }
-        };
-
-        index_definitions_of_type(Type::Pressure, bc_parameters.pressure);
-        index_definitions_of_type(Type::Flow, bc_parameters.flow);
-
-        for (const int bc_id : bc_nodes | std::views::keys)
-        {
-          if (!definitions.contains(bc_id))
-          {
-            FOUR_C_THROW(
-                "The mesh assigns the boundary condition id {} to some of its nodes, but no "
-                "definition with this id exists in the input file.",
-                bc_id);
-          }
+          case VolumeDependentPleuralPressure::Coupling::Frozen:
+            // The context carries the volume of the last converged timestep, so the value stays
+            // constant over the Newton solve.
+            return evaluate_volume_dependent_pleural_pressure(
+                pleural_pressure, assembly_context.total_terminal_unit_volume);
         }
+        FOUR_C_THROW("Unknown coupling of volume-dependent pleural pressure.");
+      }
 
-        return definitions;
+      /**
+       * Bind a value model to the callable that assembles its residual. The concrete alternative
+       * is captured here, so the assembly loop never inspects the variant again.
+       */
+      [[nodiscard]] ResidualEvaluator make_residual_evaluator(const ValueModel& value_model)
+      {
+        return std::visit(
+            [](const auto& value) -> ResidualEvaluator
+            {
+              return [value](const BoundaryConditionModel& model, Core::LinAlg::Vector<double>& rhs,
+                         const Core::LinAlg::Vector<double>& dofs,
+                         const AssemblyContext& assembly_context)
+              {
+                apply_dirichlet_residual(
+                    model, rhs, dofs, prescribed_value(value, assembly_context));
+              };
+            },
+            value_model);
       }
 
       /**
@@ -198,13 +142,141 @@ namespace ReducedLung
           sysmat.insert_my_values(model.data.local_equation_id[i], 1, &val, &local_dof_id);
         }
       }
+
+      /**
+       * Build the value a function-valued definition prescribes.
+       */
+      [[nodiscard]] ValueModel make_value_model(
+          const InputFromFunction& definition, const Core::Utils::FunctionManager& function_manager)
+      {
+        return TimeFunction{.function_id = definition.function_id,
+            .function = &function_manager.function_by_id<Core::Utils::FunctionOfTime>(
+                definition.function_id)};
+      }
+
+      /**
+       * Build the value a pleural pressure definition prescribes.
+       */
+      [[nodiscard]] ValueModel make_value_model(const VolumeDependentPleuralPressure& definition)
+      {
+        // Relates two parameters, so the input specs cannot check it.
+        if (definition.total_lung_capacity <= definition.residual_volume)
+        {
+          FOUR_C_THROW(
+              "The volume-dependent pleural pressure definition {} requires total_lung_capacity > "
+              "residual_volume, got {} <= {}.",
+              definition.id, definition.total_lung_capacity, definition.residual_volume);
+        }
+
+        return definition;
+      }
+
+      /**
+       * The definitions of the input file and the `bc_id`s of the mesh must describe the same set
+       * of boundary conditions: every id used by the mesh needs a definition, and every definition
+       * needs at least one node. Definition ids must be unique across all condition types
+       * combined; that they are positive is checked by the input specs.
+       *
+       * Runs before the definitions are resolved, so an input/mesh mismatch is reported first.
+       */
+      void check_definition_ids(const ReducedLungParameters::BoundaryConditions& bc_parameters,
+          const std::map<int, std::vector<int>>& bc_nodes)
+      {
+        std::set<int> definition_ids;
+
+        const auto check_id = [&](int id)
+        {
+          if (!definition_ids.insert(id).second)
+          {
+            FOUR_C_THROW("Boundary condition definition id {} is defined more than once.", id);
+          }
+          if (!bc_nodes.contains(id))
+          {
+            FOUR_C_THROW(
+                "Boundary condition definition {} is not used by any node of the mesh. Assign "
+                "it by setting 'bc_id' to {} on the respective nodes.",
+                id, id);
+          }
+        };
+
+        for (const auto& definition : bc_parameters.pressure) check_id(definition.id);
+        for (const auto& definition : bc_parameters.flow) check_id(definition.id);
+        for (const auto& definition : bc_parameters.volume_dependent_pleural_pressure)
+          check_id(definition.id);
+
+        for (const int bc_id : bc_nodes | std::views::keys)
+        {
+          if (!definition_ids.contains(bc_id))
+          {
+            FOUR_C_THROW(
+                "The mesh assigns the boundary condition id {} to some of its nodes, but no "
+                "definition with this id exists in the input file.",
+                bc_id);
+          }
+        }
+      }
+
+      /**
+       * Turn every definition of the input into an empty model, indexed by definition id. The
+       * caller fills in the entries of the nodes it owns. Every rank resolves every definition,
+       * so a broken one fails identically everywhere.
+       */
+      std::map<int, BoundaryConditionModel> resolve_boundary_condition_definitions(
+          const ReducedLungParameters::BoundaryConditions& bc_parameters,
+          const Core::Utils::FunctionManager& function_manager)
+      {
+        std::map<int, BoundaryConditionModel> definitions;
+
+        const auto add_model = [&](int id, ConstrainedVariable variable, ValueModel value_model)
+        {
+          BoundaryConditionModel model;
+          model.definition_id = id;
+          model.constrained_variable = variable;
+          model.value_model = std::move(value_model);
+          definitions.emplace(id, std::move(model));
+        };
+
+        const auto add_from_function_definitions =
+            [&](ConstrainedVariable variable, const std::vector<InputFromFunction>& list)
+        {
+          for (const auto& definition : list)
+          {
+            add_model(definition.id, variable, make_value_model(definition, function_manager));
+          }
+        };
+
+        add_from_function_definitions(ConstrainedVariable::Pressure, bc_parameters.pressure);
+        add_from_function_definitions(ConstrainedVariable::Flow, bc_parameters.flow);
+        for (const auto& definition : bc_parameters.volume_dependent_pleural_pressure)
+        {
+          add_model(definition.id, ConstrainedVariable::Pressure, make_value_model(definition));
+        }
+
+        return definitions;
+      }
+
+      /**
+       * Sum the volume of all terminal units across all ranks. Collective.
+       */
+      [[nodiscard]] double compute_total_terminal_unit_volume(
+          const TerminalUnits::TerminalUnitContainer& terminal_units, MPI_Comm comm)
+      {
+        double local_volume = 0.0;
+        for (const auto& model : terminal_units.models)
+        {
+          for (const double volume : model.data.volume_v)
+          {
+            local_volume += volume;
+          }
+        }
+        return Core::Communication::sum_all(local_volume, comm);
+      }
     }  // namespace
 
     void BoundaryConditionData::clear()
     {
       node_id.clear();
       global_element_id.clear();
-      input_bc_id.clear();
       local_bc_id.clear();
       local_equation_id.clear();
       global_equation_id.clear();
@@ -216,7 +288,6 @@ namespace ReducedLung
     {
       node_id.reserve(count);
       global_element_id.reserve(count);
-      input_bc_id.reserve(count);
       local_bc_id.reserve(count);
       local_equation_id.reserve(count);
       global_equation_id.reserve(count);
@@ -224,12 +295,11 @@ namespace ReducedLung
       local_dof_id.reserve(count);
     }
 
-    void BoundaryConditionData::add_entry(int node_id_value, int element_id_value,
-        int local_bc_id_value, int global_dof_id_value, int input_bc_id_value)
+    void BoundaryConditionData::add_entry(
+        int node_id_value, int element_id_value, int local_bc_id_value, int global_dof_id_value)
     {
       node_id.push_back(node_id_value);
       global_element_id.push_back(element_id_value);
-      input_bc_id.push_back(input_bc_id_value);
       local_bc_id.push_back(local_bc_id_value);
       local_equation_id.push_back(0);
       global_equation_id.push_back(0);
@@ -237,11 +307,10 @@ namespace ReducedLung
       local_dof_id.push_back(0);
     }
 
-    void BoundaryConditionModel::add_condition(int node_id_value, int element_id_value,
-        int local_bc_id_value, int global_dof_id_value, int input_bc_id_value)
+    void BoundaryConditionModel::add_condition(
+        int node_id_value, int element_id_value, int local_bc_id_value, int global_dof_id_value)
     {
-      data.add_entry(node_id_value, element_id_value, local_bc_id_value, global_dof_id_value,
-          input_bc_id_value);
+      data.add_entry(node_id_value, element_id_value, local_bc_id_value, global_dof_id_value);
     }
 
     void create_boundary_conditions(const Core::FE::Discretization& discretization,
@@ -255,9 +324,16 @@ namespace ReducedLung
       boundary_conditions.models.clear();
 
       const auto& bc_parameters = parameters.boundary_conditions;
-      const auto definitions = index_boundary_condition_definitions(bc_parameters, bc_nodes);
+      check_definition_ids(bc_parameters, bc_nodes);
+      const auto definitions =
+          resolve_boundary_condition_definitions(bc_parameters, function_manager);
 
-      std::map<ModelKey, size_t> model_indices;
+      // Derived from the input, not from the models: the reduction is collective, but a model
+      // only exists on the rank owning its element.
+      boundary_conditions.requires_total_terminal_unit_volume =
+          !bc_parameters.volume_dependent_pleural_pressure.empty();
+
+      std::map<int, size_t> model_indices;
       std::map<std::pair<int, ConstrainedVariable>, int> bc_per_node_and_variable;
       int local_bc_id = 0;
 
@@ -265,10 +341,8 @@ namespace ReducedLung
       // exactly one `bc_id`, it can never appear in more than one group.
       for (const auto& [bc_id, nodes] : bc_nodes)
       {
-        const auto& [bc_type, definition] = definitions.at(bc_id);
-
-        const int function_id = definition->function_id;
-        const ModelKey key{.type = bc_type, .function_id = function_id};
+        const auto& definition = definitions.at(bc_id);
+        const auto variable = definition.constrained_variable;
 
         for (const int node_id : nodes)
         {
@@ -306,11 +380,8 @@ namespace ReducedLung
                 node_id, bc_id, element_id);
           }
 
-          // Enforce at most one boundary condition per (node, constrained variable). For a
-          // `bc_nodes` derived from the mesh this can never trigger, since a node carries exactly
-          // one `bc_id` and therefore appears in exactly one group. It guards callers that
-          // assemble `bc_nodes` themselves, which the unit tests do.
-          const auto variable = constrained_variable(bc_type);
+          // Unreachable for a `bc_nodes` built from the mesh; guards callers that assemble it
+          // themselves.
           const auto duplicate_key = std::make_pair(node_id, variable);
           auto duplicate_it = bc_per_node_and_variable.find(duplicate_key);
           if (duplicate_it != bc_per_node_and_variable.end())
@@ -321,8 +392,6 @@ namespace ReducedLung
           }
           bc_per_node_and_variable.emplace(duplicate_key, bc_id);
 
-          // The dof a condition acts on follows from the variable it constrains, not from its
-          // type.
           int dof_offset = 0;
           switch (variable)
           {
@@ -352,23 +421,15 @@ namespace ReducedLung
               "Missing dof offset for element {}.", element_id + 1);
           const int global_dof_id = first_dof_it->second + dof_offset;
 
-          auto model_it = model_indices.find(key);
+          auto model_it = model_indices.find(bc_id);
           if (model_it == model_indices.end())
           {
-            // Create a new model block for this (type, function) group.
-            BoundaryConditionModel model;
-            model.type = bc_type;
-            model.function_id = function_id;
-            model.function =
-                &function_manager.function_by_id<Core::Utils::FunctionOfTime>(function_id);
-            boundary_conditions.models.push_back(std::move(model));
-            const size_t new_index = boundary_conditions.models.size() - 1;
-            model_indices.emplace(key, new_index);
-            model_it = model_indices.find(key);
+            boundary_conditions.models.push_back(definition);
+            model_it = model_indices.emplace(bc_id, boundary_conditions.models.size() - 1).first;
           }
 
           auto& model = boundary_conditions.models[model_it->second];
-          model.add_condition(node_id, element_id, local_bc_id, global_dof_id, bc_id);
+          model.add_condition(node_id, element_id, local_bc_id, global_dof_id);
           local_bc_id++;
         }
       }
@@ -425,7 +486,10 @@ namespace ReducedLung
     {
       for (auto& model : boundary_conditions.models)
       {
-        model.residual_evaluator = evaluate_function_value;
+        model.residual_evaluator = make_residual_evaluator(model.value_model);
+        // Every value model implemented so far prescribes a value that is constant over the
+        // Newton solve, so the equation stays a Dirichlet row inserted once. A value model that
+        // depends on the current iterate must instead assemble its own row and clear the flag.
         model.jacobian_evaluator = assemble_unit_diagonal_jacobian;
         model.has_constant_jacobian = true;
       }
@@ -435,7 +499,8 @@ namespace ReducedLung
         const BoundaryConditionContainer& boundary_conditions,
         const Core::LinAlg::Vector<double>& locally_relevant_dofs, double time)
     {
-      const AssemblyContext assembly_context{.time = time};
+      const AssemblyContext assembly_context{.time = time,
+          .total_terminal_unit_volume = boundary_conditions.total_terminal_unit_volume};
 
       for (const auto& model : boundary_conditions.models)
       {
@@ -447,7 +512,8 @@ namespace ReducedLung
         const BoundaryConditionContainer& boundary_conditions,
         const Core::LinAlg::Vector<double>& locally_relevant_dofs, double time)
     {
-      const AssemblyContext assembly_context{.time = time};
+      const AssemblyContext assembly_context{.time = time,
+          .total_terminal_unit_volume = boundary_conditions.total_terminal_unit_volume};
 
       for (const auto& model : boundary_conditions.models)
       {
@@ -458,6 +524,18 @@ namespace ReducedLung
         }
         model.jacobian_evaluator(model, sysmat, locally_relevant_dofs, assembly_context);
       }
+    }
+
+    void refresh_total_terminal_unit_volume(BoundaryConditionContainer& boundary_conditions,
+        const TerminalUnits::TerminalUnitContainer& terminal_units, MPI_Comm comm)
+    {
+      if (!boundary_conditions.requires_total_terminal_unit_volume)
+      {
+        return;
+      }
+
+      boundary_conditions.total_terminal_unit_volume =
+          compute_total_terminal_unit_volume(terminal_units, comm);
     }
   }  // namespace BoundaryConditions
 }  // namespace ReducedLung

--- a/src/reduced_lung/src/4C_reduced_lung_boundary_conditions.hpp
+++ b/src/reduced_lung/src/4C_reduced_lung_boundary_conditions.hpp
@@ -53,6 +53,14 @@ namespace ReducedLung
     struct BoundaryConditionModel;
 
     /**
+     * @brief State the boundary condition evaluators may depend on.
+     */
+    struct AssemblyContext
+    {
+      double time = 0.0;
+    };
+
+    /**
      * @brief Shared data container for all boundary condition entities.
      *
      * Stores identifiers and dof mappings for the boundary condition equations. This uses a
@@ -99,13 +107,15 @@ namespace ReducedLung
     /**
      * @brief Function handle for evaluating the residuals.
      */
-    using ResidualEvaluator = std::function<void(const BoundaryConditionModel& model,
-        Core::LinAlg::Vector<double>& rhs, const Core::LinAlg::Vector<double>& dofs, double time)>;
+    using ResidualEvaluator =
+        std::function<void(const BoundaryConditionModel& model, Core::LinAlg::Vector<double>& rhs,
+            const Core::LinAlg::Vector<double>& dofs, const AssemblyContext& assembly_context)>;
     /**
      * @brief Function handle for evaluating the boundary condition Jacobian.
      */
-    using JacobianEvaluator = std::function<void(
-        const BoundaryConditionModel& model, Core::LinAlg::SparseMatrix& sysmat)>;
+    using JacobianEvaluator =
+        std::function<void(const BoundaryConditionModel& model, Core::LinAlg::SparseMatrix& sysmat,
+            const Core::LinAlg::Vector<double>& dofs, const AssemblyContext& assembly_context)>;
 
     /**
      * @brief Boundary condition model containing a homogeneous set of equations.
@@ -122,6 +132,9 @@ namespace ReducedLung
       BoundaryConditionData data;
       ResidualEvaluator residual_evaluator;
       JacobianEvaluator jacobian_evaluator;
+      //! False if the Jacobian row depends on the current iterate and must be reassembled on
+      //! every call.
+      bool has_constant_jacobian = true;
 
       /**
        * @brief Add a boundary condition entry to this model.
@@ -189,10 +202,11 @@ namespace ReducedLung
         const Core::LinAlg::Vector<double>& locally_relevant_dofs, double time);
 
     /**
-     * @brief Assemble the boundary condition Jacobian contributions once.
+     * @brief Assemble the boundary condition Jacobian contributions.
      */
-    void update_jacobian(
-        Core::LinAlg::SparseMatrix& sysmat, const BoundaryConditionContainer& boundary_conditions);
+    void update_jacobian(Core::LinAlg::SparseMatrix& sysmat,
+        const BoundaryConditionContainer& boundary_conditions,
+        const Core::LinAlg::Vector<double>& locally_relevant_dofs, double time);
   }  // namespace BoundaryConditions
 }  // namespace ReducedLung
 

--- a/src/reduced_lung/src/4C_reduced_lung_boundary_conditions.hpp
+++ b/src/reduced_lung/src/4C_reduced_lung_boundary_conditions.hpp
@@ -12,8 +12,12 @@
 
 #include "4C_reduced_lung_input.hpp"
 
+#include <mpi.h>
+
+#include <cstdint>
 #include <functional>
 #include <map>
+#include <variant>
 #include <vector>
 
 FOUR_C_NAMESPACE_OPEN
@@ -21,6 +25,11 @@ FOUR_C_NAMESPACE_OPEN
 namespace Core::FE
 {
   class Discretization;
+}
+
+namespace ReducedLung::TerminalUnits
+{
+  struct TerminalUnitContainer;
 }
 
 namespace Core::LinAlg
@@ -42,12 +51,14 @@ namespace ReducedLung
   namespace BoundaryConditions
   {
     /**
-     * @brief Boundary condition equation types for the reduced lung model.
+     * @brief The solution variable a boundary condition constrains.
+     *
+     * At most one condition may constrain a given variable on a given node.
      */
-    enum class Type
+    enum class ConstrainedVariable : std::uint8_t
     {
       Pressure,
-      Flow
+      Flow,
     };
 
     struct BoundaryConditionModel;
@@ -58,6 +69,7 @@ namespace ReducedLung
     struct AssemblyContext
     {
       double time = 0.0;
+      double total_terminal_unit_volume = 0.0;
     };
 
     /**
@@ -72,8 +84,6 @@ namespace ReducedLung
       std::vector<int> node_id;
       // Global element id attached to the boundary node.
       std::vector<int> global_element_id;
-      // Id of the input definition this condition came from, i.e. the `bc_id` of the node.
-      std::vector<int> input_bc_id;
       // Local boundary condition id.
       std::vector<int> local_bc_id;
       // Local equation id.
@@ -100,8 +110,8 @@ namespace ReducedLung
       /**
        * @brief Append a new boundary condition entry.
        */
-      void add_entry(int node_id_value, int element_id_value, int local_bc_id_value,
-          int global_dof_id_value, int input_bc_id_value);
+      void add_entry(
+          int node_id_value, int element_id_value, int local_bc_id_value, int global_dof_id_value);
     };
 
     /**
@@ -118,17 +128,41 @@ namespace ReducedLung
             const Core::LinAlg::Vector<double>& dofs, const AssemblyContext& assembly_context)>;
 
     /**
+     * @brief A prescribed value that follows a function of time.
+     */
+    struct TimeFunction
+    {
+      int function_id = 0;
+      //! Never null after create_boundary_conditions().
+      const Core::Utils::FunctionOfTime* function = nullptr;
+    };
+
+    /**
+     * @brief A pleural pressure evaluated from the total volume of all terminal units.
+     *
+     * The input definition already holds exactly the curve parameters the assembly needs, so it
+     * is used as is.
+     */
+    using VolumeDependentPleuralPressure =
+        ReducedLungParameters::BoundaryConditions::VolumeDependentPleuralPressureDefinition;
+
+    /**
+     * @brief How a boundary condition computes the value it prescribes.
+     */
+    using ValueModel = std::variant<TimeFunction, VolumeDependentPleuralPressure>;
+
+    /**
      * @brief Boundary condition model containing a homogeneous set of equations.
      *
-     * Boundary conditions are grouped by type and function id; all equations of one model share
-     * a function pointer evaluated at assembly time.
+     * All equations of one model evaluate to the same value, so a model holds the entries of
+     * exactly one input definition.
      */
     struct BoundaryConditionModel
     {
-      Type type;
-      int function_id = 0;
-      // Cached function pointer for time-dependent boundary conditions.
-      const Core::Utils::FunctionOfTime* function = nullptr;
+      //! The `id` of the input definition all entries of this model come from.
+      int definition_id = 0;
+      ConstrainedVariable constrained_variable = ConstrainedVariable::Pressure;
+      ValueModel value_model;
       BoundaryConditionData data;
       ResidualEvaluator residual_evaluator;
       JacobianEvaluator jacobian_evaluator;
@@ -139,8 +173,8 @@ namespace ReducedLung
       /**
        * @brief Add a boundary condition entry to this model.
        */
-      void add_condition(int node_id_value, int element_id_value, int local_bc_id_value,
-          int global_dof_id_value, int input_bc_id_value);
+      void add_condition(
+          int node_id_value, int element_id_value, int local_bc_id_value, int global_dof_id_value);
     };
 
     /**
@@ -149,14 +183,19 @@ namespace ReducedLung
     struct BoundaryConditionContainer
     {
       std::vector<BoundaryConditionModel> models;
+
+      //! Total volume of all terminal units of the last converged timestep.
+      double total_terminal_unit_volume = 0.0;
+      //! Whether any condition needs the volume; the collective reduction is skipped otherwise.
+      bool requires_total_terminal_unit_volume = false;
     };
 
     /*!
      * @brief Create boundary condition models from the input parameters and the mesh.
      *
      * Every definition of the input applies to all nodes that carry its id in the `bc_id` point
-     * data of the mesh. This function groups boundary conditions by type and function id, maps
-     * boundary nodes to the connected element, and assigns the constrained dof id.
+     * data of the mesh. This function creates one model per definition, maps boundary nodes to
+     * the connected element, and assigns the constrained dof id.
      */
     void create_boundary_conditions(const Core::FE::Discretization& discretization,
         const ReducedLungParameters& parameters, const std::map<int, std::vector<int>>& bc_nodes,
@@ -207,6 +246,14 @@ namespace ReducedLung
     void update_jacobian(Core::LinAlg::SparseMatrix& sysmat,
         const BoundaryConditionContainer& boundary_conditions,
         const Core::LinAlg::Vector<double>& locally_relevant_dofs, double time);
+
+    /**
+     * @brief Refresh the total terminal unit volume the boundary conditions evaluate against.
+     *
+     * Must be called once per timestep, before the Newton solve, and collectively on all ranks.
+     */
+    void refresh_total_terminal_unit_volume(BoundaryConditionContainer& boundary_conditions,
+        const TerminalUnits::TerminalUnitContainer& terminal_units, MPI_Comm comm);
   }  // namespace BoundaryConditions
 }  // namespace ReducedLung
 

--- a/src/reduced_lung/src/4C_reduced_lung_helpers.cpp
+++ b/src/reduced_lung/src/4C_reduced_lung_helpers.cpp
@@ -107,9 +107,12 @@ namespace ReducedLung
         { Junctions::update_jacobian(jacobian, connections, bifurcations); });
     pipeline.jacobian_assemblers.emplace_back(
         [&boundary_conditions](Core::LinAlg::SparseMatrix& jacobian,
-            const Core::LinAlg::Vector<double>& /*locally_relevant_dofs*/, double /*current_time*/,
+            const Core::LinAlg::Vector<double>& locally_relevant_dofs, double current_time,
             double /*time_step_size_dt*/)
-        { BoundaryConditions::update_jacobian(jacobian, boundary_conditions); });
+        {
+          BoundaryConditions::update_jacobian(
+              jacobian, boundary_conditions, locally_relevant_dofs, current_time);
+        });
 
     pipeline.state_updaters.emplace_back(
         [&airways](

--- a/src/reduced_lung/src/4C_reduced_lung_input.cpp
+++ b/src/reduced_lung/src/4C_reduced_lung_input.cpp
@@ -277,22 +277,33 @@ Core::IO::InputSpec ReducedLung::valid_parameters()
       });
 
   using BoundaryConditions = ReducedLungParameters::BoundaryConditions;
-  using Definition = BoundaryConditions::Definition;
+  using FromFunctionDefinition = BoundaryConditions::FromFunctionDefinition;
+  using VolumeDependentPleuralPressureDefinition =
+      BoundaryConditions::VolumeDependentPleuralPressureDefinition;
 
-  // The spec is identical for every condition type, so share one instance. Entries stay flat
-  // (no wrapping group), since a named group would force an extra nesting level in the yaml.
-  const Core::IO::InputSpec definition_spec = all_of({
-      parameter<int>(
-          "id", {.description = "Unique positive id of this definition. It is referenced by the "
-                                "`bc_id` point data of the mesh: every node with this `bc_id` "
-                                "carries this boundary condition."}),
-      parameter<int>("function_id", {.description = "Id of the function of time prescribing the "
-                                                    "boundary value."}),
+  // Every definition is identified the same way, whichever value it prescribes, so share one spec.
+  const Core::IO::InputSpec definition_id_spec = parameter<int>("id",
+      {
+          .description = "Unique positive id of this definition. It is referenced by the `bc_id` "
+                         "point data of the mesh: every node with this `bc_id` carries this "
+                         "boundary condition. The id 0 marks nodes without a boundary condition "
+                         "and cannot be defined.",
+          .validator = Validators::positive<int>(),
+      });
+
+  // Entries stay flat: a named group would force an extra nesting level in the yaml.
+  const Core::IO::InputSpec from_function_definition_spec = all_of({
+      definition_id_spec,
+      parameter<int>("function_id",
+          {
+              .description = "Id of the function of time prescribing the boundary value.",
+              .validator = Validators::positive<int>(),
+          }),
   });
 
-  // Converts the list's entries into a Definition vector; the same for every condition type up
-  // to which member it targets.
-  const auto store_definitions = [](std::vector<Definition> BoundaryConditions::* member)
+  // Converts a list of function-valued definitions into @p member.
+  const auto store_from_function_definitions =
+      [](std::vector<FromFunctionDefinition> BoundaryConditions::* member)
   {
     return StoreFunction<Core::IO::InputParameterContainer::List>(
         [member](Storage& storage, Core::IO::InputParameterContainer::List&& value)
@@ -301,11 +312,12 @@ Core::IO::InputSpec ReducedLung::valid_parameters()
               "Implementation error: expected BoundaryConditions storage.");
 
           auto& target = std::any_cast<BoundaryConditions&>(storage).*member;
+          // The store also runs from set_default_value(), so it may see the same target twice.
           target.clear();
-          for (const auto& definition_entry : value)
+          for (const auto& entry : value)
           {
-            target.push_back(Definition{.id = definition_entry.get<int>("id"),
-                .function_id = definition_entry.get<int>("function_id")});
+            target.push_back(FromFunctionDefinition{
+                .id = entry.get<int>("id"), .function_id = entry.get<int>("function_id")});
           }
 
           return StoreStatus::ok();
@@ -313,20 +325,107 @@ Core::IO::InputSpec ReducedLung::valid_parameters()
         typeid(BoundaryConditions));
   };
 
+  // The curve sits behind a one_of so that further curve shapes can be added later.
+  const Core::IO::InputSpec pleural_pressure_definition_spec = all_of({
+      definition_id_spec,
+      parameter<VolumeDependentPleuralPressureDefinition::Coupling>("coupling",
+          {
+              .description = "How the pleural pressure follows the terminal unit volume. 'Frozen' "
+                             "evaluates it from the total volume of the last converged timestep, "
+                             "which makes it an explicit source term without Jacobian "
+                             "contribution.",
+              .default_value = VolumeDependentPleuralPressureDefinition::Coupling::Frozen,
+          }),
+      parameter<double>("residual_volume",
+          {
+              .description = "Total terminal unit volume at which the normalized volume is zero. "
+                             "Must be smaller than total_lung_capacity.",
+              .validator = Validators::positive_or_zero<double>(),
+          }),
+      parameter<double>("total_lung_capacity",
+          {
+              .description = "Total terminal unit volume at which the normalized volume is one. "
+                             "Must be larger than residual_volume.",
+              .validator = Validators::positive<double>(),
+          }),
+      one_of({
+          group("normalized_linear_exponential",
+              {
+                  parameter<double>("pressure_offset",
+                      {.description = "Pleural pressure at the residual volume, where the linear "
+                                      "and the exponential term both vanish."}),
+                  parameter<double>(
+                      "linear_coefficient", {.description = "Factor of the linear term."}),
+                  parameter<double>("exponential_coefficient",
+                      {.description = "Factor of the exponential term."}),
+                  parameter<double>(
+                      "exponential_rate", {.description = "Rate inside the exponential term."}),
+              },
+              {
+                  .description =
+                      "p_pl(xi) = pressure_offset + linear_coefficient * xi + "
+                      "exponential_coefficient * (exp(exponential_rate * xi) - 1), with the "
+                      "normalized volume xi = (V - residual_volume) / (total_lung_capacity - "
+                      "residual_volume).",
+              }),
+      }),
+  });
+
+  const auto store_pleural_pressure_definitions =
+      StoreFunction<Core::IO::InputParameterContainer::List>(
+          [](Storage& storage, Core::IO::InputParameterContainer::List&& value)
+          {
+            FOUR_C_ASSERT(storage.type() == typeid(BoundaryConditions),
+                "Implementation error: expected BoundaryConditions storage.");
+
+            auto& target =
+                std::any_cast<BoundaryConditions&>(storage).volume_dependent_pleural_pressure;
+            // The store also runs from set_default_value(), so it may see the same target twice.
+            target.clear();
+            for (const auto& entry : value)
+            {
+              const auto& curve = entry.group("normalized_linear_exponential");
+              target.push_back(VolumeDependentPleuralPressureDefinition{.id = entry.get<int>("id"),
+                  .coupling =
+                      entry.get<VolumeDependentPleuralPressureDefinition::Coupling>("coupling"),
+                  .residual_volume = entry.get<double>("residual_volume"),
+                  .total_lung_capacity = entry.get<double>("total_lung_capacity"),
+                  .normalized_linear_exponential =
+                      VolumeDependentPleuralPressureDefinition::NormalizedLinearExponential{
+                          .pressure_offset = curve.get<double>("pressure_offset"),
+                          .linear_coefficient = curve.get<double>("linear_coefficient"),
+                          .exponential_coefficient = curve.get<double>("exponential_coefficient"),
+                          .exponential_rate = curve.get<double>("exponential_rate")}});
+            }
+
+            return StoreStatus::ok();
+          },
+          typeid(BoundaryConditions));
+
   Core::IO::InputSpec boundary_conditions_spec =
       group<ReducedLungParameters::BoundaryConditions>("boundary_conditions",
           {
-              list("pressure", definition_spec,
+              list("pressure", from_function_definition_spec,
                   {
                       .description = "Reusable pressure boundary condition definitions.",
                       .required = false,
-                      .store = store_definitions(&BoundaryConditions::pressure),
+                      .store = store_from_function_definitions(&BoundaryConditions::pressure),
                   }),
-              list("flow", definition_spec,
+              list("flow", from_function_definition_spec,
                   {
                       .description = "Reusable volumetric flow boundary condition definitions.",
                       .required = false,
-                      .store = store_definitions(&BoundaryConditions::flow),
+                      .store = store_from_function_definitions(&BoundaryConditions::flow),
+                  }),
+              list("volume_dependent_pleural_pressure", pleural_pressure_definition_spec,
+                  {
+                      .description =
+                          "Reusable definitions of a pleural pressure that follows the total "
+                          "volume of all terminal units. Every node carrying one of these ids "
+                          "has its pressure dof constrained to the pleural pressure, evaluated "
+                          "from the curve given below at the total terminal unit volume.",
+                      .required = false,
+                      .store = store_pleural_pressure_definitions,
                   }),
           },
           {

--- a/src/reduced_lung/src/4C_reduced_lung_input.hpp
+++ b/src/reduced_lung/src/4C_reduced_lung_input.hpp
@@ -192,16 +192,58 @@ namespace ReducedLung
     struct BoundaryConditions
     {
       /**
-       * One reusable boundary condition, referenced by the `bc_id` point data of the mesh.
+       * One reusable boundary condition whose value follows a function of time. The variable it
+       * constrains is not part of the definition: it follows from the list the definition sits in.
+       * Any number of nodes may carry the same id.
        */
-      struct Definition
+      struct FromFunctionDefinition
       {
         int id;
         int function_id;
       };
 
-      std::vector<Definition> pressure;
-      std::vector<Definition> flow;
+      /**
+       * One reusable boundary condition prescribing the pleural pressure of a boundary node from
+       * the total volume of all terminal units. Any number of nodes may carry the same id.
+       */
+      struct VolumeDependentPleuralPressureDefinition
+      {
+        /**
+         * How the pleural pressure is tied to the terminal unit volume.
+         */
+        enum class Coupling : std::uint8_t
+        {
+          //! Evaluate from the total volume of the last converged timestep.
+          Frozen,
+        };
+
+        /**
+         * Pleural pressure over the normalized volume
+         * xi = (V - residual_volume) / (total_lung_capacity - residual_volume) as
+         * p_pl(xi) = pressure_offset + linear_coefficient * xi
+         *          + exponential_coefficient * (exp(exponential_rate * xi) - 1).
+         */
+        struct NormalizedLinearExponential
+        {
+          double pressure_offset;
+          double linear_coefficient;
+          double exponential_coefficient;
+          double exponential_rate;
+        };
+
+        int id;
+        Coupling coupling;
+        double residual_volume;
+        double total_lung_capacity;
+        NormalizedLinearExponential normalized_linear_exponential;
+      };
+
+      //! Definitions constraining the pressure dof, prescribing it by a function of time.
+      std::vector<FromFunctionDefinition> pressure;
+      //! Definitions constraining the flow dof, prescribing it by a function of time.
+      std::vector<FromFunctionDefinition> flow;
+      //! Definitions constraining the pressure dof, prescribing it from the terminal unit volume.
+      std::vector<VolumeDependentPleuralPressureDefinition> volume_dependent_pleural_pressure;
     } boundary_conditions;
     struct AirProperties
     {

--- a/src/reduced_lung/src/4C_reduced_lung_main.cpp
+++ b/src/reduced_lung/src/4C_reduced_lung_main.cpp
@@ -273,6 +273,9 @@ namespace ReducedLung
             "integration.");
 
         current_time_ += dt_;
+        // Constant during the solve, so refresh once per timestep rather than per iteration.
+        BoundaryConditions::refresh_total_terminal_unit_volume(
+            boundary_conditions_, terminal_units_, comm_);
         nox_solver_->solve(current_time_);
 
         TerminalUnits::end_of_timestep_routine(terminal_units_, *locally_relevant_dofs_, dt_);

--- a/src/reduced_lung/tests/4C_reduced_lung_boundary_conditions_test.cpp
+++ b/src/reduced_lung/tests/4C_reduced_lung_boundary_conditions_test.cpp
@@ -22,10 +22,12 @@
 #include <mpi.h>
 
 #include <array>
+#include <cmath>
 #include <map>
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <variant>
 #include <vector>
 
 namespace
@@ -66,15 +68,35 @@ namespace
     std::map<int, std::vector<int>> bc_nodes;
   };
 
-  //! The vector of definitions of the given type, so tests can build inputs generically.
-  std::vector<InputBc::Definition>& definitions_of_type(InputBc& boundary_conditions, Type type)
+  using PleuralPressureDefinition = InputBc::VolumeDependentPleuralPressureDefinition;
+
+  InputBc::FromFunctionDefinition make_definition(int id, int function_id)
   {
-    return type == Type::Pressure ? boundary_conditions.pressure : boundary_conditions.flow;
+    return InputBc::FromFunctionDefinition{.id = id, .function_id = function_id};
   }
 
-  InputBc::Definition make_definition(int id, int function_id)
+  PleuralPressureDefinition make_pleural_pressure_definition(
+      int id, double residual_volume = 1.0, double total_lung_capacity = 5.0)
   {
-    return InputBc::Definition{.id = id, .function_id = function_id};
+    return PleuralPressureDefinition{.id = id,
+        .coupling = PleuralPressureDefinition::Coupling::Frozen,
+        .residual_volume = residual_volume,
+        .total_lung_capacity = total_lung_capacity,
+        .normalized_linear_exponential =
+            PleuralPressureDefinition::NormalizedLinearExponential{.pressure_offset = 0.5,
+                .linear_coefficient = 2.0,
+                .exponential_coefficient = 0.25,
+                .exponential_rate = 0.1}};
+  }
+
+  BcInput make_single_pleural_bc_parameters(
+      int node_id, double residual_volume = 1.0, double total_lung_capacity = 5.0)
+  {
+    BcInput input{};
+    input.bc_nodes = {{1, {node_id}}};
+    input.parameters.boundary_conditions.volume_dependent_pleural_pressure = {
+        make_pleural_pressure_definition(1, residual_volume, total_lung_capacity)};
+    return input;
   }
 
   //! A FunctionManager with one constant-valued SymbolicFunctionOfTime per entry of @p values,
@@ -99,28 +121,29 @@ namespace
     BcInput input{};
     // Node 0 carries both a pressure and a flow condition. The mesh cannot express this
     // through its `bc_id` array, but the container API can, so the grouping is still tested here.
-    // Both pressure definitions share function id 1, so they group into a single model.
+    // The two pressure definitions share function id 1 but stay separate models, since a model
+    // holds the entries of exactly one definition.
     input.bc_nodes = {{1, {0}}, {2, {2}}, {3, {0}}};
     input.parameters.boundary_conditions.pressure = {make_definition(1, 1), make_definition(2, 1)};
     input.parameters.boundary_conditions.flow = {make_definition(3, 2)};
     return input;
   }
 
-  BcInput make_single_bc_parameters(int node_id, Type type)
+  //! A single function-valued condition on @p node_id, constraining @p variable.
+  BcInput make_function_bc_parameters(int node_id, ConstrainedVariable variable, int function_id)
   {
     BcInput input{};
     input.bc_nodes = {{1, {node_id}}};
-    definitions_of_type(input.parameters.boundary_conditions, type) = {make_definition(1, 1)};
+    auto& boundary_conditions = input.parameters.boundary_conditions;
+    auto& definitions = variable == ConstrainedVariable::Pressure ? boundary_conditions.pressure
+                                                                  : boundary_conditions.flow;
+    definitions = {make_definition(1, function_id)};
     return input;
   }
 
-  BcInput make_function_bc_parameters(int node_id, Type type, int function_id)
+  BcInput make_single_bc_parameters(int node_id, ConstrainedVariable variable)
   {
-    BcInput input{};
-    input.bc_nodes = {{1, {node_id}}};
-    definitions_of_type(input.parameters.boundary_conditions, type) = {
-        make_definition(1, function_id)};
-    return input;
+    return make_function_bc_parameters(node_id, variable, 1);
   }
 
   BcInput make_duplicate_type_parameters()
@@ -132,11 +155,12 @@ namespace
     return input;
   }
 
-  BoundaryConditionModel* find_model(BoundaryConditionContainer& container, Type type)
+  //! The model holding the entries of the definition with the given id, if this rank owns any.
+  BoundaryConditionModel* find_model(BoundaryConditionContainer& container, int definition_id)
   {
     for (auto& model : container.models)
     {
-      if (model.type == type)
+      if (model.definition_id == definition_id)
       {
         return &model;
       }
@@ -203,7 +227,7 @@ namespace
     }
   }
 
-  TEST(BoundaryConditionsTests, CreateBoundaryConditionsGroupsByType)
+  TEST(BoundaryConditionsTests, CreateBoundaryConditionsGroupsPerDefinition)
   {
     skip_if_parallel();
 
@@ -211,21 +235,35 @@ namespace
     auto function_manager = make_function_manager({2.5, -1.0});
     auto boundary_conditions = create_boundary_conditions_from_fixture(fixture, function_manager);
 
-    ASSERT_EQ(boundary_conditions.models.size(), 2u);
+    // One model per definition, including the two pressure definitions sharing function id 1.
+    ASSERT_EQ(boundary_conditions.models.size(), 3u);
 
-    auto* pressure_model = find_model(boundary_conditions, Type::Pressure);
-    auto* flow_model = find_model(boundary_conditions, Type::Flow);
-    ASSERT_NE(pressure_model, nullptr);
+    auto* first_pressure_model = find_model(boundary_conditions, 1);
+    auto* second_pressure_model = find_model(boundary_conditions, 2);
+    auto* flow_model = find_model(boundary_conditions, 3);
+    ASSERT_NE(first_pressure_model, nullptr);
+    ASSERT_NE(second_pressure_model, nullptr);
     ASSERT_NE(flow_model, nullptr);
 
-    EXPECT_EQ(pressure_model->function_id, 1);
-    EXPECT_EQ(flow_model->function_id, 2);
+    EXPECT_EQ(first_pressure_model->constrained_variable, ConstrainedVariable::Pressure);
+    EXPECT_EQ(second_pressure_model->constrained_variable, ConstrainedVariable::Pressure);
+    EXPECT_EQ(flow_model->constrained_variable, ConstrainedVariable::Flow);
 
-    EXPECT_EQ(pressure_model->data.size(), 2u);
-    EXPECT_EQ(pressure_model->data.node_id, (std::vector<int>{0, 2}));
-    EXPECT_EQ(pressure_model->data.global_element_id, (std::vector<int>{0, 1}));
-    EXPECT_EQ(pressure_model->data.global_dof_id, (std::vector<int>{0, 4}));
-    EXPECT_EQ(pressure_model->data.local_bc_id, (std::vector<int>{0, 1}));
+    EXPECT_EQ(std::get<TimeFunction>(first_pressure_model->value_model).function_id, 1);
+    EXPECT_EQ(std::get<TimeFunction>(second_pressure_model->value_model).function_id, 1);
+    EXPECT_EQ(std::get<TimeFunction>(flow_model->value_model).function_id, 2);
+
+    EXPECT_EQ(first_pressure_model->data.size(), 1u);
+    EXPECT_EQ(first_pressure_model->data.node_id, (std::vector<int>{0}));
+    EXPECT_EQ(first_pressure_model->data.global_element_id, (std::vector<int>{0}));
+    EXPECT_EQ(first_pressure_model->data.global_dof_id, (std::vector<int>{0}));
+    EXPECT_EQ(first_pressure_model->data.local_bc_id, (std::vector<int>{0}));
+
+    EXPECT_EQ(second_pressure_model->data.size(), 1u);
+    EXPECT_EQ(second_pressure_model->data.node_id, (std::vector<int>{2}));
+    EXPECT_EQ(second_pressure_model->data.global_element_id, (std::vector<int>{1}));
+    EXPECT_EQ(second_pressure_model->data.global_dof_id, (std::vector<int>{4}));
+    EXPECT_EQ(second_pressure_model->data.local_bc_id, (std::vector<int>{1}));
 
     EXPECT_EQ(flow_model->data.size(), 1u);
     EXPECT_EQ(flow_model->data.node_id, (std::vector<int>{0}));
@@ -265,7 +303,7 @@ namespace
 
     for (const auto& model : boundary_conditions.models)
     {
-      const double bc_value = model.function->evaluate(0.0);
+      const double bc_value = std::get<TimeFunction>(model.value_model).function->evaluate(0.0);
       for (size_t i = 0; i < model.data.size(); ++i)
       {
         const int eq = model.data.local_equation_id[i];
@@ -323,11 +361,11 @@ namespace
     skip_if_parallel();
 
     auto fixture = make_fixture();
-    fixture.set_bc_input(make_single_bc_parameters(0, Type::Pressure));
+    fixture.set_bc_input(make_single_bc_parameters(0, ConstrainedVariable::Pressure));
     fixture.ele_ids_per_node.erase(0);
 
     BoundaryConditionContainer boundary_conditions;
-    Core::Utils::FunctionManager function_manager;
+    auto function_manager = make_function_manager({1.0});
     FOUR_C_EXPECT_THROW_WITH_MESSAGE(
         create_boundary_conditions(*fixture.discretization, fixture.parameters, fixture.bc_nodes,
             fixture.ele_ids_per_node, fixture.global_dof_per_ele, fixture.first_global_dof_of_ele,
@@ -340,10 +378,10 @@ namespace
     skip_if_parallel();
 
     auto fixture = make_fixture();
-    fixture.set_bc_input(make_single_bc_parameters(1, Type::Pressure));
+    fixture.set_bc_input(make_single_bc_parameters(1, ConstrainedVariable::Pressure));
 
     BoundaryConditionContainer boundary_conditions;
-    Core::Utils::FunctionManager function_manager;
+    auto function_manager = make_function_manager({1.0});
     FOUR_C_EXPECT_THROW_WITH_MESSAGE(
         create_boundary_conditions(*fixture.discretization, fixture.parameters, fixture.bc_nodes,
             fixture.ele_ids_per_node, fixture.global_dof_per_ele, fixture.first_global_dof_of_ele,
@@ -364,7 +402,7 @@ namespace
     function_manager.set_functions(functions);
 
     auto fixture = make_fixture();
-    fixture.set_bc_input(make_function_bc_parameters(0, Type::Pressure, 1));
+    fixture.set_bc_input(make_function_bc_parameters(0, ConstrainedVariable::Pressure, 1));
 
     auto boundary_conditions = create_boundary_conditions_from_fixture(fixture, function_manager);
 
@@ -390,6 +428,123 @@ namespace
     EXPECT_DOUBLE_EQ(rhs.local_values_as_span()[model.data.local_equation_id[0]], 1.0 - 2.0 * time);
   }
 
+  TEST(BoundaryConditionsTests, ResidualAssemblyVolumeDependentPleuralPressure)
+  {
+    skip_if_parallel();
+
+    auto fixture = make_fixture();
+    fixture.set_bc_input(make_single_pleural_bc_parameters(0));
+
+    Core::Utils::FunctionManager function_manager;
+    auto boundary_conditions = create_boundary_conditions_from_fixture(fixture, function_manager);
+
+    int n_local_equations = 0;
+    assign_local_equation_ids(boundary_conditions, n_local_equations);
+
+    std::array<int, 1> global_dofs{0};
+    Core::LinAlg::Map col_map(-1, global_dofs.size(), global_dofs.data(), 0, MPI_COMM_WORLD);
+    assign_local_dof_ids(col_map, boundary_conditions);
+    create_evaluators(boundary_conditions);
+
+    Core::LinAlg::Map row_map(-1, n_local_equations, 0, MPI_COMM_WORLD);
+    Core::LinAlg::Vector<double> rhs(row_map, true);
+    Core::LinAlg::Vector<double> locally_relevant_dofs(col_map, true);
+    locally_relevant_dofs.get_values()[0] = 10.0;
+
+    const double total_terminal_unit_volume = 3.0;
+    boundary_conditions.total_terminal_unit_volume = total_terminal_unit_volume;
+    update_residual_vector(rhs, boundary_conditions, locally_relevant_dofs, 0.0);
+
+    const double xi = (total_terminal_unit_volume - 1.0) / (5.0 - 1.0);
+    const double expected_pressure = 0.5 + 2.0 * xi + 0.25 * (std::exp(0.1 * xi) - 1.0);
+
+    ASSERT_EQ(boundary_conditions.models.size(), 1u);
+    const auto& model = boundary_conditions.models.front();
+    ASSERT_TRUE(std::holds_alternative<VolumeDependentPleuralPressure>(model.value_model));
+    EXPECT_DOUBLE_EQ(
+        rhs.local_values_as_span()[model.data.local_equation_id[0]], 10.0 - expected_pressure);
+  }
+
+  TEST(BoundaryConditionsTests, PleuralPressureGroupsPerDefinition)
+  {
+    skip_if_parallel();
+
+    // Unlike the function-valued types, two pleural pressure definitions never share a model:
+    // they carry their own parameters and so evaluate to different values.
+    auto fixture = make_fixture();
+    fixture.bc_nodes = {{1, {0}}, {2, {2}}};
+    fixture.parameters.boundary_conditions.pressure.clear();
+    fixture.parameters.boundary_conditions.flow.clear();
+    fixture.parameters.boundary_conditions.volume_dependent_pleural_pressure = {
+        make_pleural_pressure_definition(1), make_pleural_pressure_definition(2, 2.0, 6.0)};
+
+    Core::Utils::FunctionManager function_manager;
+    auto boundary_conditions = create_boundary_conditions_from_fixture(fixture, function_manager);
+
+    ASSERT_EQ(boundary_conditions.models.size(), 2u);
+    for (const auto& model : boundary_conditions.models)
+    {
+      EXPECT_EQ(model.constrained_variable, ConstrainedVariable::Pressure);
+      ASSERT_TRUE(std::holds_alternative<VolumeDependentPleuralPressure>(model.value_model));
+      EXPECT_EQ(model.data.size(), 1u);
+    }
+    const auto residual_volume_of = [](const BoundaryConditionModel& model)
+    { return std::get<VolumeDependentPleuralPressure>(model.value_model).residual_volume; };
+    EXPECT_DOUBLE_EQ(residual_volume_of(boundary_conditions.models[0]), 1.0);
+    EXPECT_DOUBLE_EQ(residual_volume_of(boundary_conditions.models[1]), 2.0);
+  }
+
+  TEST(BoundaryConditionsTests, PleuralPressureRequestsTerminalUnitVolume)
+  {
+    skip_if_parallel();
+
+    // The global reduction computing the total volume is skipped unless a condition asks for it.
+    {
+      auto fixture = make_fixture();
+      auto function_manager = make_function_manager({2.5, -1.0});
+      auto boundary_conditions = create_boundary_conditions_from_fixture(fixture, function_manager);
+      EXPECT_FALSE(boundary_conditions.requires_total_terminal_unit_volume);
+    }
+
+    {
+      auto fixture = make_fixture();
+      fixture.set_bc_input(make_single_pleural_bc_parameters(0));
+      Core::Utils::FunctionManager function_manager;
+      auto boundary_conditions = create_boundary_conditions_from_fixture(fixture, function_manager);
+      EXPECT_TRUE(boundary_conditions.requires_total_terminal_unit_volume);
+    }
+  }
+
+  TEST(BoundaryConditionsTests, PleuralPressureClashesWithPressureOnSameNode)
+  {
+    skip_if_parallel();
+
+    // Both constrain the pressure dof of the same node, so they must be rejected even though
+    // their boundary condition types differ.
+    auto fixture = make_fixture();
+    fixture.set_bc_input(make_single_pleural_bc_parameters(0));
+    fixture.bc_nodes[2] = {0};
+    fixture.parameters.boundary_conditions.pressure = {make_definition(2, 1)};
+
+    auto function_manager = make_function_manager({1.0});
+    FOUR_C_EXPECT_THROW_WITH_MESSAGE(
+        create_boundary_conditions_from_fixture(fixture, function_manager), Core::Exception,
+        "Multiple pressure boundary conditions assigned to node 0");
+  }
+
+  TEST(BoundaryConditionsTests, PleuralPressureRejectsCapacityBelowResidualVolume)
+  {
+    skip_if_parallel();
+
+    auto fixture = make_fixture();
+    fixture.set_bc_input(make_single_pleural_bc_parameters(0, 5.0, 5.0));
+
+    Core::Utils::FunctionManager function_manager;
+    FOUR_C_EXPECT_THROW_WITH_MESSAGE(
+        create_boundary_conditions_from_fixture(fixture, function_manager), Core::Exception,
+        "requires total_lung_capacity > residual_volume");
+  }
+
   TEST(BoundaryConditionsTests, CreateBoundaryConditionsDuplicateTypeThrows)
   {
     skip_if_parallel();
@@ -413,7 +568,7 @@ namespace
     skip_if_parallel();
 
     auto fixture = make_fixture();
-    fixture.set_bc_input(make_single_bc_parameters(0, Type::Pressure));
+    fixture.set_bc_input(make_single_bc_parameters(0, ConstrainedVariable::Pressure));
     // The mesh refers to a definition that the input file does not provide.
     fixture.bc_nodes[7] = {2};
 
@@ -431,7 +586,7 @@ namespace
     skip_if_parallel();
 
     auto fixture = make_fixture();
-    auto input = make_single_bc_parameters(0, Type::Pressure);
+    auto input = make_single_bc_parameters(0, ConstrainedVariable::Pressure);
     // The input file defines a condition that no node of the mesh refers to.
     input.parameters.boundary_conditions.pressure.push_back(make_definition(2, 1));
     fixture.set_bc_input(std::move(input));
@@ -450,7 +605,7 @@ namespace
     skip_if_parallel();
 
     auto fixture = make_fixture();
-    auto input = make_single_bc_parameters(0, Type::Pressure);
+    auto input = make_single_bc_parameters(0, ConstrainedVariable::Pressure);
     input.parameters.boundary_conditions.flow.push_back(make_definition(1, 1));
     fixture.set_bc_input(std::move(input));
 

--- a/src/reduced_lung/tests/4C_reduced_lung_boundary_conditions_test.cpp
+++ b/src/reduced_lung/tests/4C_reduced_lung_boundary_conditions_test.cpp
@@ -294,8 +294,9 @@ namespace
 
     Core::LinAlg::Map row_map(-1, n_local_equations, 0, MPI_COMM_WORLD);
     Core::LinAlg::SparseMatrix jac(row_map, col_map, 1);
+    Core::LinAlg::Vector<double> locally_relevant_dofs(col_map, true);
 
-    update_jacobian(jac, boundary_conditions);
+    update_jacobian(jac, boundary_conditions, locally_relevant_dofs, 0.0);
     jac.complete();
 
     for (const auto& model : boundary_conditions.models)
@@ -306,7 +307,7 @@ namespace
       }
     }
 
-    update_jacobian(jac, boundary_conditions);
+    update_jacobian(jac, boundary_conditions, locally_relevant_dofs, 0.0);
 
     for (const auto& model : boundary_conditions.models)
     {

--- a/src/reduced_lung/tests/4C_reduced_lung_input_pipeline_test.cpp
+++ b/src/reduced_lung/tests/4C_reduced_lung_input_pipeline_test.cpp
@@ -76,7 +76,7 @@ namespace
 
     using InputBc = ReducedLungParameters::BoundaryConditions;
     const auto condition = [](int id, int function_id)
-    { return InputBc::Definition{.id = id, .function_id = function_id}; };
+    { return InputBc::FromFunctionDefinition{.id = id, .function_id = function_id}; };
     params.boundary_conditions.pressure = {condition(1, 1)};
     params.boundary_conditions.flow = {condition(2, 2), condition(3, 3)};
 

--- a/src/reduced_lung/tests/4C_reduced_lung_input_test.cpp
+++ b/src/reduced_lung/tests/4C_reduced_lung_input_test.cpp
@@ -1,0 +1,103 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "4C_reduced_lung_input.hpp"
+
+#include "4C_io_input_parameter_container.hpp"
+#include "4C_io_input_spec.hpp"
+#include "4C_io_yaml.hpp"
+#include "4C_unittest_utils_assertions_test.hpp"
+
+#include <string>
+
+namespace
+{
+  using namespace FourC;
+
+  //! A complete `reduced_dimensional_lung` section carrying one pressure boundary condition, so
+  //! that a test can make a single value invalid and match the rest.
+  std::string input_with_pressure_condition(const std::string& id, const std::string& function_id)
+  {
+    return R"(
+reduced_dimensional_lung:
+  air_properties:
+    density: 1.176e-06
+    dynamic_viscosity: 1.79105e-05
+  dynamics:
+    linear_solver: 1
+    number_of_steps: 1
+    restart_every: 1
+    results_every: 1
+    time_increment: 1
+  geometry:
+    file: "mesh.vtu"
+  lung_tree:
+    airways:
+      element_blocks: [1]
+      radius:
+        constant: 1.0
+      flow_model:
+        resistance_type:
+          constant: Linear
+        include_inertia:
+          constant: false
+      wall_model_type:
+        constant: Rigid
+    terminal_units:
+      element_blocks: [2]
+      rheological_model:
+        rheological_model_type:
+          constant: KelvinVoigt
+        kelvin_voigt:
+          viscosity_kelvin_voigt_eta:
+            constant: 0.0
+      elasticity_model:
+        elasticity_model_type:
+          constant: Linear
+        linear:
+          elasticity_e:
+            constant: 1.0
+  boundary_conditions:
+    pressure:
+      - id: )" +
+           id +
+           R"(
+        function_id: )" +
+           function_id + "\n";
+  }
+
+  void match_input(const std::string& yaml_string)
+  {
+    Core::IO::InputParameterContainer container;
+    ryml::Tree tree = Core::IO::init_yaml_tree_with_exceptions();
+    ryml::NodeRef root = tree.rootref();
+    ryml::parse_in_arena(ryml::to_csubstr(yaml_string), root);
+
+    Core::IO::ConstYamlNodeRef node(root, "");
+    ReducedLung::valid_parameters().match(node, container);
+  }
+
+  TEST(ReducedLungInputTest, AcceptsPositiveDefinitionAndFunctionIds)
+  {
+    EXPECT_NO_THROW(match_input(input_with_pressure_condition("1", "1")));
+  }
+
+  //! The id 0 marks nodes without a boundary condition and can therefore not be defined.
+  TEST(ReducedLungInputTest, RejectsNonPositiveDefinitionId)
+  {
+    FOUR_C_EXPECT_THROW_WITH_MESSAGE(match_input(input_with_pressure_condition("0", "1")),
+        Core::Exception, "'id' does not pass validation");
+  }
+
+  TEST(ReducedLungInputTest, RejectsNonPositiveFunctionId)
+  {
+    FOUR_C_EXPECT_THROW_WITH_MESSAGE(match_input(input_with_pressure_condition("1", "-1")),
+        Core::Exception, "'function_id' does not pass validation");
+  }
+}  // namespace

--- a/src/reduced_lung/tests/4C_reduced_lung_nox_solver_test.np2.cpp
+++ b/src/reduced_lung/tests/4C_reduced_lung_nox_solver_test.np2.cpp
@@ -79,7 +79,7 @@ namespace
 
     using InputBc = ReducedLungParameters::BoundaryConditions;
     const auto pressure_from_function = [](int id, int function_id)
-    { return InputBc::Definition{.id = id, .function_id = function_id}; };
+    { return InputBc::FromFunctionDefinition{.id = id, .function_id = function_id}; };
     params.boundary_conditions.pressure = {
         pressure_from_function(1, 1), pressure_from_function(2, 2)};
 

--- a/tests/input_files/reduced_lung_3_aw_2_tu_pleural_pressure.4C.yaml
+++ b/tests/input_files/reduced_lung_3_aw_2_tu_pleural_pressure.4C.yaml
@@ -1,0 +1,65 @@
+TITLE:
+  - "3 resistive airways forming a bifurcation, 2 attached terminal units with linear stiffness,"
+  - "pressure bc at airway inlet, volume-dependent pleural pressure at both terminal unit outlets."
+  - "Both outlets share one definition, and 'coupling' is omitted so that the Frozen default is"
+  - "exercised."
+PROBLEM TYPE:
+  PROBLEMTYPE: "Reduced_Lung"
+reduced_dimensional_lung:
+  air_properties:
+    density: 1.176e-06
+    dynamic_viscosity: 1.79105e-05
+  dynamics:
+    linear_solver: 1
+    number_of_steps: 2
+    restart_every: 1
+    results_every: 1
+    time_increment: 1
+  geometry:
+    file: "vtu/reduced_lung_3_aw_2_tu.vtu"
+  lung_tree:
+    airways:
+      element_blocks: [1]
+      radius:
+        from_mesh: "radius"
+      flow_model:
+        resistance_type:
+          constant: Linear
+        include_inertia:
+          constant: false
+      wall_model_type:
+        constant: Rigid
+    terminal_units:
+      element_blocks: [2]
+      rheological_model:
+        rheological_model_type:
+          constant: KelvinVoigt
+        kelvin_voigt:
+          viscosity_kelvin_voigt_eta:
+            constant: 0.0
+      elasticity_model:
+        elasticity_model_type:
+          constant: Linear
+        linear:
+          elasticity_e:
+            constant: 1.0
+  boundary_conditions:
+    pressure:
+      - id: 1
+        function_id: 1
+    volume_dependent_pleural_pressure:
+      - id: 2
+        # Both terminal units are spheres of radius 1, so the total volume starts at 8/3*pi and
+        # the normalized volume at pi/6.
+        residual_volume: 0.0
+        total_lung_capacity: 16.0
+        normalized_linear_exponential:
+          pressure_offset: 0.1
+          linear_coefficient: 0.4
+          exponential_coefficient: 0.25
+          exponential_rate: 2.0
+SOLVER 1:
+  SOLVER: "UMFPACK"
+  NAME: "Reduced_lung_solver"
+FUNCT1:
+  - SYMBOLIC_FUNCTION_OF_TIME: "t"

--- a/tests/list_of_tests.cmake
+++ b/tests/list_of_tests.cmake
@@ -1568,6 +1568,10 @@ four_c_test(TEST_FILE reduced_lung_aw_bifurcation_flow.4C.yaml REQUIRED_DEPENDEN
 four_c_test(TEST_FILE reduced_lung_aw_bifurcation_flow.4C.yaml NP 2 REQUIRED_DEPENDENCIES VTK)
 four_c_test(TEST_FILE reduced_lung_3_aw_2_tu.4C.yaml REQUIRED_DEPENDENCIES VTK)
 four_c_test(TEST_FILE reduced_lung_3_aw_2_tu.4C.yaml NP 3 REQUIRED_DEPENDENCIES VTK)
+four_c_test(TEST_FILE reduced_lung_3_aw_2_tu_pleural_pressure.4C.yaml REQUIRED_DEPENDENCIES VTK)
+four_c_test(
+  TEST_FILE reduced_lung_3_aw_2_tu_pleural_pressure.4C.yaml NP 3 REQUIRED_DEPENDENCIES VTK
+  )
 four_c_test(TEST_FILE reduced_lung_3_aw_2_tu_4elemax_and_kv.4C.yaml REQUIRED_DEPENDENCIES VTK)
 four_c_test(TEST_FILE reduced_lung_3_aw_2_tu_4elemax_and_kv.4C.yaml NP 3 REQUIRED_DEPENDENCIES VTK)
 four_c_test(TEST_FILE reduced_lung_terminal_unit.4C.yaml REQUIRED_DEPENDENCIES VTK)


### PR DESCRIPTION
## Description and Context

Adds a boundary condition that prescribes the pleural pressure of a boundary node from the total volume of all terminal units, instead of requiring it to be prescribed by hand as a function of time.

The new `volume_dependent_pleural_pressure` input list constrains the pressure dof of every node carrying its `id`, following a normalized linear-exponential pressure-volume curve. Only the `Frozen` coupling is implemented (and is the default): it uses the volume of the last converged timestep, so the value is constant during a Newton solve and the equation stays a Dirichlet row.

Two supporting changes: the evaluators now take an `AssemblyContext` instead of a bare time, so a condition can depend on more state without touching every signature; and how a value is produced is modelled by a `ValueModel` variant on `BoundaryConditionModel`, replacing the old `Type` enum that conflated the constrained variable with the source of the value.

Verified by unit tests for the assembly, the curve, and the new input checks, plus an input test on 1 and 3 ranks that covers parsing and the collective volume reduction.

## Disclosure of AI assistance

Implemented with Claude Code (Claude Opus 5): code generation, refactoring, tests, and commit messages. All changes were reviewed and validated by me.