### PR TITLE
[particle] Do not use ParticleObjShrdPtr for ghost particles data transfer

### DIFF
--- a/src/particle/src/engine/4C_particle_engine.cpp
+++ b/src/particle/src/engine/4C_particle_engine.cpp
@@ -332,8 +332,6 @@ void Particle::ParticleEngine::ghost_particles()
 {
   TEUCHOS_FUNC_TIME_MONITOR("Particle::ParticleEngine::GhostParticles");
 
-  std::map<int, std::map<Particle::Type, std::map<int, std::pair<int, int>>>> directghosting;
-
   // clear all containers of ghosted particles
   particlecontainerbundle_->clear_all_containers_of_specific_status(Status::Ghosted);
 
@@ -341,7 +339,7 @@ void Particle::ParticleEngine::ghost_particles()
   const auto sdata = pack_particles_to_be_ghosted();
 
   // communicate ghost data using cached comm graph and insert into containers (no Allreduce)
-  communicate_and_insert_ghost_particles(sdata, directghosting);
+  const auto directghosting = communicate_and_insert_ghost_particles(sdata);
 
   // communicate and build map for direct ghosting
   communicate_direct_ghosting_map(directghosting);
@@ -1920,10 +1918,12 @@ void Particle::ParticleEngine::insert_owned_particles(
   invalidate_particle_safety_flags();
 }
 
-void Particle::ParticleEngine::communicate_and_insert_ghost_particles(
-    const std::map<int, std::vector<char>>& sdata,
-    std::map<int, std::map<Particle::Type, std::map<int, std::pair<int, int>>>>& directghosting)
+std::map<int, std::map<Particle::Type, std::map<int, std::pair<int, int>>>>
+Particle::ParticleEngine::communicate_and_insert_ghost_particles(
+    const std::map<int, std::vector<char>>& sdata)
 {
+  std::map<int, std::map<Particle::Type, std::map<int, std::pair<int, int>>>> directghosting;
+
   // communicate ghost particle data using the cached comm graph derived from bin ghosting
   // topology (no MPI_Allreduce)
   const std::map<int, std::vector<char>> rdata =
@@ -1950,6 +1950,8 @@ void Particle::ParticleEngine::communicate_and_insert_ghost_particles(
       container->add_particle(ghostedindex, entry.globalid, entry.states);
 
       // add index relating (owned and ghosted) particles to col bins
+      FOUR_C_ASSERT_ALWAYS(entry.bingid >= 0,
+          "received ghosted particle contains no information about its bin gid!");
       particlestobins_[binning_->bincolmap_->lid(entry.bingid)].push_back(
           std::make_pair(entry.type, ghostedindex));
 
@@ -1966,6 +1968,8 @@ void Particle::ParticleEngine::communicate_and_insert_ghost_particles(
   validparticleneighbors_ = false;
   validglobalidtolocalindex_ = false;
   validdirectghosting_ = false;
+
+  return directghosting;
 }
 
 void Particle::ParticleEngine::remove_particles_from_containers(

--- a/src/particle/src/engine/4C_particle_engine.cpp
+++ b/src/particle/src/engine/4C_particle_engine.cpp
@@ -20,6 +20,7 @@
 #include "4C_particle_engine_communication_utils.hpp"
 #include "4C_particle_engine_container.hpp"
 #include "4C_particle_engine_container_bundle.hpp"
+#include "4C_particle_engine_ghost_entry.hpp"
 #include "4C_particle_engine_object.hpp"
 #include "4C_particle_engine_refresh_entry.hpp"
 #include "4C_particle_engine_runtime_vtp_writer.hpp"
@@ -331,22 +332,16 @@ void Particle::ParticleEngine::ghost_particles()
 {
   TEUCHOS_FUNC_TIME_MONITOR("Particle::ParticleEngine::GhostParticles");
 
-  std::vector<std::vector<ParticleObjShrdPtr>> particlestosend(
-      Core::Communication::num_mpi_ranks(comm_));
-  std::vector<std::vector<std::pair<int, ParticleObjShrdPtr>>> particlestoinsert(typevectorsize_);
   std::map<int, std::map<Particle::Type, std::map<int, std::pair<int, int>>>> directghosting;
 
   // clear all containers of ghosted particles
   particlecontainerbundle_->clear_all_containers_of_specific_status(Status::Ghosted);
 
-  // determine particles that need to be ghosted
-  determine_particles_to_be_ghosted(particlestosend);
+  // pack particles to be ghosted directly into send buffers (bypasses ParticleObject)
+  const auto sdata = pack_particles_to_be_ghosted();
 
-  // communicate particles
-  communicate_particles(particlestosend, particlestoinsert);
-
-  // insert ghosted particles received from other processors
-  insert_ghosted_particles(particlestoinsert, directghosting);
+  // communicate ghost data using cached comm graph and insert into containers (no Allreduce)
+  communicate_and_insert_ghost_particles(sdata, directghosting);
 
   // communicate and build map for direct ghosting
   communicate_direct_ghosting_map(directghosting);
@@ -1200,6 +1195,17 @@ void Particle::ParticleEngine::determine_ghosting_dependent_maps_and_sets()
       }
     }
   }
+
+  // cache procs to send/receive ghost particle data to/from, derived directly from the bin
+  // ghosting topology determined above (avoids MPI_Allreduce during ghost_particles())
+  cached_procs_send_ghost_particles_to_.clear();
+  for (const auto& it : binning_->thisbinsghostedby_)
+    for (int proc : it.second) cached_procs_send_ghost_particles_to_.insert(proc);
+
+  cached_procs_receive_ghost_particles_from_.clear();
+  for (int gid : binning_->ghostedbins_)
+    cached_procs_receive_ghost_particles_from_.insert(
+        binning_->binstrategy_->bin_discret()->g_element(gid)->owner());
 }
 
 void Particle::ParticleEngine::relate_half_neighboring_bins_to_owned_bins()
@@ -1546,11 +1552,12 @@ void Particle::ParticleEngine::determine_particles_to_be_transferred(
   }
 }
 
