### PR TITLE
Remove `ele_eval_error_flag`

### DIFF
--- a/src/mat/elast/4C_mat_elast_couptransverselyisotropic.cpp
+++ b/src/mat/elast/4C_mat_elast_couptransverselyisotropic.cpp
@@ -15,7 +15,6 @@
 #include "4C_mat_elast_aniso_structuraltensor_strategy.hpp"
 #include "4C_mat_service.hpp"
 #include "4C_material_parameter_base.hpp"
-#include "4C_structure_new_elements_paramsinterface.hpp"
 
 #include <Teuchos_ParameterList.hpp>
 
@@ -176,7 +175,7 @@ void Mat::Elastic::CoupTransverselyIsotropic::add_stress_aniso_principal(
     const int gp, const int eleGID)
 {
   // direct return if an error occurred
-  if (reset_invariants(rcg, &params)) return;
+  reset_invariants(rcg);
 
   // switch to stress notation
   Core::LinAlg::SymmetricTensor<double, 3, 3> rcg_inv_s;
@@ -249,19 +248,14 @@ void Mat::Elastic::CoupTransverselyIsotropic::update_elasticity_tensor(
   }
 }
 
-int Mat::Elastic::CoupTransverselyIsotropic::reset_invariants(
-    const Core::LinAlg::SymmetricTensor<double, 3, 3>& rcg, const Teuchos::ParameterList* params)
+void Mat::Elastic::CoupTransverselyIsotropic::reset_invariants(
+    const Core::LinAlg::SymmetricTensor<double, 3, 3>& rcg)
 {
   // calculate the square root of the third invariant alias the determinant
   // of the deformation gradient
   const double I3 = Core::LinAlg::det(rcg);
-  if (I3 < 0.0)
-  {
-    std::stringstream msg;
-    msg << __LINE__ << " -- " << __PRETTY_FUNCTION__ << "I3 is negative!";
-    error_handling(params, msg);
-    return -1;
-  }
+  FOUR_C_ASSERT_ALWAYS(
+      I3 > 0.0, "Determinant of right Cauchy-Green tensor must be positive (value: {}).", I3);
 
   // jacobian determinant
   j_ = std::sqrt(I3);
@@ -276,8 +270,6 @@ int Mat::Elastic::CoupTransverselyIsotropic::reset_invariants(
   i5_ = aa_(0, 0) * (rcg_quad(0)) + aa_(1, 1) * (rcg_quad(1)) + aa_(2, 2) * (rcg_quad(2)) +
         2 * aa_(0, 1) * (rcg_quad(3)) + 2 * aa_(1, 2) * (rcg_quad(4)) +
         2 * aa_(0, 2) * (rcg_quad(5));
-
-  return 0;
 }
 
 void Mat::Elastic::CoupTransverselyIsotropic::update_second_piola_kirchhoff_stress(
@@ -312,23 +304,4 @@ void Mat::Elastic::CoupTransverselyIsotropic::update_second_piola_kirchhoff_stre
   }
 }
 
-void Mat::Elastic::CoupTransverselyIsotropic::error_handling(
-    const Teuchos::ParameterList* params, std::stringstream& msg) const
-{
-  if (params and params->isParameter("interface"))
-  {
-    std::shared_ptr<Core::Elements::ParamsInterface> interface_ptr = nullptr;
-    interface_ptr = params->get<std::shared_ptr<Core::Elements::ParamsInterface>>("interface");
-    std::shared_ptr<Solid::Elements::ParamsInterface> solid_params =
-        std::dynamic_pointer_cast<Solid::Elements::ParamsInterface>(interface_ptr);
-
-    if (solid_params->is_tolerate_errors())
-    {
-      solid_params->set_ele_eval_error_flag(Solid::Elements::ele_error_material_failed);
-      return;
-    }
-  }
-
-  FOUR_C_THROW("Uncaught error detected:\n{}", msg.str());
-}
 FOUR_C_NAMESPACE_CLOSE

