### PR TITLE
[beaminteraction] Template rotation pair on node polynomial degree

### DIFF
--- a/src/beaminteraction/src/4C_beaminteraction_calc_utils.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_calc_utils.cpp
@@ -739,16 +739,26 @@ namespace BeamInteraction
       std::vector<int> lm_beam, gid_solid, lmowner, lmstride;
       beam3r->location_vector(discret, lm_beam, lmowner, lmstride);
 
-      // Local indices of the rotational DOFs for the Simo-Reissner beam element.
+      std::vector<int> rot_dof_indices;
 
-      const std::vector<int> rot_dof_indices =
-          is_hermite ? std::vector<int>{3, 4, 5, 12, 13, 14, 18, 19, 20}
-                     : std::vector<int>{3, 4, 5, 9, 10, 11};
+      if (is_hermite)
+      {
+        rot_dof_indices = {3, 4, 5, 12, 13, 14, 18, 19, 20};
+      }
+      else
+      {
+        rot_dof_indices.resize(3 * beam3r->num_node());
 
-      // Gather the GID of the rotational DOF
+        for (int i_node = 0; i_node < beam3r->num_node(); i_node++)
+          for (unsigned int i_dof = 0; i_dof < 3; i_dof++)
+            rot_dof_indices[i_node * 3 + i_dof] = i_node * 6 + 3 + i_dof;
+      }
+
       std::vector<int> element_rot_gid_indices(rot_dof_indices.size(), -1);
+
       for (unsigned int i = 0; i < rot_dof_indices.size(); i++)
         element_rot_gid_indices[i] = lm_beam[rot_dof_indices[i]];
+
       return element_rot_gid_indices;
     }
 

--- a/src/beaminteraction/src/4C_beaminteraction_calc_utils.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_calc_utils.cpp
@@ -733,7 +733,7 @@ namespace BeamInteraction
       if (is_hermite && (beam3r->num_node() != 3))
         FOUR_C_THROW(
             "The function get_element_rot_gid_indices is not implemented for Simo-Reissner beam "
-            "elements with hermite interpolation and %d nodes!",
+            "elements with hermite interpolation and {} nodes!",
             beam3r->num_node());
 
       // Get all GID of the element

--- a/src/beaminteraction/src/4C_beaminteraction_calc_utils.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_calc_utils.cpp
@@ -722,29 +722,32 @@ namespace BeamInteraction
     std::vector<int> get_element_rot_gid_indices(
         const Core::FE::Discretization& discret, const Core::Elements::Element* element)
     {
-      const auto* beam_sr_element = dynamic_cast<const Discret::Elements::Beam3r*>(element);
-      if (beam_sr_element == nullptr)
+      const auto* beam3r = dynamic_cast<const Discret::Elements::Beam3r*>(element);
+      if (beam3r == nullptr)
         FOUR_C_THROW(
             "The function get_element_rot_gid_indices is only implemented for Simo-Reissner beam "
             "elements!");
 
-      if (not(beam_sr_element->num_node() == 3 and
-              beam_sr_element->hermite_centerline_interpolation()))
+      const bool is_hermite = beam3r->hermite_centerline_interpolation();
+
+      if ((is_hermite && beam3r->num_node() != 3) || (!is_hermite && beam3r->num_node() != 2))
         FOUR_C_THROW(
             "The function get_element_rot_gid_indices is only implemented for Simo-Reissner beam "
-            "elements with hermite3line2 interpolation!");
+            "elements with hermite3line2 and line2line2 interpolation!");
 
       // Get all GID of the element
       std::vector<int> lm_beam, gid_solid, lmowner, lmstride;
-      beam_sr_element->location_vector(discret, lm_beam, lmowner, lmstride);
+      beam3r->location_vector(discret, lm_beam, lmowner, lmstride);
 
       // Local indices of the rotational DOFs for the Simo-Reissner beam element.
-      constexpr auto n_dof_rot = 9;
-      std::array<int, n_dof_rot> rot_dof_indices{3, 4, 5, 12, 13, 14, 18, 19, 20};
+
+      const std::vector<int> rot_dof_indices =
+          is_hermite ? std::vector<int>{3, 4, 5, 12, 13, 14, 18, 19, 20}
+                     : std::vector<int>{3, 4, 5, 9, 10, 11};
 
       // Gather the GID of the rotational DOF