-void Particle::ParticleEngine::determine_particles_to_be_ghosted(
-    std::vector<std::vector<ParticleObjShrdPtr>>& particlestosend) const
+std::map<int, std::vector<char>> Particle::ParticleEngine::pack_particles_to_be_ghosted() const
 {
   // safety check
   if (not validownedparticles_) FOUR_C_THROW("invalid relation of owned particles to bins!");
+
+  std::map<int, std::vector<char>> sdata;
 
   // iterate over this processors bins being ghosted by other processors
   for (const auto& targetIt : binning_->thisbinsghostedby_)
@@ -1581,15 +1588,18 @@ void Particle::ParticleEngine::determine_particles_to_be_ghosted(
       ParticleStates states;
       container->get_particle(ownedindex, globalid, states);
 
-      // iterate over target processors
+      // pre-pack states once, reused for all target processors of this particle
+      Core::Communication::PackBuffer statesdata;
+      add_to_pack(statesdata, states);
+
+      // iterate over target processors and append packed ghost entry
       for (int sendtoproc : targetIt.second)
-      {
-        // append particle to be send
-        particlestosend[sendtoproc].emplace_back(
-            std::make_shared<ParticleObject>(type, globalid, states, ghostedbin, ownedindex));
-      }
+        ParticleGhostEntry::pack(
+            type, globalid, ghostedbin, ownedindex, statesdata, sdata[sendtoproc]);
     }
   }
+
+  return sdata;
 }
 
 std::map<int, std::vector<char>> Particle::ParticleEngine::pack_particles_to_be_refreshed() const
@@ -1791,9 +1801,12 @@ void Particle::ParticleEngine::communicate_direct_ghosting_map(
     std::swap(sdata[p.first], data());
   }
 
-  // communicate data via non-buffered send from proc to proc
+  // communicate data using the cached ghost particle comm graph (no MPI_Allreduce): send
+  // acknowledgements to the procs we received ghost particles from and receive acknowledgements
+  // from the procs we sent ghost particles to
   const std::map<int, std::vector<char>> rdata =
-      ParticleUtils::immediate_recv_blocking_send(comm_, sdata);
+      ParticleUtils::immediate_send_recv_known_procs(comm_, sdata,
+          cached_procs_receive_ghost_particles_from_, cached_procs_send_ghost_particles_to_);
 
   // init receiving map
   std::map<Particle::Type, std::map<int, std::pair<int, int>>> receiveddirectghosting;
@@ -1907,58 +1920,44 @@ void Particle::ParticleEngine::insert_owned_particles(
   invalidate_particle_safety_flags();
 }
 
