### PR TITLE
Fix broken rulesets for merge requests

### DIFF
--- a/.github/workflows/buildtest_kokkosparallel.yml
+++ b/.github/workflows/buildtest_kokkosparallel.yml
@@ -102,7 +102,7 @@ jobs:
           build-directory: ${{ github.workspace }}/build
           use-ccache: "true"
 
-  ensure_all_tests_pass:
+  ensure_all_tests_pass_kokkos:
     needs:
       - kokkoscuda_build
       - kokkosopenmp_build


### PR DESCRIPTION
## Description and Context
We currently have a broken ruleset definition that ensures all tests have been successfully executed before a PR can be merged. This originates from the fact, that both, the **buildtest** and **buildtest_kokkosparallel** is defining a **ensure_all_tests_pass**, meaning that the check was successful as soon as one of those two was successful. This is now changed by renaming one of those to **ensure_all_tests_pass_kokkos**.

We could also do a larger redesign, but this should do the trick for now. This issue appeared for:
 - https://github.com/4C-multiphysics/4C/pull/2212
 - https://github.com/4C-multiphysics/4C/pull/2221

But the pipeline was not affected because all tests ran successfully (after the merge), which should not be the case. ;-) 


## Related Issues and Pull Requests
follows #2212 #2221

## Disclosure of AI assistance
AI within my fork found the root cause, see here: https://github.com/c-p-schmidt/4C/tasks/614c22ec-89d7-4c32-bd7d-aef8673d8b89