-      std::vector<int> element_rot_gid_indices(9, -1);
-      for (unsigned int i = 0; i < n_dof_rot; i++)
+      std::vector<int> element_rot_gid_indices(rot_dof_indices.size(), -1);
+      for (unsigned int i = 0; i < rot_dof_indices.size(); i++)
         element_rot_gid_indices[i] = lm_beam[rot_dof_indices[i]];
       return element_rot_gid_indices;
     }

--- a/src/beaminteraction/src/4C_beaminteraction_calc_utils.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_calc_utils.cpp
@@ -730,10 +730,11 @@ namespace BeamInteraction
 
       const bool is_hermite = beam3r->hermite_centerline_interpolation();
 
-      if ((is_hermite && beam3r->num_node() != 3) || (!is_hermite && beam3r->num_node() != 2))
+      if (is_hermite && (beam3r->num_node() != 3))
         FOUR_C_THROW(
-            "The function get_element_rot_gid_indices is only implemented for Simo-Reissner beam "
-            "elements with hermite3line2 and line2line2 interpolation!");
+            "The function get_element_rot_gid_indices is not implemented for Simo-Reissner beam "
+            "elements with hermite interpolation and %d nodes!",
+            beam3r->num_node());
 
       // Get all GID of the element
       std::vector<int> lm_beam, gid_solid, lmowner, lmstride;