-void Particle::ParticleEngine::insert_ghosted_particles(
-    std::vector<std::vector<std::pair<int, ParticleObjShrdPtr>>>& particlestoinsert,
+void Particle::ParticleEngine::communicate_and_insert_ghost_particles(
+    const std::map<int, std::vector<char>>& sdata,
     std::map<int, std::map<Particle::Type, std::map<int, std::pair<int, int>>>>& directghosting)
 {
-  // iterate over particle types
-  for (const auto& type : particlecontainerbundle_->get_particle_types())
+  // communicate ghost particle data using the cached comm graph derived from bin ghosting
+  // topology (no MPI_Allreduce)
+  const std::map<int, std::vector<char>> rdata =
+      ParticleUtils::immediate_send_recv_known_procs(comm_, sdata,
+          cached_procs_send_ghost_particles_to_, cached_procs_receive_ghost_particles_from_);
+
+  // unpack received data directly into ghosted particle containers
+  for (const auto& [msgsource, rmsg] : rdata)
   {
-    // check for particles of current type
-    if (particlestoinsert[static_cast<int>(type)].empty()) continue;
+    const int sendingproc = msgsource;
 
-    // get container of ghosted particles of current particle type
-    ParticleContainer* container =
-        particlecontainerbundle_->get_specific_container(type, Status::Ghosted);
-
-    // iterate over particle objects pairs
-    for (const auto& objectpair : particlestoinsert[static_cast<int>(type)])
+    Core::Communication::UnpackBuffer buffer(rmsg);
+    while (!buffer.at_end())
     {
-      // get owner of sending processor
-      int sendingproc = objectpair.first;
+      // unpack ghost entry packed by ParticleGhostEntry::pack()
+      ParticleGhostEntry entry = ParticleGhostEntry::unpack(buffer);
 
-      // get particle object
-      ParticleObjShrdPtr particleobject = objectpair.second;
-
-      // get global id of particle
-      int globalid = particleobject->return_particle_global_id();
-
-      // get states of particle
-      const ParticleStates& states = particleobject->return_particle_states();
-
-      // get bin of particle
-      const int gidofbin = particleobject->return_bin_gid();
-      if (gidofbin < 0)
-        FOUR_C_THROW("received ghosted particle contains no information about its bin gid!");
+      // get container of ghosted particles of current particle type
+      ParticleContainer* container =
+          particlecontainerbundle_->get_specific_container(entry.type, Status::Ghosted);
 
       // add particle to container of ghosted particles
       int ghostedindex(0);
-      container->add_particle(ghostedindex, globalid, states);
+      container->add_particle(ghostedindex, entry.globalid, entry.states);
 
       // add index relating (owned and ghosted) particles to col bins
-      particlestobins_[binning_->bincolmap_->lid(gidofbin)].push_back(
-          std::make_pair(type, ghostedindex));
-
-      // get local index of particle in container of owned particles of sending processor
-      int ownedindex = particleobject->return_container_index();
+      particlestobins_[binning_->bincolmap_->lid(entry.bingid)].push_back(
+          std::make_pair(entry.type, ghostedindex));
 
       // insert necessary information being communicated to other processors for direct ghosting
-      (((directghosting[sendingproc])[type])[ownedindex]) = std::make_pair(myrank_, ghostedindex);
+      (((directghosting[sendingproc])[entry.type])[entry.ownedindex]) =
+          std::make_pair(myrank_, ghostedindex);
     }
   }
-
-  // clear after all particles are inserted
-  particlestoinsert.clear();
 
   // validate flag denoting valid relation of ghosted particles to bins
   validghostedparticles_ = true;

--- a/src/particle/src/engine/4C_particle_engine.hpp
+++ b/src/particle/src/engine/4C_particle_engine.hpp
@@ -558,16 +558,16 @@ namespace Particle
         std::vector<std::vector<ParticleObjShrdPtr>>& particlestosend);
 
     /*!
-     * \brief determine particles that need to be ghosted
+     * \brief pack particles to be ghosted into send buffers
      *
-     * Determine all particles that need to be ghosted on other processors based on the information
-     * of owned bins, that are ghosted by other processors.
+     * Pack all data of particles that need to be ghosted on other processors directly into send
+     * buffers, bypassing ParticleObject creation. Data packed per particle:
+     * [int type][int globalid][int bingid][int ownedindex][ParticleStates states].
      *
      *
-     * \param[out] particlestosend particles to be send to other processors
+     * \return send buffers indexed by target processor rank
      */
-    void determine_particles_to_be_ghosted(
-        std::vector<std::vector<ParticleObjShrdPtr>>& particlestosend) const;
+    std::map<int, std::vector<char>> pack_particles_to_be_ghosted() const;
 
     /*!
      * \brief pack particles to be refreshed into send buffers
@@ -657,14 +657,19 @@ namespace Particle
         std::vector<std::vector<std::pair<int, ParticleObjShrdPtr>>>& particlestoinsert);
 
     /*!
-     * \brief insert ghosted particles received from other processors
+     * \brief communicate ghost particle data and insert into containers
+     *
+     * Exchanges ghost particle send buffers with remote processors using the cached
+     * cached_procs_send_ghost_particles_to_ / cached_procs_receive_ghost_particles_from_ sets
+     * derived from the bin ghosting topology (no MPI_Allreduce). Unpacks received data directly
+     * into ghosted particle containers and builds the direct ghosting map, bypassing
+     * ParticleObject creation.
      *
      *
-     * \param[in]  particlestoinsert particles to be inserted into containers on this processor
-     * \param[out] directghosting    direct ghosting information
+     * \param[in]  sdata         send buffers indexed by target processor rank
+     * \param[out] directghosting direct ghosting information
      */
-    void insert_ghosted_particles(
-        std::vector<std::vector<std::pair<int, ParticleObjShrdPtr>>>& particlestoinsert,
+    void communicate_and_insert_ghost_particles(const std::map<int, std::vector<char>>& sdata,
         std::map<int, std::map<Particle::Type, std::map<int, std::pair<int, int>>>>&
             directghosting);
 
@@ -771,6 +776,13 @@ namespace Particle
 
     //! cached set of procs to receive refreshed particle data from
     std::set<int> cached_procs_receive_ghost_data_from_;
+
+    //! cached set of procs to send ghost particle data to (derived from bin ghosting topology)
+    std::set<int> cached_procs_send_ghost_particles_to_;
+
+    //! cached set of procs to receive ghost particle data from (derived from bin ghosting
+    //! topology)
+    std::set<int> cached_procs_receive_ghost_particles_from_;
   };
 
 }  // namespace Particle