--- a/src/mat/elast/4C_mat_elast_couptransverselyisotropic.hpp
+++ b/src/mat/elast/4C_mat_elast_couptransverselyisotropic.hpp
@@ -218,11 +218,9 @@ namespace Mat
       /*!
        * \brief Reset the pseudo invariants and the jacobian determinant
        *
-       * \param[in] rcg   right cauchy green tensor in perturbed Voigt strain notation
-       * \param[in] param parameter list pointer (optional)
+       * \param[in] rcg right cauchy green tensor in perturbed Voigt strain notation
        */
-      int reset_invariants(const Core::LinAlg::SymmetricTensor<double, 3, 3>& rcg,
-          const Teuchos::ParameterList* params = nullptr);
+      void reset_invariants(const Core::LinAlg::SymmetricTensor<double, 3, 3>& rcg);
 
       /*!
        * \brief Add the material contributions to the second Piola Kirchhoff stress tensor
@@ -292,10 +290,6 @@ namespace Mat
       void update_elasticity_tensor(Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3>& cmat,
           const Core::LinAlg::SymmetricTensor<double, 3, 3>& rcg_inv_s) const;
 
-      /// error handling in case of a negative deformation gradient determinant
-      void error_handling(const Teuchos::ParameterList* params, std::stringstream& msg) const;
-
-     private:
       /// pointer to the fiber parameters
       my_params* params_ = nullptr;
 

--- a/src/structure_new/src/4C_structure_new_elements_paramsinterface.hpp
+++ b/src/structure_new/src/4C_structure_new_elements_paramsinterface.hpp
@@ -42,40 +42,6 @@ namespace Solid
   {
     class BeamParamsInterface;
 
-    //! evaluation error flags
-    enum EvalErrorFlag : int
-    {
-      ele_error_none = 0,                          //!< no error occurred (default)
-      ele_error_negative_det_of_def_gradient = 1,  //!< negative determinant of deformation gradient
-      ele_error_determinant_at_corner = 2,         /*!< invalid/negative jac determinant at the
-                                                        element corner nodes */
-      ele_error_material_failed = 3,               //!< material evaluation failed
-      ele_error_determinant_analysis = 4 /*!< this flag is used to get an idea when the det
-                                              analysis found an invalid element */
-    };
-
-    //! Map evaluation error flag to a std::string
-    static inline std::string eval_error_flag_to_string(const EvalErrorFlag& errorflag)
-    {
-      switch (errorflag)
-      {
-        case ele_error_none:
-          return "ele_error_none";
-        case ele_error_negative_det_of_def_gradient:
-          return "ele_error_negative_det_of_def_gradient";
-        case ele_error_determinant_at_corner:
-          return "ele_error_determinant_at_corner";
-        case ele_error_material_failed:
-          return "ele_error_material_failed";
-        case ele_error_determinant_analysis:
-          return "ele_error_determinant_analysis";
-        default:
-          return "unknown";
-          break;
-      }
-      return "";
-    };  // EvalErrorFlag2String
-
     /*! \brief Parameter interface for the structural elements and the Solid::Integrator data
      * exchange
      *
@@ -98,9 +64,6 @@ namespace Solid
 
       //! return the predictor type
       virtual Solid::PredEnum get_predictor_type() const = 0;
-
-      /// Shall errors during the element evaluation be tolerated?
-      virtual bool is_tolerate_errors() const = 0;
 
       //! @name General time integration parameters
       //! @{
@@ -128,23 +91,6 @@ namespace Solid
 
       //! Is the current step a default step, or e.g. a line search step?
       virtual bool is_default_step() const = 0;
-      //! @}
-
-      //! @name Accessors
-      //! @{
-
-      //! get the evaluation error flag
-      virtual Solid::Elements::EvalErrorFlag get_ele_eval_error_flag() const = 0;
-
-      //! @}
-
-      //! @name Set functions
-      //! @{
-
-      /*! \brief set evaluation error flag
-       *
-       *  See the EvalErrorFlag enumerators for more information. */
-      virtual void set_ele_eval_error_flag(const EvalErrorFlag& error_flag) = 0;
       //! @}
 
       //! @name output related functions