--- a/src/beaminteraction/src/contact/beam_to_solid/4C_beaminteraction_contact_beam_to_solid_utils.cpp
+++ b/src/beaminteraction/src/contact/beam_to_solid/4C_beaminteraction_contact_beam_to_solid_utils.cpp
@@ -183,10 +183,12 @@ BeamInteraction::mortar_shape_functions_to_number_of_lagrange_values(
 /**
  *
  */
+template <unsigned int n_nodes_rot>
 void BeamInteraction::get_beam_triad_interpolation_scheme(const Core::FE::Discretization& discret,
     const Core::LinAlg::Vector<double>& displacement_vector, const Core::Elements::Element* ele,
-    LargeRotations::TriadInterpolationLocalRotationVectors<3, double>& triad_interpolation_scheme,
-    LargeRotations::TriadInterpolationLocalRotationVectors<3, double>&
+    LargeRotations::TriadInterpolationLocalRotationVectors<n_nodes_rot, double>&
+        triad_interpolation_scheme,
+    LargeRotations::TriadInterpolationLocalRotationVectors<n_nodes_rot, double>&
         ref_triad_interpolation_scheme)
 {
   // Check that the beam element is a SR beam.
@@ -200,14 +202,14 @@ void BeamInteraction::get_beam_triad_interpolation_scheme(const Core::FE::Discre
       discret, beam_ele, displacement_vector, beam_displacement_vector_full_double);
 
   // Create object for triad interpolation schemes.
-  std::vector<Core::LinAlg::Matrix<4, 1, double>> nodal_quaternions(3);
-  beam_ele->get_nodal_triads_from_full_disp_vec_or_from_disp_theta<3, double>(
+  std::vector<Core::LinAlg::Matrix<4, 1, double>> nodal_quaternions(n_nodes_rot);
+  beam_ele->get_nodal_triads_from_full_disp_vec_or_from_disp_theta<n_nodes_rot, double>(
       beam_displacement_vector_full_double, nodal_quaternions);
   triad_interpolation_scheme.reset(nodal_quaternions);
 
   std::vector<double> beam_displacement_vector_full_ref(
       beam_displacement_vector_full_double.size(), 0.0);
-  beam_ele->get_nodal_triads_from_full_disp_vec_or_from_disp_theta<3, double>(
+  beam_ele->get_nodal_triads_from_full_disp_vec_or_from_disp_theta<n_nodes_rot, double>(
       beam_displacement_vector_full_ref, nodal_quaternions);
   ref_triad_interpolation_scheme.reset(nodal_quaternions);
 }
@@ -882,6 +884,24 @@ void BeamInteraction::check_diagonal_like_structure(
 namespace BeamInteraction
 {
   using namespace GeometryPair;
+
+  template void get_beam_triad_interpolation_scheme<2>(const Core::FE::Discretization& discret,
+      const Core::LinAlg::Vector<double>& displacement_vector, const Core::Elements::Element* ele,
+      LargeRotations::TriadInterpolationLocalRotationVectors<2, double>& triad_interpolation_scheme,
+      LargeRotations::TriadInterpolationLocalRotationVectors<2, double>&
+          ref_triad_interpolation_scheme);
+
+  template void get_beam_triad_interpolation_scheme<3>(const Core::FE::Discretization& discret,
+      const Core::LinAlg::Vector<double>& displacement_vector, const Core::Elements::Element* ele,
+      LargeRotations::TriadInterpolationLocalRotationVectors<3, double>& triad_interpolation_scheme,
+      LargeRotations::TriadInterpolationLocalRotationVectors<3, double>&
+          ref_triad_interpolation_scheme);
+
+  template void get_beam_triad_interpolation_scheme<4>(const Core::FE::Discretization& discret,
+      const Core::LinAlg::Vector<double>& displacement_vector, const Core::Elements::Element* ele,
+      LargeRotations::TriadInterpolationLocalRotationVectors<4, double>& triad_interpolation_scheme,
+      LargeRotations::TriadInterpolationLocalRotationVectors<4, double>&
+          ref_triad_interpolation_scheme);
 
   // Helper types for the macro initialization. The compiler has troubles inserting the templated
   // typenames into the macros.

--- a/src/beaminteraction/src/contact/beam_to_solid/4C_beaminteraction_contact_beam_to_solid_utils.hpp
+++ b/src/beaminteraction/src/contact/beam_to_solid/4C_beaminteraction_contact_beam_to_solid_utils.hpp
@@ -117,16 +117,19 @@ namespace BeamInteraction
   /**
    * \brief Setup the triad interpolation scheme for the current triad and reference triad of the
    * given beam element.
+   * @tparam n_nodes_rot number of rotational nodes.
    * @param discret (in) discretization.
    * @param displacement_vector (in) Global displacement vector.
    * @param ele (in) Pointer to the beam element.
    * @param triad_interpolation_scheme (out) Interpolation of current triad field..
    * @param ref_triad_interpolation_scheme (out) Interpolation of reference triad field.
    */
+  template <unsigned int n_nodes_rot>
   void get_beam_triad_interpolation_scheme(const Core::FE::Discretization& discret,
       const Core::LinAlg::Vector<double>& displacement_vector, const Core::Elements::Element* ele,
-      LargeRotations::TriadInterpolationLocalRotationVectors<3, double>& triad_interpolation_scheme,
-      LargeRotations::TriadInterpolationLocalRotationVectors<3, double>&
+      LargeRotations::TriadInterpolationLocalRotationVectors<n_nodes_rot, double>&
+          triad_interpolation_scheme,
+      LargeRotations::TriadInterpolationLocalRotationVectors<n_nodes_rot, double>&
           ref_triad_interpolation_scheme);
 
   /**

--- a/src/beaminteraction/src/contact/beam_to_solid/volume/4C_beaminteraction_contact_beam_to_solid_volume_meshtying_pair_mortar_rotation.cpp
+++ b/src/beaminteraction/src/contact/beam_to_solid/volume/4C_beaminteraction_contact_beam_to_solid_volume_meshtying_pair_mortar_rotation.cpp
@@ -267,11 +267,7 @@ void BeamInteraction::BeamToSolidVolumeMeshtyingPairMortarRotation<Beam, Solid, 
         for (unsigned int i_dim = 0; i_dim < 3; i_dim++)
           lambda_shape_functions_full(i_dim, 3 * i_node + i_dim) = lambda_shape_functions(i_node);
 
-      constexpr auto rotation_cell_type = n_nodes_rot_ == 2   ? Core::FE::CellType::line2
-                                          : n_nodes_rot_ == 3 ? Core::FE::CellType::line3
-                                                              : Core::FE::CellType::line4;
-
-      Core::FE::shape_function_1d(L_i, projected_gauss_point.get_eta(), rotation_cell_type);
+      Core::FE::shape_function_1d(L_i, projected_gauss_point.get_eta(), rotation_cell_type_);
       for (unsigned int i_node = 0; i_node < n_nodes_rot_; i_node++)
         for (unsigned int i_dim = 0; i_dim < 3; i_dim++)
           L_full(i_dim, 3 * i_node + i_dim) = L_i(i_node);
@@ -567,11 +563,7 @@ void BeamInteraction::BeamToSolidVolumeMeshtyingPairMortarRotation<Beam, Solid, 
         for (unsigned int i_dim = 0; i_dim < 3; i_dim++)
           lambda_shape_functions_full(i_dim, 3 * i_node + i_dim) = lambda_shape_functions(i_node);
 
-      constexpr auto rotation_cell_type = n_nodes_rot_ == 2   ? Core::FE::CellType::line2
-                                          : n_nodes_rot_ == 3 ? Core::FE::CellType::line3
-                                                              : Core::FE::CellType::line4;
-
-      Core::FE::shape_function_1d(L_i, projected_gauss_point.get_eta(), rotation_cell_type);
+      Core::FE::shape_function_1d(L_i, projected_gauss_point.get_eta(), rotation_cell_type_);
       for (unsigned int i_node = 0; i_node < n_nodes_rot_; i_node++)
         for (unsigned int i_dim = 0; i_dim < 3; i_dim++)
           L_full(i_dim, 3 * i_node + i_dim) = L_i(i_node);

--- a/src/beaminteraction/src/contact/beam_to_solid/volume/4C_beaminteraction_contact_beam_to_solid_volume_meshtying_pair_mortar_rotation.cpp
+++ b/src/beaminteraction/src/contact/beam_to_solid/volume/4C_beaminteraction_contact_beam_to_solid_volume_meshtying_pair_mortar_rotation.cpp
@@ -62,8 +62,10 @@ void BeamInteraction::BeamToSolidVolumeMeshtyingPairMortarRotation<Beam, Solid, 
   if (this->line_to_3D_segments_.size() == 0) return;
 
   // Get the beam triad interpolation schemes.
-  LargeRotations::TriadInterpolationLocalRotationVectors<3, double> triad_interpolation_scheme;
-  LargeRotations::TriadInterpolationLocalRotationVectors<3, double> ref_triad_interpolation_scheme;
+  LargeRotations::TriadInterpolationLocalRotationVectors<n_nodes_rot_, double>
+      triad_interpolation_scheme;
+  LargeRotations::TriadInterpolationLocalRotationVectors<n_nodes_rot_, double>
+      ref_triad_interpolation_scheme;
   get_beam_triad_interpolation_scheme(discret, *displacement_vector, this->element1(),
       triad_interpolation_scheme, ref_triad_interpolation_scheme);
 
@@ -156,9 +158,9 @@ void BeamInteraction::BeamToSolidVolumeMeshtyingPairMortarRotation<Beam, Solid, 
     MortarRot>::evaluate_rotational_coupling_terms(  //
     const BeamToSolid::BeamToSolidRotationCoupling& rot_coupling_type,
     const GeometryPair::ElementData<Solid, scalar_type_rot_1st>& q_solid,
-    const LargeRotations::TriadInterpolationLocalRotationVectors<3, double>&
+    const LargeRotations::TriadInterpolationLocalRotationVectors<n_nodes_rot_, double>&
         triad_interpolation_scheme,
-    const LargeRotations::TriadInterpolationLocalRotationVectors<3, double>&
+    const LargeRotations::TriadInterpolationLocalRotationVectors<n_nodes_rot_, double>&
         ref_triad_interpolation_scheme,
     Core::LinAlg::Matrix<MortarRot::n_dof_, 1, double>& local_g,
     Core::LinAlg::Matrix<MortarRot::n_dof_, n_dof_rot_, double>& local_G_B,
@@ -187,7 +189,7 @@ void BeamInteraction::BeamToSolidVolumeMeshtyingPairMortarRotation<Beam, Solid, 
   Core::LinAlg::Matrix<MortarRot::n_nodes_, 1, double> lambda_shape_functions;
   Core::LinAlg::Matrix<3, MortarRot::n_dof_, double> lambda_shape_functions_full(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::SerialDenseVector L_i(3);
+  Core::LinAlg::SerialDenseVector L_i(n_nodes_rot_);
   Core::LinAlg::Matrix<3, n_dof_rot_, double> L_full(Core::LinAlg::Initialization::zero);
   std::vector<Core::LinAlg::Matrix<3, 3, double>> I_beam_tilde;
   Core::LinAlg::Matrix<3, n_dof_rot_, double> I_beam_tilde_full;
@@ -265,14 +267,18 @@ void BeamInteraction::BeamToSolidVolumeMeshtyingPairMortarRotation<Beam, Solid, 
         for (unsigned int i_dim = 0; i_dim < 3; i_dim++)
           lambda_shape_functions_full(i_dim, 3 * i_node + i_dim) = lambda_shape_functions(i_node);
 
-      Core::FE::shape_function_1d(L_i, projected_gauss_point.get_eta(), Core::FE::CellType::line3);
-      for (unsigned int i_node = 0; i_node < 3; i_node++)
+      constexpr auto rotation_cell_type = n_nodes_rot_ == 2   ? Core::FE::CellType::line2
+                                          : n_nodes_rot_ == 3 ? Core::FE::CellType::line3
+                                                              : Core::FE::CellType::line4;
+
+      Core::FE::shape_function_1d(L_i, projected_gauss_point.get_eta(), rotation_cell_type);
+      for (unsigned int i_node = 0; i_node < n_nodes_rot_; i_node++)
         for (unsigned int i_dim = 0; i_dim < 3; i_dim++)
           L_full(i_dim, 3 * i_node + i_dim) = L_i(i_node);
 
       triad_interpolation_scheme.get_nodal_generalized_rotation_interpolation_matrices_at_xi(
           I_beam_tilde, projected_gauss_point.get_eta());
-      for (unsigned int i_node = 0; i_node < 3; i_node++)
+      for (unsigned int i_node = 0; i_node < n_nodes_rot_; i_node++)
         for (unsigned int i_dim_0 = 0; i_dim_0 < 3; i_dim_0++)
           for (unsigned int i_dim_1 = 0; i_dim_1 < 3; i_dim_1++)
             I_beam_tilde_full(i_dim_0, i_node * 3 + i_dim_1) =
@@ -353,8 +359,10 @@ void BeamInteraction::BeamToSolidVolumeMeshtyingPairMortarRotation<Beam, Solid, 
   if (stiffness_matrix == nullptr) return;
 
   // Get the beam triad interpolation schemes.
-  LargeRotations::TriadInterpolationLocalRotationVectors<3, double> triad_interpolation_scheme;
-  LargeRotations::TriadInterpolationLocalRotationVectors<3, double> ref_triad_interpolation_scheme;
+  LargeRotations::TriadInterpolationLocalRotationVectors<n_nodes_rot_, double>
+      triad_interpolation_scheme;
+  LargeRotations::TriadInterpolationLocalRotationVectors<n_nodes_rot_, double>
+      ref_triad_interpolation_scheme;
   get_beam_triad_interpolation_scheme(discret, displacement_vector, this->element1(),
       triad_interpolation_scheme, ref_triad_interpolation_scheme);
 
@@ -442,9 +450,9 @@ void BeamInteraction::BeamToSolidVolumeMeshtyingPairMortarRotation<Beam, Solid, 
         const BeamToSolid::BeamToSolidRotationCoupling& rot_coupling_type,
         const GeometryPair::ElementData<Solid, scalar_type_rot_2nd>& q_solid,
         Core::LinAlg::Matrix<MortarRot::n_dof_, 1, double>& lambda_rot,
-        const LargeRotations::TriadInterpolationLocalRotationVectors<3, double>&
+        const LargeRotations::TriadInterpolationLocalRotationVectors<n_nodes_rot_, double>&
             triad_interpolation_scheme,
-        const LargeRotations::TriadInterpolationLocalRotationVectors<3, double>&
+        const LargeRotations::TriadInterpolationLocalRotationVectors<n_nodes_rot_, double>&
             ref_triad_interpolation_scheme,
         Core::LinAlg::Matrix<n_dof_rot_, n_dof_rot_, double>& local_stiff_BB,
         Core::LinAlg::Matrix<n_dof_rot_, Solid::n_dof_, double>& local_stiff_BS,
@@ -472,7 +480,7 @@ void BeamInteraction::BeamToSolidVolumeMeshtyingPairMortarRotation<Beam, Solid, 
   Core::LinAlg::Matrix<MortarRot::n_nodes_, 1, double> lambda_shape_functions;
   Core::LinAlg::Matrix<3, MortarRot::n_dof_, scalar_type_rot_1st> lambda_shape_functions_full(
       Core::LinAlg::Initialization::zero);
-  Core::LinAlg::SerialDenseVector L_i(3);
+  Core::LinAlg::SerialDenseVector L_i(n_nodes_rot_);
   Core::LinAlg::Matrix<3, n_dof_rot_, scalar_type_rot_1st> L_full(
       Core::LinAlg::Initialization::zero);
   std::vector<Core::LinAlg::Matrix<3, 3, double>> I_beam_tilde;
@@ -559,14 +567,18 @@ void BeamInteraction::BeamToSolidVolumeMeshtyingPairMortarRotation<Beam, Solid, 
         for (unsigned int i_dim = 0; i_dim < 3; i_dim++)
           lambda_shape_functions_full(i_dim, 3 * i_node + i_dim) = lambda_shape_functions(i_node);
 
-      Core::FE::shape_function_1d(L_i, projected_gauss_point.get_eta(), Core::FE::CellType::line3);
-      for (unsigned int i_node = 0; i_node < 3; i_node++)
+      constexpr auto rotation_cell_type = n_nodes_rot_ == 2   ? Core::FE::CellType::line2
+                                          : n_nodes_rot_ == 3 ? Core::FE::CellType::line3
+                                                              : Core::FE::CellType::line4;
+
+      Core::FE::shape_function_1d(L_i, projected_gauss_point.get_eta(), rotation_cell_type);
+      for (unsigned int i_node = 0; i_node < n_nodes_rot_; i_node++)
         for (unsigned int i_dim = 0; i_dim < 3; i_dim++)
           L_full(i_dim, 3 * i_node + i_dim) = L_i(i_node);
 
       triad_interpolation_scheme.get_nodal_generalized_rotation_interpolation_matrices_at_xi(
           I_beam_tilde, projected_gauss_point.get_eta());
-      for (unsigned int i_node = 0; i_node < 3; i_node++)
+      for (unsigned int i_node = 0; i_node < n_nodes_rot_; i_node++)
         for (unsigned int i_dim_0 = 0; i_dim_0 < 3; i_dim_0++)
           for (unsigned int i_dim_1 = 0; i_dim_1 < 3; i_dim_1++)
             I_beam_tilde_full(i_dim_0, i_node * 3 + i_dim_1) =

--- a/src/beaminteraction/src/contact/beam_to_solid/volume/4C_beaminteraction_contact_beam_to_solid_volume_meshtying_pair_mortar_rotation.hpp
+++ b/src/beaminteraction/src/contact/beam_to_solid/volume/4C_beaminteraction_contact_beam_to_solid_volume_meshtying_pair_mortar_rotation.hpp
@@ -30,6 +30,18 @@ namespace LargeRotations
 
 namespace BeamInteraction
 {
+  template <unsigned int n_nodes>
+  inline constexpr Core::FE::CellType line_cell_type;
+
+  template <>
+  inline constexpr auto line_cell_type<2> = Core::FE::CellType::line2;
+
+  template <>
+  inline constexpr auto line_cell_type<3> = Core::FE::CellType::line3;
+
+  template <>
+  inline constexpr auto line_cell_type<4> = Core::FE::CellType::line4;
+
   /**
    * \brief Class for beam to solid rotational meshtying.
    * @param beam Type from GeometryPair::ElementDiscretization... representing the beam.
@@ -62,6 +74,8 @@ namespace BeamInteraction
     static constexpr unsigned int n_dof_rot_ = 3 * n_nodes_rot_;
 
     static constexpr unsigned int n_dof_pair_ = n_dof_rot_ + Solid::n_dof_;
+
+    Core::FE::CellType rotation_cell_type_ = line_cell_type<n_nodes_rot_>;
 
    public:
     /**

--- a/src/beaminteraction/src/contact/beam_to_solid/volume/4C_beaminteraction_contact_beam_to_solid_volume_meshtying_pair_mortar_rotation.hpp
+++ b/src/beaminteraction/src/contact/beam_to_solid/volume/4C_beaminteraction_contact_beam_to_solid_volume_meshtying_pair_mortar_rotation.hpp
@@ -62,7 +62,10 @@ namespace BeamInteraction
         std::is_same_v<Beam, GeometryPair::t_hermite> ? 3 : Beam::n_nodes_;
     static constexpr unsigned int n_dof_rot_ = 3 * n_nodes_rot_;
 
-    Core::FE::CellType rotation_cell_type_ = GeometryPair::line_n_nodes_to_cell_type<n_nodes_rot_>;
+    static constexpr Core::FE::CellType rotation_cell_type_ =
+        GeometryPair::line_n_nodes_to_cell_type<n_nodes_rot_>;
+    static_assert(rotation_cell_type_ != Core::FE::CellType::dis_none,
+        "Unsupported rotational interpolation node count (expected 2, 3 or 4).");
 
     static constexpr unsigned int n_dof_pair_ = n_dof_rot_ + Solid::n_dof_;
 

--- a/src/beaminteraction/src/contact/beam_to_solid/volume/4C_beaminteraction_contact_beam_to_solid_volume_meshtying_pair_mortar_rotation.hpp
+++ b/src/beaminteraction/src/contact/beam_to_solid/volume/4C_beaminteraction_contact_beam_to_solid_volume_meshtying_pair_mortar_rotation.hpp
@@ -57,7 +57,10 @@ namespace BeamInteraction
         typename Core::FADUtils::HigherOrderFadType<2, scalar_type_rot_1st>::type;
 
     //! Number of rotational DOF for the SR beams;
-    static constexpr unsigned int n_dof_rot_ = 9;
+    static constexpr unsigned int n_nodes_rot_ =
+        std::is_same_v<Beam, GeometryPair::t_hermite> ? 3 : Beam::n_nodes_;
+    static constexpr unsigned int n_dof_rot_ = 3 * n_nodes_rot_;
+
     static constexpr unsigned int n_dof_pair_ = n_dof_rot_ + Solid::n_dof_;
 
    public:
@@ -100,9 +103,9 @@ namespace BeamInteraction
     void evaluate_rotational_coupling_terms(
         const BeamToSolid::BeamToSolidRotationCoupling& rot_coupling_type,
         const GeometryPair::ElementData<Solid, scalar_type_rot_1st>& q_solid,
-        const LargeRotations::TriadInterpolationLocalRotationVectors<3, double>&
+        const LargeRotations::TriadInterpolationLocalRotationVectors<n_nodes_rot_, double>&
             triad_interpolation_scheme,
-        const LargeRotations::TriadInterpolationLocalRotationVectors<3, double>&
+        const LargeRotations::TriadInterpolationLocalRotationVectors<n_nodes_rot_, double>&
             ref_triad_interpolation_scheme,
         Core::LinAlg::Matrix<MortarRot::n_dof_, 1, double>& local_g,
         Core::LinAlg::Matrix<MortarRot::n_dof_, n_dof_rot_, double>& local_G_B,
@@ -118,9 +121,9 @@ namespace BeamInteraction
         const BeamToSolid::BeamToSolidRotationCoupling& rot_coupling_type,
         const GeometryPair::ElementData<Solid, scalar_type_rot_2nd>& q_solid,
         Core::LinAlg::Matrix<MortarRot::n_dof_, 1, double>& lambda_rot,
-        const LargeRotations::TriadInterpolationLocalRotationVectors<3, double>&
+        const LargeRotations::TriadInterpolationLocalRotationVectors<n_nodes_rot_, double>&
             triad_interpolation_scheme,
-        const LargeRotations::TriadInterpolationLocalRotationVectors<3, double>&
+        const LargeRotations::TriadInterpolationLocalRotationVectors<n_nodes_rot_, double>&
             ref_triad_interpolation_scheme,
         Core::LinAlg::Matrix<n_dof_rot_, n_dof_rot_, double>& local_stiff_BB,
         Core::LinAlg::Matrix<n_dof_rot_, Solid::n_dof_, double>& local_stiff_BS,

--- a/src/beaminteraction/src/contact/beam_to_solid/volume/4C_beaminteraction_contact_beam_to_solid_volume_meshtying_pair_mortar_rotation.hpp
+++ b/src/beaminteraction/src/contact/beam_to_solid/volume/4C_beaminteraction_contact_beam_to_solid_volume_meshtying_pair_mortar_rotation.hpp
@@ -12,6 +12,7 @@
 #include "4C_config.hpp"
 
 #include "4C_beaminteraction_contact_beam_to_solid_volume_meshtying_pair_mortar.hpp"
+#include "4C_geometry_pair_utility_functions.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -30,18 +31,6 @@ namespace LargeRotations
 
 namespace BeamInteraction
 {
-  template <unsigned int n_nodes>
-  inline constexpr Core::FE::CellType line_cell_type;
-
-  template <>
-  inline constexpr auto line_cell_type<2> = Core::FE::CellType::line2;
-
-  template <>
-  inline constexpr auto line_cell_type<3> = Core::FE::CellType::line3;
-
-  template <>
-  inline constexpr auto line_cell_type<4> = Core::FE::CellType::line4;
-
   /**
    * \brief Class for beam to solid rotational meshtying.
    * @param beam Type from GeometryPair::ElementDiscretization... representing the beam.
@@ -73,9 +62,9 @@ namespace BeamInteraction
         std::is_same_v<Beam, GeometryPair::t_hermite> ? 3 : Beam::n_nodes_;
     static constexpr unsigned int n_dof_rot_ = 3 * n_nodes_rot_;
 
-    static constexpr unsigned int n_dof_pair_ = n_dof_rot_ + Solid::n_dof_;
+    Core::FE::CellType rotation_cell_type_ = GeometryPair::line_n_nodes_to_cell_type<n_nodes_rot_>;
 
-    Core::FE::CellType rotation_cell_type_ = line_cell_type<n_nodes_rot_>;
+    static constexpr unsigned int n_dof_pair_ = n_dof_rot_ + Solid::n_dof_;
 
    public:
     /**

--- a/src/geometry_pair/4C_geometry_pair_utility_functions.hpp
+++ b/src/geometry_pair/4C_geometry_pair_utility_functions.hpp
@@ -30,6 +30,27 @@ namespace GeometryPair
 namespace GeometryPair
 {
   /**
+   * @brief Maps the number of nodes of a line element to its finite-element cell type.
+   *
+   * The mapping is evaluated at compile time. Line elements with two, three, or four
+   * nodes are mapped to @c line2, @c line3, and @c line4, respectively. Unsupported
+   * node counts are mapped to @c Core::FE::CellType::dis_none.
+   *
+   * @tparam n_nodes Number of nodes of the line element.
+   */
+  template <unsigned int n_nodes>
+  inline constexpr Core::FE::CellType line_n_nodes_to_cell_type = Core::FE::CellType::dis_none;
+
+  template <>
+  inline constexpr auto line_n_nodes_to_cell_type<2> = Core::FE::CellType::line2;
+
+  template <>
+  inline constexpr auto line_n_nodes_to_cell_type<3> = Core::FE::CellType::line3;
+
+  template <>
+  inline constexpr auto line_n_nodes_to_cell_type<4> = Core::FE::CellType::line4;
+
+  /**
    * \brief Convert the enum DiscretizationTypeGeometry to a human readable string.
    * @param discretization_type (in)
    * @return Human readable string representation of the enum.


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
This PR templates the mortar rotation pair on the number of nodes used for the interpolation of the rotational part of the beam-solid volume coupling. Currently it is hardcoded for `beam3rherm2line3`.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
#2208