--- a/src/particle/src/engine/4C_particle_engine.hpp
+++ b/src/particle/src/engine/4C_particle_engine.hpp
@@ -666,12 +666,11 @@ namespace Particle
      * ParticleObject creation.
      *
      *
-     * \param[in]  sdata         send buffers indexed by target processor rank
-     * \param[out] directghosting direct ghosting information
+     * \param[in] sdata send buffers indexed by target processor rank
+     * \return directghosting direct ghosting information
      */
-    void communicate_and_insert_ghost_particles(const std::map<int, std::vector<char>>& sdata,
-        std::map<int, std::map<Particle::Type, std::map<int, std::pair<int, int>>>>&
-            directghosting);
+    std::map<int, std::map<Particle::Type, std::map<int, std::pair<int, int>>>>
+    communicate_and_insert_ghost_particles(const std::map<int, std::vector<char>>& sdata);
 
     /*!
      * \brief remove particles from containers

--- a/src/particle/src/engine/4C_particle_engine_ghost_entry.cpp
+++ b/src/particle/src/engine/4C_particle_engine_ghost_entry.cpp
@@ -1,0 +1,54 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "4C_particle_engine_ghost_entry.hpp"
+
+#include "4C_comm_pack_helpers.hpp"
+
+FOUR_C_NAMESPACE_OPEN
+
+/*---------------------------------------------------------------------------*
+ | definitions                                                               |
+ *---------------------------------------------------------------------------*/
+void Particle::ParticleGhostEntry::pack(Particle::Type type, int globalid, int bingid,
+    int ownedindex, const Core::Communication::PackBuffer& prepacked_states,
+    std::vector<char>& sendbuffer)
+{
+  // pack type, global id, bin id and owned index header
+  Core::Communication::PackBuffer header;
+  add_to_pack(header, static_cast<int>(type));
+  add_to_pack(header, globalid);
+  add_to_pack(header, bingid);
+  add_to_pack(header, ownedindex);
+
+  // append header + pre-packed states to send buffer
+  sendbuffer.insert(sendbuffer.end(), header().begin(), header().end());
+  sendbuffer.insert(sendbuffer.end(), prepacked_states().begin(), prepacked_states().end());
+}
+
+Particle::ParticleGhostEntry Particle::ParticleGhostEntry::unpack(
+    Core::Communication::UnpackBuffer& buffer)
+{
+  ParticleGhostEntry entry;
+
+  // unpack particle type
+  int type_idx;
+  extract_from_pack(buffer, type_idx);
+  entry.type = static_cast<Particle::Type>(type_idx);
+
+  // unpack global id, bin id and owned index
+  extract_from_pack(buffer, entry.globalid);
+  extract_from_pack(buffer, entry.bingid);
+  extract_from_pack(buffer, entry.ownedindex);
+
+  // unpack states
+  extract_from_pack(buffer, entry.states);
+
+  return entry;
+}
+
+FOUR_C_NAMESPACE_CLOSE

