### PR TITLE
Particle: accessor for all state data

### DIFF
--- a/src/particle/src/algorithm/4C_particle_algorithm_constraints.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_constraints.cpp
@@ -45,11 +45,11 @@ void Particle::ConstraintsProjectionBase::apply(
     if (n_particle_stored <= 0) continue;
 
     // get pointer to particle velocity and acceleration
-    double* vel = container->get_ptr_to_state_writable(Particle::State::Velocity, 0);
-    double* acc = container->get_ptr_to_state_writable(Particle::State::Acceleration, 0);
-    double* modvel = container->try_get_ptr_to_state_writable(Particle::State::ModifiedVelocity, 0);
+    double* vel = container->get_ptr_to_state_writable(Particle::State::Velocity);
+    double* acc = container->get_ptr_to_state_writable(Particle::State::Acceleration);
+    double* modvel = container->try_get_ptr_to_state_writable(Particle::State::ModifiedVelocity);
     double* modacc =
-        container->try_get_ptr_to_state_writable(Particle::State::ModifiedAcceleration, 0);
+        container->try_get_ptr_to_state_writable(Particle::State::ModifiedAcceleration);
 
     // get particle state dimension
     const int pos_state_dim = container->get_state_dim(Particle::State::Position);
@@ -105,10 +105,10 @@ void Particle::ConstraintsProjectionBase::check_particles(
     if (n_particle_stored <= 0) continue;
 
     // get pointer to particle position
-    const double* pos = container->get_ptr_to_state(Particle::State::Position, 0);
+    const double* pos = container->get_ptr_to_state(Particle::State::Position);
 
     // get pointer to particle radius
-    const double* rad = container->get_ptr_to_state(Particle::State::Radius, 0);
+    const double* rad = container->get_ptr_to_state(Particle::State::Radius);
 
     // get particle state dimension
     const int pos_state_dim = container->get_state_dim(Particle::State::Position);
@@ -145,8 +145,8 @@ int Particle::ConstraintsProjection2D::calc_primary_axis_local(
     if (n_particle_stored < 3) continue;
 
     // get pointer to particle position and radius
-    const double* pos = container->get_ptr_to_state(Particle::State::Position, 0);
-    const double* rad = container->get_ptr_to_state(Particle::State::Radius, 0);
+    const double* pos = container->get_ptr_to_state(Particle::State::Position);
+    const double* rad = container->get_ptr_to_state(Particle::State::Radius);
 
     // get particle state dimension
     const int pos_state_dim = container->get_state_dim(Particle::State::Position);
@@ -271,7 +271,7 @@ int Particle::ConstraintsProjection1D::calc_primary_axis_local(
     if (n_particle_stored < 2) continue;
 
     // get pointer to particle position
-    const double* pos = container->get_ptr_to_state(Particle::State::Position, 0);
+    const double* pos = container->get_ptr_to_state(Particle::State::Position);
 
     // get particle state dimension
     const int pos_state_dim = container->get_state_dim(Particle::State::Position);

--- a/src/particle/src/algorithm/4C_particle_algorithm_dirichlet_bc.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_dirichlet_bc.cpp
@@ -209,10 +209,10 @@ void Particle::DirichletBoundaryConditionHandler::evaluate_dirichlet_boundary_co
         "dimension of function defining dirichlet boundary condition not correct!");
 
     // get pointer to particle states
-    const double* refpos = container->get_ptr_to_state(Particle::State::ReferencePosition, 0);
-    double* pos = container->get_ptr_to_state_writable(Particle::State::Position, 0);
-    double* vel = container->get_ptr_to_state_writable(Particle::State::Velocity, 0);
-    double* acc = container->get_ptr_to_state_writable(Particle::State::Acceleration, 0);
+    const double* refpos = container->get_ptr_to_state(Particle::State::ReferencePosition);
+    double* pos = container->get_ptr_to_state_writable(Particle::State::Position);
+    double* vel = container->get_ptr_to_state_writable(Particle::State::Velocity);
+    double* acc = container->get_ptr_to_state_writable(Particle::State::Acceleration);
 
     // iterate over owned particles of current type and apply dbc values to particle states
     for (int i = 0; i < particlestored; ++i)
@@ -239,11 +239,11 @@ void Particle::DirichletBoundaryConditionHandler::evaluate_dirichlet_boundary_co
 
     // get pointer to particle states
     const double* dirichlet_function_id =
-        container->get_ptr_to_state(Particle::State::DirichletFunctionId, 0);
-    const double* refpos = container->get_ptr_to_state(Particle::State::ReferencePosition, 0);
-    double* pos = container->get_ptr_to_state_writable(Particle::State::Position, 0);
-    double* vel = container->get_ptr_to_state_writable(Particle::State::Velocity, 0);
-    double* acc = container->get_ptr_to_state_writable(Particle::State::Acceleration, 0);
+        container->get_ptr_to_state(Particle::State::DirichletFunctionId);
+    const double* refpos = container->get_ptr_to_state(Particle::State::ReferencePosition);
+    double* pos = container->get_ptr_to_state_writable(Particle::State::Position);
+    double* vel = container->get_ptr_to_state_writable(Particle::State::Velocity);
+    double* acc = container->get_ptr_to_state_writable(Particle::State::Acceleration);
 
     // iterate over owned particles of current type
     for (int i = 0; i < particlestored; ++i)
@@ -285,8 +285,7 @@ void Particle::DirichletBoundaryConditionHandler::build_funct_cache(MPI_Comm com
     const int n = container->particles_stored();
     if (n <= 0) continue;
 
-    const double* funct_id_ptr =
-        container->get_ptr_to_state(Particle::State::DirichletFunctionId, 0);
+    const double* funct_id_ptr = container->get_ptr_to_state(Particle::State::DirichletFunctionId);
     for (int i = 0; i < n; ++i)
     {
       const int funct_id = static_cast<int>(funct_id_ptr[i]);

--- a/src/particle/src/algorithm/4C_particle_algorithm_initial_field.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_initial_field.cpp
@@ -92,8 +92,8 @@ void Particle::InitialFieldHandler::set_initial_fields()
           Global::Problem::instance()->function_by_id<Core::Utils::FunctionOfSpaceTime>(functid);
 
       // get pointer to particle states
-      const double* pos = container->get_ptr_to_state(Particle::State::Position, 0);
-      double* state = container->get_ptr_to_state_writable(particleState, 0);
+      const double* pos = container->get_ptr_to_state(Particle::State::Position);
+      double* state = container->get_ptr_to_state_writable(particleState);
 
       // get particle state dimensions
       int posstatedim = container->get_state_dim(Particle::State::Position);

--- a/src/particle/src/algorithm/4C_particle_algorithm_result_test.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_result_test.cpp
@@ -195,13 +195,10 @@ void Particle::ParticleResultTest::test_special(
             "state '{}' not found in container!", Particle::enum_to_state_name(particleState));
 
       // get pointer to particle state
-      const double* state = container->get_ptr_to_state(particleState, 0);
-
-      // get particle state dimension
-      int statedim = container->get_state_dim(particleState);
+      const double* state = container->get_ptr_to_state(particleState, index);
 
       // get actual result
-      actresult = state[statedim * index + dim];
+      actresult = state[dim];
 
       // compare values
       const int err = compare_values(actresult, "SPECIAL", result_container);

--- a/src/particle/src/algorithm/4C_particle_algorithm_temperature_bc.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_temperature_bc.cpp
@@ -105,8 +105,8 @@ void Particle::TemperatureBoundaryConditionHandler::evaluate_temperature_boundar
         Global::Problem::instance()->function_by_id<Core::Utils::FunctionOfSpaceTime>(functid);
 
     // get pointer to particle states
-    const double* refpos = container->get_ptr_to_state(Particle::State::ReferencePosition, 0);
-    double* temp = container->get_ptr_to_state_writable(Particle::State::Temperature, 0);
+    const double* refpos = container->get_ptr_to_state(Particle::State::ReferencePosition);
+    double* temp = container->get_ptr_to_state_writable(Particle::State::Temperature);
 
     // get particle state dimension
     int statedim = container->get_state_dim(Particle::State::Position);

--- a/src/particle/src/algorithm/4C_particle_algorithm_timint.cpp
+++ b/src/particle/src/algorithm/4C_particle_algorithm_timint.cpp
@@ -206,7 +206,7 @@ void Particle::TimInt::add_initial_random_noise_to_position()
     if (particlestored <= 0) continue;
 
     // get pointer to particle state
-    double* pos = container->get_ptr_to_state_writable(Particle::State::Position, 0);
+    double* pos = container->get_ptr_to_state_writable(Particle::State::Position);
 
     // get particle state dimension
     int statedim = container->get_state_dim(Particle::State::Position);

--- a/src/particle/src/engine/4C_particle_engine.cpp
+++ b/src/particle/src/engine/4C_particle_engine.cpp
@@ -2012,8 +2012,8 @@ void Particle::ParticleEngine::store_positions_after_particle_transfer()
     if (particlestored == 0) continue;
 
     // get pointer to particle states
-    const double* pos = container->get_ptr_to_state(State::Position, 0);
-    double* lasttransferpos = container->get_ptr_to_state_writable(State::LastTransferPosition, 0);
+    const double* pos = container->get_ptr_to_state(State::Position);
+    double* lasttransferpos = container->get_ptr_to_state_writable(State::LastTransferPosition);
 
     // get particle state dimension
     int statedim = container->get_state_dim(State::Position);
@@ -2046,7 +2046,7 @@ void Particle::ParticleEngine::relate_owned_particles_to_bins()
     if (particlestored <= 0) continue;
 
     // get pointer to position of particle after last transfer
-    const double* lasttransferpos = container->get_ptr_to_state(State::LastTransferPosition, 0);
+    const double* lasttransferpos = container->get_ptr_to_state(State::LastTransferPosition);
 
     // get particle state dimension
     int statedim = container->get_state_dim(State::Position);

--- a/src/particle/src/engine/4C_particle_engine_container.cpp
+++ b/src/particle/src/engine/4C_particle_engine_container.cpp
@@ -264,7 +264,7 @@ double Particle::ParticleContainer::get_min_value_of_state(Particle::State state
 
   if (particlestored_ <= 0) return 0.0;
 
-  const double* state_ptr = get_ptr_to_state(state, 0);
+  const double* state_ptr = get_ptr_to_state(state);
   double min = state_ptr[0];
 
   for (int i = 1; i < (particlestored_ * statedim_[static_cast<int>(state)]); ++i)
@@ -280,7 +280,7 @@ double Particle::ParticleContainer::get_max_value_of_state(Particle::State state
 
   if (particlestored_ <= 0) return 0.0;
 
-  const double* state_ptr = get_ptr_to_state(state, 0);
+  const double* state_ptr = get_ptr_to_state(state);
   double max = state_ptr[0];
 
   for (int i = 1; i < (particlestored_ * statedim_[static_cast<int>(state)]); ++i)

--- a/src/particle/src/engine/4C_particle_engine_container.hpp
+++ b/src/particle/src/engine/4C_particle_engine_container.hpp
@@ -184,6 +184,32 @@ namespace Particle
     const double* get_ptr_to_state(Particle::State state, int index) const;
 
     /*!
+     * \brief get read-only pointer to state of all particles
+     *
+     * This is the default method to be used to get a pointer with read-only access to the state of
+     * all particles. Returns a nullptr if the container is empty.
+     *
+     * \note Throws an error in the debug version in case the requested state is not stored in the
+     *       particle container.
+     *
+     * \note The returned pointer may not be used to access memory without checking for a nullptr.
+     *
+     *
+     * \param[in] state particle state
+     *
+     * \return pointer with read-only access to particle state or nullptr
+     */
+    inline const double* get_ptr_to_state(Particle::State state) const
+    {
+      FOUR_C_ASSERT(storedstates_.contains(state), "particle state '{}' not stored in container!",
+          enum_to_state_name(state));
+
+      if (particlestored_ == 0) return nullptr;
+
+      return get_ptr_to_state(state, 0);
+    };
+
+    /*!
      * \brief conditionally get read-only pointer to state of a particle at index
      *
      * This method to get a pointer with read-only access to the state of a particle at a certain
@@ -210,6 +236,28 @@ namespace Particle
     };
 
     /*!
+     * \brief conditionally get read-only pointer to state of all particles
+     *
+     * This method to get a pointer with read-only access to the state of all particles
+     * is used in cases when a state may not be stored in the particle container.
+     * Conditionally, a pointer is returned in case the state is stored in the particle container,
+     * otherwise, a nullptr is returned. Returns a nullptr if the container is empty.
+     *
+     * \note The returned pointer may not be used to access memory without checking for a nullptr.
+     *
+     *
+     * \param[in] state particle state
+     *
+     * \return pointer with read-only access to particle state or nullptr
+     */
+    inline const double* try_get_ptr_to_state(Particle::State state) const
+    {
+      if (particlestored_ == 0) return nullptr;
+
+      return try_get_ptr_to_state(state, 0);
+    };
+
+    /*!
      * \brief get writable pointer to state of a particle at index
      *
      * This is the default method to be used to get a pointer with writable access to the state of
@@ -225,6 +273,32 @@ namespace Particle
      * \return pointer with writable access to particle state
      */
     double* get_ptr_to_state_writable(Particle::State state, int index);
+
+    /*!
+     * \brief get writable pointer to state of all particles
+     *
+     * This is the default method to be used to get a pointer with writable access to the state of
+     * all particles. Returns a nullptr if the container is empty.
+     *
+     * \note Throws an error in the debug version in case the requested state is not stored in the
+     *       particle container.
+     *
+     * \note The returned pointer may not be used to access memory without checking for a nullptr.
+     *
+     *
+     * \param[in] state particle state
+     *
+     * \return pointer with writable access to particle state or nullptr
+     */
+    double* get_ptr_to_state_writable(Particle::State state)
+    {
+      FOUR_C_ASSERT(storedstates_.contains(state), "particle state '{}' not stored in container!",
+          enum_to_state_name(state));
+
+      if (particlestored_ == 0) return nullptr;
+
+      return get_ptr_to_state_writable(state, 0);
+    };
 
     /*!
      * \brief conditionally get writable pointer to state of a particle at index
@@ -250,6 +324,28 @@ namespace Particle
       if (storedstates_.contains(state)) return get_ptr_to_state_writable(state, index);
 
       return nullptr;
+    };
+
+    /*!
+     * \brief conditionally get writable pointer to state of all particles
+     *
+     * This method to get a pointer with writable access to the state of all particles
+     * is used in cases when a state may not be stored in the particle container.
+     * Conditionally, a pointer is returned in case the state is stored in the particle container,
+     * otherwise, a nullptr is returned. Returns a nullptr if the container is empty.
+     *
+     * \note The returned pointer may not be used to access memory without checking for a nullptr.
+     *
+     *
+     * \param[in] state particle state
+     *
+     * \return pointer with writable access to particle state or nullptr
+     */
+    inline double* try_get_ptr_to_state_writable(Particle::State state)
+    {
+      if (particlestored_ == 0) return nullptr;
+
+      return try_get_ptr_to_state_writable(state, 0);
     };
 
     /*!
@@ -285,9 +381,7 @@ namespace Particle
       FOUR_C_ASSERT(storedstates_.contains(state), "particle state '{}' not stored in container!",
           enum_to_state_name(state));
 
-      if (particlestored_ <= 0) return;
-
-      double* state_ptr = get_ptr_to_state_writable(state, 0);
+      double* state_ptr = get_ptr_to_state_writable(state);
 
       for (int i = 0; i < (particlestored_ * statedim_[static_cast<int>(state)]); ++i)
         state_ptr[i] *= fac;
@@ -319,10 +413,8 @@ namespace Particle
       FOUR_C_ASSERT(statedim_[static_cast<int>(stateA)] == statedim_[static_cast<int>(stateB)],
           "dimensions of states do not match!");
 
-      if (particlestored_ <= 0) return;
-
-      const double* state_b_ptr = get_ptr_to_state(stateB, 0);
-      double* state_a_ptr = get_ptr_to_state_writable(stateA, 0);
+      const double* state_b_ptr = get_ptr_to_state(stateB);
+      double* state_a_ptr = get_ptr_to_state_writable(stateA);
 
       for (int i = 0; i < (particlestored_ * statedim_[static_cast<int>(stateA)]); ++i)
         state_a_ptr[i] = facA * state_a_ptr[i] + facB * state_b_ptr[i];
@@ -343,9 +435,7 @@ namespace Particle
       FOUR_C_ASSERT(statedim_[static_cast<int>(state)] == static_cast<int>(val.size()),
           "dimensions of states do not match!");
 
-      if (particlestored_ <= 0) return;
-
-      double* state_ptr = get_ptr_to_state_writable(state, 0);
+      double* state_ptr = get_ptr_to_state_writable(state);
 
       for (int i = 0; i < particlestored_; ++i)
         for (int dim = 0; dim < statedim_[static_cast<int>(state)]; ++dim)
@@ -363,9 +453,7 @@ namespace Particle
       FOUR_C_ASSERT(storedstates_.contains(state), "particle state '{}' not stored in container!",
           enum_to_state_name(state));
 
-      if (particlestored_ <= 0) return;
-
-      double* state_ptr = get_ptr_to_state_writable(state, 0);
+      double* state_ptr = get_ptr_to_state_writable(state);
 
       for (int i = 0; i < (particlestored_ * statedim_[static_cast<int>(state)]); ++i)
         state_ptr[i] = 0.0;

--- a/src/particle/src/engine/4C_particle_engine_runtime_vtp_writer.cpp
+++ b/src/particle/src/engine/4C_particle_engine_runtime_vtp_writer.cpp
@@ -121,8 +121,7 @@ void Particle::ParticleRuntimeVtpWriter::set_particle_positions_and_states()
         std::string statename = enum_to_state_name(state);
 
         // get pointer to particle state
-        const double* state_ptr =
-            (particlestored > 0) ? container->get_ptr_to_state(state, 0) : nullptr;
+        const double* state_ptr = container->get_ptr_to_state(state);
 
         if (state == State::Position)
         {

--- a/src/particle/src/interaction/4C_particle_interaction_dem.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_dem.cpp
@@ -334,7 +334,7 @@ void Particle::ParticleInteractionDEM::set_initial_radius()
             particlematerial_->get_ptr_to_particle_mat_parameter(type_i);
 
         // get pointer to particle state
-        double* radius = container->get_ptr_to_state_writable(Particle::State::Radius, 0);
+        double* radius = container->get_ptr_to_state_writable(Particle::State::Radius);
 
         // determine mu of random particle radius distribution
         const double mu = (radiusdistributiontype == Particle::NormalRadiusDistribution)
@@ -392,8 +392,8 @@ void Particle::ParticleInteractionDEM::set_initial_mass()
         particlematerial_->get_ptr_to_particle_mat_parameter(type_i);
 
     // get pointer to particle states
-    const double* radius = container->get_ptr_to_state(Particle::State::Radius, 0);
-    double* mass = container->get_ptr_to_state_writable(Particle::State::Mass, 0);
+    const double* radius = container->get_ptr_to_state(Particle::State::Radius);
+    double* mass = container->get_ptr_to_state_writable(Particle::State::Mass);
 
     // compute mass via particle volume and initial density
     const double fac = material->initDensity_ * 4.0 / 3.0 * std::numbers::pi;
@@ -420,9 +420,9 @@ void Particle::ParticleInteractionDEM::set_initial_inertia()
     if (not container->have_stored_state(Particle::State::Inertia)) continue;
 
     // get pointer to particle states
-    const double* radius = container->get_ptr_to_state(Particle::State::Radius, 0);
-    const double* mass = container->get_ptr_to_state(Particle::State::Mass, 0);
-    double* inertia = container->get_ptr_to_state_writable(Particle::State::Inertia, 0);
+    const double* radius = container->get_ptr_to_state(Particle::State::Radius);
+    const double* mass = container->get_ptr_to_state(Particle::State::Mass);
+    double* inertia = container->get_ptr_to_state_writable(Particle::State::Inertia);
 
     // compute mass via particle volume and initial density
     for (int i = 0; i < particlestored; ++i)
@@ -469,13 +469,12 @@ void Particle::ParticleInteractionDEM::compute_acceleration() const
     const int statedim = container->get_state_dim(Particle::State::Acceleration);
 
     // get pointer to particle states
-    const double* radius = container->get_ptr_to_state(Particle::State::Radius, 0);
-    const double* mass = container->get_ptr_to_state(Particle::State::Mass, 0);
-    const double* force = container->get_ptr_to_state(Particle::State::Force, 0);
-    const double* moment = container->try_get_ptr_to_state(Particle::State::Moment, 0);
-    double* acc = container->get_ptr_to_state_writable(Particle::State::Acceleration, 0);
-    double* angacc =
-        container->try_get_ptr_to_state_writable(Particle::State::AngularAcceleration, 0);
+    const double* radius = container->get_ptr_to_state(Particle::State::Radius);
+    const double* mass = container->get_ptr_to_state(Particle::State::Mass);
+    const double* force = container->get_ptr_to_state(Particle::State::Force);
+    const double* moment = container->try_get_ptr_to_state(Particle::State::Moment);
+    double* acc = container->get_ptr_to_state_writable(Particle::State::Acceleration);
+    double* angacc = container->try_get_ptr_to_state_writable(Particle::State::AngularAcceleration);
 
     // compute acceleration
     for (int i = 0; i < particlestored; ++i)
@@ -550,10 +549,10 @@ void Particle::ParticleInteractionDEM::evaluate_particle_kinetic_energy(double& 
     const int statedim = container->get_state_dim(Particle::State::Position);
 
     // get pointer to particle states
-    const double* radius = container->get_ptr_to_state(Particle::State::Radius, 0);
-    const double* mass = container->get_ptr_to_state(Particle::State::Mass, 0);
-    const double* vel = container->get_ptr_to_state(Particle::State::Velocity, 0);
-    const double* angvel = container->try_get_ptr_to_state(Particle::State::AngularVelocity, 0);
+    const double* radius = container->get_ptr_to_state(Particle::State::Radius);
+    const double* mass = container->get_ptr_to_state(Particle::State::Mass);
+    const double* vel = container->get_ptr_to_state(Particle::State::Velocity);
+    const double* angvel = container->try_get_ptr_to_state(Particle::State::AngularVelocity);
 
     // add translational kinetic energy contribution
     for (int i = 0; i < particlestored; ++i)
@@ -594,8 +593,8 @@ void Particle::ParticleInteractionDEM::evaluate_particle_gravitational_potential
     const int statedim = container->get_state_dim(Particle::State::Position);
 
     // get pointer to particle states
-    const double* pos = container->get_ptr_to_state(Particle::State::Position, 0);
-    const double* mass = container->get_ptr_to_state(Particle::State::Mass, 0);
+    const double* pos = container->get_ptr_to_state(Particle::State::Position);
+    const double* mass = container->get_ptr_to_state(Particle::State::Mass);
 
     // add gravitational potential energy contribution
     for (int i = 0; i < particlestored; ++i)

--- a/src/particle/src/interaction/4C_particle_interaction_sph_density.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_density.cpp
@@ -924,9 +924,9 @@ void Particle::SPHDensityPredictCorrect::correct_density() const
     if (particlestored <= 0) continue;
 
     // get pointer to particle state
-    const double* denssum = container_i->get_ptr_to_state(Particle::State::DensitySum, 0);
-    const double* colorfield = container_i->get_ptr_to_state(Particle::State::Colorfield, 0);
-    double* dens = container_i->get_ptr_to_state_writable(Particle::State::Density, 0);
+    const double* denssum = container_i->get_ptr_to_state(Particle::State::DensitySum);
+    const double* colorfield = container_i->get_ptr_to_state(Particle::State::Colorfield);
+    double* dens = container_i->get_ptr_to_state_writable(Particle::State::Density);
 
     // get material for current particle type
     const Mat::PAR::ParticleMaterialBase* material =

--- a/src/particle/src/interaction/4C_particle_interaction_sph_phase_change.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_phase_change.cpp
@@ -154,7 +154,7 @@ void Particle::SPHPhaseChangeBase::evaluate_phase_change_from_below_to_above_pha
   if (particlestored <= 0) return;
 
   // get pointer to particle state
-  const double* state = container->get_ptr_to_state(transitionstate_, 0);
+  const double* state = container->get_ptr_to_state(transitionstate_);
 
   // get material for particle types
   const Mat::PAR::ParticleMaterialBase* material_source =
@@ -239,7 +239,7 @@ void Particle::SPHPhaseChangeBase::evaluate_phase_change_from_above_to_below_pha
   if (particlestored <= 0) return;
 
   // get pointer to particle state
-  const double* state = container->get_ptr_to_state(transitionstate_, 0);
+  const double* state = container->get_ptr_to_state(transitionstate_);
 
   // get material for particle types
   const Mat::PAR::ParticleMaterialBase* material_source =

--- a/src/particle/src/interaction/4C_particle_interaction_sph_pressure.cpp
+++ b/src/particle/src/interaction/4C_particle_interaction_sph_pressure.cpp
@@ -73,8 +73,8 @@ void Particle::SPHPressure::compute_pressure() const
     if (particlestored <= 0) continue;
 
     // get pointer to particle state
-    const double* dens = container->get_ptr_to_state(Particle::State::Density, 0);
-    double* press = container->get_ptr_to_state_writable(Particle::State::Pressure, 0);
+    const double* dens = container->get_ptr_to_state(Particle::State::Density);
+    double* press = container->get_ptr_to_state_writable(Particle::State::Pressure);
 
     // get material for current particle type
     const Mat::PAR::ParticleMaterialBase* material =

--- a/src/particle/tests/4C_particle_container_test.cpp
+++ b/src/particle/tests/4C_particle_container_test.cpp
@@ -19,6 +19,7 @@ namespace
   {
    protected:
     std::unique_ptr<Particle::ParticleContainer> container_;
+    std::unique_ptr<Particle::ParticleContainer> container_empty_;
 
     int statesvectorsize_;
 
@@ -31,6 +32,10 @@ namespace
       // create, init and setup container
       container_ = std::make_unique<Particle::ParticleContainer>();
       container_->setup(size, stateEnumSet);
+
+      // and the empty container
+      container_empty_ = std::make_unique<Particle::ParticleContainer>();
+      container_empty_->setup(0, stateEnumSet);
 
       const int maximum_stored_state_enum_set_value{static_cast<int>(*(--stateEnumSet.end()))};
       statesvectorsize_ = maximum_stored_state_enum_set_value + 1;
@@ -301,12 +306,20 @@ namespace
       {
         double* newmass = container_->get_ptr_to_state_writable(Particle::State::Mass, index);
         newmass[0] = newmass[0] * 3.14;
+
+        double* newvel = container_->get_ptr_to_state_writable(Particle::State::Velocity);
+        newvel[index * 3] = newvel[index * 3] * 3.14;
       }
       {
         const double* currmass = container_->get_ptr_to_state(Particle::State::Mass, index);
         EXPECT_NEAR(currmass[0], mass[0] * 3.14, 1e-14);
+
+        const double* currvel = container_->get_ptr_to_state(Particle::State::Velocity, index);
+        EXPECT_NEAR(currvel[0], vel[0] * 3.14, 1e-14);
       }
     }
+    EXPECT_EQ(container_empty_->get_ptr_to_state(Particle::State::Velocity), nullptr);
+    EXPECT_EQ(container_empty_->get_ptr_to_state_writable(Particle::State::Velocity), nullptr);
   }
 
   TEST_F(ParticleContainerTest, TryGetPtrToState)
@@ -360,21 +373,36 @@ namespace
       {
         double* newmass = container_->try_get_ptr_to_state_writable(Particle::State::Mass, index);
         newmass[0] = newmass[0] * 3.14;
+
+        double* newvel = container_->try_get_ptr_to_state_writable(Particle::State::Velocity);
+        newvel[index * 3] = newvel[index * 3] * 3.14;
       }
       {
         const double* currmass = container_->try_get_ptr_to_state(Particle::State::Mass, index);
         EXPECT_NEAR(currmass[0], mass[0] * 3.14, 1e-14);
+
+        const double* currvel = container_->try_get_ptr_to_state(Particle::State::Velocity, index);
+        EXPECT_NEAR(currvel[0], vel[0] * 3.14, 1e-14);
       }
     }
+    EXPECT_EQ(container_empty_->try_get_ptr_to_state(Particle::State::Velocity), nullptr);
+    EXPECT_EQ(container_empty_->try_get_ptr_to_state_writable(Particle::State::Velocity), nullptr);
   }
 
   TEST_F(ParticleContainerTest, TryGetPtrToStateNotStored)
   {
-    const double* acc = container_->try_get_ptr_to_state(Particle::State::Acceleration, 0);
+    const double* acc_0 = container_->try_get_ptr_to_state(Particle::State::Acceleration, 0);
+    EXPECT_EQ(acc_0, nullptr);
+
+    const double* acc = container_->try_get_ptr_to_state(Particle::State::Acceleration);
     EXPECT_EQ(acc, nullptr);
 
-    double* angacc =
+    double* angacc_0 =
         container_->try_get_ptr_to_state_writable(Particle::State::AngularAcceleration, 0);
+    EXPECT_EQ(angacc_0, nullptr);
+
+    double* angacc =
+        container_->try_get_ptr_to_state_writable(Particle::State::AngularAcceleration);
     EXPECT_EQ(angacc, nullptr);
   }
 


### PR DESCRIPTION
## Description and Context

We use `*get_ptr_to_state*` to do two different tasks - accessing the particle state for a single particle and accessing the particle state for all particles. This works fine until we try to access the state for an empty container and get an error when 4C is built with assertions (see #2224).

This PR adds overloaded versions of `*get_ptr_to_state*` that drops the `index` argument. In these, if the container is empty, then a `nullptr` is returned. This should be perfectly fine, as in these cases the array should be accessed in a loop over the number of particles in the container, so this `nullptr` should never be dereferenced. This matches with conventions I've seen in other projects. The alternative would be to insert checks at every callsite for `*get_ptr_to_state*` that is accessing the state for all particles and prevent the call if the container is empty. That is a lot of places in #2224, so I think this solution is much better.

- ToDo: I need to add some tests

## Related Issues and Pull Requests

#2148 #2224

## Disclosure of AI assistance

None