--- a/src/structure_new/src/explicit/4C_structure_new_expl_generic.cpp
+++ b/src/structure_new/src/explicit/4C_structure_new_expl_generic.cpp
@@ -179,7 +179,6 @@ void Solid::EXPLICIT::Generic::reset_eval_params()
   // set the time step dependent parameters for the element evaluation
   eval_data().set_total_time(global_state().get_time_np());
   eval_data().set_delta_time(global_state().get_delta_time()[0]);
-  eval_data().set_is_tolerate_error(true);
   eval_data().set_function_manager(Global::Problem::instance()->function_manager());
 }
 

--- a/src/structure_new/src/implicit/4C_structure_new_impl_generic.cpp
+++ b/src/structure_new/src/implicit/4C_structure_new_impl_generic.cpp
@@ -112,7 +112,6 @@ void Solid::IMPLICIT::Generic::reset_eval_params()
   // set the time step dependent parameters for the element evaluation
   eval_data().set_total_time(global_state().get_time_np());
   eval_data().set_delta_time(global_state().get_delta_time()[0]);
-  eval_data().set_is_tolerate_error(true);
   eval_data().set_function_manager(Global::Problem::instance()->function_manager());
 }
 

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_data.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_data.cpp
@@ -165,8 +165,6 @@ Solid::ModelEvaluator::Data::Data()
       isntmaps_filled_(false),
       ele_action_(Core::Elements::none),
       predict_type_(Solid::pred_vague),
-      ele_eval_error_flag_(Solid::Elements::ele_error_none),
-      is_tolerate_errors_(false),
       total_time_(-1.0),
       delta_time_(-1.0),
       step_length_(-1.0),
@@ -478,14 +476,6 @@ void Solid::ModelEvaluator::Data::reset_my_norms(const bool& isdefaultstep)
     std::map<NOX::Nln::StatusTest::QuantityType, std::size_t>::iterator dit;
     for (dit = my_dof_number_.begin(); dit != my_dof_number_.end(); ++dit) dit->second = 0;
   }