--- a/src/particle/src/engine/4C_particle_engine_ghost_entry.cpp
+++ b/src/particle/src/engine/4C_particle_engine_ghost_entry.cpp
@@ -11,12 +11,8 @@
 
 FOUR_C_NAMESPACE_OPEN
 
-/*---------------------------------------------------------------------------*
- | definitions                                                               |
- *---------------------------------------------------------------------------*/
-void Particle::ParticleGhostEntry::pack(Particle::Type type, int globalid, int bingid,
-    int ownedindex, const Core::Communication::PackBuffer& prepacked_states,
-    std::vector<char>& sendbuffer)
+void Particle::ParticleGhostEntry::pack(ParticleType type, int globalid, int bingid, int ownedindex,
+    const Core::Communication::PackBuffer& prepacked_states, std::vector<char>& sendbuffer)
 {
   // pack type, global id, bin id and owned index header
   Core::Communication::PackBuffer header;
@@ -38,7 +34,7 @@ Particle::ParticleGhostEntry Particle::ParticleGhostEntry::unpack(
   // unpack particle type
   int type_idx;
   extract_from_pack(buffer, type_idx);
-  entry.type = static_cast<Particle::Type>(type_idx);
+  entry.type = static_cast<ParticleType>(type_idx);
 
   // unpack global id, bin id and owned index
   extract_from_pack(buffer, entry.globalid);

--- a/src/particle/src/engine/4C_particle_engine_ghost_entry.hpp
+++ b/src/particle/src/engine/4C_particle_engine_ghost_entry.hpp
@@ -8,9 +8,6 @@
 #ifndef FOUR_C_PARTICLE_ENGINE_GHOST_ENTRY_HPP
 #define FOUR_C_PARTICLE_ENGINE_GHOST_ENTRY_HPP
 
-/*---------------------------------------------------------------------------*
- | headers                                                                   |
- *---------------------------------------------------------------------------*/
 #include "4C_config.hpp"
 
 #include "4C_particle_engine_typedefs.hpp"
@@ -19,18 +16,13 @@
 
 FOUR_C_NAMESPACE_OPEN
 
-/*---------------------------------------------------------------------------*
- | forward declarations                                                      |
- *---------------------------------------------------------------------------*/
+// Forwards declarations
 namespace Core::Communication
 {
   class PackBuffer;
   class UnpackBuffer;
 }  // namespace Core::Communication
 
-/*---------------------------------------------------------------------------*
- | class declarations                                                        |
- *---------------------------------------------------------------------------*/
 namespace Particle
 {
   /*!
@@ -45,7 +37,7 @@ namespace Particle
   struct ParticleGhostEntry
   {
     //! particle type
-    Particle::Type type;
+    ParticleType type;
 
     //! global id of the particle
     int globalid;
@@ -74,7 +66,7 @@ namespace Particle
      * \param[in]  prepacked_states pre-packed particle states
      * \param[out] sendbuffer       send buffer of the target processor to append to
      */
-    static void pack(Particle::Type type, int globalid, int bingid, int ownedindex,
+    static void pack(ParticleType type, int globalid, int bingid, int ownedindex,
         const Core::Communication::PackBuffer& prepacked_states, std::vector<char>& sendbuffer);
 
     /*!

--- a/src/particle/src/engine/4C_particle_engine_ghost_entry.hpp
+++ b/src/particle/src/engine/4C_particle_engine_ghost_entry.hpp
@@ -1,0 +1,95 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef FOUR_C_PARTICLE_ENGINE_GHOST_ENTRY_HPP
+#define FOUR_C_PARTICLE_ENGINE_GHOST_ENTRY_HPP
+
+/*---------------------------------------------------------------------------*
+ | headers                                                                   |
+ *---------------------------------------------------------------------------*/
+#include "4C_config.hpp"
+
+#include "4C_particle_engine_typedefs.hpp"
+
+#include <vector>
+
+FOUR_C_NAMESPACE_OPEN
+
+/*---------------------------------------------------------------------------*
+ | forward declarations                                                      |
+ *---------------------------------------------------------------------------*/
+namespace Core::Communication
+{
+  class PackBuffer;
+  class UnpackBuffer;
+}  // namespace Core::Communication
+
+/*---------------------------------------------------------------------------*
+ | class declarations                                                        |
+ *---------------------------------------------------------------------------*/
+namespace Particle
+{
+  /*!
+   * \brief entry for ghosting an owned particle on another processor
+   *
+   * pack() and unpack() together define the wire format used by
+   * ParticleEngine::pack_particles_to_be_ghosted() and
+   * ParticleEngine::communicate_and_insert_ghost_particles() to create ghosted particles directly
+   * from send buffers, bypassing ParticleObject creation. Both must be kept in sync: unpack()
+   * extracts fields in exactly the order pack() writes them.
+   */
+  struct ParticleGhostEntry
+  {
+    //! particle type
+    Particle::Type type;
+
+    //! global id of the particle
+    int globalid;
+
+    //! global id of the bin the particle is ghosted in on the target processor
+    int bingid;
+
+    //! local index of the particle in the container of owned particles on the sending processor
+    int ownedindex;
+
+    //! states of the particle
+    ParticleStates states;
+
+    /*!
+     * \brief pack header (type, global id, bin id, owned index) and append pre-packed states to a
+     *        send buffer
+     *
+     * The states are passed in already packed since, for a single owned particle that is ghosted
+     * on multiple processors, the same packed bytes are appended to every target processor's send
+     * buffer without re-serializing the states for each target.
+     *
+     * \param[in]  type             particle type
+     * \param[in]  globalid         global id of the particle
+     * \param[in]  bingid           global id of the bin the particle is ghosted in
+     * \param[in]  ownedindex       local index of the particle in the container of owned particles
+     * \param[in]  prepacked_states pre-packed particle states
+     * \param[out] sendbuffer       send buffer of the target processor to append to
+     */
+    static void pack(Particle::Type type, int globalid, int bingid, int ownedindex,
+        const Core::Communication::PackBuffer& prepacked_states, std::vector<char>& sendbuffer);
+
+    /*!
+     * \brief unpack one ghost entry previously packed by pack()
+     *
+     *
+     * \param[in,out] buffer buffer to unpack from
+     * \return unpacked ghost entry
+     */
+    static ParticleGhostEntry unpack(Core::Communication::UnpackBuffer& buffer);
+  };
+
+}  // namespace Particle
+
+/*---------------------------------------------------------------------------*/
+FOUR_C_NAMESPACE_CLOSE
+
+#endif


### PR DESCRIPTION
## Description and Context

This is continuation of the previous optimizations and #2117 in particular. The current implementation already follows the pattern established in that PR after the comments of the others. This PR:

- introduces `ParticleGhostEntry` (mirrors `ParticleRefreshEntry`) to pack/unpack `[type][globalid][bingid][ownedindex][states]` directly into send buffers, bypassing `ParticleObject` creation when creating ghost particles.
- Cache `cached_procs_send_ghost_particles_to_` / `cached_procs_receive_ghost_particles_from_` from the bin ghosting topology in `determine_ghosting_dependent_maps_and_sets()`, avoiding an `MPI_Allreduce` in `ghost_particles()`.
- Reuse `ParticleUtils::immediate_send_recv_known_procs()` for both the new ghost particle exchange (`communicate_and_insert_ghost_particles()`) and the direct ghosting map handshake (`communicate_direct_ghosting_map()`), instead of duplicating MPI `Isend`/`Irecv` logic.

This optimization gets more efficient as the number of ranks grows (not surprising).
<img width="1282" height="469" alt="image" src="https://github.com/user-attachments/assets/a0c6fec2-551c-4019-8b0e-ffae146df354" />


## Related Issues and Pull Requests
#2117, #2145, #2074

## Disclosure of AI assistance
Claude Sonnet 5 was used to "smart" rebase the modifications I had originally prepared earlier 2 months ago https://github.com/4C-multiphysics/4C/compare/main...vovannikov:4C:particle_remove_particleobj_ghosts_orig onto the actual `main` in order to accommodate immediately the code structure suggested in #2117.