-}
-
-/*----------------------------------------------------------------------------*
- *----------------------------------------------------------------------------*/
-bool Solid::ModelEvaluator::Data::is_ele_eval_error() const
-{
-  check_init_setup();
-  return (ele_eval_error_flag_ != Solid::Elements::ele_error_none);
 }
 
 /*----------------------------------------------------------------------------*

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_data.hpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_data.hpp
@@ -138,13 +138,6 @@ namespace Solid
       //! get the current damping type [derived]
       [[nodiscard]] Solid::DampKind get_damping_type() const override;
 
-      //! get the tolerate errors indicator [derived]
-      [[nodiscard]] inline bool is_tolerate_errors() const override
-      {
-        check_init_setup();
-        return is_tolerate_errors_;
-      }
-
       //! get the structural time integration factor for the displacement [derived]
       [[nodiscard]] inline double get_tim_int_factor_disp() const override
       {
@@ -255,18 +248,6 @@ namespace Solid
         FOUR_C_ASSERT(model_ptr_, "No reference to the model evaluator available!");
 
         return *model_ptr_;
-      }
-
-      //!@name set routines which can be called inside of the element [derived]
-      //! @{
-
-      /*! \brief Set the element evaluation error flag inside the element
-       *
-       * @param[in] error_flag Error flag to be set
-       */
-      inline void set_ele_eval_error_flag(const Elements::EvalErrorFlag& error_flag) override
-      {
-        ele_eval_error_flag_ = error_flag;
       }
 
       /*! \brief Collects and calculates the update norm of the current processor
@@ -406,21 +387,6 @@ namespace Solid
         return static_cast<int>(c_it->second);
       }
 
-      /*! \brief Did an element evaluation error occur?
-       *
-       * @return Boolean flag to indicate occurrence error during element evaluation
-       */
-      bool is_ele_eval_error() const;
-
-      /*! brief Access the element evaluation error flag
-       *
-       * @return Flag describing errors during element evaluation
-       */
-      inline Solid::Elements::EvalErrorFlag get_ele_eval_error_flag() const override
-      {
-        return ele_eval_error_flag_;
-      }
-
       /*! @name Set routines which are used to set the parameters of the data container
        *
        *  \warning These functions are not allowed to be called by the elements!
@@ -434,15 +400,6 @@ namespace Solid
       inline void set_action_type(const Core::Elements::ActionType& actiontype)
       {
         ele_action_ = actiontype;
-      }
-
-      /*! \brief Set the tolerate errors flag
-       *
-       * @param[in] is_tolerate_errors Boolean flag to indicate error tolerance
-       */
-      inline void set_is_tolerate_error(const bool& is_tolerate_errors)
-      {
-        is_tolerate_errors_ = is_tolerate_errors;
       }
 
       /*! \brief Set the current step length
@@ -820,12 +777,6 @@ namespace Solid
 
       //! Current predictor type
       Solid::PredEnum predict_type_;
-
-      //! element evaluation error flag
-      Solid::Elements::EvalErrorFlag ele_eval_error_flag_;
-
-      //! tolerate errors flag
-      bool is_tolerate_errors_;
 
       //! total time for the evaluation
       double total_time_;

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_generic.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_generic.cpp
@@ -235,21 +235,6 @@ bool Solid::ModelEvaluator::Generic::eval_error_check() const
               << Core::Communication::my_mpi_rank(gstate_ptr_->get_comm()) << ".\n";
   }
 
-  // --- Did the element evaluation detect an error? ---------------------------
-  ok = (ok and (not eval_data_ptr_->is_ele_eval_error()));
-
-  if (eval_data_ptr_->is_ele_eval_error())
-    std::cout << "ELEMENT EVALUATION failed on proc "
-                 "#"
-              << Core::Communication::my_mpi_rank(gstate_ptr_->get_comm()) << ".\n"
-              << "(Error: "
-              << Solid::Elements::eval_error_flag_to_string(
-                     eval_data_ptr_->get_ele_eval_error_flag())
-              << ")\n";
-
-  // reset the flag
-  eval_data_ptr_->set_ele_eval_error_flag(Solid::Elements::ele_error_none);
-
   // --- check for local errors on each proc and communicate the information ---
   int lerr = (ok ? 0 : 1);
   int gerr = 0;


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

Preparation for #2216 

This proposes to remove the existing `ele_eval_error_flag`. I believe that it was originally introduced to _somehow_ communicate local failure on material level upwards, but it is a bit of a strange design and does not work in its current form:
1. Materials rely on the possibility that the `Solid::Elements::ParamsInterface` pointer is passed to them via the `Teuchos::ParameterList` (which only ever happens in pure solid problems).
2. They can use this pointer to set the mentioned flag, which then hopefully will be read by the structure model evaluator (only if the model evaluator is the current evaluation path, which might not be the case for coupled problems.)
3. Even if the flag is set and read, the model evaluator will return false, which results in an untyped exception in nox, so no action is taken from it. The more dangerous case is if the flag is set but not processed correctly.

On top of that, the only material that sets this flag is `couptransverselyisotropic`, at a place where I believe it can only be reached due to a programming error, because it asserts that the determinant of the right Cauchy Green tensor is positive. 

 

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->

## Disclosure of AI assistance
<!--
If AI tools were used in this contribution, we strongly recommend disclosing their use. This may include:

* A brief description of how AI contributed (e.g., code generation, refactoring, documentation, testing)
* The AI agent(s) and/or tool(s) used
* Any notable successes, limitations, or lessons learned

Any AI-assisted code must be reviewed, understood, and validated by the contributing author, who takes full responsibility for the contribution.
-->
none
